### PR TITLE
Order Editing: Add Address Form fields dynamic type support

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveStack.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct AdaptiveStack<Content: View>: View {
+    @Environment(\.sizeCategory) var sizeCategory
+
+    let horizontalAlignment: HorizontalAlignment
+    let verticalAlignment: VerticalAlignment
+    let spacing: CGFloat?
+    let content: () -> Content
+
+    init(horizontalAlignment: HorizontalAlignment = .center,
+         verticalAlignment: VerticalAlignment = .center,
+         spacing: CGFloat? = nil,
+         @ViewBuilder content: @escaping () -> Content) {
+        self.horizontalAlignment = horizontalAlignment
+        self.verticalAlignment = verticalAlignment
+        self.spacing = spacing
+        self.content = content
+    }
+
+    var body: some View {
+        Group {
+            if sizeCategory.isAccessibilityCategory {
+                VStack(alignment: horizontalAlignment, spacing: spacing, content: content)
+            } else {
+                HStack(alignment: verticalAlignment, spacing: spacing, content: content)
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveStack.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AdaptiveStack<Content: View>: View {
     @Environment(\.sizeCategory) var sizeCategory
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
     let horizontalAlignment: HorizontalAlignment
     let verticalAlignment: VerticalAlignment
@@ -20,7 +21,7 @@ struct AdaptiveStack<Content: View>: View {
 
     var body: some View {
         Group {
-            if sizeCategory.isAccessibilityCategory {
+            if sizeCategory.isAccessibilityCategory, horizontalSizeClass == .compact {
                 VStack(alignment: horizontalAlignment, spacing: spacing, content: content)
             } else {
                 HStack(alignment: verticalAlignment, spacing: spacing, content: content)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
@@ -30,13 +30,15 @@ struct TitleAndTextFieldRow: View {
                 .bodyStyle()
                 .lineLimit(1)
                 .fixedSize()
-            TextField(placeholder, text: $text, onEditingChanged: onEditingChanged ?? { _ in })
-                .multilineTextAlignment(.trailing)
-                .font(.body)
-                .keyboardType(keyboardType)
-            if let symbol = symbol {
-                Text(symbol)
-                    .bodyStyle()
+            HStack {
+                TextField(placeholder, text: $text, onEditingChanged: onEditingChanged ?? { _ in })
+                    .multilineTextAlignment(.trailing)
+                    .font(.body)
+                    .keyboardType(keyboardType)
+                if let symbol = symbol {
+                    Text(symbol)
+                        .bodyStyle()
+                }
             }
         }
         .frame(minHeight: Constants.height)
@@ -76,5 +78,23 @@ struct TitleAndTextFieldRow_Previews: PreviewProvider {
                              keyboardType: .default)
             .previewLayout(.fixed(width: 375, height: 100))
             .previewDisplayName("With symbol")
+
+        TitleAndTextFieldRow(title: "Add your text",
+                             placeholder: "Start typing",
+                             text: .constant("Hello"),
+                             symbol: nil,
+                             keyboardType: .default)
+            .environment(\.sizeCategory, .accessibilityExtraLarge)
+            .previewLayout(.fixed(width: 375, height: 150))
+            .previewDisplayName("Dynamic Type: Large Font Size")
+
+        TitleAndTextFieldRow(title: "Total package weight",
+                             placeholder: "Value",
+                             text: .constant(""),
+                             symbol: "oz",
+                             keyboardType: .default)
+            .environment(\.sizeCategory, .accessibilityExtraLarge)
+            .previewLayout(.fixed(width: 375, height: 150))
+            .previewDisplayName("Dynamic Type: Large Font Size with symbol")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
@@ -25,12 +25,11 @@ struct TitleAndTextFieldRow: View {
     }
 
     var body: some View {
-        HStack {
+        AdaptiveStack(horizontalAlignment: .leading) {
             Text(title)
                 .bodyStyle()
                 .lineLimit(1)
                 .fixedSize()
-            Spacer()
             TextField(placeholder, text: $text, onEditingChanged: onEditingChanged ?? { _ in })
                 .multilineTextAlignment(.trailing)
                 .font(.body)
@@ -40,7 +39,7 @@ struct TitleAndTextFieldRow: View {
                     .bodyStyle()
             }
         }
-        .frame(height: Constants.height)
+        .frame(minHeight: Constants.height)
         .padding([.leading, .trailing], Constants.padding)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -17,12 +17,14 @@ struct TitleAndValueRow: View {
             action()
         }, label: {
             HStack {
-                Text(title)
-                    .bodyStyle()
-                Spacer()
-                Text(value.text)
-                    .style(for: value)
-                    .padding(.vertical, Constants.verticalPadding)
+                AdaptiveStack(horizontalAlignment: .leading) {
+                    Text(title)
+                        .bodyStyle()
+                    Text(value.text)
+                        .style(for: value)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .padding(.vertical, Constants.verticalPadding)
+                }
 
                 Image(uiImage: .chevronImage)
                     .flipsForRightToLeftLayoutDirection(true)
@@ -96,5 +98,10 @@ struct TitleAndValueRow_Previews: PreviewProvider {
         TitleAndValueRow(title: "Package selected", value: .placeholder("Small package 2"), selectable: false, action: { })
             .previewLayout(.fixed(width: 375, height: 100))
             .previewDisplayName("Row Not Selectable")
+
+        TitleAndValueRow(title: "Package selected", value: .placeholder("Small"), selectable: true, action: { })
+            .environment(\.sizeCategory, .accessibilityExtraLarge)
+            .previewLayout(.fixed(width: 375, height: 150))
+            .previewDisplayName("Dynamic Type: Large Font Size")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -873,6 +873,7 @@
 		A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE852578E76600C655E0 /* MockStorageManager.swift */; };
 		A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
 		A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */; };
+		AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */; };
 		AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */; };
 		AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */; };
 		AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */; };
@@ -2296,6 +2297,7 @@
 		A650BE852578E76600C655E0 /* MockStorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockStorageManager.swift; path = ../../../Yosemite/YosemiteTests/Mocks/MockStorageManager.swift; sourceTree = "<group>"; };
 		A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModel.swift; sourceTree = "<group>"; };
 		A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModelTests.swift; sourceTree = "<group>"; };
+		AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveStack.swift; sourceTree = "<group>"; };
 		AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModel.swift; sourceTree = "<group>"; };
 		AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModelTests.swift; sourceTree = "<group>"; };
 		AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressForm.swift; sourceTree = "<group>"; };
@@ -4535,6 +4537,7 @@
 				DEE6437726D8DAD900888A75 /* InProgressView.swift */,
 				26C6E8E926E8FD3900C7BB0F /* LazyView.swift */,
 				26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */,
+				AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -7583,6 +7586,7 @@
 				028296EC237D28B600E84012 /* TextViewViewController.swift in Sources */,
 				02B8650F24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift in Sources */,
 				454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */,
+				AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */,
 				024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */,
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/4787.

## Description

This PR adds Dynamic Type support for address form. It splits title-value rows into 2 lines when accessibility text size is selected.

### How

AdaptiveStack wrapper view added. It switches between HStack and VStack depending on sizeCategory.

### Considerations

`TitleAndTextFieldRow` is also used in shipping labels screens. Quick test shows that they are broken before and after this change (screen doesn't fit in width in portrait phone mode) and require additional work. Example screenshots are below. Created issue https://github.com/woocommerce/woocommerce-ios/issues/5336.

## Test

1. Enable accessibility text size in iOS settings
2. Open existing order details
3. Tap edit icon on shipping address

## Screenshots

/ | before | after
--|--|--
regular size|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140081750-c2f78ab9-39c7-439c-ae2d-cf7aae759b1e.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140081953-e5659b39-da41-4d9b-b74f-2912a92bfde0.png)
accessibility size|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140081757-b371aed7-db9e-432c-aa35-2e75a114366c.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140082006-0d233b61-acd0-47ae-be71-7a2dd1bc4119.png)
shipping labels 1|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140088580-43fba99e-9fd9-4aa0-8c7b-db8009f4474e.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140088708-12c6310c-f19a-4bb2-94e6-b8efc71aef66.png)
shipping labels 2|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140088846-9def1368-59a3-44cc-8173-a90490ada49a.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/140088857-79a86323-269e-44a6-af45-ea4d260798d7.png)

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
