### PR TITLE
Simple Payments: Summary UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/QuickOrderSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/QuickOrderSummary.swift
@@ -6,73 +6,102 @@ struct QuickOrderSummary: View {
     var body: some View {
         VStack {
             ScrollView {
-                VStack(spacing: 10) {
+                VStack(spacing: 0) {
 
-                    HStack {
-                        Rectangle()
-                            .fill()
-                            .foregroundColor(.gray)
-                            .frame(width: 48, height: 48)
+                    Group {
 
-                        Text("Custom Amount")
+                        Divider()
 
-                        Spacer()
+                        HStack {
+                            Rectangle()
+                                .fill()
+                                .foregroundColor(.gray)
+                                .frame(width: 48, height: 48)
 
-                        Text("$40.00")
-                    }
-                    .background(Color.white)
+                            Text("Custom Amount")
 
+                            Spacer()
 
-                    TitleAndTextFieldRow(title: "Email", placeholder: "Enter Email", text: .constant(""))
+                            Text("$40.00")
+                        }
+                        .padding()
                         .background(Color.white)
 
-                    VStack(alignment: .leading) {
-                        Text("Payment")
-
-                        TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
-
-                        TitleAndToggleRow(title: "Charge Taxes", isOn: .constant(false))
-
-                        TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
+                        Divider()
+                        Spacer(minLength: 16)
                     }
-                    .background(Color.white)
 
-                    VStack(alignment: .leading) {
-                        Text("Order Note")
-
-                        Button(action: {
-                            print("Tapped add note")
-                        }, label: {
-                            HStack {
-                                Rectangle()
-                                    .fill()
-                                    .frame(width: 24, height: 24)
-
-                                Text("Add Note")
-
-                                Spacer()
-                            }
-                            .foregroundColor(Color(.accent))
-                        })
-                        .frame(maxWidth: .infinity)
-
-
+                    Group {
+                        Divider()
+                        TitleAndTextFieldRow(title: "Email", placeholder: "Enter Email", text: .constant(""))
+                            .background(Color.white)
+                        Divider()
+                        Spacer(minLength: 16)
                     }
-                    .background(Color.white)
+
+                    Group {
+                        Divider()
+                        VStack(alignment: .leading) {
+
+                            Text("Payment")
+                                .padding([.horizontal, .top])
+
+                            TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
+
+                            TitleAndToggleRow(title: "Charge Taxes", isOn: .constant(false))
+                                .padding([.leading, .trailing])
+
+                            TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
+                        }
+                        .background(Color.white)
+
+                        Divider()
+                        Spacer(minLength: 16)
+                    }
+
+                    Group {
+                        Divider()
+
+                        VStack(alignment: .leading) {
+                            Text("Order Note")
+
+                            Button(action: {
+                                print("Tapped add note")
+                            }, label: {
+                                HStack {
+                                    Rectangle()
+                                        .fill()
+                                        .frame(width: 24, height: 24)
+
+                                    Text("Add Note")
+
+                                    Spacer()
+                                }
+                                .foregroundColor(Color(.accent))
+                            })
+                            .frame(maxWidth: .infinity)
+                        }
+                        .padding()
+                        .background(Color.white)
+
+                        Divider()
+                    }
 
                 }
-                .background(Color(.listBackground))
             }
 
             VStack {
                 Divider()
 
                 Button("Take Payment ($40.0)", action: {
-
+                    print("Take payment pressed")
                 })
                 .buttonStyle(PrimaryButtonStyle())
+                .padding()
+
             }
         }
+        .background(Color(.listBackground))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/QuickOrderSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/QuickOrderSummary.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// View to summarize the quick order to be created
+///
+struct QuickOrderSummary: View {
+    var body: some View {
+        Text("Holi")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/QuickOrderSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/QuickOrderSummary.swift
@@ -4,6 +4,84 @@ import SwiftUI
 ///
 struct QuickOrderSummary: View {
     var body: some View {
-        Text("Holi")
+        VStack {
+            ScrollView {
+                VStack(spacing: 10) {
+
+                    HStack {
+                        Rectangle()
+                            .fill()
+                            .foregroundColor(.gray)
+                            .frame(width: 48, height: 48)
+
+                        Text("Custom Amount")
+
+                        Spacer()
+
+                        Text("$40.00")
+                    }
+                    .background(Color.white)
+
+
+                    TitleAndTextFieldRow(title: "Email", placeholder: "Enter Email", text: .constant(""))
+                        .background(Color.white)
+
+                    VStack(alignment: .leading) {
+                        Text("Payment")
+
+                        TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
+
+                        TitleAndToggleRow(title: "Charge Taxes", isOn: .constant(false))
+
+                        TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
+                    }
+                    .background(Color.white)
+
+                    VStack(alignment: .leading) {
+                        Text("Order Note")
+
+                        Button(action: {
+                            print("Tapped add note")
+                        }, label: {
+                            HStack {
+                                Rectangle()
+                                    .fill()
+                                    .frame(width: 24, height: 24)
+
+                                Text("Add Note")
+
+                                Spacer()
+                            }
+                            .foregroundColor(Color(.accent))
+                        })
+                        .frame(maxWidth: .infinity)
+
+
+                    }
+                    .background(Color.white)
+
+                }
+                .background(Color(.listBackground))
+            }
+
+            VStack {
+                Divider()
+
+                Button("Take Payment ($40.0)", action: {
+
+                })
+                .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+    }
+}
+
+// MARK: Previews
+
+struct QuickOrderSummary_Preview: PreviewProvider {
+    static var previews: some View {
+        QuickOrderSummary()
+            .previewDevice(PreviewDevice(rawValue: "iPhone 12"))
+            .previewDisplayName("iPhone 12")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// View to summarize the quick order to be created
+/// View to summarize the Simple Payments order to be created
 ///
-struct QuickOrderSummary: View {
+struct SimplePaymentsSummary: View {
     var body: some View {
         VStack {
             ScrollView {
@@ -107,9 +107,9 @@ struct QuickOrderSummary: View {
 
 // MARK: Previews
 
-struct QuickOrderSummary_Preview: PreviewProvider {
+struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
-        QuickOrderSummary()
+        SimplePaymentsSummary()
             .previewDevice(PreviewDevice(rawValue: "iPhone 12"))
             .previewDisplayName("iPhone 12")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -213,7 +213,7 @@ private extension SimplePaymentsSummary {
         static let emailPlaceHolder = NSLocalizedString("Enter Email",
                                                         comment: "Placeholder of the row that holds the provided email when creating a simple payment")
         static let payment = NSLocalizedString("Payment",
-                                               comment: "Title text of the row that shows that list the payment when creating a simple payment")
+                                               comment: "Title text of the row that shows the payment headline when creating a simple payment")
         static let subtotal = NSLocalizedString("Subtotal",
                                                comment: "Title text of the row that shows the subtotal when creating a simple payment")
         static let chargeTaxes = NSLocalizedString("Charge Taxes",

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -19,9 +19,11 @@ struct SimplePaymentsSummary: View {
                                 .background(Color(.listBackground))
 
                             Text(Localization.customAmount)
+                                .headlineStyle()
 
                             // Temporary data
                             Text("$40.00")
+                                .headlineStyle()
                                 .frame(maxWidth: .infinity, alignment: .trailing)
                         }
                         .bodyStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -12,7 +12,7 @@ struct SimplePaymentsSummary: View {
 
                         Divider()
 
-                        HStack {
+                        HStack(spacing: 16) {
                             Rectangle()
                                 .fill()
                                 .foregroundColor(.gray)
@@ -24,6 +24,7 @@ struct SimplePaymentsSummary: View {
 
                             Text("$40.00")
                         }
+                        .bodyStyle()
                         .padding()
                         .background(Color.white)
 
@@ -41,9 +42,10 @@ struct SimplePaymentsSummary: View {
 
                     Group {
                         Divider()
-                        VStack(alignment: .leading) {
+                        VStack(alignment: .leading, spacing: 8) {
 
                             Text("Payment")
+                                .headlineStyle()
                                 .padding([.horizontal, .top])
 
                             TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
@@ -51,7 +53,8 @@ struct SimplePaymentsSummary: View {
                             TitleAndToggleRow(title: "Charge Taxes", isOn: .constant(false))
                                 .padding([.leading, .trailing])
 
-                            TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
+                            // TODO: Update this to be able to inject proper style values
+                            TitleAndValueRow(title: "Order Total", value: .content("$40.0"), selectable: false) {}
                         }
                         .background(Color.white)
 
@@ -100,6 +103,7 @@ struct SimplePaymentsSummary: View {
                 .padding()
 
             }
+            .background(Color.white)
         }
         .background(Color(.listBackground))
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -26,7 +26,7 @@ struct SimplePaymentsSummary: View {
                         }
                         .bodyStyle()
                         .padding()
-                        .background(Color.white)
+                        .background(Color(.listForeground))
 
                         Divider()
                         Spacer(minLength: 16)
@@ -35,7 +35,7 @@ struct SimplePaymentsSummary: View {
                     Group {
                         Divider()
                         TitleAndTextFieldRow(title: "Email", placeholder: "Enter Email", text: .constant(""))
-                            .background(Color.white)
+                            .background(Color(.listForeground))
                         Divider()
                         Spacer(minLength: 16)
                     }
@@ -56,7 +56,7 @@ struct SimplePaymentsSummary: View {
                             // TODO: Update this to be able to inject proper style values
                             TitleAndValueRow(title: "Order Total", value: .content("$40.0"), selectable: false) {}
                         }
-                        .background(Color.white)
+                        .background(Color(.listForeground))
 
                         Divider()
                         Spacer(minLength: 16)
@@ -85,7 +85,7 @@ struct SimplePaymentsSummary: View {
                             .frame(maxWidth: .infinity)
                         }
                         .padding()
-                        .background(Color.white)
+                        .background(Color(.listForeground))
 
                         Divider()
                     }
@@ -103,7 +103,7 @@ struct SimplePaymentsSummary: View {
                 .padding()
 
             }
-            .background(Color.white)
+            .background(Color(.listForeground))
         }
         .background(Color(.listBackground))
     }
@@ -114,7 +114,15 @@ struct SimplePaymentsSummary: View {
 struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
         SimplePaymentsSummary()
-            .previewDevice(PreviewDevice(rawValue: "iPhone 12"))
-            .previewDisplayName("iPhone 12")
+            .environment(\.colorScheme, .light)
+            .previewDisplayName("Light")
+
+        SimplePaymentsSummary()
+            .environment(\.colorScheme, .dark)
+            .previewDisplayName("Dark")
+
+        SimplePaymentsSummary()
+            .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
+            .previewDisplayName("Accessibility")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -18,10 +18,11 @@ struct SimplePaymentsSummary: View {
                                 .foregroundColor(Color(.systemGray))
                                 .background(Color(.listBackground))
 
-                            Text("Custom Amount")
+                            Text(Localization.customAmount)
 
                             Spacer()
 
+                            // Temporary data
                             Text("$40.00")
                         }
                         .bodyStyle()
@@ -34,7 +35,7 @@ struct SimplePaymentsSummary: View {
 
                     Group {
                         Divider()
-                        TitleAndTextFieldRow(title: "Email", placeholder: "Enter Email", text: .constant(""))
+                        TitleAndTextFieldRow(title: Localization.email, placeholder: Localization.emailPlaceHolder, text: .constant(""))
                             .background(Color(.listForeground))
                         Divider()
                         Spacer(minLength: Layout.spacerHeight)
@@ -44,17 +45,20 @@ struct SimplePaymentsSummary: View {
                         Divider()
                         VStack(alignment: .leading, spacing: Layout.verticalSummarySpacing) {
 
-                            Text("Payment")
+                            Text(Localization.payment)
                                 .headlineStyle()
                                 .padding([.horizontal, .top])
 
-                            TitleAndValueRow(title: "Subtotal", value: .content("$40.0"), selectable: false) {}
+                            // Temporary data
+                            TitleAndValueRow(title: Localization.subtotal, value: .content("$40.0"), selectable: false) {}
 
-                            TitleAndToggleRow(title: "Charge Taxes", isOn: .constant(false))
+                            // Temporary data
+                            TitleAndToggleRow(title: Localization.chargeTaxes, isOn: .constant(false))
                                 .padding([.leading, .trailing])
 
                             // TODO: Update this to be able to inject proper style values
-                            TitleAndValueRow(title: "Order Total", value: .content("$40.0"), selectable: false) {}
+                            // Temporary data
+                            TitleAndValueRow(title: Localization.total, value: .content("$40.0"), selectable: false) {}
                         }
                         .background(Color(.listForeground))
 
@@ -66,7 +70,7 @@ struct SimplePaymentsSummary: View {
                         Divider()
 
                         VStack(alignment: .leading, spacing: Layout.verticalNoteSpacing) {
-                            Text("Order Note")
+                            Text(Localization.orderNote)
                                 .headlineStyle()
 
                             Button(action: {
@@ -75,7 +79,7 @@ struct SimplePaymentsSummary: View {
                                 HStack() {
                                     Image(uiImage: .plusImage)
 
-                                    Text("Add Note")
+                                    Text(Localization.addNote)
 
                                     Spacer()
                                 }
@@ -96,7 +100,8 @@ struct SimplePaymentsSummary: View {
             VStack {
                 Divider()
 
-                Button("Take Payment ($40.0)", action: {
+                // Temporary data
+                Button(Localization.takePayment(total: "$40.0"), action: {
                     print("Take payment pressed")
                 })
                 .buttonStyle(PrimaryButtonStyle())
@@ -117,6 +122,31 @@ private extension SimplePaymentsSummary {
         static let verticalSummarySpacing: CGFloat = 8.0
         static let verticalNoteSpacing: CGFloat = 22.0
         static let noSpacing: CGFloat = 0.0
+    }
+
+    enum Localization {
+        static let customAmount = NSLocalizedString("Custom Amount",
+                                                    comment: "Title text of the row that shows the provided amount when creating a simple payment")
+        static let email = NSLocalizedString("Email",
+                                             comment: "Title text of the row that holds the provided email when creating a simple payment")
+        static let emailPlaceHolder = NSLocalizedString("Enter Email",
+                                                        comment: "Placeholder of the row that holds the provided email when creating a simple payment")
+        static let payment = NSLocalizedString("Payment",
+                                               comment: "Title text of the row that shows that list the payment when creating a simple payment")
+        static let subtotal = NSLocalizedString("Subtotal",
+                                               comment: "Title text of the row that shows the subtotal when creating a simple payment")
+        static let chargeTaxes = NSLocalizedString("Charge Taxes",
+                                               comment: "Title text of the row that has a switch when creating a simple payment")
+        static let total = NSLocalizedString("Order Total",
+                                               comment: "Title text of the row that shows the total to charge when creating a simple payment")
+        static let orderNote = NSLocalizedString("Order Note",
+                                               comment: "Title text of the row that holds the order note when creating a simple payment")
+        static let addNote = NSLocalizedString("Add Note",
+                                               comment: "Title text of the button that adds a note when creating a simple payment")
+
+        static func takePayment(total: String) -> String {
+            NSLocalizedString("Take Payment (\(total))", comment: "Text of the button that creates a simple payment order. Contains the total amount to collect")
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -3,6 +3,11 @@ import SwiftUI
 /// View to summarize the Simple Payments order to be created
 ///
 struct SimplePaymentsSummary: View {
+
+    /// Order note content
+    ///
+    let noteContent: String?
+
     var body: some View {
         VStack {
             ScrollView {
@@ -20,7 +25,7 @@ struct SimplePaymentsSummary: View {
 
                     Spacer(minLength: Layout.spacerHeight)
 
-                    NoteSection()
+                    NoteSection(content: noteContent)
                 }
             }
 
@@ -110,32 +115,63 @@ private struct PaymentsSection: View {
 /// Represents the Order note section
 ///
 private struct NoteSection: View {
+
+    /// Order note content
+    ///
+    let content: String?
+
     var body: some View {
         Group {
             Divider()
 
             VStack(alignment: .leading, spacing: SimplePaymentsSummary.Layout.verticalNoteSpacing) {
-                Text(SimplePaymentsSummary.Localization.orderNote)
-                    .headlineStyle()
 
-                Button(action: {
-                    print("Tapped add note")
-                }, label: {
-                    HStack() {
-                        Image(uiImage: .plusImage)
+                HStack {
+                    Text(SimplePaymentsSummary.Localization.orderNote)
+                        .headlineStyle()
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Text(SimplePaymentsSummary.Localization.addNote)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                    Button(SimplePaymentsSummary.Localization.editNote) {
+                        print("Tapped on Edit")
                     }
                     .foregroundColor(Color(.accent))
                     .bodyStyle()
-                })
-                .frame(maxWidth: .infinity)
+                    .renderedIf(content != nil)
+                }
+
+                noteContent()
+
             }
             .padding()
             .background(Color(.listForeground))
 
             Divider()
+        }
+    }
+
+    /// Builds a button to add a note if no note is present. If there is a note present only displays it
+    ///
+    @ViewBuilder private func noteContent() -> some View {
+        if let content = content {
+
+            Text(content)
+                .bodyStyle()
+
+        } else {
+
+            Button(action: {
+                print("Tapped add note")
+            }, label: {
+                HStack() {
+                    Image(uiImage: .plusImage)
+
+                    Text(SimplePaymentsSummary.Localization.addNote)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .foregroundColor(Color(.accent))
+                .bodyStyle()
+            })
+            .frame(maxWidth: .infinity)
         }
     }
 }
@@ -188,6 +224,8 @@ private extension SimplePaymentsSummary {
                                                comment: "Title text of the row that holds the order note when creating a simple payment")
         static let addNote = NSLocalizedString("Add Note",
                                                comment: "Title text of the button that adds a note when creating a simple payment")
+        static let editNote = NSLocalizedString("Edit",
+                                               comment: "Title text of the button that edits a note when creating a simple payment")
 
         static func takePayment(total: String) -> String {
             NSLocalizedString("Take Payment (\(total))",
@@ -199,15 +237,19 @@ private extension SimplePaymentsSummary {
 // MARK: Previews
 struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
-        SimplePaymentsSummary()
+        SimplePaymentsSummary(noteContent: nil)
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
-        SimplePaymentsSummary()
+        SimplePaymentsSummary(noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard.")
+            .environment(\.colorScheme, .light)
+            .previewDisplayName("Light Content")
+
+        SimplePaymentsSummary(noteContent: nil)
             .environment(\.colorScheme, .dark)
             .previewDisplayName("Dark")
 
-        SimplePaymentsSummary()
+        SimplePaymentsSummary(noteContent: nil)
             .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
             .previewDisplayName("Accessibility")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -12,7 +12,7 @@ struct SimplePaymentsSummary: View {
 
                         Divider()
 
-                        HStack(spacing: Layout.horizontalStackSpacing) {
+                        AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.horizontalStackSpacing) {
                             Image(uiImage: .priceImage)
                                 .padding()
                                 .foregroundColor(Color(.systemGray))
@@ -20,10 +20,9 @@ struct SimplePaymentsSummary: View {
 
                             Text(Localization.customAmount)
 
-                            Spacer()
-
                             // Temporary data
                             Text("$40.00")
+                                .frame(maxWidth: .infinity, alignment: .trailing)
                         }
                         .bodyStyle()
                         .padding()
@@ -80,8 +79,7 @@ struct SimplePaymentsSummary: View {
                                     Image(uiImage: .plusImage)
 
                                     Text(Localization.addNote)
-
-                                    Spacer()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
                                 }
                                 .foregroundColor(Color(.accent))
                                 .bodyStyle()
@@ -145,7 +143,8 @@ private extension SimplePaymentsSummary {
                                                comment: "Title text of the button that adds a note when creating a simple payment")
 
         static func takePayment(total: String) -> String {
-            NSLocalizedString("Take Payment (\(total))", comment: "Text of the button that creates a simple payment order. Contains the total amount to collect")
+            NSLocalizedString("Take Payment (\(total))",
+                              comment: "Text of the button that creates a simple payment order. Contains the total amount to collect")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -13,10 +13,10 @@ struct SimplePaymentsSummary: View {
                         Divider()
 
                         HStack(spacing: 16) {
-                            Rectangle()
-                                .fill()
-                                .foregroundColor(.gray)
-                                .frame(width: 48, height: 48)
+                            Image(uiImage: .priceImage)
+                                .padding()
+                                .foregroundColor(Color(.systemGray))
+                                .background(Color(.listBackground))
 
                             Text("Custom Amount")
 
@@ -65,22 +65,22 @@ struct SimplePaymentsSummary: View {
                     Group {
                         Divider()
 
-                        VStack(alignment: .leading) {
+                        VStack(alignment: .leading, spacing: 22) {
                             Text("Order Note")
+                                .headlineStyle()
 
                             Button(action: {
                                 print("Tapped add note")
                             }, label: {
-                                HStack {
-                                    Rectangle()
-                                        .fill()
-                                        .frame(width: 24, height: 24)
+                                HStack() {
+                                    Image(uiImage: .plusImage)
 
                                     Text("Add Note")
 
                                     Spacer()
                                 }
                                 .foregroundColor(Color(.accent))
+                                .bodyStyle()
                             })
                             .frame(maxWidth: .infinity)
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -6,13 +6,13 @@ struct SimplePaymentsSummary: View {
     var body: some View {
         VStack {
             ScrollView {
-                VStack(spacing: 0) {
+                VStack(spacing: Layout.noSpacing) {
 
                     Group {
 
                         Divider()
 
-                        HStack(spacing: 16) {
+                        HStack(spacing: Layout.horizontalStackSpacing) {
                             Image(uiImage: .priceImage)
                                 .padding()
                                 .foregroundColor(Color(.systemGray))
@@ -29,7 +29,7 @@ struct SimplePaymentsSummary: View {
                         .background(Color(.listForeground))
 
                         Divider()
-                        Spacer(minLength: 16)
+                        Spacer(minLength: Layout.spacerHeight)
                     }
 
                     Group {
@@ -37,12 +37,12 @@ struct SimplePaymentsSummary: View {
                         TitleAndTextFieldRow(title: "Email", placeholder: "Enter Email", text: .constant(""))
                             .background(Color(.listForeground))
                         Divider()
-                        Spacer(minLength: 16)
+                        Spacer(minLength: Layout.spacerHeight)
                     }
 
                     Group {
                         Divider()
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: Layout.verticalSummarySpacing) {
 
                             Text("Payment")
                                 .headlineStyle()
@@ -59,13 +59,13 @@ struct SimplePaymentsSummary: View {
                         .background(Color(.listForeground))
 
                         Divider()
-                        Spacer(minLength: 16)
+                        Spacer(minLength: Layout.spacerHeight)
                     }
 
                     Group {
                         Divider()
 
-                        VStack(alignment: .leading, spacing: 22) {
+                        VStack(alignment: .leading, spacing: Layout.verticalNoteSpacing) {
                             Text("Order Note")
                                 .headlineStyle()
 
@@ -109,8 +109,18 @@ struct SimplePaymentsSummary: View {
     }
 }
 
-// MARK: Previews
+// MARK: Constants
+private extension SimplePaymentsSummary {
+    enum Layout {
+        static let spacerHeight: CGFloat = 16.0
+        static let horizontalStackSpacing: CGFloat = 16.0
+        static let verticalSummarySpacing: CGFloat = 8.0
+        static let verticalNoteSpacing: CGFloat = 22.0
+        static let noSpacing: CGFloat = 0.0
+    }
+}
 
+// MARK: Previews
 struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
         SimplePaymentsSummary()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -55,9 +55,8 @@ struct SimplePaymentsSummary: View {
                             TitleAndToggleRow(title: Localization.chargeTaxes, isOn: .constant(false))
                                 .padding([.leading, .trailing])
 
-                            // TODO: Update this to be able to inject proper style values
                             // Temporary data
-                            TitleAndValueRow(title: Localization.total, value: .content("$40.0"), selectable: false) {}
+                            TitleAndValueRow(title: Localization.total, value: .content("$40.0"), bold: true, selectable: false) {}
                         }
                         .background(Color(.listForeground))
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -74,7 +74,7 @@ private struct EmailSection: View {
 
             TitleAndTextFieldRow(title: SimplePaymentsSummary.Localization.email,
                                  placeholder: SimplePaymentsSummary.Localization.emailPlaceHolder,
-                                 text: .constant(""))
+                                 text: .constant("")) // Temporary data
                 .background(Color(.listForeground))
 
             Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -8,108 +8,154 @@ struct SimplePaymentsSummary: View {
             ScrollView {
                 VStack(spacing: Layout.noSpacing) {
 
-                    Group {
+                    CustomAmountSection()
 
-                        Divider()
+                    Spacer(minLength: Layout.spacerHeight)
 
-                        AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.horizontalStackSpacing) {
-                            Image(uiImage: .priceImage)
-                                .padding()
-                                .foregroundColor(Color(.systemGray))
-                                .background(Color(.listBackground))
+                    EmailSection()
 
-                            Text(Localization.customAmount)
-                                .headlineStyle()
+                    Spacer(minLength: Layout.spacerHeight)
 
-                            // Temporary data
-                            Text("$40.00")
-                                .headlineStyle()
-                                .frame(maxWidth: .infinity, alignment: .trailing)
-                        }
-                        .bodyStyle()
-                        .padding()
-                        .background(Color(.listForeground))
+                    PaymentsSection()
 
-                        Divider()
-                        Spacer(minLength: Layout.spacerHeight)
-                    }
+                    Spacer(minLength: Layout.spacerHeight)
 
-                    Group {
-                        Divider()
-                        TitleAndTextFieldRow(title: Localization.email, placeholder: Localization.emailPlaceHolder, text: .constant(""))
-                            .background(Color(.listForeground))
-                        Divider()
-                        Spacer(minLength: Layout.spacerHeight)
-                    }
-
-                    Group {
-                        Divider()
-                        VStack(alignment: .leading, spacing: Layout.verticalSummarySpacing) {
-
-                            Text(Localization.payment)
-                                .headlineStyle()
-                                .padding([.horizontal, .top])
-
-                            // Temporary data
-                            TitleAndValueRow(title: Localization.subtotal, value: .content("$40.0"), selectable: false) {}
-
-                            // Temporary data
-                            TitleAndToggleRow(title: Localization.chargeTaxes, isOn: .constant(false))
-                                .padding([.leading, .trailing])
-
-                            // Temporary data
-                            TitleAndValueRow(title: Localization.total, value: .content("$40.0"), bold: true, selectable: false) {}
-                        }
-                        .background(Color(.listForeground))
-
-                        Divider()
-                        Spacer(minLength: Layout.spacerHeight)
-                    }
-
-                    Group {
-                        Divider()
-
-                        VStack(alignment: .leading, spacing: Layout.verticalNoteSpacing) {
-                            Text(Localization.orderNote)
-                                .headlineStyle()
-
-                            Button(action: {
-                                print("Tapped add note")
-                            }, label: {
-                                HStack() {
-                                    Image(uiImage: .plusImage)
-
-                                    Text(Localization.addNote)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                }
-                                .foregroundColor(Color(.accent))
-                                .bodyStyle()
-                            })
-                            .frame(maxWidth: .infinity)
-                        }
-                        .padding()
-                        .background(Color(.listForeground))
-
-                        Divider()
-                    }
-
+                    NoteSection()
                 }
             }
 
-            VStack {
-                Divider()
-
-                // Temporary data
-                Button(Localization.takePayment(total: "$40.0"), action: {
-                    print("Take payment pressed")
-                })
-                .buttonStyle(PrimaryButtonStyle())
-                .padding()
-
-            }
-            .background(Color(.listForeground))
+            TakePaymentSection()
         }
         .background(Color(.listBackground))
+    }
+}
+
+/// Represents the Custom amount section
+///
+private struct CustomAmountSection: View {
+    var body: some View {
+        Group {
+            Divider()
+
+            AdaptiveStack(horizontalAlignment: .leading, spacing: SimplePaymentsSummary.Layout.horizontalStackSpacing) {
+                Image(uiImage: .priceImage)
+                    .padding()
+                    .foregroundColor(Color(.systemGray))
+                    .background(Color(.listBackground))
+
+                Text(SimplePaymentsSummary.Localization.customAmount)
+                    .headlineStyle()
+
+                // Temporary data
+                Text("$40.00")
+                    .headlineStyle()
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .bodyStyle()
+            .padding()
+            .background(Color(.listForeground))
+
+            Divider()
+        }
+    }
+}
+
+/// Represents the email section
+///
+private struct EmailSection: View {
+    var body: some View {
+        Group {
+            Divider()
+
+            TitleAndTextFieldRow(title: SimplePaymentsSummary.Localization.email,
+                                 placeholder: SimplePaymentsSummary.Localization.emailPlaceHolder,
+                                 text: .constant(""))
+                .background(Color(.listForeground))
+
+            Divider()
+        }
+    }
+}
+
+/// Represents the Payments Section
+///
+private struct PaymentsSection: View {
+    var body: some View {
+        Group {
+            Divider()
+
+            VStack(alignment: .leading, spacing: SimplePaymentsSummary.Layout.verticalSummarySpacing) {
+
+                Text(SimplePaymentsSummary.Localization.payment)
+                    .headlineStyle()
+                    .padding([.horizontal, .top])
+
+                // Temporary data
+                TitleAndValueRow(title: SimplePaymentsSummary.Localization.subtotal, value: .content("$40.0"), selectable: false) {}
+
+                // Temporary data
+                TitleAndToggleRow(title: SimplePaymentsSummary.Localization.chargeTaxes, isOn: .constant(false))
+                    .padding([.leading, .trailing])
+
+                // Temporary data
+                TitleAndValueRow(title: SimplePaymentsSummary.Localization.total, value: .content("$40.0"), bold: true, selectable: false) {}
+            }
+            .background(Color(.listForeground))
+
+            Divider()
+        }
+    }
+}
+
+/// Represents the Order note section
+///
+private struct NoteSection: View {
+    var body: some View {
+        Group {
+            Divider()
+
+            VStack(alignment: .leading, spacing: SimplePaymentsSummary.Layout.verticalNoteSpacing) {
+                Text(SimplePaymentsSummary.Localization.orderNote)
+                    .headlineStyle()
+
+                Button(action: {
+                    print("Tapped add note")
+                }, label: {
+                    HStack() {
+                        Image(uiImage: .plusImage)
+
+                        Text(SimplePaymentsSummary.Localization.addNote)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .foregroundColor(Color(.accent))
+                    .bodyStyle()
+                })
+                .frame(maxWidth: .infinity)
+            }
+            .padding()
+            .background(Color(.listForeground))
+
+            Divider()
+        }
+    }
+}
+
+/// Represents the bottom take payment button
+///
+private struct TakePaymentSection: View {
+    var body: some View {
+        VStack {
+            Divider()
+
+            // Temporary data
+            Button(SimplePaymentsSummary.Localization.takePayment(total: "$40.0"), action: {
+                print("Take payment pressed")
+            })
+            .buttonStyle(PrimaryButtonStyle())
+            .padding()
+
+        }
+        .background(Color(.listForeground))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -6,6 +6,7 @@ struct TitleAndValueRow: View {
 
     let title: String
     let value: Value
+    var bold: Bool = false
     let selectable: Bool
     var action: () -> Void
 
@@ -19,9 +20,9 @@ struct TitleAndValueRow: View {
             HStack {
                 AdaptiveStack(horizontalAlignment: .leading) {
                     Text(title)
-                        .bodyStyle()
+                        .style(bold: bold)
                     Text(value.text)
-                        .style(for: value)
+                        .style(for: value, bold: bold)
                         .frame(maxWidth: .infinity, alignment: .trailing)
                         .padding(.vertical, Constants.verticalPadding)
                 }
@@ -69,11 +70,13 @@ extension TitleAndValueRow {
 private extension Text {
     /// Styles the text based on the type of content.
     ///
-    @ViewBuilder func style(for value: TitleAndValueRow.Value) -> some View {
-        switch value {
-        case .placeholder:
+    @ViewBuilder func style(for value: TitleAndValueRow.Value = .content(""), bold: Bool) -> some View {
+        switch (value, bold) {
+        case (.placeholder, _):
             self.modifier(SecondaryBodyStyle())
-        case .content:
+        case (.content, true):
+            self.modifier(HeadlineStyle())
+        case (.content, false):
             self.modifier(BodyStyle(isEnabled: true))
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -12,9 +12,6 @@ struct TitleAndValueRow: View {
 
     var body: some View {
         Button(action: {
-            guard selectable else {
-                return
-            }
             action()
         }, label: {
             HStack {
@@ -35,6 +32,7 @@ struct TitleAndValueRow: View {
             }
             .contentShape(Rectangle())
         })
+        .disabled(!selectable)
         .frame(minHeight: Constants.minHeight)
         .padding(.horizontal, Constants.horizontalPadding)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 		26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
-		26CFDB2727357E8000AB940B /* QuickOrderSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* QuickOrderSummary.swift */; };
+		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
 		26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE12263359F900A5EB3B /* View+Conditionals.swift */; };
 		26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE1826335AA900A5EB3B /* Survey.swift */; };
@@ -1911,7 +1911,7 @@
 		26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyNavigationLink.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
-		26CFDB2627357E8000AB940B /* QuickOrderSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOrderSummary.swift; sourceTree = "<group>"; };
+		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
 		26E0AE12263359F900A5EB3B /* View+Conditionals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Conditionals.swift"; sourceTree = "<group>"; };
 		26E0AE1826335AA900A5EB3B /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
@@ -3975,7 +3975,7 @@
 				2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */,
 				262AF386271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift */,
 				26100B1D2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift */,
-                26CFDB2627357E8000AB940B /* QuickOrderSummary.swift */,
+				26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */,
 			);
 			path = "Simple Payments";
 			sourceTree = "<group>";
@@ -8097,7 +8097,7 @@
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
 				0229ED00258767BC00C336F8 /* ShippingLabelPrintingStepContentView.swift in Sources */,
 				D8EE9698264D3CCB0033B2F9 /* ReceiptViewModel.swift in Sources */,
-				26CFDB2727357E8000AB940B /* QuickOrderSummary.swift in Sources */,
+				26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */,
 				CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
 				02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 		26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
+		26CFDB2727357E8000AB940B /* QuickOrderSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* QuickOrderSummary.swift */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
 		26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE12263359F900A5EB3B /* View+Conditionals.swift */; };
 		26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE1826335AA900A5EB3B /* Survey.swift */; };
@@ -1910,6 +1911,7 @@
 		26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyNavigationLink.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
+		26CFDB2627357E8000AB940B /* QuickOrderSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOrderSummary.swift; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
 		26E0AE12263359F900A5EB3B /* View+Conditionals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Conditionals.swift"; sourceTree = "<group>"; };
 		26E0AE1826335AA900A5EB3B /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
@@ -3973,6 +3975,7 @@
 				2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */,
 				262AF386271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift */,
 				26100B1D2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift */,
+                26CFDB2627357E8000AB940B /* QuickOrderSummary.swift */,
 			);
 			path = "Simple Payments";
 			sourceTree = "<group>";
@@ -8094,6 +8097,7 @@
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
 				0229ED00258767BC00C336F8 /* ShippingLabelPrintingStepContentView.swift in Sources */,
 				D8EE9698264D3CCB0033B2F9 /* ReceiptViewModel.swift in Sources */,
+				26CFDB2727357E8000AB940B /* QuickOrderSummary.swift in Sources */,
 				CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
 				02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */,


### PR DESCRIPTION
# Why

In order to continue the Simple Payments (Quick Order before) project, this PR adds the Simple Payments Summary Screen UI.

PS: This is only UI, no interaction is coded yet.

# How
- Updated `TitleAndValueRow` to be able to style its labels with a headling/bold style.
- Created `SimplePaymentsSummary` which is broken into sections for easier reading & maintenance.

# Screenshots

Light | Light With Note | Dark
--- | --- | ---
<img width="426" alt="light-no-content" src="https://user-images.githubusercontent.com/562080/140867132-95f7a012-7c36-42af-a6f8-190c91a216f5.png"> | <img width="429" alt="light-content" src="https://user-images.githubusercontent.com/562080/140867134-64ac8c83-3533-4c66-907f-2573c14526ce.png"> | <img width="432" alt="dark" src="https://user-images.githubusercontent.com/562080/140867135-c6a5f576-6644-44cd-ae22-e41994cf4e65.png">

## Accessibility

https://user-images.githubusercontent.com/562080/140867120-25b91878-8507-482c-a3ca-c3b381346588.mov


# Testing Steps

- See the previews on XCode canvas.



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
