### PR TITLE
Dismiss site picker without switching to a different selected site

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.0
 -----
-
+- [*] Fix: in Settings > Switch Store, tapping "Dismiss" after selecting a different store does not switch stores anymore. [https://github.com/woocommerce/woocommerce-ios/pull/5359]
 
 7.9
 -----

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -214,7 +214,7 @@ private extension StorePickerViewController {
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: dismissLiteral,
                                                            style: .plain,
                                                            target: self,
-                                                           action: #selector(cleanupAndDismiss))
+                                                           action: #selector(dismissStorePicker))
     }
 
     func setupNavigationForListOfConnectedStores() {
@@ -365,12 +365,7 @@ private extension StorePickerViewController {
 
     /// Dismiss this VC
     ///
-    @objc func cleanupAndDismiss() {
-        if let siteID = currentlySelectedSite?.siteID {
-            delegate?.didSelectStore(with: siteID, onCompletion: {
-            })
-        }
-
+    @objc func dismissStorePicker() {
         dismiss()
     }
 


### PR DESCRIPTION
Fixes #3834 

## Why

In the site picker, if you select a different site and then tap on the dismiss button, it currently dismisses the site picker and switches to the selected site. This is unexpected since the intention is just to "dismiss" the site picker. From Sheri's screenshot and description:

<img src="https://user-images.githubusercontent.com/1119271/111366685-72226480-8659-11eb-8736-2028c5a7975a.png" width="300" />

## Changes

This PR fixes the issue by removing the code that switches to the selected site. I checked the history for this code, and it looks like it was from a different navigation design then stayed on for some reason.

## Testing

Prerequisite: the account is connected to more than one site

- Launch the app and log in if needed
- Go to My Store > Settings > Switch Store
- Tap another store
- Tap dismiss --> the modal should dismiss without switching to the selected store (before this PR, it used to switch stores)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
