### PR TITLE
Simple Payments: Connect Summary View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmount.swift
@@ -85,6 +85,10 @@ struct SimplePaymentsAmount: View {
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsAmountViewModel
 
+    /// Tracks if the summary view should be presented.
+    ///
+    @State private var showSummaryView: Bool = false
+
     var body: some View {
         VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
 
@@ -105,10 +109,18 @@ struct SimplePaymentsAmount: View {
 
             // Done button
             Button(Localization.buttonTitle()) {
-                viewModel.createSimplePaymentsOrder()
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplePaymentsPrototype) {
+                    showSummaryView.toggle()
+                } else {
+                    viewModel.createSimplePaymentsOrder()
+                }
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)
+
+            LazyNavigationLink(destination: SimplePaymentsSummary(noteContent: nil), isActive: $showSummaryView) {
+                EmptyView()
+            }
         }
         .padding()
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsAmount.swift
@@ -104,7 +104,7 @@ struct SimplePaymentsAmount: View {
             Spacer()
 
             // Done button
-            Button(Localization.buttonTitle) {
+            Button(Localization.buttonTitle()) {
                 viewModel.createSimplePaymentsOrder()
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
@@ -128,9 +128,16 @@ private extension SimplePaymentsAmount {
     enum Localization {
         static let title = NSLocalizedString("Take Payment", comment: "Title for the simple payments screen")
         static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the simple payments screen")
-        static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the simple payments screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the simple payments screen")
         static let error = NSLocalizedString("There was an error creating the order", comment: "Notice text after failing to create a simple payments order.")
+
+        static func buttonTitle() -> String {
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplePaymentsPrototype) {
+                return NSLocalizedString("Next", comment: "Title for the button to confirm the amount in the simple payments screen")
+            } else {
+                return NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the simple payments screen")
+            }
+        }
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -192,7 +192,7 @@ private struct TakePaymentSection: View {
             .padding()
 
         }
-        .background(Color(.listForeground))
+        .background(Color(.listForeground).ignoresSafeArea())
     }
 }
 
@@ -243,11 +243,15 @@ struct SimplePaymentsSummary_Preview: PreviewProvider {
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
+        NavigationView {
         SimplePaymentsSummary(noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard.")
+        }
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
 
+        NavigationView {
         SimplePaymentsSummary(noteContent: nil)
+        }
             .environment(\.colorScheme, .dark)
             .previewDisplayName("Dark")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -31,7 +31,7 @@ struct SimplePaymentsSummary: View {
 
             TakePaymentSection()
         }
-        .background(Color(.listBackground))
+        .background(Color(.listBackground).ignoresSafeArea())
         .navigationTitle(Localization.title)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -32,6 +32,7 @@ struct SimplePaymentsSummary: View {
             TakePaymentSection()
         }
         .background(Color(.listBackground))
+        .navigationTitle(Localization.title)
     }
 }
 
@@ -206,6 +207,7 @@ private extension SimplePaymentsSummary {
     }
 
     enum Localization {
+        static let title = NSLocalizedString("Take Payment", comment: "Title for the simple payments screen")
         static let customAmount = NSLocalizedString("Custom Amount",
                                                     comment: "Title text of the row that shows the provided amount when creating a simple payment")
         static let email = NSLocalizedString("Email",

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/SimplePaymentsSummary.swift
@@ -243,15 +243,11 @@ struct SimplePaymentsSummary_Preview: PreviewProvider {
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
-        NavigationView {
         SimplePaymentsSummary(noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard.")
-        }
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
 
-        NavigationView {
         SimplePaymentsSummary(noteContent: nil)
-        }
             .environment(\.colorScheme, .dark)
             .previewDisplayName("Dark")
 


### PR DESCRIPTION
closes #5344

# Why 

After the "Summary UI" was merged in #5377, now is time to make it accessible from the "Enter Ammount" view.
This is done under a feature flag, so the current prototype keeps working as it is in production.

Also, This PR fixes a small glitch where the bottom section of the summary screen had the wrong color in dark mode.

# How

- Added a programmatic navigation link in `SimplePaymentsAmount` to navigate to `SimplePaymentsSummary`
- Updated `SimplePaymentsAmount` to change the done button text depending on the feature flag status.
- Added a navigation title in `SimplePaymentsSummary`

# Demo

https://user-images.githubusercontent.com/562080/141027721-28863012-d4d4-48da-8e5a-9eddb5b4b315.mov

## Dark Mode

Before | After
---- | ----
<img width="462" alt="Screen Shot 2021-11-09 at 7 39 03 PM" src="https://user-images.githubusercontent.com/562080/141028324-01d5248d-3d03-4ae0-b0cf-6aaa73850024.png"> | <img width="463" alt="Screen Shot 2021-11-09 at 7 35 52 PM" src="https://user-images.githubusercontent.com/562080/141027968-f374775b-8171-4337-a4dd-7ca908f503be.png">

# Testing Steps

- Login with an IPP eligible store and make sure the Simple Payments Feature is enabled 
- Tap On the + button on the order list screen
- Enter an amount and tap next
- See that the app navigates to the summary screen 

PS: The summary screen has hardcoded data.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
