### PR TITLE
Fix: warnings in `AttributedText` view under Xcode 13

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
@@ -197,13 +197,13 @@ extension EnvironmentValues {
 
 private extension EnvironmentValues {
     var foregroundColor: Color? {
-        get { self[ForegroundColorKey] }
-        set { self[ForegroundColorKey] = newValue }
+        get { self[ForegroundColorKey.self] }
+        set { self[ForegroundColorKey.self] = newValue }
     }
 
     var linkColor: Color? {
-        get { self[LinkColorKey] }
-        set { self[LinkColorKey] = newValue }
+        get { self[LinkColorKey.self] }
+        set { self[LinkColorKey.self] = newValue }
     }
 }
 


### PR DESCRIPTION
In this PR I fixed some warnings on Xcode 13 related to `AttributedText`.
@koke I choose you as a reviewer since you are the one how worked on that component, but feel free to re-assign it if you don't have time to review it.
*Note:* This PR is targeting #5311.


## Testing
1. Run the app under Xcode 13
2. Make sure you will no more see these type of warnings:
<img width="490" alt="Schermata 2021-10-29 alle 12 11 32" src="https://user-images.githubusercontent.com/495617/139418947-589bad8e-8a9f-4490-b9f4-5b5d4cde73b2.png">



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
