### PR TITLE
[Mobile Payments] Prompt user to take live account out of test mode to do in-person payments

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -489,7 +489,9 @@ extension PaymentGatewayAccount {
             defaultCurrency: .fake(),
             supportedCurrencies: .fake(),
             country: .fake(),
-            isCardPresentEligible: .fake()
+            isCardPresentEligible: .fake(),
+            isLive: .fake(),
+            isInTestMode: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -286,7 +286,9 @@ extension PaymentGatewayAccount {
         defaultCurrency: CopiableProp<String> = .copy,
         supportedCurrencies: CopiableProp<[String]> = .copy,
         country: CopiableProp<String> = .copy,
-        isCardPresentEligible: CopiableProp<Bool> = .copy
+        isCardPresentEligible: CopiableProp<Bool> = .copy,
+        isLive: CopiableProp<Bool> = .copy,
+        isInTestMode: CopiableProp<Bool> = .copy
     ) -> PaymentGatewayAccount {
         let siteID = siteID ?? self.siteID
         let gatewayID = gatewayID ?? self.gatewayID
@@ -299,6 +301,8 @@ extension PaymentGatewayAccount {
         let supportedCurrencies = supportedCurrencies ?? self.supportedCurrencies
         let country = country ?? self.country
         let isCardPresentEligible = isCardPresentEligible ?? self.isCardPresentEligible
+        let isLive = isLive ?? self.isLive
+        let isInTestMode = isInTestMode ?? self.isInTestMode
 
         return PaymentGatewayAccount(
             siteID: siteID,
@@ -311,7 +315,9 @@ extension PaymentGatewayAccount {
             defaultCurrency: defaultCurrency,
             supportedCurrencies: supportedCurrencies,
             country: country,
-            isCardPresentEligible: isCardPresentEligible
+            isCardPresentEligible: isCardPresentEligible,
+            isLive: isLive,
+            isInTestMode: isInTestMode
         )
     }
 }

--- a/Networking/Networking/Model/PaymentGatewayAccount.swift
+++ b/Networking/Networking/Model/PaymentGatewayAccount.swift
@@ -30,6 +30,14 @@ public struct PaymentGatewayAccount: GeneratedCopiable, GeneratedFakeable {
     /// A boolean flag indicating if this Account is eligible for card present payments
     public let isCardPresentEligible: Bool
 
+    /// Indicates if the account is live (i.e. can accept actual payments)
+    public let isLive: Bool
+
+    /// Indicates if the gateway is set for test mode. This is NOT the same as
+    /// whether the account is live or not. You can have a live account set for
+    /// test mode, although we cannot accept in-person payments in that situation.
+    public let isInTestMode: Bool
+
     /// Struct initializer
     ///
     public init(siteID: Int64,
@@ -42,7 +50,9 @@ public struct PaymentGatewayAccount: GeneratedCopiable, GeneratedFakeable {
                 defaultCurrency: String,
                 supportedCurrencies: [String],
                 country: String,
-                isCardPresentEligible: Bool
+                isCardPresentEligible: Bool,
+                isLive: Bool,
+                isInTestMode: Bool
         ) {
         self.siteID = siteID
         self.gatewayID = gatewayID
@@ -55,5 +65,7 @@ public struct PaymentGatewayAccount: GeneratedCopiable, GeneratedFakeable {
         self.supportedCurrencies = supportedCurrencies
         self.country = country
         self.isCardPresentEligible = isCardPresentEligible
+        self.isLive = isLive
+        self.isInTestMode = isInTestMode
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -223,8 +223,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isWCPayInTestModeWithLiveStripeAccount(account: PaymentGatewayAccount) -> Bool {
-        // TODO: not implemented yet
-        return false
+        account.isLive && account.isInTestMode
     }
 
     func isStripeAccountUnderReview(account: PaymentGatewayAccount) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -35,6 +35,9 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsPluginNotSupportedVersion(onRefresh: viewModel.refresh)
             case .wcpayNotActivated:
                 InPersonPaymentsPluginNotActivated(onRefresh: viewModel.refresh)
+            case .wcpayInTestModeWithLiveStripeAccount:
+                InPersonPaymentsLiveSiteInTestMode(onRefresh:
+                    viewModel.refresh)
             case .wcpaySetupNotCompleted:
                 InPersonPaymentsWCPayNotSetup(onRefresh: viewModel.refresh)
             case .stripeAccountOverdueRequirement:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct InPersonPaymentsLiveSiteInTestMode: View {
+    let onRefresh: () -> Void
+
+    var body: some View {
+        ScrollableVStack {
+            Spacer()
+
+            VStack(alignment: .center, spacing: 42) {
+                Text(Localization.title)
+                    .font(.headline)
+                Image(uiImage: .paymentsPlugin)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 108.0)
+                Text(Localization.message)
+                    .font(.callout)
+            }
+            .multilineTextAlignment(.center)
+
+            Spacer()
+
+            Button(Localization.primaryButton, action: onRefresh)
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.bottom, 24.0)
+            InPersonPaymentsLearnMore()
+        }
+    }
+}
+
+private enum Localization {
+    static let title = NSLocalizedString(
+        "WooCommerce Payments is in Test Mode",
+        comment: "Title for the error screen when WooCommerce Payments is in test mode on a live site"
+    )
+
+    static let message = NSLocalizedString(
+        "The WooCommerce Payments extension cannot be in test mode for In-Person Payments. "
+            + "Please disable test mode.",
+        comment: "Error message when WooCommerce Payments is in test mode on a live site"
+    )
+
+    static let primaryButton = NSLocalizedString(
+        "Refresh After Updating",
+        comment: "Button to reload plugin data after updating the WooCommerce Payments plugin settings"
+    )
+}
+
+struct InPersonPaymentsLiveSiteInTestMode_Previews: PreviewProvider {
+    static var previews: some View {
+        InPersonPaymentsLiveSiteInTestMode(onRefresh: {})
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
+		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
 		311D21ED264AF0E700102316 /* CardReaderSettingsAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21EC264AF0E700102316 /* CardReaderSettingsAlerts.swift */; };
@@ -1930,6 +1931,7 @@
 		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
 		311D21EC264AF0E700102316 /* CardReaderSettingsAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsAlerts.swift; sourceTree = "<group>"; };
@@ -6618,6 +6620,7 @@
 				D8B4D5ED26C2C26C00F34E94 /* InPersonPaymentsStripeAcountReviewView.swift */,
 				D8B4D5F326C30E7C00F34E94 /* InPersonPaymentsStripeRejectedView.swift */,
 				E15F163026C5117300D3059B /* InPersonPaymentsNoConnectionView.swift */,
+				310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */,
 			);
 			path = "Onboarding Errors";
 			sourceTree = "<group>";
@@ -7604,6 +7607,7 @@
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */,
 				456BEFB626D912EC002AC16C /* AuthenticatedWebView.swift in Sources */,
+				310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */,
 				26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */,
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,
 				CE1EC8F120B8A408009762BF /* OrderNoteTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -95,6 +95,20 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .wcpayUnsupportedVersion)
     }
 
+    func test_onboarding_returns_wcpay_in_test_mode_with_live_stripe_account_when_live_account_in_test_mode() {
+        // Given
+        setupCountry(country: .us)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
+        setupPaymentGatewayAccount(status: .complete, isLive: true, isInTestMode: true)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .wcpayInTestModeWithLiveStripeAccount)
+    }
+
     func test_onboarding_returns_complete_when_plugin_version_has_newer_patch_release() {
         // Given
         setupCountry(country: .us)
@@ -112,7 +126,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_active() {
         // Given
         setupCountry(country: .us)
-        setupPlugin(status: .networkActive, version: .minimumSupportedVersionWithPatch)
+        setupPlugin(status: .active, version: .minimumSupportedVersionWithPatch)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -386,6 +400,8 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
         status: WCPayAccountStatusEnum,
         hasPendingRequirements: Bool = false,
         hasOverdueRequirements: Bool = false,
+        isLive: Bool = false,
+        isInTestMode: Bool = false,
         isCardPresentEligible: Bool = true
     ) {
         let paymentGatewayAccount = PaymentGatewayAccount
@@ -396,7 +412,9 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
                 status: status.rawValue,
                 hasPendingRequirements: hasPendingRequirements,
                 hasOverdueRequirements: hasOverdueRequirements,
-                isCardPresentEligible: isCardPresentEligible
+                isCardPresentEligible: isCardPresentEligible,
+                isLive: isLive,
+                isInTestMode: isInTestMode
             )
         storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
     }

--- a/Yosemite/Yosemite/Model/Payments/WCPayAccount+PaymentGatewayAccount.swift
+++ b/Yosemite/Yosemite/Model/Payments/WCPayAccount+PaymentGatewayAccount.swift
@@ -15,7 +15,9 @@ public extension WCPayAccount {
             defaultCurrency: defaultCurrency,
             supportedCurrencies: supportedCurrencies,
             country: country,
-            isCardPresentEligible: isCardPresentEligible
+            isCardPresentEligible: isCardPresentEligible,
+            isLive: isLiveAccount,
+            isInTestMode: isInTestMode
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
@@ -19,6 +19,8 @@ extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
         supportedCurrencies = paymentGatewayAccount.supportedCurrencies
         country = paymentGatewayAccount.country
         isCardPresentEligible = paymentGatewayAccount.isCardPresentEligible
+        isLive = paymentGatewayAccount.isLive
+        isInTestMode = paymentGatewayAccount.isInTestMode
     }
 
     /// Returns a ReadOnly version for Yosemite.

--- a/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
@@ -36,6 +36,8 @@ extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
                                      defaultCurrency: defaultCurrency,
                                      supportedCurrencies: supportedCurrencies,
                                      country: country,
-                                     isCardPresentEligible: isCardPresentEligible)
+                                     isCardPresentEligible: isCardPresentEligible,
+                                     isLive: isLive,
+                                     isInTestMode: isInTestMode)
     }
 }


### PR DESCRIPTION
Closes #4428 

@adamzelinski - would you review the in-app screenshot at the bottom of this description, let me know if there are any changes needed, and add it to the Figma? Thanks!

A NOTE ON LIVE ACCOUNTS and TEST MODE:

Bear in mind while testing this that a "live account" and "test mode" are (mostly) independent concepts. You can have 1) a live account not in test mode, 2) a live account in test mode and 3) a developer account in test mode. Only the first and last support card reader operations. Live accounts in test mode DO NOT support card reader operations.

A merchant can set their live site for test mode here (the checkbox can be checked and unchecked by the merchant and is unchecked by default)

<img width="1516" alt="live" src="https://user-images.githubusercontent.com/1595739/140550314-f3dfb5cd-1029-4d21-9b67-79d7d9448f12.png">

So... the message "WooCommerce Payments is in Test Mode" is meant for a **merchant.**.  Merchants get **live** accounts. I didn't mention live accounts versus developer accounts on this page because merchants are very unlikely to know about developer accounts.

If a developer sets up their site with a developer account using WCPay developer tools - 1) they automatically are placed in test mode - and 2) they will **NOT** see this screen because their site is using a developer account i.e. not a live account.

Developer mode looks like this in wp-admin (note: the checkbox CANNOT be unchecked):

<img width="1527" alt="devmode" src="https://user-images.githubusercontent.com/1595739/140550400-4071b086-e2f7-4caa-8c3b-d28b56b142db.png">

@joshheald @jaclync - if either of you could take a look, that would be great - just one of y'all are needed of course, but both of y'all are welcome. If you don't have access to a live site to test with, you're welcome to ask me for access to mine, or hack `WCPayAccountMapper` to return `true` for `isLive`

Changes:
- This is the final PR in the sequence to hook up prompting users to deactivate test mode if active on WooCommerce Payments for stores with "live" accounts (i.e. accounts that can actually accept real money.)
- Adding isLive and isInTestMode to the PaymentGatewayAccount model required `rake generate` as expected

To test:
- Set your live site for test mode (see screenshot above)
- Launch the app and enter settings, in-person payments
- Ensure you are prompted to take your site out of test mode ("WooCommerce Payments is in Test Mode")
- Take your site out of test mode
- Refresh using the "Refresh After Updating" button provided on the "WooCommerce Payments is in Test Mode" screen
- Ensure you no longer see the "WooCommerce Payments is in Test Mode" screen under In-Person Payments

Screenshots:

![IMG_0231](https://user-images.githubusercontent.com/1595739/140547542-540fd375-100d-4709-adbd-1a5ba0a5c56a.PNG)

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
