### PR TITLE
Quick order customer note on receipts

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -86,6 +86,7 @@ public extension ReceiptRenderer {
                     </header>
                     <h3>\(summarySectionTitle.uppercased())</h3>
                     \(summaryTable())
+                    \(orderNoteSection())
                     <footer>
                         <p>
                             \(requiredItems())
@@ -135,6 +136,16 @@ private extension ReceiptRenderer {
                     \(amount) \(content.parameters.currency.uppercased())
                 </td>
             </tr>
+        """
+    }
+
+    private func orderNoteSection() -> String {
+        guard let orderNote = content.orderNote else {
+            return ""
+        }
+        return """
+        <h3>\(Localization.orderNoteSectionTitle.uppercased())</h3>
+        <p>\(orderNote)
         """
     }
 
@@ -213,6 +224,10 @@ private extension ReceiptRenderer {
             "Summary",
             comment: "Title of 'Summary' section in the receipt when the order number is unknown"
         )
+
+        static let orderNoteSectionTitle = NSLocalizedString(
+            "Notes",
+            comment: "Title of order note section in the receipt, commonly used for Quick Orders.")
 
         static let summarySectionTitleWithOrderFormat = NSLocalizedString(
             "Summary: Order #%1$@",

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -3,9 +3,7 @@ import UIKit
 /// Renders a receipt in an AirPrint enabled printer.
 ///
 public final class ReceiptRenderer: UIPrintPageRenderer {
-    private let lines: [ReceiptLineItem]
-    private let parameters: CardPresentReceiptParameters
-    private let cartTotals: [ReceiptTotalLine]
+    private let content: ReceiptContent
 
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -17,9 +15,7 @@ public final class ReceiptRenderer: UIPrintPageRenderer {
     }()
 
     public init(content: ReceiptContent) {
-        self.lines = content.lineItems
-        self.parameters = content.parameters
-        self.cartTotals = content.cartTotals
+        self.content = content
 
         super.init()
 
@@ -77,15 +73,15 @@ public extension ReceiptRenderer {
                         <h1>\(receiptTitle)</h1>
                         <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
                         <p>
-                            \(parameters.formattedAmount) \(parameters.currency.uppercased())
+                            \(content.parameters.formattedAmount) \(content.parameters.currency.uppercased())
                         </p>
                         <h3>\(Localization.datePaidSectionTitle.uppercased())</h3>
                         <p>
-                            \(dateFormatter.string(from: parameters.date))
+                            \(dateFormatter.string(from: content.parameters.date))
                         </p>
                         <h3>\(Localization.paymentMethodSectionTitle.uppercased())</h3>
                         <p>
-                            <span class="card-icon \(parameters.cardDetails.brand.iconName)-icon"></span> - \(parameters.cardDetails.last4)
+                            <span class="card-icon \(content.parameters.cardDetails.brand.iconName)-icon"></span> - \(content.parameters.cardDetails.last4)
                         </p>
                     </header>
                     <h3>\(summarySectionTitle.uppercased())</h3>
@@ -112,8 +108,8 @@ private extension ReceiptRenderer {
 
     private func summaryTable() -> String {
         var summaryContent = "<table>"
-        for line in lines {
-            summaryContent += "<tr><td>\(line.title) × \(line.quantity)</td><td>\(line.amount) \(parameters.currency.uppercased())</td></tr>"
+        for line in content.lineItems {
+            summaryContent += "<tr><td>\(line.title) × \(line.quantity)</td><td>\(line.amount) \(content.parameters.currency.uppercased())</td></tr>"
         }
         summaryContent += totalRows()
         summaryContent += "</table>"
@@ -123,7 +119,7 @@ private extension ReceiptRenderer {
 
     private func totalRows() -> String {
         var rows = ""
-        for total in cartTotals {
+        for total in content.cartTotals {
             rows += summaryRow(title: total.description, amount: total.amount)
         }
         return rows
@@ -136,14 +132,14 @@ private extension ReceiptRenderer {
                     \(title)
                 </td>
                 <td>
-                    \(amount) \(parameters.currency.uppercased())
+                    \(amount) \(content.parameters.currency.uppercased())
                 </td>
             </tr>
         """
     }
 
     private func requiredItems() -> String {
-        guard let emv = parameters.cardDetails.receipt else {
+        guard let emv = content.parameters.cardDetails.receipt else {
             return "<br/>"
         }
 
@@ -163,7 +159,7 @@ private extension ReceiptRenderer {
     }
 
     private var receiptTitle: String {
-        guard let storeName = parameters.storeName else {
+        guard let storeName = content.parameters.storeName else {
             return Localization.receiptTitle
         }
 
@@ -171,7 +167,7 @@ private extension ReceiptRenderer {
     }
 
     private var summarySectionTitle: String {
-        guard let orderID = parameters.orderID else {
+        guard let orderID = content.parameters.orderID else {
             return Localization.summarySectionTitle
         }
         return String(format: Localization.summarySectionTitleWithOrderFormat, String(orderID))

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -145,7 +145,7 @@ private extension ReceiptRenderer {
         }
         return """
         <h3>\(Localization.orderNoteSectionTitle.uppercased())</h3>
-        <p>\(orderNote)
+        <p>\(orderNote)</p>
         """
     }
 

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -45,7 +45,7 @@ public extension ReceiptRenderer {
                         background-color:#F5F5F5;
                         width:100%;
                         color: #707070;
-                        margin: \(Constants.margin / 2)pt 0 0 0;
+                        margin: \(Constants.margin / 2)pt 0;
                         padding: \(Constants.margin / 2)pt;
                     }
                     table td:last-child { width: 30%; text-align: right; }

--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -4,11 +4,16 @@ public struct ReceiptContent: Codable {
     public let lineItems: [ReceiptLineItem]
     public let parameters: CardPresentReceiptParameters
     public let cartTotals: [ReceiptTotalLine]
+    public let orderNote: String?
 
-    public init(parameters: CardPresentReceiptParameters, lineItems: [ReceiptLineItem], cartTotals: [ReceiptTotalLine]) {
+    public init(parameters: CardPresentReceiptParameters,
+                lineItems: [ReceiptLineItem],
+                cartTotals: [ReceiptTotalLine],
+                orderNote: String?) {
         self.lineItems = lineItems
         self.parameters = parameters
         self.cartTotals = cartTotals
+        self.orderNote = orderNote
     }
 }
 
@@ -17,6 +22,7 @@ extension ReceiptContent {
         case lineItems = "line_items"
         case parameters = "parameters"
         case cartTotals = "cart_totals"
+        case orderNote = "order_note"
     }
 }
 


### PR DESCRIPTION
Resolves #5342 

## Description
The quick order flow will include an opportunity for the merchant to add an `Order.customerNote`, which is intended to allow them to provide some detail/context to the customer for what was bought; otherwise the receipt for a quick order has no detail on it, as there are no items.

## Testing
1. Add a quick order (or any other IPP-eligible order)
2. Before taking payment, add a "Customer Provided Note" on the Order Details screen.
3. Collect payment using a card reader
4. Observe the receipt contains the note when you print or email it
5. Observe that printed receipts have HTML stripped from them

https://user-images.githubusercontent.com/2472348/140806707-13ed059c-6fc7-4e44-b824-871ef61f4a63.mp4


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
