### PR TITLE
Simple Payments: Rename Quick Order to Simple Payments

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -21,7 +21,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .pushNotificationsForAllStores:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .quickOrderPrototype:
+        case .simplePaymentsPrototype:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderListFilters:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -42,9 +42,9 @@ public enum FeatureFlag: Int {
     ///
     case pushNotificationsForAllStores
 
-    /// Allows to create quick order orders
+    /// Allows to create simple payments orders
     ///
-    case quickOrderPrototype
+    case simplePaymentsPrototype
 
     /// Display the bar for displaying the filters in the Order List
     ///

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -9,14 +9,14 @@ extension GeneralAppSettings {
         installationDate: NullableCopiableProp<Date> = .copy,
         feedbacks: CopiableProp<[FeedbackType: FeedbackSettings]> = .copy,
         isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy,
-        isQuickOrderSwitchEnabled: CopiableProp<Bool> = .copy,
+        isSimplePaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
         knownCardReaders: CopiableProp<[String]> = .copy,
         lastEligibilityErrorInfo: NullableCopiableProp<EligibilityErrorInfo> = .copy
     ) -> GeneralAppSettings {
         let installationDate = installationDate ?? self.installationDate
         let feedbacks = feedbacks ?? self.feedbacks
         let isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled ?? self.isViewAddOnsSwitchEnabled
-        let isQuickOrderSwitchEnabled = isQuickOrderSwitchEnabled ?? self.isQuickOrderSwitchEnabled
+        let isSimplePaymentsSwitchEnabled = isSimplePaymentsSwitchEnabled ?? self.isSimplePaymentsSwitchEnabled
         let knownCardReaders = knownCardReaders ?? self.knownCardReaders
         let lastEligibilityErrorInfo = lastEligibilityErrorInfo ?? self.lastEligibilityErrorInfo
 
@@ -24,7 +24,7 @@ extension GeneralAppSettings {
             installationDate: installationDate,
             feedbacks: feedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
-            isQuickOrderSwitchEnabled: isQuickOrderSwitchEnabled,
+            isSimplePaymentsSwitchEnabled: isSimplePaymentsSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -24,9 +24,9 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isViewAddOnsSwitchEnabled: Bool
 
-    /// The state(`true` or `false`) for the Quick Order feature switch.
+    /// The state(`true` or `false`) for the Simple Payments feature switch.
     ///
-    public let isQuickOrderSwitchEnabled: Bool
+    public let isSimplePaymentsSwitchEnabled: Bool
 
     /// A list (possibly empty) of known card reader IDs - i.e. IDs of card readers that should be reconnected to automatically
     /// e.g. ["CHB204909005931"]
@@ -40,13 +40,13 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     public init(installationDate: Date?,
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
-                isQuickOrderSwitchEnabled: Bool,
+                isSimplePaymentsSwitchEnabled: Bool,
                 knownCardReaders: [String],
                 lastEligibilityErrorInfo: EligibilityErrorInfo? = nil) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
-        self.isQuickOrderSwitchEnabled = isQuickOrderSwitchEnabled
+        self.isSimplePaymentsSwitchEnabled = isSimplePaymentsSwitchEnabled
         self.knownCardReaders = knownCardReaders
         self.lastEligibilityErrorInfo = lastEligibilityErrorInfo
     }
@@ -72,7 +72,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             installationDate: installationDate,
             feedbacks: updatedFeedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
-            isQuickOrderSwitchEnabled: isQuickOrderSwitchEnabled,
+            isSimplePaymentsSwitchEnabled: isSimplePaymentsSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )
@@ -89,7 +89,7 @@ extension GeneralAppSettings {
         self.installationDate = try container.decodeIfPresent(Date.self, forKey: .installationDate)
         self.feedbacks = try container.decodeIfPresent([FeedbackType: FeedbackSettings].self, forKey: .feedbacks) ?? [:]
         self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
-        self.isQuickOrderSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isQuickOrderSwitchEnabled) ?? false
+        self.isSimplePaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSimplePaymentsSwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
         self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)
 

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -9,7 +9,7 @@ class GeneralAppSettingsTests: XCTestCase {
         let settings = GeneralAppSettings(installationDate: nil,
                                           feedbacks: [.general: feedback],
                                           isViewAddOnsSwitchEnabled: false,
-                                          isQuickOrderSwitchEnabled: false,
+                                          isSimplePaymentsSwitchEnabled: false,
                                           knownCardReaders: [])
 
         // When
@@ -24,7 +24,7 @@ class GeneralAppSettingsTests: XCTestCase {
         let settings = GeneralAppSettings(installationDate: nil,
                                           feedbacks: [:],
                                           isViewAddOnsSwitchEnabled: false,
-                                          isQuickOrderSwitchEnabled: false,
+                                          isSimplePaymentsSwitchEnabled: false,
                                           knownCardReaders: [])
 
         // When
@@ -41,7 +41,7 @@ class GeneralAppSettingsTests: XCTestCase {
             installationDate: nil,
             feedbacks: [.general: existingFeedback],
             isViewAddOnsSwitchEnabled: false,
-            isQuickOrderSwitchEnabled: false,
+            isSimplePaymentsSwitchEnabled: false,
             knownCardReaders: []
         )
 
@@ -58,7 +58,7 @@ class GeneralAppSettingsTests: XCTestCase {
         let settings = GeneralAppSettings(installationDate: nil,
                                           feedbacks: [:],
                                           isViewAddOnsSwitchEnabled: false,
-                                          isQuickOrderSwitchEnabled: false,
+                                          isSimplePaymentsSwitchEnabled: false,
                                           knownCardReaders: [])
 
         // When
@@ -78,7 +78,7 @@ class GeneralAppSettingsTests: XCTestCase {
         let previousSettings = GeneralAppSettings(installationDate: currentDate,
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
-                                                  isQuickOrderSwitchEnabled: true,
+                                                  isSimplePaymentsSwitchEnabled: true,
                                                   knownCardReaders: readers,
                                                   lastEligibilityErrorInfo: eligibilityInfo)
 
@@ -96,6 +96,6 @@ class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.knownCardReaders, readers)
         assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
-        assertEqual(newSettings.isQuickOrderSwitchEnabled, true)
+        assertEqual(newSettings.isSimplePaymentsSwitchEnabled, true)
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -64,8 +64,8 @@ extension WooAnalyticsEvent {
         case shippingLabelsRelease3 = "shipping_labels_m3"
         /// Shown in beta feature banner for order add-ons.
         case addOnsI1 = "add-ons_i1"
-        /// Shown in beta feature banner for quick order prototype.
-        case quickOrderPrototype = "quick_order_prototype"
+        /// Shown in beta feature banner for simple payments prototype.
+        case simplePaymentsPrototype = "simple_payments_prototype"
     }
 
     /// The action performed on the survey screen.
@@ -371,11 +371,11 @@ extension WooAnalyticsEvent {
     }
 }
 
-// MARK: - Quick Order
+// MARK: - Simple Payments
 //
 extension WooAnalyticsEvent {
     // Namespace
-    enum QuickOrder {
+    enum SimplePayments {
         /// Common event keys
         ///
         private enum Keys {
@@ -383,24 +383,24 @@ extension WooAnalyticsEvent {
             static let amount = "amount"
         }
 
-        static func quickOrderFlowStarted() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .quickOrderFlowStarted, properties: [:])
+        static func simplePaymentsFlowStarted() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowStarted, properties: [:])
         }
 
-        static func quickOrderFlowCompleted(amount: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .quickOrderFlowCompleted, properties: [Keys.amount: amount])
+        static func simplePaymentsFlowCompleted(amount: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowCompleted, properties: [Keys.amount: amount])
         }
 
-        static func quickOrderFlowCanceled() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .quickOrderFlowCanceled, properties: [:])
+        static func simplePaymentsFlowCanceled() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowCanceled, properties: [:])
         }
 
