### PR TITLE
Merge 7.9 release notes into develop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.522.0)
-    aws-sdk-core (3.121.5)
+    aws-partitions (1.523.0)
+    aws-sdk-core (3.121.6)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.520.1)
       aws-sigv4 (~> 1.1)
@@ -155,7 +155,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-appcenter (1.11.1)
-    fastlane-plugin-sentry (1.10.0)
+    fastlane-plugin-sentry (1.11.0)
     fastlane-plugin-test_center (3.15.3)
       colorize
       json
@@ -226,7 +226,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.6.1)

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -57,11 +57,11 @@ msgctxt "app_store_promo_text"
 msgid "Run your store from anywhere"
 msgstr ""
 
-msgctxt "v7.8-whats-new"
+msgctxt "v7.9-whats-new"
 msgid ""
-"Merchants using WooCommerce Shipping & Tax will find you can now create multiple shipping labels for an order. You can quickly move items between the packages to match how you’ve decided to ship things to your customer. We’ve also addressed some glitches that were reported on the same screens.\n"
+"Some merchants had problems loading order details because of a technical issue with how field names in the REST API are ordered. We’ve made a correction that should address that for you if you were experiencing it.\n"
 "\n"
-"We also made a few accessibility improvements based on feedback. Thank you!\n"
+"This release contains several other fixes based on your feedback. Please continue to send us feedback – we are listening!\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,6 +1,3 @@
-- [*] Fix: after disconnecting a site or connecting to a new site, the sites in site picker (Settings > Switch Store) should be updated accordingly. The only exception is when the newly disconnected site is the currently selected site. [https://github.com/woocommerce/woocommerce-ios/pull/5241]
-- [*] Order Details: Show a button on the "Product" section of Order Details screen to allow recreating shipping labels. [https://github.com/woocommerce/woocommerce-ios/pull/5255]
-- [*] Edit Order Address - Enable `Done` button when `Use as {Shipping/Billing} Address` toggle is turned on. [https://github.com/woocommerce/woocommerce-ios/pull/5254]
-- [*] Add/Edit Product: fix an issue where the product name keyboard is English only. [https://github.com/woocommerce/woocommerce-ios/pull/5288]
-- [*] Order Details: some sites cannot parse order requests where the fields parameter has spaces, and the products section cannot load as a result. The spaces are now removed. [https://github.com/woocommerce/woocommerce-ios/pull/5298]
+Some merchants had problems loading order details because of a technical issue with how field names in the REST API are ordered. We’ve made a correction that should address that for you if you were experiencing it.
 
+This release contains several other fixes based on your feedback. Please continue to send us feedback – we are listening!


### PR DESCRIPTION
Merges the `7.9` release notes into `develop`.

Also includes an update to the Sentry Fastlane plugin.