### PR TITLE
Add check to skip secrets code generation in non `indexbuild` actions

### DIFF
--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash -euo pipefail
 
+if [[ $ACTION == 'indexbuild' ]]; then
+  echo "ℹ️: Skipping code generation in 'indexbuild' build. See https://github.com/mac-cain13/R.swift/issues/719#issuecomment-937733804 for more info."
+  exit 0
+fi
+
 DERIVED_PATH=${SOURCE_ROOT}/DerivedSources
 SCRIPT_PATH=${SOURCE_ROOT}/Credentials/replace_secrets.rb
 


### PR DESCRIPTION
This is a followup to the work from #5049.

See discussion at:

- https://github.com/mac-cain13/R.swift/issues/719#issuecomment-937733804
- https://github.com/woocommerce/woocommerce-ios/pull/5311#issuecomment-955837332

The folks in the `R.swift` issue seem happy with the fix, but I haven't used it myself yet so I cannot attest to whether it's solid, also because this kind of error is not consistently occurring.

I think it's worth applying and seeing whether it works for us and it doesn't introduce unexpected side-effects.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**