### PR TITLE
[Mobile Payments] Allow pass presentation after payment cancellation

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
@@ -10,6 +10,9 @@ final class CardPresentModalTapCard: CardPresentPaymentsModalViewModel {
     /// Charge amount
     private let amount: String
 
+    /// Cancellation callback
+    private let onCancel: () -> Void
+
     let textMode: PaymentsModalTextMode = .fullInfo
     let actionsMode: PaymentsModalActionsMode = .secondaryOnlyAction
 
@@ -33,9 +36,10 @@ final class CardPresentModalTapCard: CardPresentPaymentsModalViewModel {
 
     let bottomSubtitle: String? = Localization.tapInsertOrSwipe
 
-    init(name: String, amount: String) {
+    init(name: String, amount: String, onCancel: @escaping () -> Void) {
         self.name = name
         self.amount = amount
+        self.onCancel = onCancel
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -43,12 +47,9 @@ final class CardPresentModalTapCard: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        ServiceLocator.analytics.track(.collectPaymentCanceled)
-        let action = CardPresentPaymentAction.cancelPayment(onCompletion: nil)
-
-        ServiceLocator.stores.dispatch(action)
-
-        viewController?.dismiss(animated: true, completion: nil)
+        viewController?.dismiss(animated: true, completion: { [weak self] in
+            self?.onCancel()
+        })
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -60,8 +60,8 @@ final class PaymentCaptureOrchestrator {
                     }
                 },
                 onCompletion: { [weak self] result in
-                    onProcessingMessage()
                     self?.allowPassPresentation()
+                    onProcessingMessage()
                     self?.completePaymentIntentCapture(
                         order: order,
                         captureResult: result,

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -77,7 +77,10 @@ final class PaymentCaptureOrchestrator {
     }
 
     func cancelPayment(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = CardPresentPaymentAction.cancelPayment(onCompletion: onCompletion)
+        let action = CardPresentPaymentAction.cancelPayment() { [weak self] result in
+            self?.allowPassPresentation()
+            onCompletion(result)
+        }
         ServiceLocator.stores.dispatch(action)
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -1,5 +1,4 @@
 import Yosemite
-import PassKit
 
 /// Orchestrates the sequence of actions required to capture a payment:
 /// 1. Check if there is a card reader connected
@@ -11,8 +10,6 @@ final class PaymentCaptureOrchestrator {
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
 
     private let celebration = PaymentCaptureCelebration()
-
-    private var walletSuppressionRequestToken: PKSuppressionRequestToken?
 
     func collectPayment(for order: Order,
                         paymentsAccount: PaymentGatewayAccount?,
@@ -38,11 +35,6 @@ final class PaymentCaptureOrchestrator {
                 return
             }
 
-            /// Briefly suppress pass (wallet) presentation so that the merchant doesn't attempt to pay for the buyer's order when the
-            /// reader begins to collect payment.
-            ///
-            suppressPassPresentation()
-
             let paymentAction = CardPresentPaymentAction.collectPayment(
                 siteID: order.siteID,
                 orderID: order.orderID,
@@ -60,7 +52,6 @@ final class PaymentCaptureOrchestrator {
                     }
                 },
                 onCompletion: { [weak self] result in
-                    self?.allowPassPresentation()
                     onProcessingMessage()
                     self?.completePaymentIntentCapture(
                         order: order,
@@ -108,54 +99,6 @@ final class PaymentCaptureOrchestrator {
         let action = ReceiptAction.saveReceipt(order: order, parameters: params)
 
         ServiceLocator.stores.dispatch(action)
-    }
-}
-
-private extension PaymentCaptureOrchestrator {
-    /// Supress wallet presentation. This requires a special entitlement from Apple:
-    /// `com.apple.developer.passkit.pass-presentation-suppression`
-    /// See Woo-*.entitlements in WooCommerce/Resources
-    ///
-    func suppressPassPresentation() {
-        /// iPads don't support NFC passes. Attempting to call `requestAutomaticPassPresentationSuppression` on them will
-        /// return 0 `notSupported`
-        ///
-        guard !UIDevice.isPad() else {
-            return
-        }
-
-        guard !PKPassLibrary.isSuppressingAutomaticPassPresentation() else {
-            return
-        }
-
-        walletSuppressionRequestToken = PKPassLibrary.requestAutomaticPassPresentationSuppression() { result in
-            guard result == .success else {
-                DDLogWarn("Automatic pass presentation suppression request failed. Reason: \(result.rawValue)")
-
-                let logProperties: [String: Any] = ["PKAutomaticPassPresentationSuppressionResult": result.rawValue]
-                ServiceLocator.crashLogging.logMessage(
-                    "Automatic pass presentation suppression request failed",
-                    properties: logProperties,
-                    level: .warning
-                )
-                return
-            }
-        }
-    }
-
-    /// Restore wallet presentation.
-    func allowPassPresentation() {
-        /// iPads don't have passes (wallets) to present
-        ///
-        guard !UIDevice.isPad() else {
-            return
-        }
-
-        guard let walletSuppressionRequestToken = walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
-            return
-        }
-
-        PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: walletSuppressionRequestToken)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import PassKit
 
 /// Orchestrates the sequence of actions required to capture a payment:
 /// 1. Check if there is a card reader connected
@@ -10,6 +11,8 @@ final class PaymentCaptureOrchestrator {
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
 
     private let celebration = PaymentCaptureCelebration()
+
+    private var walletSuppressionRequestToken: PKSuppressionRequestToken?
 
     func collectPayment(for order: Order,
                         paymentsAccount: PaymentGatewayAccount?,
@@ -35,6 +38,11 @@ final class PaymentCaptureOrchestrator {
                 return
             }
 
+            /// Briefly suppress pass (wallet) presentation so that the merchant doesn't attempt to pay for the buyer's order when the
+            /// reader begins to collect payment.
+            ///
+            suppressPassPresentation()
+
             let paymentAction = CardPresentPaymentAction.collectPayment(
                 siteID: order.siteID,
                 orderID: order.orderID,
@@ -53,6 +61,7 @@ final class PaymentCaptureOrchestrator {
                 },
                 onCompletion: { [weak self] result in
                     onProcessingMessage()
+                    self?.allowPassPresentation()
                     self?.completePaymentIntentCapture(
                         order: order,
                         captureResult: result,
@@ -99,6 +108,54 @@ final class PaymentCaptureOrchestrator {
         let action = ReceiptAction.saveReceipt(order: order, parameters: params)
 
         ServiceLocator.stores.dispatch(action)
+    }
+}
+
+private extension PaymentCaptureOrchestrator {
+    /// Supress wallet presentation. This requires a special entitlement from Apple:
+    /// `com.apple.developer.passkit.pass-presentation-suppression`
+    /// See Woo-*.entitlements in WooCommerce/Resources
+    ///
+    func suppressPassPresentation() {
+        /// iPads don't support NFC passes. Attempting to call `requestAutomaticPassPresentationSuppression` on them will
+        /// return 0 `notSupported`
+        ///
+        guard !UIDevice.isPad() else {
+            return
+        }
+
+        guard !PKPassLibrary.isSuppressingAutomaticPassPresentation() else {
+            return
+        }
+
+        walletSuppressionRequestToken = PKPassLibrary.requestAutomaticPassPresentationSuppression() { result in
+            guard result == .success else {
+                DDLogWarn("Automatic pass presentation suppression request failed. Reason: \(result.rawValue)")
+
+                let logProperties: [String: Any] = ["PKAutomaticPassPresentationSuppressionResult": result.rawValue]
+                ServiceLocator.crashLogging.logMessage(
+                    "Automatic pass presentation suppression request failed",
+                    properties: logProperties,
+                    level: .warning
+                )
+                return
+            }
+        }
+    }
+
+    /// Restore wallet presentation.
+    func allowPassPresentation() {
+        /// iPads don't have passes (wallets) to present
+        ///
+        guard !UIDevice.isPad() else {
+            return
+        }
+
+        guard let walletSuppressionRequestToken = walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
+            return
+        }
+
+        PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: walletSuppressionRequestToken)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -48,8 +48,8 @@ final class OrderDetailsPaymentAlerts {
         presentViewModel(viewModel: viewModel)
     }
 
-    func tapOrInsertCard() {
-        let viewModel = tapOrInsert()
+    func tapOrInsertCard(onCancel: @escaping () -> Void) {
+        let viewModel = tapOrInsert(onCancel: onCancel)
         presentViewModel(viewModel: viewModel)
     }
 
@@ -89,8 +89,8 @@ private extension OrderDetailsPaymentAlerts {
         CardPresentModalReaderIsReady(name: name, amount: amount)
     }
 
-    func tapOrInsert() -> CardPresentPaymentsModalViewModel {
-        CardPresentModalTapCard(name: name, amount: amount)
+    func tapOrInsert(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalTapCard(name: name, amount: amount, onCancel: onCancel)
     }
 
     func remove() -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -728,7 +728,11 @@ private extension OrderDetailsViewController {
 
         ServiceLocator.analytics.track(.collectPaymentTapped)
         viewModel.collectPayment { [weak self] readerEventMessage in
-            self?.paymentAlerts.tapOrInsertCard()
+            self?.paymentAlerts.tapOrInsertCard(onCancel: {
+                self?.viewModel.cancelPayment(onCompletion: { _ in
+                    ServiceLocator.analytics.track(.collectPaymentCanceled)
+                })
+            })
         } onClearMessage: { [weak self] in
             self?.paymentAlerts.removeCard()
         } onProcessingMessage: { [weak self] in

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -2,6 +2,7 @@ import Storage
 import Hardware
 import Networking
 import Combine
+import PassKit
 
 /// MARK: CardPresentPaymentStore
 ///
@@ -17,6 +18,8 @@ public final class CardPresentPaymentStore: Store {
 
     /// We need to be able to cancel the process of collecting a payment.
     private var paymentCancellable: AnyCancellable? = nil
+
+    private var walletSuppressionRequestToken: PKSuppressionRequestToken?
 
     public init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, cardReaderService: CardReaderService) {
         self.cardReaderService = cardReaderService
@@ -161,12 +164,15 @@ private extension CardPresentPaymentStore {
                         parameters: PaymentParameters,
                         onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
                         onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) {
+        suppressPassPresentation()
+
         // Observe status events fired by the card reader
         let readerEventsSubscription = cardReaderService.readerEvents.sink { event in
             onCardReaderMessage(event)
         }
 
         paymentCancellable = cardReaderService.capturePayment(parameters).sink { error in
+            self.allowPassPresentation()
             readerEventsSubscription.cancel()
             switch error {
             case .failure(let error):
@@ -185,15 +191,18 @@ private extension CardPresentPaymentStore {
 
         cardReaderService.cancelPaymentIntent()
             .subscribe(Subscribers.Sink(receiveCompletion: { value in
-            switch value {
-            case .failure(let error):
-                onCompletion?(.failure(error))
-            case .finished:
-                break
-            }
-        }, receiveValue: {
-            onCompletion?(.success(()))
-        }))
+                self.allowPassPresentation()
+
+                switch value {
+                case .failure(let error):
+                    onCompletion?(.failure(error))
+                case .finished:
+                    break
+                }
+            }, receiveValue: {
+                onCompletion?(.success(()))
+            })
+        )
     }
 
     func checkForCardReaderUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
@@ -258,6 +267,42 @@ private extension CardPresentPaymentStore {
     }
 }
 
+private extension CardPresentPaymentStore {
+    /// Supress wallet presentation. This requires a special entitlement from Apple:
+    /// `com.apple.developer.passkit.pass-presentation-suppression`
+    /// See Woo-*.entitlements in WooCommerce/Resources
+    ///
+    /// Note: iPads don't support NFC passes.
+    ///
+    func suppressPassPresentation() {
+        guard UIDevice.current.userInterfaceIdiom != .pad else {
+            return
+        }
+
+        guard !PKPassLibrary.isSuppressingAutomaticPassPresentation() else {
+            return
+        }
+
+        walletSuppressionRequestToken = PKPassLibrary.requestAutomaticPassPresentationSuppression() { result in
+            guard result == .success else {
+                DDLogWarn("Automatic pass presentation suppression request failed. Reason: \(result.rawValue)")
+                return
+            }
+        }
+    }
+
+    func allowPassPresentation() {
+        guard UIDevice.current.userInterfaceIdiom != .pad else {
+            return
+        }
+
+        guard let walletSuppressionRequestToken = walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
+            return
+        }
+
+        PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: walletSuppressionRequestToken)
+    }
+}
 
 /// Implementation of the CardReaderNetworkingAdapter
 /// that fetches a token using WCPayRemote

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -185,16 +185,15 @@ private extension CardPresentPaymentStore {
 
         cardReaderService.cancelPaymentIntent()
             .subscribe(Subscribers.Sink(receiveCompletion: { value in
-                switch value {
-                case .failure(let error):
-                    onCompletion?(.failure(error))
-                case .finished:
-                    break
-                }
-            }, receiveValue: {
-                onCompletion?(.success(()))
-            })
-        )
+            switch value {
+            case .failure(let error):
+                onCompletion?(.failure(error))
+            case .finished:
+                break
+            }
+        }, receiveValue: {
+            onCompletion?(.success(()))
+        }))
     }
 
     func checkForCardReaderUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
@@ -258,6 +257,7 @@ private extension CardPresentPaymentStore {
         onCompletion(publisher)
     }
 }
+
 
 /// Implementation of the CardReaderNetworkingAdapter
 /// that fetches a token using WCPayRemote


### PR DESCRIPTION
Closes #4649 

@ctarda @joshheald  @jaclync - just one review needed from one of you, but all of you are welcome of course

Changes
- In CardPresentModalTapCard, instead of allowing the modal to create and enqueue the cancel payment action directly, it now accepts an onCancel closure to call when the user taps the button. This fixes a hole where the modal was bypassing PaymentCaptureOrchestrator.
- In OrderDetailsPaymentAlerts, allow that onCancel closure to be passed
- In OrderDetailsViewController, pass viewModel cancelPayment to tapOrInsertCard onCancel. Move the call to tracks (that used to be in the modal) here too
- Lastly, and most importantly, in PaymentCaptureOrchestrator, restore pass presentation in cancelPayment

To test:
- Use this branch to begin payment collection on a qualifying order with an iPhone and with the powered on reader directly in contact with the iPhone
- Ensure the iPhone’s wallet does NOT present
- Cancel the payment
- Remove the iPhone from contact with the reader
- Disconnect from the reader in Settings > In-Person Payments > Manage Card Reader
- Use this branch on another device (e.g. an iPad) to begin payment collection on that order
- Tap the iPhone to the reader
- Ensure the iPhone’s wallet DOES present
- Cancel the payment
- Begin payment collection again
- Tap a Point of Sale Test Card to the reader and ensure you can complete the payment

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
