### PR TITLE
Add card reader software update tracks events

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -499,10 +499,10 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
 
     public func reader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
         if let error = error {
-            let underlyingError = UnderlyingError(with: error)
-            if underlyingError != .commandCancelled {
-                softwareUpdateSubject.send(.failed(error: error))
-            }
+            softwareUpdateSubject.send(.failed(
+                error: CardReaderServiceError.softwareUpdate(underlyingError: UnderlyingError(with: error),
+                                                             batteryLevel: reader.batteryLevel?.doubleValue))
+            )
             softwareUpdateSubject.send(.available)
         } else {
             softwareUpdateSubject.send(.completed)

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -155,6 +155,15 @@ public enum WooAnalyticsStat: String {
     case cardReaderConnectionSuccess = "card_reader_connection_success"
     case cardReaderDisconnectTapped = "card_reader_disconnect_tapped"
 
+    // MARK: Card Reader Software Update Events
+    //
+    case cardReaderSoftwareUpdateTapped = "card_reader_software_update_tapped"
+    case cardReaderSoftwareUpdateStarted = "card_reader_software_update_started"
+    case cardReaderSoftwareUpdateSuccess = "card_reader_software_update_success"
+    case cardReaderSoftwareUpdateFailed = "card_reader_software_update_failed"
+    case cardReaderSoftwareUpdateCancelTapped = "card_reader_software_update_cancel_tapped"
+    case cardReaderSoftwareUpdateCanceled = "card_reader_software_update_canceled"
+
     // MARK: Card-Present Payments Onboarding
     case cardPresentOnboardingLearnMoreTapped = "card_present_onboarding_learn_more_tapped"
     case cardPresentOnboardingNotCompleted = "card_present_onboarding_not_completed"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -63,6 +63,11 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                     case .installing(progress: let progress):
                         self.readerUpdateProgress = progress
                     case .failed(error: let error):
+                        if case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: _) = error,
+                           underlyingError == .readerSoftwareUpdateFailedInterrupted {
+                            // Update was cancelled, don't treat this as an error
+                            break
+                        }
                         self.readerUpdateError = error
                         self.completeCardReaderUpdate(success: false)
                         ServiceLocator.analytics.track(.cardReaderSoftwareUpdateFailed)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -59,14 +59,17 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                         self.readerUpdateError = nil
                         self.softwareUpdateCancelable = cancelable
                         self.readerUpdateProgress = 0
+                        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateStarted)
                     case .installing(progress: let progress):
                         self.readerUpdateProgress = progress
                     case .failed(error: let error):
                         self.readerUpdateError = error
                         self.completeCardReaderUpdate(success: false)
+                        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateFailed)
                     case .completed:
                         self.readerUpdateProgress = 1
                         self.softwareUpdateCancelable = nil
+                        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateSuccess)
                         // If we were installing a software update, introduce a small delay so the user can
                         // actually see a success message showing the installation was complete
                         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [weak self] in
@@ -117,16 +120,19 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     /// Allows the view controller to kick off a card reader update
     ///
     func startCardReaderUpdate() {
+        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateTapped)
         let action = CardPresentPaymentAction.startCardReaderUpdate
         ServiceLocator.stores.dispatch(action)
     }
 
     func cancelCardReaderUpdate() {
+        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCancelTapped)
         softwareUpdateCancelable?.cancel(completion: { [weak self] result in
             if case .failure(let error) = result {
                 print("=== error canceling software update: \(error)")
             } else {
                 self?.completeCardReaderUpdate(success: false)
+                ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCanceled)
             }
         })
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -86,3 +86,21 @@ extension MockCardPresentPaymentsStoresManager {
         case connectionFailure
     }
 }
