### PR TITLE
[Mobile Payments] Update minimum plugin version; make enums in test more expressive

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -197,6 +197,10 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isWCPayVersionSupported(plugin: SystemPlugin) -> Bool {
+        /// NOTE: It does feel a bit risky to be using .numeric here since Apple documentation say it treats
+        /// the string as a number, so decimal numbers with extra decimals (like versions with patches M.m.p)
+        /// wouldn't necessarily be expected to be compared correctly, but it does seem to work.
+        /// TODO: Implement / source a comparator that explicitly supports version strings with patches.
         plugin.version.compare(Constants.supportedWCPayVersion, options: .numeric) != .orderedAscending
     }
 
@@ -265,6 +269,6 @@ private extension PaymentGatewayAccount {
 
 private enum Constants {
     static let pluginName = "WooCommerce Payments"
-    static let supportedWCPayVersion = "3.1"
+    static let supportedWCPayVersion = "3.2.1"
     static let supportedCountryCodes = ["US"]
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -72,7 +72,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_not_activated_when_wcpay_installed_but_not_active() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .inactive, version: .supported)
+        setupPlugin(status: .inactive, version: .minimumSupportedVersionWithPatch)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -95,10 +95,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .wcpayUnsupportedVersion)
     }
 
-    func test_onboarding_returns_complete_when_supported_exact() {
+    func test_onboarding_returns_complete_when_plugin_version_has_newer_patch_release() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .networkActive, version: .supportedExact)
+        setupPlugin(status: .networkActive, version: .supportedVersionWithNewerPatch)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -112,7 +112,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_active() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .networkActive, version: .supported)
+        setupPlugin(status: .networkActive, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -126,7 +126,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_network_active() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .networkActive, version: .supported)
+        setupPlugin(status: .networkActive, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -142,7 +142,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_generic_error_with_no_account() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -155,7 +155,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_generic_error_when_account_is_not_eligible() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .complete, isCardPresentEligible: false)
 
         // When
@@ -169,7 +169,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_not_completed_when_account_is_not_connected() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .noAccount)
 
         // When
@@ -183,7 +183,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_pending_requirements_when_account_is_restricted_with_pending_requirements() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .restricted, hasPendingRequirements: true)
 
         // When
@@ -197,7 +197,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_pending_requirements_when_account_is_restricted_soon_with_pending_requirements() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .restrictedSoon, hasPendingRequirements: true)
 
         // When
@@ -211,7 +211,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_requirements() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .restricted, hasOverdueRequirements: true)
 
         // When
@@ -225,7 +225,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_and_pending_requirements() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .restricted, hasPendingRequirements: true, hasOverdueRequirements: true)
 
         // When
@@ -239,7 +239,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_review_when_account_is_restricted_with_no_requirements() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .restricted)
 
         // When
@@ -254,7 +254,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_rejected_for_fraud() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .rejectedFraud)
 
         // When
@@ -268,7 +268,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_rejected_for_tos() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .rejectedTermsOfService)
 
         // When
@@ -282,7 +282,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_listed() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .rejectedListed)
 
         // When
@@ -296,7 +296,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_rejected_for_other_reasons() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .rejectedOther)
 
         // When
@@ -310,7 +310,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_generic_error_when_account_status_unknown() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .unknown)
 
         // When
@@ -324,7 +324,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_account_is_setup_successfully() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .active, version: .supported)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -374,8 +374,8 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
     }
 
     enum PluginVersion: String {
-        case supported = "3.1.1"
-        case supportedExact = "3.1"
+        case minimumSupportedVersionWithPatch = "3.2.1"
+        case supportedVersionWithNewerPatch = "3.2.5"
         case unsupported = "2.4.2"
     }
 }


### PR DESCRIPTION
Closes #5321 

Changes made:
- Bumped minimum version to 3.2.1
- Made enums more expressive in unit tests

Follow on work:
- Added a note that the way we are using compare is a little sus. Opened an issue to look at that more closely and at least add more unit tests around plugin versions lacking patch decimals: https://github.com/woocommerce/woocommerce-ios/issues/5357

To test:
- Ensure unit tests pass especially `CardPresentPaymentsOnboardingUseCaseTests`
- Install 3.2.1 on a site and make sure you can get to the manage card reader screen
- Edit the plugin to be 3.2 and make sure you cannot
- Edit the plugin to be 3.2.5 and make sure you can
- Edit the plugin to be 3.3 and make sure you can

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
