### PR TITLE
Issue/4385 empty filter view

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -330,6 +330,7 @@ public enum WooAnalyticsStat: String {
     case productListSearched = "product_list_searched"
     case productListMenuSearchTapped = "product_list_menu_search_tapped"
     case productListAddProductTapped = "product_list_add_product_button_tapped"
+    case productListClearFiltersTapped = "product_list_clear_filters_button_tapped"
 
     // MARK: Add Product Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -680,7 +680,7 @@ private extension ProductsViewController {
 
     func clearFilter(sourceBarButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
         ServiceLocator.analytics.track(.productListClearFiltersTapped)
-        self.filters = FilterProductListViewModel.Filters()
+        filters = FilterProductListViewModel.Filters()
     }
 
     /// Presents products survey

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -253,15 +253,6 @@ private extension ProductsViewController {
         }
         coordinatingController.start()
     }
-
-    func clearFilter(sourceBarButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
-        ServiceLocator.analytics.track(.productListClearFiltersTapped)
-        self.filters = FilterProductListViewModel.Filters(stockStatus: nil,
-                                                          productStatus: nil,
-                                                          productType: nil,
-                                                          productCategory: nil,
-                                                          numberOfActiveFilters: 0)
-    }
 }
 
 // MARK: - View Configuration
@@ -685,6 +676,11 @@ private extension ProductsViewController {
             ServiceLocator.analytics.track(.productFilterListDismissButtonTapped)
         })
         present(filterProductListViewController, animated: true, completion: nil)
