### PR TITLE
[Mobile Payments] Do not pass the entire account, just pass the statement descriptor

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -549,8 +549,10 @@ extension OrderDetailsViewModel {
             DDLogWarn("Expected one card present gateway account. Got something else.")
         }
 
+        let statementDescriptor = cardPresentPaymentGatewayAccounts.first?.statementDescriptor
+
         paymentOrchestrator.collectPayment(for: self.order,
-                                           paymentsAccount: self.cardPresentPaymentGatewayAccounts.first,
+                                           statementDescriptor: statementDescriptor,
                                            onPresentMessage: onPresentMessage,
                                            onClearMessage: onClearMessage,
                                            onProcessingMessage: onProcessingMessage,


### PR DESCRIPTION
Fixes #4860 

All y'all are welcome to review. Only one review needed. Thx!

Changes:
- Replaces passing the PaymentGatewayAccount into PaymentCaptureOrchestrator collectPayment with the only thing we need from the account - the descriptor for the buyer's credit card statement.

To test:
- Go to wp-admin and set your descriptor to something recognizable if you haven't already
- Complete an in-person payment
- Go to the Stripe dashboard for that account, then Payments, then ensure you see the updated descriptor

<img width="1524" alt="wp-admin" src="https://user-images.githubusercontent.com/1595739/139324032-a8d3754e-a408-4dce-931a-7531a5ffb398.png">

<img width="1652" alt="dashboard" src="https://user-images.githubusercontent.com/1595739/139324039-c83554f3-2bfa-4c6b-b1a1-d8d062143bbe.png">

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