+
+extension MockCardPresentPaymentsStoresManager {
+    func simulateSuccessfulUpdate() {
+        softwareUpdateSubject.send(.completed)
+    }
+
+    func simulateFailedUpdate(error: Error) {
+        softwareUpdateSubject.send(.failed(error: error))
+    }
+
+    func simulateCancelableUpdate(onCancel: @escaping () -> Void) {
+        softwareUpdateSubject.send(.started(cancelable: MockFallibleCancelable(onCancel: onCancel)))
+    }
+
+    func simulateUpdateStarted() {
+        softwareUpdateSubject.send(.started(cancelable: nil))
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -97,7 +97,15 @@ extension MockCardPresentPaymentsStoresManager {
     }
 
     func simulateCancelableUpdate(onCancel: @escaping () -> Void) {
-        softwareUpdateSubject.send(.started(cancelable: MockFallibleCancelable(onCancel: onCancel)))
+        softwareUpdateSubject.send(.started(cancelable: MockFallibleCancelable(onCancel: {
+            onCancel()
+            self.softwareUpdateSubject.send(
+                .failed(error: CardReaderServiceError.softwareUpdate(
+                    underlyingError: .readerSoftwareUpdateFailedInterrupted,
+                    batteryLevel: 0.86
+                ))
+            )
+        })))
     }
 
     func simulateUpdateStarted() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -3,8 +3,27 @@ import XCTest
 @testable import WooCommerce
 
 final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
+    private var mockStoresManager: MockCardPresentPaymentsStoresManager!
+    private var analytics: MockAnalyticsProvider!
+
+    private var viewModel: CardReaderSettingsConnectedViewModel!
+
+    override func setUpWithError() throws {
+        mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            discoveredReaders: [],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        analytics = MockAnalyticsProvider()
+        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
+
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+    }
+
     func test_did_change_should_show_returns_false_if_no_connected_readers() {
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+        mockStoresManager = MockCardPresentPaymentsStoresManager(
             connectedReaders: [],
             discoveredReaders: [],
             sessionManager: SessionManager.testingInstance
@@ -21,16 +40,9 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
     }
 
     func test_did_change_should_show_returns_true_if_a_reader_is_connected() {
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
         let expectation = self.expectation(description: #function)
 
-        let _ = CardReaderSettingsConnectedViewModel(didChangeShouldShow: { shouldShow in
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: { shouldShow in
             XCTAssertTrue(shouldShow == .isTrue)
             expectation.fulfill()
         } )
@@ -39,14 +51,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
     }
 
     func test_view_model_correctly_formats_connected_card_reader_battery_level() {
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "50% Battery")
     }
 
@@ -58,18 +63,11 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "Unknown Battery Level")
     }
 
     func test_view_model_correctly_formats_connected_card_reader_software_version() {
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
         let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Version: 1.00.03.34-SZZZ_Generic_v45-300001")
     }
@@ -82,7 +80,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Unknown Software Version")
     }
 
@@ -90,26 +88,17 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Given
         let expectation = self.expectation(description: #function)
 
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
-
         var updateDidBegin = false
 
         viewModel.didUpdate = {
-            if viewModel.readerUpdateInProgress {
+            if self.viewModel.readerUpdateInProgress {
                 updateDidBegin = true
             }
 
             // Update began
             if updateDidBegin {
                 // But now it has stopped
-                if !viewModel.readerUpdateInProgress {
+                if !self.viewModel.readerUpdateInProgress {
                     expectation.fulfill()
                 }
             }
@@ -135,19 +124,19 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
 
         var updateDidBegin = false
 
         viewModel.didUpdate = {
-            if viewModel.readerUpdateInProgress {
+            if self.viewModel.readerUpdateInProgress {
                 updateDidBegin = true
             }
 
             // Update began
             if updateDidBegin {
                 // But now it has stopped
-                if !viewModel.readerUpdateInProgress {
+                if !self.viewModel.readerUpdateInProgress {
                     expectation.fulfill()
                 }
             }
@@ -162,16 +151,6 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_startCardReaderUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateTapped() {
         // Given
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let analytics = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
 
         // When
         viewModel.startCardReaderUpdate()
@@ -182,16 +161,6 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_startCardReaderUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateStarted() {
         // Given
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let analytics = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
 
         // When
         mockStoresManager.simulateUpdateStarted()
@@ -202,16 +171,6 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_WhenStoreSendsUpdateComplete_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateSuccess() {
         // Given
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let analytics = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
 
         // When
         mockStoresManager.simulateSuccessfulUpdate()
@@ -222,16 +181,6 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_WhenStoreSendsUpdateFailed_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateFailed() {
         // Given
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let analytics = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
 
         // When
         let expectedError = CardReaderServiceError.softwareUpdate(underlyingError: .readerSoftwareUpdateFailedBatteryLow,
@@ -244,16 +193,6 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_WhenUserCancelsUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateCancelTapped() {
         // Given
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let analytics = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
 
         // When
         viewModel.cancelCardReaderUpdate()
@@ -264,16 +203,6 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_WhenUpdateIsSuccessfullyCanceled_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateCanceled() {
         // Given
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [MockCardReader.bbposChipper2XBT()],
-            discoveredReaders: [],
-            sessionManager: SessionManager.testingInstance
-        )
-        ServiceLocator.setStores(mockStoresManager)
-
-        let analytics = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
         let expectation = self.expectation(description: #function)
 
         mockStoresManager.simulateCancelableUpdate {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -216,4 +216,20 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateCanceled.rawValue))
     }
+
+    func test_WhenUpdateIsSuccessfullyCanceled_ViewModel_DoesNotLogTracksEvent_cardReaderSoftwareUpdateFailed() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        mockStoresManager.simulateCancelableUpdate {
+            expectation.fulfill()
+        }
+
+        // When
+        viewModel.cancelCardReaderUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        XCTAssertFalse(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateFailed.rawValue))
+    }
 }


### PR DESCRIPTION
Part of #5300 

## Description
This adds the events below, however there is further work to do before closing the ticket, to add the properties matching Android.

- `card_reader_software_update_tapped`
- `card_reader_software_update_started`
- `card_reader_software_update_success`
- `card_reader_software_update_failed`
- `card_reader_software_update_cancel_tapped`
- `card_reader_software_update_canceled`

## Testing
Testing can probably wait until the next PR adding properties, as it'll be pretty duplicative checking the tracks events are posted and then checking again that the properties are logged correctly.

- [x] Start a software update, check that the `card_reader_software_update_tapped` and `card_reader_software_update_started` events are logged
- [x] Start a software update using a reader with a low battery, check that `card_reader_software_update_failed` is logged
- [x] Cancel a software update, check that `card_reader_software_update_cancel_tapped` and `card_reader_software_update_canceled` are logged, and that `card_reader_software_update_failed` _is not_ logged.
- [x] Complete a software update, check that `card_reader_software_update_success` is logged

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
