### PR TITLE
Update README.md with more api credentials information

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In order to login to WordPress.com using the app:
 
 1. Create a [WordPress.com account](https://wordpress.com/start/user) (if you don't already have one).
 2. Create a new developer application [here](https://developer.wordpress.com/apps/).
-3. Set **"Redirect URLs"** = `https://localhost` and **"Type"** = `Native` and click **Create**. On the next page, click **Update**.
+3. Set **"Website URL"** = `http://www.wordpress.com`, **"Redirect URLs"** = `https://localhost`, **"Javascript Origins"** = `https://localhost` and **"Type"** = `Native` and click **Create**. On the next page, click **Update**.
 4. Copy the *Client ID* and *Client Secret* from the OAuth Information.
 5. Build the app. A file named `ApiCredentials.swift` should be generated.
 6. Navigate to the generated `WooCommerce/DerivedSources/ApiCredentials.swift` file.


### PR DESCRIPTION
# Why

Recently, one trial candidate had problems configuring its app setup. Upon investigation, what was missing was some more URLs on the "Javascript Origins" and "Website URL" fields.

This PR update the docs to make those instructions more clear.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
