### PR TITLE
Jetpack CP: benefits banner UI

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -13,6 +13,12 @@ extension UIImage {
         return UIImage.gridicon(.addOutline)
     }
 
+    /// Alarm Bell Ring Image
+    ///
+    static var alarmBellRingImage: UIImage {
+        return UIImage(named: "icon-alarm-bell-ring")!
+    }
+
     /// Arrow Up Icon
     ///
     static var arrowUp: UIImage {
@@ -23,6 +29,12 @@ extension UIImage {
     ///
     static var alignJustifyImage: UIImage {
         return UIImage.gridicon(.alignJustify)
+    }
+
+    /// Analytics Image
+    ///
+    static var analyticsImage: UIImage {
+        return UIImage(named: "icon-analytics")!
     }
 
     /// Notice Icon
@@ -730,6 +742,12 @@ extension UIImage {
     ///
     static var megaphoneIcon: UIImage {
         return UIImage(imageLiteralResourceName: "megaphone").imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Multiple Users Image
+    ///
+    static var multipleUsersImage: UIImage {
+        return UIImage(named: "icon-multiple-users")!
     }
 
     /// Error image

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -13,12 +13,6 @@ extension UIImage {
         return UIImage.gridicon(.addOutline)
     }
 
-    /// Alarm Bell Ring Image
-    ///
-    static var alarmBellRingImage: UIImage {
-        return UIImage(named: "icon-alarm-bell-ring")!
-    }
-
     /// Arrow Up Icon
     ///
     static var arrowUp: UIImage {
@@ -29,12 +23,6 @@ extension UIImage {
     ///
     static var alignJustifyImage: UIImage {
         return UIImage.gridicon(.alignJustify)
-    }
-
-    /// Analytics Image
-    ///
-    static var analyticsImage: UIImage {
-        return UIImage(named: "icon-analytics")!
     }
 
     /// Notice Icon
@@ -742,12 +730,6 @@ extension UIImage {
     ///
     static var megaphoneIcon: UIImage {
         return UIImage(imageLiteralResourceName: "megaphone").imageFlippedForRightToLeftLayoutDirection()
-    }
-
-    /// Multiple Users Image
-    ///
-    static var multipleUsersImage: UIImage {
-        return UIImage(named: "icon-multiple-users")!
     }
 
     /// Error image

--- a/WooCommerce/Classes/Styles/ColorStudio.swift
+++ b/WooCommerce/Classes/Styles/ColorStudio.swift
@@ -3,6 +3,7 @@ enum ColorStudioName: String, CustomStringConvertible {
     // MARK: - Base colors
     case blue
     case celadon
+    case jetpackGreen
     case gray
     case green
     case orange
@@ -68,6 +69,7 @@ struct ColorStudio {
     static let red = ColorStudio(name: .red)
     static let gray = ColorStudio(name: .gray)
     static let blue = ColorStudio(name: .blue)
+    static let jetpackGreen = ColorStudio(name: .jetpackGreen)
     static let green = ColorStudio(name: .green)
     static let yellow = ColorStudio(name: .yellow)
     static let orange = ColorStudio(name: .orange)

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -301,6 +301,19 @@ extension UIColor {
     static var softwareUpdateProgressFill: UIColor {
         return UIColor(red: 0.498, green: 0.329, blue: 0.702, alpha: 1)
     }
+
+    /// Jetpack benefits banner background color.
+    ///
+    static var jetpackBenefitsBackground: UIColor {
+        return UIColor(red: 11.0/255, green: 38.0/255, blue: 33.0/255, alpha: 1)
+    }
+
+    /// Jetpack logo color.
+    ///
+    static var jetpackGreen: UIColor {
+        return UIColor(light: .withColorStudio(.jetpackGreen, shade: .shade30),
+                       dark: .withColorStudio(.jetpackGreen, shade: .shade30))
+    }
 }
 
 // MARK: - UI elements.

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -305,14 +305,13 @@ extension UIColor {
     /// Jetpack benefits banner background color.
     ///
     static var jetpackBenefitsBackground: UIColor {
-        return UIColor(red: 11.0/255, green: 38.0/255, blue: 33.0/255, alpha: 1)
+        UIColor(red: 11.0/255, green: 38.0/255, blue: 33.0/255, alpha: 1)
     }
 
     /// Jetpack logo color.
     ///
     static var jetpackGreen: UIColor {
-        return UIColor(light: .withColorStudio(.jetpackGreen, shade: .shade30),
-                       dark: .withColorStudio(.jetpackGreen, shade: .shade30))
+        .withColorStudio(.jetpackGreen, shade: .shade20)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
@@ -35,7 +35,7 @@ struct JetpackBenefitsBanner: View {
     var body: some View {
         Group {
             HStack(spacing: Layout.horizontalSpacing) {
-                Image("icon-jetpack-gray")
+                Image(uiImage: .jetpackLogoImage)
                     .resizable()
                     .renderingMode(.template)
                     .foregroundColor(Color(.jetpackGreen))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
@@ -85,9 +85,19 @@ struct JetpackBenefitsBanner_Previews: PreviewProvider {
     static var previews: some View {
         JetpackBenefitsBanner()
             .preferredColorScheme(.dark)
-            .environment(\.sizeCategory, .extraExtraLarge)
+            .environment(\.sizeCategory, .extraSmall)
+            .previewLayout(.sizeThatFits)
         JetpackBenefitsBanner()
             .preferredColorScheme(.light)
+            .environment(\.sizeCategory, .medium)
+            .previewLayout(.sizeThatFits)
+        JetpackBenefitsBanner()
+            .preferredColorScheme(.dark)
             .environment(\.sizeCategory, .extraExtraLarge)
+            .previewLayout(.sizeThatFits)
+        JetpackBenefitsBanner()
+            .preferredColorScheme(.light)
+            .environment(\.sizeCategory, .extraExtraExtraLarge)
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
@@ -56,14 +56,12 @@ struct JetpackBenefitsBanner: View {
             }
             .padding(insets: Layout.padding)
         }
-        .gesture(
-            TapGesture()
-                .onEnded { _ in
-                    self.tapAction()
-                }
-        )
         .background(Color(.jetpackBenefitsBackground))
         .fixedSize(horizontal: false, vertical: true)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            self.tapAction()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Hosting controller wrapper for `JetpackBenefitsBanner`
+///
+final class JetpackBenefitsBannerHostingController: UIHostingController<JetpackBenefitsBanner> {
+    init() {
+        super.init(rootView: JetpackBenefitsBanner())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Actions are set in a separate function because most of the time, they will require to access `self` to be able to present new view controllers.
+    ///
+    func setActions(tapAction: @escaping () -> Void, dismissAction: @escaping () -> Void) {
+        rootView.tapAction = tapAction
+        rootView.dismissAction = dismissAction
+    }
+}
+
+/// A banner about Jetpack benefits that can be tapped to show more details or dismiss.
+struct JetpackBenefitsBanner: View {
+    /// Closure invoked when the banner is tapped
+    ///
+    var tapAction: () -> Void = {}
+
+    /// Closure invoked when the dismiss button is tapped
+    ///
+    var dismissAction: () -> Void = {}
+
+    // Tracks the scale of the view due to accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    var body: some View {
+        Group {
+            HStack(spacing: Layout.horizontalSpacing) {
+                Image("icon-jetpack-gray")
+                    .resizable()
+                    .renderingMode(.template)
+                    .foregroundColor(Color(.jetpackGreen))
+                    .frame(width: Layout.iconDimension * scale, height: Layout.iconDimension * scale)
+                VStack(alignment: .leading, spacing: Layout.verticalTextSpacing) {
+                    Text(Localization.title)
+                        .foregroundColor(.white)
+                        .bodyStyle()
+                    Text(Localization.subtitle)
+                        .foregroundColor(Color(.gray(.shade30)))
+                        .bodyStyle()
+                }
+                Spacer()
+                Button(action: dismissAction) {
+                    Image(uiImage: .closeButton)
+                        .foregroundColor(Color(.gray(.shade30)))
+                }
+            }
+            .padding(insets: Layout.padding)
+        }
+        .gesture(
+            TapGesture()
+                .onEnded { _ in
+                    self.tapAction()
+                }
+        )
+        .background(Color(.jetpackBenefitsBackground))
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private extension JetpackBenefitsBanner {
+    enum Localization {
+        static let title = NSLocalizedString("Get the full experience with Jetpack", comment: "Title of the Jetpack benefits banner.")
+        static let subtitle = NSLocalizedString("See the benefits", comment: "Subtitle of the Jetpack benefits banner.")
+    }
+
+    enum Layout {
+        static let padding = EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let iconDimension = CGFloat(24)
+        static let horizontalSpacing = CGFloat(10)
+        static let verticalTextSpacing = CGFloat(5)
+    }
+}
+
+struct JetpackBenefitsBanner_Previews: PreviewProvider {
+    static var previews: some View {
+        JetpackBenefitsBanner()
+            .preferredColorScheme(.dark)
+            .environment(\.sizeCategory, .extraExtraLarge)
+        JetpackBenefitsBanner()
+            .preferredColorScheme(.light)
+            .environment(\.sizeCategory, .extraExtraLarge)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 		02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F67FF425806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift */; };
 		02F6800325807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */; };
 		02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800825807CD300C3BAD2 /* GridStackView.swift */; };
+		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
@@ -1830,6 +1831,7 @@
 		02F67FF425806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelTrackingURLGeneratorTests.swift; sourceTree = "<group>"; };
 		02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionListView.swift; sourceTree = "<group>"; };
 		02F6800825807CD300C3BAD2 /* GridStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridStackView.swift; sourceTree = "<group>"; };
+		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -3853,6 +3855,14 @@
 				4569D3F225DC1BEC00CDC3E2 /* Create Shipping Label */,
 			);
 			path = "Shipping Label";
+			sourceTree = "<group>";
+		};
+		02F843D8273646190017FE12 /* JetpackConnectionPackageSites */ = {
+			isa = PBXGroup;
+			children = (
+				02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */,
+			);
+			path = JetpackConnectionPackageSites;
 			sourceTree = "<group>";
 		};
 		2611EE57243A46C500A74490 /* Categories */ = {
@@ -6092,6 +6102,7 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				02F843D8273646190017FE12 /* JetpackConnectionPackageSites */,
 				028BAC4322F3AE3B008BB4AF /* Stats v4 */,
 				029D444B22F1417400DEFA8A /* Stats v3 */,
 				029D444722F13F5C00DEFA8A /* Factories */,
@@ -8102,6 +8113,7 @@
 				B5AA7B3D20ED5D15004DA14F /* SessionManager.swift in Sources */,
 				74C6FEA521C2F1FA009286B6 /* AboutViewController.swift in Sources */,
 				B53B3F37219C75AC00DF1EB6 /* OrderLoaderViewController.swift in Sources */,
+				02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */,
 				027D4A8D2526FD1800108626 /* SettingsViewController.swift in Sources */,
 				02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */,
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,


### PR DESCRIPTION
Part of #5362 

## Why

We want to inform users with Jetpack Connection Package (JCP) sites (without Jetpack-the-plugin) about the benefits of installing Jetpack-the-plugin. In the My Store tab, we show a bottom banner for JCP sites with two actions:
- Tapping on the banner shows a screen with Jetpack benefits with a CTA to install Jetpack
- Tapping on the dismiss button dismisses the banner for the site

This PR just contains the UI for the banner for easier code review.

## Changes

- Created `JetpackBenefitsBanner` with a hosting controller `JetpackBenefitsBannerHostingController`. Please note that the design is the same for Dark and Light mode
- Added JetpackGreen colors that are in `ColorPalette.xcassets`

## Testing

Feel free to play with SwiftUI previews with more configurations!

## Example screenshots

<img width="428" alt="Screen Shot 2021-11-09 at 1 28 10 PM" src="https://user-images.githubusercontent.com/1945542/140868412-f8acd278-0316-4845-9723-562582886e5d.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
