### PR TITLE
Add a feature flag for JCP support

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -27,6 +27,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .filterProductsByCategory:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .jetpackConnectionPackageSupport:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -53,4 +53,8 @@ public enum FeatureFlag: Int {
     /// Allows to filter products by a product category, persisting it so the filter can remain after restarting the app
     ///
     case filterProductsByCategory
+
+    /// Allows sites with plugins that include Jetpack Connection Package and without Jetpack-the-plugin to connect to the app
+    ///
+    case jetpackConnectionPackageSupport
 }


### PR DESCRIPTION
Fixes #5354 

## Why

A feature flag enables us to merge changes to `develop` before the feature is ready for launch.

## Changes

- Added a new feature flag `jetpackConnectionPackageSupport`
- Only enabled it in debug or alpha builds like other WIP features

## Testing

The feature flag isn't used yet, just CI!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
