### PR TITLE
Commit bundlers new preferred without line location

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -2,5 +2,5 @@
 BUNDLE_RETRY: "3"
 BUNDLE_PATH: "vendor/bundle"
 BUNDLE_JOBS: "16"
-BUNDLE_WITHOUT: "screenshots"
 BUNDLE_SPECIFIC_PLATFORM: "false"
+BUNDLE_WITHOUT: "screenshots"


### PR DESCRIPTION
Fixes #5384 

Changes:
- Commits bundler's new preferred location for the BUNDLE_WITHOUT line in the .bundle/config file
- Tested with bundler 2.2.27

To test:
- ensure that after running `bundle install` that the .bundle/config file is not marked modified

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