-        static func quickOrderFlowFailed() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .quickOrderFlowFailed, properties: [:])
+        static func simplePaymentsFlowFailed() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowFailed, properties: [:])
         }
 
-        static func settingsBetaFeaturesQuickOrderToggled(isOn: Bool) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .settingsBetaFeaturesQuickOrderToggled, properties: [Keys.state: isOn ? "on" : "off"])
+        static func settingsBetaFeaturesSimplePaymentsToggled(isOn: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .settingsBetaFeaturesSimplePaymentsToggled, properties: [Keys.state: isOn ? "on" : "off"])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -130,7 +130,7 @@ public enum WooAnalyticsStat: String {
     case settingsBetaFeaturesButtonTapped = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled = "settings_beta_features_products_toggled"
     case settingsBetaFeaturesOrderAddOnsToggled = "settings_beta_features_order_addons_toggled"
-    case settingsBetaFeaturesQuickOrderToggled = "settings_beta_features_quick_order_toggled"
+    case settingsBetaFeaturesSimplePaymentsToggled = "settings_beta_features_simple_payments_toggled"
 
     case settingsPrivacySettingsTapped = "settings_privacy_settings_button_tapped"
     case settingsCollectInfoToggled = "privacy_settings_collect_info_toggled"
@@ -512,12 +512,12 @@ public enum WooAnalyticsStat: String {
     //
     case featureAnnouncementShown = "feature_announcement_shown"
 
-    // MARK: Quick Order events
+    // MARK: Simple Payments events
     //
-    case quickOrderFlowStarted = "quick_order_flow_started"
-    case quickOrderFlowCompleted = "quick_order_flow_completed"
-    case quickOrderFlowCanceled = "quick_order_flow_canceled"
-    case quickOrderFlowFailed = "quick_order_flow_failed"
+    case simplePaymentsFlowStarted = "simple_payments_flow_started"
+    case simplePaymentsFlowCompleted = "simple_payments_flow_completed"
+    case simplePaymentsFlowCanceled = "simple_payments_flow_canceled"
+    case simplePaymentsFlowFailed = "simple_payments_flow_failed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -124,9 +124,9 @@ extension WooConstants {
         case addPaymentMethodWCShip = "https://wordpress.com/me/purchases/add-payment-method"
 
 #if DEBUG
-        case quickOrderPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-testing"
+        case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-simple-payments-testing"
 #else
-        case quickOrderPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-production"
+        case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-simple-payments-production"
 #endif
 
         /// Returns the URL version of the receiver

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -124,9 +124,9 @@ extension WooConstants {
         case addPaymentMethodWCShip = "https://wordpress.com/me/purchases/add-payment-method"
 
 #if DEBUG
-        case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-simple-payments-testing"
+        case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-testing"
 #else
-        case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-simple-payments-production"
+        case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-production"
 #endif
 
         /// Returns the URL version of the receiver

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -94,8 +94,8 @@ private extension BetaFeaturesViewController {
             return nil
         }
 
-        return Section(rows: [.quickOrder,
-                              .quickOrderDescription])
+        return Section(rows: [.simplePayments,
+                              .simplePaymentsDescription])
     }
 
     /// Register table cells.
@@ -121,10 +121,10 @@ private extension BetaFeaturesViewController {
         case let cell as BasicTableViewCell where row == .orderAddOnsDescription:
             configureOrderAddOnsDescription(cell: cell)
         // Orders
-        case let cell as SwitchTableViewCell where row == .quickOrder:
-            configureQuickOrderSwitch(cell: cell)
-        case let cell as BasicTableViewCell where row == .quickOrderDescription:
-            configureQuickOrderDescription(cell: cell)
+        case let cell as SwitchTableViewCell where row == .simplePayments:
+            configureSimplePaymentsSwitch(cell: cell)
+        case let cell as BasicTableViewCell where row == .simplePaymentsDescription:
+            configureSimplePaymentsDescription(cell: cell)
         default:
             fatalError()
         }
@@ -165,12 +165,12 @@ private extension BetaFeaturesViewController {
         cell.textLabel?.text = Localization.orderAddOnsDescription
     }
 
-    func configureQuickOrderSwitch(cell: SwitchTableViewCell) {
+    func configureSimplePaymentsSwitch(cell: SwitchTableViewCell) {
         configureCommonStylesForSwitchCell(cell)
-        cell.title = Localization.quickOrderTitle
+        cell.title = Localization.simplePaymentsTitle
 
         // Fetch switch's state stored value.
-        let action = AppSettingsAction.loadQuickOrderSwitchState() { result in
+        let action = AppSettingsAction.loadSimplePaymentsSwitchState() { result in
             guard let isEnabled = try? result.get() else {
                 return cell.isOn = false
             }
@@ -180,9 +180,9 @@ private extension BetaFeaturesViewController {
 
         // Change switch's state stored value
         cell.onChange = { isSwitchOn in
-            ServiceLocator.analytics.track(event: WooAnalyticsEvent.QuickOrder.settingsBetaFeaturesQuickOrderToggled(isOn: isSwitchOn))
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.SimplePayments.settingsBetaFeaturesSimplePaymentsToggled(isOn: isSwitchOn))
 
-            let action = AppSettingsAction.setQuickOrderFeatureSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
+            let action = AppSettingsAction.setSimplePaymentsFeatureSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
                 // Roll back toggle if an error occurred
                 if result.isFailure {
                     cell.isOn.toggle()
@@ -190,12 +190,12 @@ private extension BetaFeaturesViewController {
             })
             ServiceLocator.stores.dispatch(action)
         }
-        cell.accessibilityIdentifier = "beta-features-order-quick-order-cell"
+        cell.accessibilityIdentifier = "beta-features-order-simple-payments-cell"
     }
 
-    func configureQuickOrderDescription(cell: BasicTableViewCell) {
+    func configureSimplePaymentsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
-        cell.textLabel?.text = Localization.quickOrderDescription
+        cell.textLabel?.text = Localization.simplePaymentsDescription
     }
 }
 
@@ -262,14 +262,14 @@ private enum Row: CaseIterable {
     case orderAddOnsDescription
 
     // Orders.
-    case quickOrder
-    case quickOrderDescription
+    case simplePayments
+    case simplePaymentsDescription
 
     var type: UITableViewCell.Type {
         switch self {
-        case .orderAddOns, .quickOrder:
+        case .orderAddOns, .simplePayments:
             return SwitchTableViewCell.self
-        case .orderAddOnsDescription, .quickOrderDescription:
+        case .orderAddOnsDescription, .simplePaymentsDescription:
             return BasicTableViewCell.self
         }
     }
@@ -285,8 +285,9 @@ private extension BetaFeaturesViewController {
         static let orderAddOnsDescription = NSLocalizedString("Test out viewing Order Add-Ons as we get ready to launch",
                                                               comment: "Cell description on the beta features screen to enable the order add-ons feature")
 
-        static let quickOrderTitle = NSLocalizedString("Quick Order", comment: "Cell title on the beta features screen to enable the Quick Order feature")
-        static let quickOrderDescription = NSLocalizedString("Test out creating orders with minimal information as we get ready to launch",
-                                                              comment: "Cell description on the beta features screen to enable the Quick Order feature")
+        static let simplePaymentsTitle = NSLocalizedString("Simple Payments",
+                                                           comment: "Cell title on the beta features screen to enable the Simple Payments feature")
+        static let simplePaymentsDescription = NSLocalizedString("Test out creating orders with minimal information as we get ready to launch",
+                                                              comment: "Cell description on the beta features screen to enable the Simple Payments feature")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -140,7 +140,7 @@ final class OrderListViewController: UIViewController {
 
         // Needed in `viewWillAppear` because this ViewController is not recreated
         // and the toggle can be switch in the Settings section that resides in a different tab.
-        viewModel.reloadQuickOrderExperimentalFeatureState()
+        viewModel.reloadSimplePaymentsExperimentalFeatureState()
 
         syncingCoordinator.resynchronize(reason: SyncReason.viewWillAppear.rawValue)
 
@@ -206,10 +206,10 @@ private extension OrderListViewController {
                     self.hideTopBannerView()
                 case .error:
                     self.setErrorTopBanner()
-                case .quickOrderEnabled:
-                    self.setQuickOrderEnabledTopBanner()
-                case .quickOrderDisabled:
-                    self.setQuickOrderDisabledTopBanner()
+                case .simplePaymentsEnabled:
+                    self.setSimplePaymentsEnabledTopBanner()
+                case .simplePaymentsDisabled:
+                    self.setSimplePaymentsDisabledTopBanner()
                 }
             }
             .store(in: &cancellables)
@@ -603,26 +603,26 @@ private extension OrderListViewController {
         showTopBannerView()
     }
 
-    /// Sets the `topBannerView` property to a quick order disabled banner.
+    /// Sets the `topBannerView` property to a simple payments disabled banner.
     ///
-    func setQuickOrderDisabledTopBanner() {
-        topBannerView = QuickOrderTopBannerFactory.createFeatureDisabledBanner(onTopButtonPressed: { [weak self] in
+    func setSimplePaymentsDisabledTopBanner() {
+        topBannerView = SimplePaymentsTopBannerFactory.createFeatureDisabledBanner(onTopButtonPressed: { [weak self] in
             self?.tableView.updateHeaderHeight()
         }, onDismissButtonPressed: { [weak self] in
-            self?.viewModel.hideQuickOrderBanners = true
+            self?.viewModel.hideSimplePaymentsBanners = true
         })
         showTopBannerView()
     }
 
-    /// Sets the `topBannerView` property to a quick order enabled banner.
+    /// Sets the `topBannerView` property to a simple payments enabled banner.
     ///
-    func setQuickOrderEnabledTopBanner() {
-        topBannerView = QuickOrderTopBannerFactory.createFeatureEnabledBanner(onTopButtonPressed: { [weak self] in
+    func setSimplePaymentsEnabledTopBanner() {
+        topBannerView = SimplePaymentsTopBannerFactory.createFeatureEnabledBanner(onTopButtonPressed: { [weak self] in
             self?.tableView.updateHeaderHeight()
         }, onDismissButtonPressed: { [weak self] in
-            self?.viewModel.hideQuickOrderBanners = true
+            self?.viewModel.hideSimplePaymentsBanners = true
         }, onGiveFeedbackButtonPressed: { [weak self] in
-            let surveyNavigation = SurveyCoordinatingController(survey: .quickOrderPrototype)
+            let surveyNavigation = SurveyCoordinatingController(survey: .simplePaymentsPrototype)
             self?.present(surveyNavigation, animated: true, completion: nil)
         })
         showTopBannerView()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -81,14 +81,14 @@ final class OrderListViewModel {
     ///
     private let inPersonPaymentsReadyUseCase: CardPresentPaymentsOnboardingUseCaseProtocol
 
-    /// Tracks if the merchant has enabled the Quick Order experimental feature toggle
+    /// Tracks if the merchant has enabled the Simple Payments experimental feature toggle
     ///
-    @Published private var isQuickOrderEnabled = false
+    @Published private var isSimplePaymentsEnabled = false
 
-    /// If true, no quick order banner will be shown as the user has told us that they are not interested in this information.
+    /// If true, no simple payments banner will be shown as the user has told us that they are not interested in this information.
     /// Resets with every session.
     ///
-    @Published var hideQuickOrderBanners: Bool = false
+    @Published var hideSimplePaymentsBanners: Bool = false
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -228,14 +228,14 @@ private extension OrderListViewModel {
     }
 }
 
-// MARK: Quick Order
+// MARK: Simple Payments
 
 extension OrderListViewModel {
-    /// Reloads the state of the Quick Order experimental feature switch state.
+    /// Reloads the state of the Simple Payments experimental feature switch state.
     ///
-    func reloadQuickOrderExperimentalFeatureState() {
-        let action = AppSettingsAction.loadQuickOrderSwitchState { [weak self] result in
-            self?.isQuickOrderEnabled = (try? result.get()) ?? false
+    func reloadSimplePaymentsExperimentalFeatureState() {
+        let action = AppSettingsAction.loadSimplePaymentsSwitchState { [weak self] result in
+            self?.isSimplePaymentsEnabled = (try? result.get()) ?? false
         }
         stores.dispatch(action)
     }
@@ -245,9 +245,9 @@ extension OrderListViewModel {
     private func bindTopBannerState() {
         let enrolledState = inPersonPaymentsReadyUseCase.statePublisher.removeDuplicates()
         let errorState = $hasErrorLoadingData.removeDuplicates()
-        let experimentalState = $isQuickOrderEnabled.removeDuplicates()
-        Publishers.CombineLatest4(enrolledState, errorState, experimentalState, $hideQuickOrderBanners)
-            .map { enrolledState, hasError, isQuickOrderEnabled, hasDismissedBanners -> TopBanner in
+        let experimentalState = $isSimplePaymentsEnabled.removeDuplicates()
+        Publishers.CombineLatest4(enrolledState, errorState, experimentalState, $hideSimplePaymentsBanners)
+            .map { enrolledState, hasError, isSimplePaymentsEnabled, hasDismissedBanners -> TopBanner in
 
                 guard !hasError else {
                     return .error
@@ -257,11 +257,11 @@ extension OrderListViewModel {
                     return .none
                 }
 
-                switch (enrolledState, isQuickOrderEnabled) {
+                switch (enrolledState, isSimplePaymentsEnabled) {
                 case (.completed, false):
-                    return .quickOrderDisabled
+                    return .simplePaymentsDisabled
                 case (.completed, true):
-                    return .quickOrderEnabled
+                    return .simplePaymentsEnabled
                 default:
                     return .none
                 }
@@ -306,8 +306,8 @@ extension OrderListViewModel {
     ///
     enum TopBanner {
         case error
-        case quickOrderEnabled
-        case quickOrderDisabled
+        case simplePaymentsEnabled
+        case simplePaymentsDisabled
         case none
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -64,7 +64,7 @@ final class OrdersRootViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         // Needed in ViewWillAppear because this View Controller is never recreated.
-        fetchQuickOrderExperimentalToggleAndConfigureNavigationButtons()
+        fetchSimplePaymentsExperimentalToggleAndConfigureNavigationButtons()
     }
 
     override func viewDidLayoutSubviews() {
@@ -106,16 +106,16 @@ private extension OrdersRootViewController {
 
     /// Sets navigation buttons.
     /// Search: Is always present.
-    /// Quick Order: Depends on the local feature flag, experimental feature toggle and the inPersonPayments state.
+    /// Simple Payments: Depends on the local feature flag, experimental feature toggle and the inPersonPayments state.
     ///
-    func configureNavigationButtons(isQuickOrderExperimentalToggleEnabled: Bool) {
-        let shouldShowQuickOrderButton: Bool = {
+    func configureNavigationButtons(isSimplePaymentsExperimentalToggleEnabled: Bool) {
+        let shouldShowSimplePaymentsButton: Bool = {
             let isInPersonPaymentsConfigured = inPersonPaymentsUseCase.state == .completed
-            return isQuickOrderExperimentalToggleEnabled && isInPersonPaymentsConfigured
+            return isSimplePaymentsExperimentalToggleEnabled && isInPersonPaymentsConfigured
         }()
         let buttons: [UIBarButtonItem?] = [
             ordersViewController.createSearchBarButtonItem(),
-            shouldShowQuickOrderButton ? ordersViewController.createAddQuickOrderOrderItem() : nil
+            shouldShowSimplePaymentsButton ? ordersViewController.createAddSimplePaymentsOrderItem() : nil
         ]
         navigationItem.rightBarButtonItems = buttons.compactMap { $0 }
     }
@@ -153,18 +153,18 @@ private extension OrdersRootViewController {
         inPersonPaymentsUseCase.$state
             .removeDuplicates()
             .sink { [weak self] _ in
-                self?.fetchQuickOrderExperimentalToggleAndConfigureNavigationButtons()
+                self?.fetchSimplePaymentsExperimentalToggleAndConfigureNavigationButtons()
             }
             .store(in: &subscriptions)
         inPersonPaymentsUseCase.refresh()
     }
 
-    /// Fetches the latest value of the QuickOrder experimental feature toggle and re configures navigation buttons.
+    /// Fetches the latest value of the SimplePayments experimental feature toggle and re configures navigation buttons.
     ///
-    func fetchQuickOrderExperimentalToggleAndConfigureNavigationButtons() {
-        let action = AppSettingsAction.loadQuickOrderSwitchState { [weak self] result in
+    func fetchSimplePaymentsExperimentalToggleAndConfigureNavigationButtons() {
+        let action = AppSettingsAction.loadSimplePaymentsSwitchState { [weak self] result in
             let isEnabled = (try? result.get()) ?? false
-            self?.configureNavigationButtons(isQuickOrderExperimentalToggleEnabled: isEnabled)
+            self?.configureNavigationButtons(isSimplePaymentsExperimentalToggleEnabled: isEnabled)
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -130,10 +130,10 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID, "status": order.status.rawValue])
     }
 
-    /// Presents `QuickOrderAmountHostingController`.
+    /// Presents `SimplePaymentsAmountHostingController`.
     ///
-    @objc private func presentQuickOrderAmountController() {
-        let viewModel = QuickOrderAmountViewModel(siteID: siteID)
+    @objc private func presentSimplePaymentsAmountController() {
+        let viewModel = SimplePaymentsAmountViewModel(siteID: siteID)
         viewModel.onOrderCreated = { [weak self] order in
             guard let self = self else { return }
 
@@ -143,11 +143,11 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
             }
         }
 
-        let viewController = QuickOrderAmountHostingController(viewModel: viewModel)
+        let viewController = SimplePaymentsAmountHostingController(viewModel: viewModel)
         let navigationController = WooNavigationController(rootViewController: viewController)
         present(navigationController, animated: true)
 
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowStarted())
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowStarted())
     }
 
     // MARK: - ButtonBarPagerTabStripViewController Conformance
@@ -262,16 +262,16 @@ extension OrdersTabbedViewController {
         return button
     }
 
-    /// Create a `UIBarButtonItem` to be used as a way to create a new quick order order.
+    /// Create a `UIBarButtonItem` to be used as a way to create a new simple payments order.
     ///
-    func createAddQuickOrderOrderItem() -> UIBarButtonItem {
+    func createAddSimplePaymentsOrderItem() -> UIBarButtonItem {
         let button = UIBarButtonItem(image: .plusBarButtonItemImage,
                                      style: .plain,
                                      target: self,
-                                     action: #selector(presentQuickOrderAmountController))
+                                     action: #selector(presentSimplePaymentsAmountController))
         button.accessibilityTraits = .button
-        button.accessibilityLabel = NSLocalizedString("Add quick order order", comment: "Navigates to a screen to create a quick order order")
-        button.accessibilityIdentifier = "quick-order-add-button"
+        button.accessibilityLabel = NSLocalizedString("Add simple payments order", comment: "Navigates to a screen to create a simple payments order")
+        button.accessibilityIdentifier = "simple-payments-add-button"
         return button
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmount.swift
@@ -2,9 +2,9 @@ import Foundation
 import SwiftUI
 import Combine
 
-/// Hosting controller that wraps an `QuickOrderAmount` view.
+/// Hosting controller that wraps an `SimplePaymentsAmount` view.
 ///
-final class QuickOrderAmountHostingController: UIHostingController<QuickOrderAmount> {
+final class SimplePaymentsAmountHostingController: UIHostingController<SimplePaymentsAmount> {
 
     /// References to keep the Combine subscriptions alive within the lifecycle of the object.
     ///
@@ -18,8 +18,8 @@ final class QuickOrderAmountHostingController: UIHostingController<QuickOrderAmo
         return presenter
     }()
 
-    init(viewModel: QuickOrderAmountViewModel) {
-        super.init(rootView: QuickOrderAmount(viewModel: viewModel))
+    init(viewModel: SimplePaymentsAmountViewModel) {
+        super.init(rootView: SimplePaymentsAmount(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismiss = { [weak self] in
@@ -36,7 +36,7 @@ final class QuickOrderAmountHostingController: UIHostingController<QuickOrderAmo
 
                 switch notice {
                 case .error:
-                    self?.modalNoticePresenter.enqueue(notice: .init(title: QuickOrderAmount.Localization.error, feedbackType: .error))
+                    self?.modalNoticePresenter.enqueue(notice: .init(title: SimplePaymentsAmount.Localization.error, feedbackType: .error))
                 }
 
                 // Nullify the presentation intent.
@@ -63,15 +63,15 @@ final class QuickOrderAmountHostingController: UIHostingController<QuickOrderAmo
 
 /// Intercepts to the dismiss drag gesture.
 ///
-extension QuickOrderAmountHostingController: UIAdaptivePresentationControllerDelegate {
+extension SimplePaymentsAmountHostingController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         rootView.viewModel.userDidCancelFlow()
     }
 }
 
-/// View that receives an arbitrary amount for creating a quick order order.
+/// View that receives an arbitrary amount for creating a simple payments order.
 ///
-struct QuickOrderAmount: View {
+struct SimplePaymentsAmount: View {
 
     /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
     ///
@@ -83,7 +83,7 @@ struct QuickOrderAmount: View {
 
     /// ViewModel to drive the view content
     ///
-    @ObservedObject private(set) var viewModel: QuickOrderAmountViewModel
+    @ObservedObject private(set) var viewModel: SimplePaymentsAmountViewModel
 
     var body: some View {
         VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
@@ -105,7 +105,7 @@ struct QuickOrderAmount: View {
 
             // Done button
             Button(Localization.buttonTitle) {
-                viewModel.createQuickOrderOrder()
+                viewModel.createSimplePaymentsOrder()
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)
@@ -124,13 +124,13 @@ struct QuickOrderAmount: View {
 }
 
 // MARK: Constants
-private extension QuickOrderAmount {
+private extension SimplePaymentsAmount {
     enum Localization {
-        static let title = NSLocalizedString("Take Payment", comment: "Title for the quick order screen")
-        static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the quick order screen")
-        static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the quick order screen")
-        static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the quick order screen")
-        static let error = NSLocalizedString("There was an error creating the order", comment: "Notice text after failing to create a quick order order.")
+        static let title = NSLocalizedString("Take Payment", comment: "Title for the simple payments screen")
+        static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the simple payments screen")
+        static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the simple payments screen")
+        static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the simple payments screen")
+        static let error = NSLocalizedString("There was an error creating the order", comment: "Notice text after failing to create a simple payments order.")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModel.swift
@@ -1,9 +1,9 @@
 import Foundation
 import Yosemite
 
-/// View Model for the `QuickOrderAmount` view.
+/// View Model for the `SimplePaymentsAmount` view.
 ///
-final class QuickOrderAmountViewModel: ObservableObject {
+final class SimplePaymentsAmountViewModel: ObservableObject {
 
     /// Stores amount entered by the merchant.
     ///
@@ -79,23 +79,23 @@ final class QuickOrderAmountViewModel: ObservableObject {
     }
 
     /// Called when the view taps the done button.
-    /// Creates a quick order order.
+    /// Creates a simple payments order.
     ///
-    func createQuickOrderOrder() {
+    func createSimplePaymentsOrder() {
         loading = true
-        let action = OrderAction.createQuickOrderOrder(siteID: siteID, amount: amount) { [weak self] result in
+        let action = OrderAction.createSimplePaymentsOrder(siteID: siteID, amount: amount) { [weak self] result in
             guard let self = self else { return }
             self.loading = false
 
             switch result {
             case .success(let order):
                 self.onOrderCreated(order)
-                self.analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowCompleted(amount: order.total))
+                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowCompleted(amount: order.total))
 
             case .failure(let error):
                 self.presentNotice = .error
-                self.analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowFailed())
-                DDLogError("⛔️ Error creating quick order order: \(error)")
+                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowFailed())
+                DDLogError("⛔️ Error creating simple payments order: \(error)")
             }
         }
         stores.dispatch(action)
@@ -104,12 +104,12 @@ final class QuickOrderAmountViewModel: ObservableObject {
     /// Track the flow cancel scenario.
     ///
     func userDidCancelFlow() {
-        analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowCanceled())
+        analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowCanceled())
     }
 }
 
 // MARK: Helpers
-private extension QuickOrderAmountViewModel {
+private extension SimplePaymentsAmountViewModel {
 
     /// Formats a received value by making sure the `$` symbol is present and trimming content to two decimal places.
     /// TODO: Update to support multiple currencies
@@ -150,7 +150,7 @@ private extension QuickOrderAmountViewModel {
 }
 
 // MARK: Definitions
-extension QuickOrderAmountViewModel {
+extension SimplePaymentsAmountViewModel {
     /// Representation of possible notices that can be displayed
     enum Notice: Equatable {
         case error

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsTopBannerFactory.swift
@@ -1,10 +1,10 @@
 import Yosemite
 
-/// Factory for the QuickOrder top banners
+/// Factory for the SimplePayments top banners
 ///
-struct QuickOrderTopBannerFactory {
+struct SimplePaymentsTopBannerFactory {
 
-    /// Creates a banner to be shown when the quick order has not been enabled in the beta features screen
+    /// Creates a banner to be shown when the simple payments has not been enabled in the beta features screen
     ///
     static func createFeatureDisabledBanner(onTopButtonPressed: @escaping () -> Void,
                                             onDismissButtonPressed: @escaping () -> Void) -> TopBannerView {
@@ -20,7 +20,7 @@ struct QuickOrderTopBannerFactory {
         return topBannerView
     }
 
-    /// Creates a banner to be shown when the quick order has been enabled in the beta features screen
+    /// Creates a banner to be shown when the simple payments has been enabled in the beta features screen
     ///
     static func createFeatureEnabledBanner(onTopButtonPressed: @escaping () -> Void,
                                            onDismissButtonPressed: @escaping () -> Void,
@@ -39,16 +39,16 @@ struct QuickOrderTopBannerFactory {
     }
 }
 
-private extension QuickOrderTopBannerFactory {
+private extension SimplePaymentsTopBannerFactory {
     enum Localization {
-        static let title = NSLocalizedString("Take payments from your device!", comment: "Title of the banner notice in the Quick Order feature")
+        static let title = NSLocalizedString("Take payments from your device!", comment: "Title of the banner notice in the Simple Payments feature")
         static let disabledInfo = NSLocalizedString("We are working on making it easier for you to take payments from your device! " +
-                                                    "Enable Quick Order in Settings > Experimental Features.",
-                                                    comment: "Content of the top banner to announce the quick pay feature.")
+                                                    "Enable Simple Payments in Settings > Experimental Features.",
+                                                    comment: "Content of the top banner to announce the simple payments feature.")
         static let enabledInfo = NSLocalizedString("We are working on making it easier for you to take payments from your device! " +
                                                    "For now, tap on the \"+\" button and you’ll be able to create an order with the amount you want to collect",
-                                                   comment: "Content of the banner notice in the Quick Order view")
-        static let dismiss = NSLocalizedString("Dismiss", comment: "The title of the button to dismiss the QuickOrder top banner")
-        static let giveFeedback = NSLocalizedString("Give feedback", comment: "Title of the button to give feedback about the Quick Order feature")
+                                                   comment: "Content of the banner notice in the Simple Payments view")
+        static let dismiss = NSLocalizedString("Dismiss", comment: "The title of the button to dismiss the SimplePayments top banner")
+        static let giveFeedback = NSLocalizedString("Give feedback", comment: "Title of the button to give feedback about the Simple Payments feature")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -66,7 +66,7 @@ extension SurveyViewController {
         case productsVariationsFeedback
         case shippingLabelsRelease3Feedback
         case addOnsI1
-        case quickOrderPrototype
+        case simplePaymentsPrototype
 
         fileprivate var url: URL {
             switch self {
@@ -92,8 +92,8 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
-            case .quickOrderPrototype:
-                return WooConstants.URLs.quickOrderPrototypeFeedback
+            case .simplePaymentsPrototype:
+                return WooConstants.URLs.simplePaymentsPrototypeFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -104,7 +104,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsVariationsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .quickOrderPrototype:
+            case .productsVariationsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .simplePaymentsPrototype:
                 return Localization.giveFeedback
             }
         }
@@ -120,8 +120,8 @@ extension SurveyViewController {
                 return .shippingLabelsRelease3
             case .addOnsI1:
                 return .addOnsI1
-            case .quickOrderPrototype:
-                return .quickOrderPrototype
+            case .simplePaymentsPrototype:
+                return .simplePaymentsPrototype
             }
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
 		260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */; };
-		26100B1E2721BAD800473045 /* QuickOrderTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1D2721BAD800473045 /* QuickOrderTopBannerFactory.swift */; };
+		26100B1E2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1D2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift */; };
 		26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
@@ -392,8 +392,8 @@
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
 		262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
-		262AF387271114CC00E39AFF /* QuickOrderAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF386271114CC00E39AFF /* QuickOrderAmountViewModel.swift */; };
-		262AF38A2713B67600E39AFF /* QuickOrderAmountViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF3892713B67600E39AFF /* QuickOrderAmountViewModelTests.swift */; };
+		262AF387271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF386271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift */; };
+		262AF38A2713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF3892713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift */; };
 		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
 		262C922126F1370000011F92 /* StorePickerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C922026F1370000011F92 /* StorePickerError.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
@@ -424,7 +424,7 @@
 		2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */; };
 		2667BFED25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */; };
 		26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */; };
-		2678897C270E6E8B00BD249E /* QuickOrderAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* QuickOrderAmount.swift */; };
+		2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
@@ -1841,7 +1841,7 @@
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
 		260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModel.swift; sourceTree = "<group>"; };
-		26100B1D2721BAD800473045 /* QuickOrderTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOrderTopBannerFactory.swift; sourceTree = "<group>"; };
+		26100B1D2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsTopBannerFactory.swift; sourceTree = "<group>"; };
 		26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
@@ -1851,8 +1851,8 @@
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
 		262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnTopBanner.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
-		262AF386271114CC00E39AFF /* QuickOrderAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOrderAmountViewModel.swift; sourceTree = "<group>"; };
-		262AF3892713B67600E39AFF /* QuickOrderAmountViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOrderAmountViewModelTests.swift; sourceTree = "<group>"; };
+		262AF386271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmountViewModel.swift; sourceTree = "<group>"; };
+		262AF3892713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmountViewModelTests.swift; sourceTree = "<group>"; };
 		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		262C922026F1370000011F92 /* StorePickerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerError.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
@@ -1878,7 +1878,7 @@
 		2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCase.swift; sourceTree = "<group>"; };
 		2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCaseTests.swift; sourceTree = "<group>"; };
 		26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundCoordinatingController.swift; sourceTree = "<group>"; };
-		2678897B270E6E8B00BD249E /* QuickOrderAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOrderAmount.swift; sourceTree = "<group>"; };
+		2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmount.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
 		2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SurveySubmittedViewController.xib; sourceTree = "<group>"; };
@@ -3893,12 +3893,12 @@
 			path = "View Modifiers";
 			sourceTree = "<group>";
 		};
-		262AF3882713B65700E39AFF /* QuickOrder */ = {
+		262AF3882713B65700E39AFF /* Simple Payments */ = {
 			isa = PBXGroup;
 			children = (
-				262AF3892713B67600E39AFF /* QuickOrderAmountViewModelTests.swift */,
+				262AF3892713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift */,
 			);
-			path = QuickOrder;
+			path = "Simple Payments";
 			sourceTree = "<group>";
 		};
 		265284002624933B00F91BA1 /* AddOns */ = {
@@ -3967,14 +3967,14 @@
 			path = "Issue Refund";
 			sourceTree = "<group>";
 		};
-		2678897A270E6E3C00BD249E /* Quick Order */ = {
+		2678897A270E6E3C00BD249E /* Simple Payments */ = {
 			isa = PBXGroup;
 			children = (
-				2678897B270E6E8B00BD249E /* QuickOrderAmount.swift */,
-				262AF386271114CC00E39AFF /* QuickOrderAmountViewModel.swift */,
-				26100B1D2721BAD800473045 /* QuickOrderTopBannerFactory.swift */,
+				2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */,
+				262AF386271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift */,
+				26100B1D2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift */,
 			);
-			path = "Quick Order";
+			path = "Simple Payments";
 			sourceTree = "<group>";
 		};
 		268EC45D26CEA4E500716F5C /* Customer Note */ = {
@@ -4749,7 +4749,7 @@
 				265284072624ACAF00F91BA1 /* AddOns */,
 				2667BFD5252E5D4C008099D4 /* Issue Refund */,
 				57F2C6C9246DEBB10074063B /* Order Details */,
-				262AF3882713B65700E39AFF /* QuickOrder */,
+				262AF3882713B65700E39AFF /* Simple Payments */,
 				570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */,
 				57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */,
 				5767E93F256D9A4A00CFA652 /* OrderListViewModelTests.swift */,
@@ -5819,7 +5819,7 @@
 			children = (
 				CEE006022077D0F80079161F /* Cells */,
 				CE35F1092343E482007B2A6B /* Order Details */,
-				2678897A270E6E3C00BD249E /* Quick Order */,
+				2678897A270E6E3C00BD249E /* Simple Payments */,
 				CEE005F52076C4040079161F /* Orders.storyboard */,
 				57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */,
 				57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */,
@@ -7533,7 +7533,7 @@
 				0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */,
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
-				262AF387271114CC00E39AFF /* QuickOrderAmountViewModel.swift in Sources */,
+				262AF387271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
 				AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */,
 				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,
@@ -7668,7 +7668,7 @@
 				023D877925EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift in Sources */,
 				2664210326F40FB1001FC5B4 /* View+ScrollModifiers.swift in Sources */,
 				02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */,
-				26100B1E2721BAD800473045 /* QuickOrderTopBannerFactory.swift in Sources */,
+				26100B1E2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift in Sources */,
 				26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */,
 				027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */,
 				4524CD9E242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift in Sources */,
@@ -8024,7 +8024,7 @@
 				318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
-				2678897C270E6E8B00BD249E /* QuickOrderAmount.swift in Sources */,
+				2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */,
 				450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */,
 				029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
@@ -8398,7 +8398,7 @@
 				02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
 				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStorageTests.swift in Sources */,
-				262AF38A2713B67600E39AFF /* QuickOrderAmountViewModelTests.swift in Sources */,
+				262AF38A2713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
 				578195FC25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -227,7 +227,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertFalse(resynchronizeRequested)
     }
 
-    func test_having_no_error_and_no_quick_order_does_not_show_banner() {
+    func test_having_no_error_and_no_simple_payments_does_not_show_banner() {
         // Given
         let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .wcpayNotInstalled)
         let viewModel = OrderListViewModel(siteID: siteID, statusFilter: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
@@ -260,7 +260,7 @@ final class OrderListViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case .loadQuickOrderSwitchState(let onCompletion):
+            case .loadSimplePaymentsSwitchState(let onCompletion):
                 onCompletion(.success(true))
             default:
                 XCTFail("Unsupported action: \(action)")
@@ -272,7 +272,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
-        viewModel.reloadQuickOrderExperimentalFeatureState()
+        viewModel.reloadSimplePaymentsExperimentalFeatureState()
         viewModel.hasErrorLoadingData = true
 
         // Then
@@ -281,12 +281,12 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_having_store_onboarded_and_quick_order_disabled_shows_disabled_top_banner() {
+    func test_having_store_onboarded_and_simple_payments_disabled_shows_disabled_top_banner() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case .loadQuickOrderSwitchState(let onCompletion):
+            case .loadSimplePaymentsSwitchState(let onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported action: \(action)")
@@ -298,20 +298,20 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
-        viewModel.reloadQuickOrderExperimentalFeatureState()
+        viewModel.reloadSimplePaymentsExperimentalFeatureState()
 
         // Then
         waitUntil {
-            viewModel.topBanner == .quickOrderDisabled
+            viewModel.topBanner == .simplePaymentsDisabled
         }
     }
 
-    func test_having_store_onboarded_and_quick_order_enabled_shows_enabled_top_banner() {
+    func test_having_store_onboarded_and_simple_payments_enabled_shows_enabled_top_banner() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case .loadQuickOrderSwitchState(let onCompletion):
+            case .loadSimplePaymentsSwitchState(let onCompletion):
                 onCompletion(.success(true))
             default:
                 XCTFail("Unsupported action: \(action)")
@@ -323,20 +323,20 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
-        viewModel.reloadQuickOrderExperimentalFeatureState()
+        viewModel.reloadSimplePaymentsExperimentalFeatureState()
 
         // Then
         waitUntil {
-            viewModel.topBanner == .quickOrderEnabled
+            viewModel.topBanner == .simplePaymentsEnabled
         }
     }
 
-    func test_having_store_not_onboarded_and_quick_order_enabled_shows_no_banner() {
+    func test_having_store_not_onboarded_and_simple_payments_enabled_shows_no_banner() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case .loadQuickOrderSwitchState(let onCompletion):
+            case .loadSimplePaymentsSwitchState(let onCompletion):
                 onCompletion(.success(true))
             default:
                 XCTFail("Unsupported action: \(action)")
@@ -348,7 +348,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
-        viewModel.reloadQuickOrderExperimentalFeatureState()
+        viewModel.reloadSimplePaymentsExperimentalFeatureState()
 
         // Then
         waitUntil {
@@ -356,12 +356,12 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_dismissing_quick_order_banners_does_not_show_banners() {
+    func test_dismissing_simple_payments_banners_does_not_show_banners() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case .loadQuickOrderSwitchState(let onCompletion):
+            case .loadSimplePaymentsSwitchState(let onCompletion):
                 onCompletion(.success(true))
             default:
                 XCTFail("Unsupported action: \(action)")
@@ -373,8 +373,8 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
-        viewModel.reloadQuickOrderExperimentalFeatureState()
-        viewModel.hideQuickOrderBanners = true
+        viewModel.reloadSimplePaymentsExperimentalFeatureState()
+        viewModel.hideSimplePaymentsBanners = true
 
         // Then
         waitUntil {
@@ -382,14 +382,14 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_hiding_quickOrder_banners_still_shows_error_banner() {
+    func test_hiding_simplePayments_banners_still_shows_error_banner() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, statusFilter: nil)
 
         // When
         viewModel.activate()
         viewModel.hasErrorLoadingData = true
-        viewModel.hideQuickOrderBanners = true
+        viewModel.hideSimplePaymentsBanners = true
 
         // Then
         waitUntil {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
-final class QuickOrderAmountViewModelTests: XCTestCase {
+final class SimplePaymentsAmountViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 123
 
@@ -13,7 +13,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_prepends_currency_symbol() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "12"
@@ -24,7 +24,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_non_digit_characters() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "hi:11.30-"
@@ -35,7 +35,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_trims_more_than_two_decimal_numbers() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "$67.321432432"
@@ -46,7 +46,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_duplicated_decimal_separators() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "$6.7.3"
@@ -57,7 +57,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_consecutive_decimal_separators() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "$6..."
@@ -68,7 +68,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_disables_next_button_when_there_is_no_amount() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = ""
@@ -79,7 +79,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_disables_next_button_when_amount_only_has_currency_symbol() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "$"
@@ -90,7 +90,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
 
     func test_view_model_enables_next_button_when_amount_has_more_than_one_character() {
         // Given
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "$2"
@@ -102,7 +102,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
     func test_view_model_changes_coma_separator_for_dot_separator_when_the_store_requires_it() {
         // Given
         let comaSeparatorLocale = Locale(identifier: "es_AR")
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: comaSeparatorLocale, storeCurrencySettings: usStoreSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: comaSeparatorLocale, storeCurrencySettings: usStoreSettings)
 
         // When
         viewModel.amount = "10,25"
@@ -114,7 +114,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
     func test_view_model_uses_the_store_currency_symbol() {
         // Given
         let storeSettings = CurrencySettings(currencyCode: .EUR, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
 
         // When
         viewModel.amount = "10.25"
@@ -126,7 +126,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
     func test_amount_placeholder_is_formatted_with_store_currency_settings() {
         // Given
         let storeSettings = CurrencySettings(currencyCode: .EUR, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ",", numberOfDecimals: 2)
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
 
         // When & Then
         XCTAssertEqual(viewModel.amountPlaceholder, "€0,00")
@@ -135,7 +135,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
     func test_view_model_enables_loading_state_while_performing_network_operations() {
         // Given
         let testingStore = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, stores: testingStore)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore)
         viewModel.amount = "$12.30"
         XCTAssertFalse(viewModel.loading)
 
@@ -143,13 +143,13 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
         let isLoading: Bool = waitFor { promise in
             testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {
-                case .createQuickOrderOrder:
+                case .createSimplePaymentsOrder:
                     promise(viewModel.loading)
                 default:
                     XCTFail("Received unsupported action: \(action)")
                 }
             }
-            viewModel.createQuickOrderOrder()
+            viewModel.createSimplePaymentsOrder()
         }
 
         // Then
@@ -159,10 +159,10 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
     func test_view_model_call_onOrderCreated_closure_after_an_order_is_created() {
         // Given
         let testingStore = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, stores: testingStore)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore)
         testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .createQuickOrderOrder(_, _, onCompletion):
+            case let .createSimplePaymentsOrder(_, _, onCompletion):
                 onCompletion(.success(.fake()))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -174,7 +174,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
             viewModel.onOrderCreated = { _ in
                 promise(true)
             }
-            viewModel.createQuickOrderOrder()
+            viewModel.createSimplePaymentsOrder()
         }
 
         // Then
@@ -184,10 +184,10 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
     func test_view_model_attempts_error_notice_presentation_when_failing_to_crete_order() {
         // Given
         let testingStore = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = QuickOrderAmountViewModel(siteID: sampleSiteID, stores: testingStore)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore)
         testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .createQuickOrderOrder(_, _, onCompletion):
+            case let .createSimplePaymentsOrder(_, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -195,7 +195,7 @@ final class QuickOrderAmountViewModelTests: XCTestCase {
         }
 
         // When
-        viewModel.createQuickOrderOrder()
+        viewModel.createSimplePaymentsOrder()
 
         // Then
         XCTAssertEqual(viewModel.presentNotice, .error)

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -102,13 +102,13 @@ public enum AppSettingsAction: Action {
     ///
     case loadOrderAddOnsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
 
-    /// Loads the most recent state for the Quick Order beta feature switch
+    /// Loads the most recent state for the Simple Payments beta feature switch
     ///
-    case loadQuickOrderSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
+    case loadSimplePaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
 
-    /// Sets the state for the Quick Order beta feature switch.
+    /// Sets the state for the Simple Payments beta feature switch.
     ///
-    case setQuickOrderFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
+    case setSimplePaymentsFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
 
     /// Remember the given card reader (to support automatic reconnection)
     /// where `cardReaderID` is a String e.g. "CHB204909005931"

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -65,7 +65,7 @@ public enum OrderAction: Action {
     ///
     case updateOrder(siteID: Int64, order: Order, fields: [OrderUpdateField], onCompletion: (Result<Order, Error>) -> Void)
 
-    /// Creates a quick order order with a specific amount value and no tax.
+    /// Creates a simple payments order with a specific amount value and no tax.
     ///
-    case createQuickOrderOrder(siteID: Int64, amount: String, onCompletion: (Result<Order, Error>) -> Void)
+    case createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -142,10 +142,10 @@ public class AppSettingsStore: Store {
             setOrderAddOnsFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .loadOrderAddOnsSwitchState(onCompletion: let onCompletion):
             loadOrderAddOnsSwitchState(onCompletion: onCompletion)
-        case .setQuickOrderFeatureSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
-            setQuickOrderFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
-        case .loadQuickOrderSwitchState(onCompletion: let onCompletion):
-            loadQuickOrderSwitchState(onCompletion: onCompletion)
+        case .setSimplePaymentsFeatureSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
+            setSimplePaymentsFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
+        case .loadSimplePaymentsSwitchState(onCompletion: let onCompletion):
+            loadSimplePaymentsSwitchState(onCompletion: onCompletion)
         case .rememberCardReader(cardReaderID: let cardReaderID, onCompletion: let onCompletion):
             rememberCardReader(cardReaderID: cardReaderID, onCompletion: onCompletion)
         case .forgetCardReader(onCompletion: let onCompletion):
@@ -241,18 +241,18 @@ private extension AppSettingsStore {
         onCompletion(.success(settings.isViewAddOnsSwitchEnabled))
     }
 
-    /// Loads the current QuickOrder beta feature switch state from `GeneralAppSettings`
+    /// Loads the current SimplePayments beta feature switch state from `GeneralAppSettings`
     ///
-    func loadQuickOrderSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
+    func loadSimplePaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
         let settings = loadOrCreateGeneralAppSettings()
-        onCompletion(.success(settings.isQuickOrderSwitchEnabled))
+        onCompletion(.success(settings.isSimplePaymentsSwitchEnabled))
     }
 
-    /// Sets the provided QuickOrder beta feature switch state into `GeneralAppSettings`
+    /// Sets the provided SimplePayments beta feature switch state into `GeneralAppSettings`
     ///
-    func setQuickOrderFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
+    func setSimplePaymentsFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
         do {
-            let settings = loadOrCreateGeneralAppSettings().copy(isQuickOrderSwitchEnabled: isEnabled)
+            let settings = loadOrCreateGeneralAppSettings().copy(isSimplePaymentsSwitchEnabled: isEnabled)
             try saveGeneralAppSettings(settings)
             onCompletion(.success(()))
         } catch {
@@ -289,7 +289,7 @@ private extension AppSettingsStore {
             return GeneralAppSettings(installationDate: nil,
                                       feedbacks: [:],
                                       isViewAddOnsSwitchEnabled: false,
-                                      isQuickOrderSwitchEnabled: false,
+                                      isSimplePaymentsSwitchEnabled: false,
                                       knownCardReaders: [],
                                       lastEligibilityErrorInfo: nil)
         }

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -4,10 +4,10 @@ import Networking
 /// Factory to create convenience order types.
 ///
 enum OrderFactory {
-    /// Creates an order suitable to be used as a quick order order.
+    /// Creates an order suitable to be used as a simple payments order.
     /// Under the hood it uses a fee line without taxes to create an order with the desired amount.
     ///
-    static func quickOrderOrder(amount: String) -> Order {
+    static func simplePaymentsOrder(amount: String) -> Order {
         Order(siteID: 0,
               orderID: 0,
               parentID: 0,
@@ -33,6 +33,6 @@ enum OrderFactory {
               shippingLines: [],
               coupons: [],
               refunds: [],
-              fees: [.init(feeID: 0, name: "Quick Order", taxClass: "", taxStatus: .none, total: amount, totalTax: "", taxes: [], attributes: [])])
+              fees: [.init(feeID: 0, name: "Simple Payments", taxClass: "", taxStatus: .none, total: amount, totalTax: "", taxes: [], attributes: [])])
     }
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -62,8 +62,8 @@ public class OrderStore: Store {
         case let .updateOrder(siteID, order, fields, onCompletion):
             updateOrder(siteID: siteID, order: order, fields: fields, onCompletion: onCompletion)
 
-        case let .createQuickOrderOrder(siteID, amount, onCompletion):
-            createQuickOrderOrder(siteID: siteID, amount: amount, onCompletion: onCompletion)
+        case let .createSimplePaymentsOrder(siteID, amount, onCompletion):
+            createSimplePaymentsOrder(siteID: siteID, amount: amount, onCompletion: onCompletion)
         }
     }
 }
@@ -247,10 +247,10 @@ private extension OrderStore {
         }
     }
 
-    /// Creates a quick order order with a specific amount value and no tax.
+    /// Creates a simple payments order with a specific amount value and no tax.
     ///
-    func createQuickOrderOrder(siteID: Int64, amount: String, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        let order = OrderFactory.quickOrderOrder(amount: amount)
+    func createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        let order = OrderFactory.simplePaymentsOrder(amount: amount)
         remote.createOrder(siteID: siteID, order: order, fields: [.feeLines]) { [weak self] result in
             switch result {
             case .success(let order):

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -159,7 +159,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         // Given
         let settings = GeneralAppSettings(installationDate: nil,
                                           feedbacks: [:], isViewAddOnsSwitchEnabled: false,
-                                          isQuickOrderSwitchEnabled: false,
+                                          isSimplePaymentsSwitchEnabled: false,
                                           knownCardReaders: [])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
@@ -224,7 +224,7 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             installationDate: instalationDate,
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
-            isQuickOrderSwitchEnabled: false,
+            isSimplePaymentsSwitchEnabled: false,
             knownCardReaders: []
         )
         return settings

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -447,13 +447,13 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(isEnabled)
     }
 
-    func test_loadQuickOrderSwitchState_returns_false_on_new_generalAppSettings() throws {
+    func test_loadSimplePaymentsSwitchState_returns_false_on_new_generalAppSettings() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
-            let action = AppSettingsAction.loadQuickOrderSwitchState { result in
+            let action = AppSettingsAction.loadSimplePaymentsSwitchState { result in
                 promise(result)
             }
             self.subject?.onAction(action)
@@ -464,15 +464,15 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertFalse(isEnabled)
     }
 
-    func test_loadQuickOrderSwitchState_returns_true_after_updating_switch_state_to_true() throws {
+    func test_loadSimplePaymentsSwitchState_returns_true_after_updating_switch_state_to_true() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.setQuickOrderFeatureSwitchState(isEnabled: true, onCompletion: { _ in })
+        let updateAction = AppSettingsAction.setSimplePaymentsFeatureSwitchState(isEnabled: true, onCompletion: { _ in })
         subject?.onAction(updateAction)
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
-            let action = AppSettingsAction.loadQuickOrderSwitchState { result in
+            let action = AppSettingsAction.loadSimplePaymentsSwitchState { result in
                 promise(result)
             }
             self.subject?.onAction(action)
@@ -641,7 +641,7 @@ private extension AppSettingsStoreTests {
             installationDate: installationDate,
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
-            isQuickOrderSwitchEnabled: false,
+            isSimplePaymentsSwitchEnabled: false,
             knownCardReaders: []
         )
         return (settings, feedback)

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -633,20 +633,20 @@ final class OrderStoreTests: XCTestCase {
     }
 
 
-    func test_create_quick_order_order_properly_sends_values_as_fees() throws {
+    func test_create_simple_payments_order_properly_sends_values_as_fees() throws {
         // Given
         let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "orders", filename: "order")
 
         // When
-        let action = OrderAction.createQuickOrderOrder(siteID: self.sampleSiteID, amount: "125.50") { _ in }
+        let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, amount: "125.50") { _ in }
         store.onAction(action)
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
         let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: String]]).first
         let expected = [
-            "name": "Quick Order",
+            "name": "Simple Payments",
             "tax_status": "none",
             "tax_class": "",
             "total": "125.50"
@@ -654,14 +654,14 @@ final class OrderStoreTests: XCTestCase {
         assertEqual(received, expected)
     }
 
-    func test_create_quick_order_order_stores_orders_correctly() throws {
+    func test_create_simple_payments_order_stores_orders_correctly() throws {
         // Given
         let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "orders", filename: "order")
 
         // When
         let storedOrder: Yosemite.Order? = waitFor { promise in
-            let action = OrderAction.createQuickOrderOrder(siteID: self.sampleSiteID, amount: "125.50") { _ in
+            let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, amount: "125.50") { _ in
                 let order = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)?.toReadOnly()
                 promise(order)
             }


### PR DESCRIPTION
# Why

As requested on p91TBi-6nk#comment-7153 we are renaming "Quick Order" to "Simple Payments".

Reasoning:
> Searches with the word ‘payments’ rank higher than searches for orders. While the end user may see it more of an order, for our merchants it’s much more about getting paid (and collecting payments). By using ‘payments’ in the term, we’re also creating a much stronger link between the umbrella of “in-person payments” and the sub-feature of the card reader products. As we continue to grow our in-person payments offerings, our focus should really be on the getting paid part, as much as possible.

# Event Registration
- [x] https://github.com/Automattic/tracks-events-registration/pull/633
- [x] https://github.com/Automattic/tracks-events-registration/pull/634
- [x] https://github.com/Automattic/tracks-events-registration/pull/635
- [x] https://github.com/Automattic/tracks-events-registration/pull/636
- [x] https://github.com/Automattic/tracks-events-registration/pull/637    

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
