### PR TITLE
Fix: tab bar background color under iOS 15 and Xcode 13

### DIFF
--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -15,6 +15,13 @@ extension UITabBar {
         /// To fix it, we have to specifically set it in the `standardAppearance` object.
         ///
         appearance.standardAppearance = createWooTabBarAppearance()
+
+        /// This is needed because the tab bar background has the wrong color under iOS 15 (using Xcode 13).
+        /// More: issue-5018
+        ///
+        if #available(iOS 15.0, *) {
+            appearance.scrollEdgeAppearance = appearance.standardAppearance
+        }
     }
 
     /// Creates an appearance object for a tabbar with the default WC style.


### PR DESCRIPTION
Fixes #5018 

Compiling the project with Xcode 13 under iOS 15, we discovered a bug where the background of the tab bar has the wrong color. @jaclync proposed a solution to fix it, that works perfectly.
*Note*: This PR is targeting https://github.com/woocommerce/woocommerce-ios/pull/5311.

## Testing
1. Run the app under Xcode 13 (first in light mode, then in dark mode).
2. Navigate between tabs.
3. The background color of the tab should be correct.


## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro - 2021-10-29 at 11 24 57](https://user-images.githubusercontent.com/495617/139416158-45015c32-b4e2-4561-bd00-d872d5af6b11.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-10-29 at 12 02 10](https://user-images.githubusercontent.com/495617/139416293-b1d2032c-f416-49a1-81f4-d1f539703ae1.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