+    }
+
+    func clearFilter(sourceBarButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
+        ServiceLocator.analytics.track(.productListClearFiltersTapped)
+        self.filters = FilterProductListViewModel.Filters()
     }
 
     /// Presents products survey

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -255,6 +255,7 @@ private extension ProductsViewController {
     }
 
     func clearFilter(sourceBarButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
+        ServiceLocator.analytics.track(.productListClearFiltersTapped)
         self.filters = FilterProductListViewModel.Filters(stockStatus: nil,
                                                           productStatus: nil,
                                                           productType: nil,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -733,9 +733,17 @@ private extension ProductsViewController {
     ///
     func displayNoResultsOverlay() {
         let emptyStateViewController = EmptyStateViewController(style: .list)
-        let config = filters.numberOfActiveFilters == 0 ? createNoProductsConfig() : createNoProductsMatchFilterConfig()
+        let config = createFilterConfig()
         displayEmptyStateViewController(emptyStateViewController)
         emptyStateViewController.configure(config)
+    }
+
+    func createFilterConfig() ->  EmptyStateViewController.Config {
+        if filters.numberOfActiveFilters == 0 {
+            return createNoProductsConfig()
+        } else {
+            return createNoProductsMatchFilterConfig()
+        }
     }
 
     /// Creates EmptyStateViewController.Config for no products empty view

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -253,7 +253,7 @@ private extension ProductsViewController {
         }
         coordinatingController.start()
     }
-    
+
     func clearFilter(sourceBarButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
         self.filters = FilterProductListViewModel.Filters(stockStatus: nil,
                                                           productStatus: nil,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -769,7 +769,7 @@ private extension ProductsViewController {
         return EmptyStateViewController.Config.withButton(
             message: .init(string: message),
             image: .emptyProductsTabImage,
-            details: nil,
+            details: "",
             buttonTitle: buttonTitle) { [weak self] button in
                 self?.clearFilter(sourceView: button)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -764,14 +764,12 @@ private extension ProductsViewController {
     func createNoProductsMatchFilterConfig() ->  EmptyStateViewController.Config {
         let message = NSLocalizedString("No matching products found",
                                         comment: "The text on the placeholder overlay when no products match the filter on the Products tab")
-        let details = NSLocalizedString("Try adjusting the filters",
-                                        comment: "The details on the placeholder overlay when no products match the filter on the Products tab")
         let buttonTitle = NSLocalizedString("Clear Filters",
                                             comment: "Action to add product on the placeholder overlay when no products match the filter on the Products tab")
         return EmptyStateViewController.Config.withButton(
             message: .init(string: message),
             image: .emptyProductsTabImage,
-            details: details,
+            details: nil,
             buttonTitle: buttonTitle) { [weak self] button in
                 self?.clearFilter(sourceView: button)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -253,6 +253,14 @@ private extension ProductsViewController {
         }
         coordinatingController.start()
     }
+    
+    func clearFilter(sourceBarButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
+        self.filters = FilterProductListViewModel.Filters(stockStatus: nil,
+                                                          productStatus: nil,
+                                                          productType: nil,
+                                                          productCategory: nil,
+                                                          numberOfActiveFilters: 0)
+    }
 }
 
 // MARK: - View Configuration
@@ -728,11 +736,13 @@ private extension ProductsViewController {
     ///
     func displayNoResultsOverlay() {
         let emptyStateViewController = EmptyStateViewController(style: .list)
-        let config = createNoProductsConfig()
+        let config = filters.numberOfActiveFilters == 0 ? createNoProductsConfig() : createNoProductsMatchFilterConfig()
         displayEmptyStateViewController(emptyStateViewController)
         emptyStateViewController.configure(config)
     }
 
+    /// Creates EmptyStateViewController.Config for no products empty view
+    ///
     func createNoProductsConfig() ->  EmptyStateViewController.Config {
         let message = NSLocalizedString("No products yet",
                                         comment: "The text on the placeholder overlay when there are no products on the Products tab")
@@ -746,6 +756,24 @@ private extension ProductsViewController {
             details: details,
             buttonTitle: buttonTitle) { [weak self] button in
             self?.addProduct(sourceView: button)
+        }
+    }
+
+    /// Creates EmptyStateViewController.Config for no products match the filter empty view
+    ///
+    func createNoProductsMatchFilterConfig() ->  EmptyStateViewController.Config {
+        let message = NSLocalizedString("No matching products found",
+                                        comment: "The text on the placeholder overlay when no products match the filter on the Products tab")
+        let details = NSLocalizedString("Try adjusting the filters",
+                                        comment: "The details on the placeholder overlay when no products match the filter on the Products tab")
+        let buttonTitle = NSLocalizedString("Clear Filters",
+                                            comment: "Action to add product on the placeholder overlay when no products match the filter on the Products tab")
+        return EmptyStateViewController.Config.withButton(
+            message: .init(string: message),
+            image: .emptyProductsTabImage,
+            details: details,
+            buttonTitle: buttonTitle) { [weak self] button in
+                self?.clearFilter(sourceView: button)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -728,21 +728,25 @@ private extension ProductsViewController {
     ///
     func displayNoResultsOverlay() {
         let emptyStateViewController = EmptyStateViewController(style: .list)
+        let config = createNoProductsConfig()
+        displayEmptyStateViewController(emptyStateViewController)
+        emptyStateViewController.configure(config)
+    }
+
+    func createNoProductsConfig() ->  EmptyStateViewController.Config {
         let message = NSLocalizedString("No products yet",
                                         comment: "The text on the placeholder overlay when there are no products on the Products tab")
         let details = NSLocalizedString("Start selling today by adding your first product to the store.",
                                         comment: "The details on the placeholder overlay when there are no products on the Products tab")
         let buttonTitle = NSLocalizedString("Add Product",
                                             comment: "Action to add product on the placeholder overlay when there are no products on the Products tab")
-        let config = EmptyStateViewController.Config.withButton(
+        return EmptyStateViewController.Config.withButton(
             message: .init(string: message),
             image: .emptyProductsTabImage,
             details: details,
             buttonTitle: buttonTitle) { [weak self] button in
             self?.addProduct(sourceView: button)
         }
-        displayEmptyStateViewController(emptyStateViewController)
-        emptyStateViewController.configure(config)
     }
 
     /// Shows the EmptyStateViewController as a child view controller.


### PR DESCRIPTION
Closes #4385 

Before this PR, the app would show identical empty view for both "Store has no products" and "No products match the selected filters" screens. This PR shows a more specific message "No matching products found" and action "Clear Filters" for the latter.

<img src="https://user-images.githubusercontent.com/2261188/140733455-44b7ce27-f870-400b-b6ab-b82fd12e132d.png" width="250px" />

Questions:
1. I've created a new track event - do we need to do something else to start tracking this event (I've updated the internal xls)
2. I've removed "hint/details" message on the "No matching products found" screen. Do you think we should keep it?

To Test:
1. Open products screen
2. Tap on Filters
3. Select filter(s) that don't match any products (example for my store: Status - Pending Review, Product Type - Grouped)
4. Tap on Show Products
5. Notice an empty view saying "No matching products" and "Clear Filters" button is shown
6. Tap on "Clear filters" and notice the filters get cleared and the products re-loaded
7. Switch to a store which doesn't have any products
8. Open Product list screen
9. Notice the original "No products yet" and "Add Product" button is shown


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
