### PR TITLE
[Mobile Payments] Cancel payment capture if order amount is below minimum (USD only)

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -186,6 +186,9 @@ public enum UnderlyingError: Error {
     /// The SDK will attempt to auto-disconnect for you and you should instruct your user to reconnect it.
     case readerSessionExpired
 
+    /// The underlying request returned an API error.
+    case stripeAPIError
+
     /// Catch-all error case. Indicates there is something wrong with the
     /// internal state of the CardReaderService.
     case internalServiceError
@@ -305,6 +308,9 @@ updating the application or using a different reader
         case .readerSessionExpired:
             return NSLocalizedString("The card reader session has expired - please disconnect and reconnect the card reader and then try again",
                                      comment: "Error message when the card reader session has timed out.")
+        case .stripeAPIError:
+            return NSLocalizedString("Unable to process payment. Order Total amount is below the minimum amount you can charge.",
+                                     comment: "Error message when the order amount is below the minimum amount allowed.")
         case .internalServiceError:
             return NSLocalizedString("Sorry, this payment couldn’t be processed",
                                      comment: "Error message when the card reader service experiences an unexpected internal service error.")

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -187,7 +187,7 @@ public enum UnderlyingError: Error {
     case readerSessionExpired
 
     /// The underlying request returned an API error.
-    case APIError
+    case processorAPIError
 
     /// Catch-all error case. Indicates there is something wrong with the
     /// internal state of the CardReaderService.
@@ -308,7 +308,7 @@ updating the application or using a different reader
         case .readerSessionExpired:
             return NSLocalizedString("The card reader session has expired - please disconnect and reconnect the card reader and then try again",
                                      comment: "Error message when the card reader session has timed out.")
-        case .APIError:
+        case .processorAPIError:
             return NSLocalizedString("Unable to process payment. Order Total amount is below the minimum amount you can charge.",
                                      comment: "Error message when the order amount is below the minimum amount allowed.")
         case .internalServiceError:

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -309,8 +309,8 @@ updating the application or using a different reader
             return NSLocalizedString("The card reader session has expired - please disconnect and reconnect the card reader and then try again",
                                      comment: "Error message when the card reader session has timed out.")
         case .processorAPIError:
-            return NSLocalizedString("Unable to process payment. Order Total amount is below the minimum amount you can charge.",
-                                     comment: "Error message when the order amount is below the minimum amount allowed.")
+            return NSLocalizedString("The payment can not be processed by the payment processor.",
+                                     comment: "Error message when the payment can not be processed (i.e. order amount is below the minimum amount allowed.)")
         case .internalServiceError:
             return NSLocalizedString("Sorry, this payment couldn’t be processed",
                                      comment: "Error message when the card reader service experiences an unexpected internal service error.")

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -187,7 +187,7 @@ public enum UnderlyingError: Error {
     case readerSessionExpired
 
     /// The underlying request returned an API error.
-    case stripeAPIError
+    case APIError
 
     /// Catch-all error case. Indicates there is something wrong with the
     /// internal state of the CardReaderService.
@@ -308,7 +308,7 @@ updating the application or using a different reader
         case .readerSessionExpired:
             return NSLocalizedString("The card reader session has expired - please disconnect and reconnect the card reader and then try again",
                                      comment: "Error message when the card reader session has timed out.")
-        case .stripeAPIError:
+        case .APIError:
             return NSLocalizedString("Unable to process payment. Order Total amount is below the minimum amount you can charge.",
                                      comment: "Error message when the order amount is below the minimum amount allowed.")
         case .internalServiceError:

--- a/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
@@ -79,6 +79,8 @@ extension UnderlyingError {
             self = .requestTimedOut
         case ErrorCode.Code.sessionExpired.rawValue:
             self = .readerSessionExpired
+        case ErrorCode.Code.stripeAPIError.rawValue:
+            self = .stripeAPIError
         default:
             self = .internalServiceError
         }

--- a/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
@@ -80,7 +80,7 @@ extension UnderlyingError {
         case ErrorCode.Code.sessionExpired.rawValue:
             self = .readerSessionExpired
         case ErrorCode.Code.stripeAPIError.rawValue:
-            self = .stripeAPIError
+            self = .APIError
         default:
             self = .internalServiceError
         }

--- a/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
@@ -80,7 +80,7 @@ extension UnderlyingError {
         case ErrorCode.Code.sessionExpired.rawValue:
             self = .readerSessionExpired
         case ErrorCode.Code.stripeAPIError.rawValue:
-            self = .APIError
+            self = .processorAPIError
         default:
             self = .internalServiceError
         }

--- a/Hardware/HardwareTests/ErrorCodesTests.swift
+++ b/Hardware/HardwareTests/ErrorCodesTests.swift
@@ -155,7 +155,7 @@ final class CardReaderServiceErrorTests: XCTestCase {
     }
 
     func test_stripe_error_api_maps_to_stripeAPI() {
-        XCTAssertEqual(.stripeAPIError, domainError(stripeCode: 9020))
+        XCTAssertEqual(.APIError, domainError(stripeCode: 9020))
     }
 
     func test_stripe_catch_all_error() {

--- a/Hardware/HardwareTests/ErrorCodesTests.swift
+++ b/Hardware/HardwareTests/ErrorCodesTests.swift
@@ -155,7 +155,7 @@ final class CardReaderServiceErrorTests: XCTestCase {
     }
 
     func test_stripe_error_api_maps_to_stripeAPI() {
-        XCTAssertEqual(.APIError, domainError(stripeCode: 9020))
+        XCTAssertEqual(.processorAPIError, domainError(stripeCode: 9020))
     }
 
     func test_stripe_catch_all_error() {

--- a/Hardware/HardwareTests/ErrorCodesTests.swift
+++ b/Hardware/HardwareTests/ErrorCodesTests.swift
@@ -154,6 +154,10 @@ final class CardReaderServiceErrorTests: XCTestCase {
         XCTAssertEqual(.readerSessionExpired, domainError(stripeCode: 9060))
     }
 
+    func test_stripe_error_api_maps_to_stripeAPI() {
+        XCTAssertEqual(.stripeAPIError, domainError(stripeCode: 9020))
+    }
+
     func test_stripe_catch_all_error() {
         // Any error code not mapped to an specific error will be
         // mapped to `internalServiceError`

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -20,6 +20,11 @@ final class PaymentCaptureOrchestrator {
                         onClearMessage: @escaping () -> Void,
                         onProcessingMessage: @escaping () -> Void,
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
+        guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total), orderTotal.compare(Constants.minimumAmount) == .orderedDescending else {
+            DDLogError("💳 Error: failed to capture payment for order. Minim")
+            onCompletion(.failure(CardReaderServiceError.intentCreation(underlyingError: .stripeAPIError)))
+            return
+        }
         /// First ask the backend to create/assign a Stripe customer for the order
         ///
         var customerID: String?
@@ -266,5 +271,11 @@ private extension PaymentCaptureOrchestrator {
                                                             + "Order @{number} for @{store name} "
                                                             + "Parameters: %1$@ - order number, "
                                                             + "%2$@ - store name")
+    }
+}
+
+private extension PaymentCaptureOrchestrator {
+    enum Constants {
+        static let minimumAmount = NSDecimalNumber(string: "0.5")
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -22,7 +22,7 @@ final class PaymentCaptureOrchestrator {
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total), orderTotal.compare(Constants.minimumAmount) == .orderedDescending else {
             DDLogError("💳 Error: failed to capture payment for order. Minim")
-            onCompletion(.failure(CardReaderServiceError.intentCreation(underlyingError: .stripeAPIError)))
+            onCompletion(.failure(CardReaderServiceError.intentCreation(underlyingError: .APIError)))
             return
         }
         /// First ask the backend to create/assign a Stripe customer for the order

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -22,7 +22,7 @@ final class PaymentCaptureOrchestrator {
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total), orderTotal.compare(Constants.minimumAmount) == .orderedDescending else {
             DDLogError("💳 Error: failed to capture payment for order. Minim")
-            onCompletion(.failure(CardReaderServiceError.intentCreation(underlyingError: .APIError)))
+            onCompletion(.failure(CardReaderServiceError.intentCreation(underlyingError: .processorAPIError)))
             return
         }
         /// First ask the backend to create/assign a Stripe customer for the order

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -267,6 +267,8 @@ private extension PaymentCaptureOrchestrator {
 
 private extension PaymentCaptureOrchestrator {
     enum Constants {
+        /// Minimum order amount in USD:
+        /// https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
         static let minimumAmount = NSDecimalNumber(string: "0.5")
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -277,7 +277,7 @@ private extension PaymentCaptureOrchestrator {
             return false
         }
 
-        return orderTotal.compare(Constants.minimumAmount) == .orderedDescending
+        return orderTotal as Decimal >= Constants.minimumAmount as Decimal
     }
 
     func minimumAmountError(order: Order, minimumAmount: NSDecimalNumber) -> Error {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -1087,7 +1087,6 @@ private extension OrderDetailsViewController {
         static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
-        static let minimumAmount = NSDecimalNumber(string: "0.5")
     }
 
     /// Mailing a receipt failed but the SDK didn't return a more specific error

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -704,14 +704,6 @@ private extension OrderDetailsViewController {
     }
 
     @objc private func collectPayment(at: IndexPath) {
-        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        guard let orderTotal = currencyFormatter.convertToDecimal(from: viewModel.order.total),
-                orderTotal.compare(Constants.minimumAmount) == .orderedDescending else {
-            DDLogError("💳 Error: failed to capture payment for order. Minim")
-            let error = CardReaderServiceError.intentCreation(underlyingError: .stripeAPIError)
-            paymentAlerts.error(error: error, tryAgain: {})
-            return
-        }
         cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
             .sink(
                 receiveCompletion: { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -704,6 +704,14 @@ private extension OrderDetailsViewController {
     }
 
     @objc private func collectPayment(at: IndexPath) {
+        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+        guard let orderTotal = currencyFormatter.convertToDecimal(from: viewModel.order.total),
+                orderTotal.compare(Constants.minimumAmount) == .orderedDescending else {
+            DDLogError("💳 Error: failed to capture payment for order. Minim")
+            let error = CardReaderServiceError.intentCreation(underlyingError: .stripeAPIError)
+            paymentAlerts.error(error: error, tryAgain: {})
+            return
+        }
         cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
             .sink(
                 receiveCompletion: { [weak self] result in
@@ -1087,6 +1095,7 @@ private extension OrderDetailsViewController {
         static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
+        static let minimumAmount = NSDecimalNumber(string: "0.5")
     }
 
     /// Mailing a receipt failed but the SDK didn't return a more specific error


### PR DESCRIPTION
Closes #4911 

> As Stripe’s processing fee combines a small fixed amount and a percentage, we enforce a minimum amount when creating a charge. This ensures you don’t lose money on a charge. The minimum amount you can charge depends on which bank account settlement currency the payment would be paid out to. [Source](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts)

That minimum amount turns out to be 0.50 USD.

<img src="https://user-images.githubusercontent.com/2722505/139289494-094f077f-8c43-4b7c-977c-12a7176f4bfd.png" width="350"/>


## Changes
* CardReaderService: Add a case in the error enumeration that the service exposes to model "api errors". 
* PaymentCaptureOrchestrator: check the order total amount **before** attempting to capture a payment, and throw a specific error.

This covers both ends of the problem:
* it prevents initiating a payment capture in the UI when we know that it is going to fail
* if an attempt to capture the payment got initiated somehow, we would still present a meaningful error.

However, there is a bit of duplication (the error is kind of defined in two different places). To me, this is one of those cases where a bit of duplication is better that introducing the wrong abstraction.

Also, this solution could be a bit better: we still attempt to connect to the card reader even though we know that the payment capture is going to fail. More about that in a comment in the actual diff.

## How to test
* Create three orders: Order A is a total 0.15 USD. Order B is a total 0.50 USD. Order C is over 0.50 USD
* Attempt to capture payment all those orders. Order B and C should work fine. For Order A, the app should present an error message before attempting to capture the payment.


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
