### PR TITLE
Quick Order: Remove feature flag conditionals

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -90,7 +90,7 @@ private extension BetaFeaturesViewController {
     /// A section is returned only when the store is ready to receive payments
     ///
     func ordersSection() -> Section? {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickOrderPrototype), paymentsStoreUseCase.state == .completed else {
+        guard paymentsStoreUseCase.state == .completed else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -90,10 +90,6 @@ final class OrderListViewModel {
     ///
     @Published var hideQuickOrderBanners: Bool = false
 
-    /// Tracks if the Quick Order feature is ready to be released to the public
-    ///
-    private let isQuickOrderDevelopmentComplete = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickOrderPrototype)
-
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -251,14 +247,13 @@ extension OrderListViewModel {
         let errorState = $hasErrorLoadingData.removeDuplicates()
         let experimentalState = $isQuickOrderEnabled.removeDuplicates()
         Publishers.CombineLatest4(enrolledState, errorState, experimentalState, $hideQuickOrderBanners)
-            .map { [weak self] enrolledState, hasError, isQuickOrderEnabled, hasDismissedBanners -> TopBanner in
-                guard let self = self else { return .none }
+            .map { enrolledState, hasError, isQuickOrderEnabled, hasDismissedBanners -> TopBanner in
 
                 guard !hasError else {
                     return .error
                 }
 
-                guard self.isQuickOrderDevelopmentComplete, !hasDismissedBanners else {
+                guard !hasDismissedBanners else {
                     return .none
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -110,9 +110,8 @@ private extension OrdersRootViewController {
     ///
     func configureNavigationButtons(isQuickOrderExperimentalToggleEnabled: Bool) {
         let shouldShowQuickOrderButton: Bool = {
-            let isQuickOrderEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickOrderPrototype) && isQuickOrderExperimentalToggleEnabled
             let isInPersonPaymentsConfigured = inPersonPaymentsUseCase.state == .completed
-            return isQuickOrderEnabled && isInPersonPaymentsConfigured
+            return isQuickOrderExperimentalToggleEnabled && isInPersonPaymentsConfigured
         }()
         let buttons: [UIBarButtonItem?] = [
             ordersViewController.createSearchBarButtonItem(),


### PR DESCRIPTION
# Why

When #5287 is merged, the prototype is ready to be released to iPP merchants based on the plan drafted in p91TBi-6iQ.

Note: I'm not removing the feature flag definition because the quick order project will continue its development until it reaches its final form.

# Testing Steps

- Launch the app using an IPP eligible store
- Go to settings > exp features and make sure the quick order toggle is on
- Go to the order list screen and tap on the plus button
- Tap on the amount placeholder and enter an amount
- Tap done and the that the app redirects you to the order detail
- See and tap the "Collect Payment" button
- Continue normal IPP flow.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
