### PR TITLE
Product List: Prepare "filter products by product category" issue for release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -25,8 +25,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderListFilters:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .filterProductsByCategory:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .jetpackConnectionPackageSupport:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -50,10 +50,6 @@ public enum FeatureFlag: Int {
     ///
     case orderListFilters
 
-    /// Allows to filter products by a product category, persisting it so the filter can remain after restarting the app
-    ///
-    case filterProductsByCategory
-
     /// Allows sites with plugins that include Jetpack Connection Package and without Jetpack-the-plugin to connect to the app
     ///
     case jetpackConnectionPackageSupport

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 8.0
 -----
+- [*] Product List: Add support for product filtering by category. [https://github.com/woocommerce/woocommerce-ios/pull/5388]
 - [***] Push notifications are now supported for all connected stores. [https://github.com/woocommerce/woocommerce-ios/pull/5299]
 - [*] Fix: in Settings > Switch Store, tapping "Dismiss" after selecting a different store does not switch stores anymore. [https://github.com/woocommerce/woocommerce-ios/pull/5359]
 

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -35,9 +35,9 @@ final class FilterProductListViewModel: FilterListViewModel {
             self.numberOfActiveFilters = numberOfActiveFilters
         }
 
-        // Generate a string based on populated filters, like "instock,publish,simple"
+        // Generate a string based on populated filters, like "instock,publish,simple,clothes"
         var analyticsDescription: String {
-            let elements: [String?] = [stockStatus?.rawValue, productStatus?.rawValue, productType?.rawValue]
+            let elements: [String?] = [stockStatus?.rawValue, productStatus?.rawValue, productType?.rawValue, productCategory?.slug]
             return elements.compactMap { $0 }.joined(separator: ",")
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -51,41 +51,27 @@ final class FilterProductListViewModel: FilterListViewModel {
     private let productTypeFilterViewModel: FilterTypeViewModel
     private let productCategoryFilterViewModel: FilterTypeViewModel
 
-    private let featureFlagService: FeatureFlagService
-
     /// - Parameters:
     ///   - filters: the filters to be applied initially.
-    init(filters: Filters, siteID: Int64, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
-        self.featureFlagService = featureFlagService
-
+    init(filters: Filters, siteID: Int64) {
         self.stockStatusFilterViewModel = ProductListFilter.stockStatus.createViewModel(filters: filters)
         self.productStatusFilterViewModel = ProductListFilter.productStatus.createViewModel(filters: filters)
         self.productTypeFilterViewModel = ProductListFilter.productType.createViewModel(filters: filters)
         self.productCategoryFilterViewModel = ProductListFilter.productCategory(siteID: siteID).createViewModel(filters: filters)
 
-        var filterTypeViewModels = [
+        self.filterTypeViewModels = [
             stockStatusFilterViewModel,
             productStatusFilterViewModel,
-            productTypeFilterViewModel
+            productTypeFilterViewModel,
+            productCategoryFilterViewModel
         ]
-
-        if featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory) {
-            filterTypeViewModels.append(productCategoryFilterViewModel)
-        }
-
-        self.filterTypeViewModels = filterTypeViewModels
     }
 
     var criteria: Filters {
         let stockStatus = stockStatusFilterViewModel.selectedValue as? ProductStockStatus ?? nil
         let productStatus = productStatusFilterViewModel.selectedValue as? ProductStatus ?? nil
         let productType = productTypeFilterViewModel.selectedValue as? ProductType ?? nil
-        var productCategory: ProductCategory? = nil
-
-        if featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory),
-           let selectedProductCategory = productCategoryFilterViewModel.selectedValue as? ProductCategory {
-            productCategory = selectedProductCategory
-        }
+        let productCategory = productCategoryFilterViewModel.selectedValue as? ProductCategory ?? nil
 
         let numberOfActiveFilters = filterTypeViewModels.numberOfActiveFilters
 
@@ -106,10 +92,8 @@ final class FilterProductListViewModel: FilterListViewModel {
         let clearedProductType: ProductType? = nil
         productTypeFilterViewModel.selectedValue = clearedProductType
 
-        if featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory) {
-            let clearedProductCategory: ProductCategory? = nil
-            productCategoryFilterViewModel.selectedValue = clearedProductCategory
-        }
+        let clearedProductCategory: ProductCategory? = nil
+        productCategoryFilterViewModel.selectedValue = clearedProductCategory
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -8,22 +8,19 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShippingLabelsPackageCreationOn: Bool
     private let isShippingLabelsMultiPackageOn: Bool
     private let isPushNotificationsForAllStoresOn: Bool
-    private let isFilterProductsByCategoryOn: Bool
 
     init(isShippingLabelsM2M3On: Bool = false,
          isInternationalShippingLabelsOn: Bool = false,
          isShippingLabelsPaymentMethodCreationOn: Bool = false,
          isShippingLabelsPackageCreationOn: Bool = false,
          isShippingLabelsMultiPackageOn: Bool = false,
-         isPushNotificationsForAllStoresOn: Bool = false,
-         isFilterProductsByCategoryOn: Bool = false) {
+         isPushNotificationsForAllStoresOn: Bool = false) {
         self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
         self.isInternationalShippingLabelsOn = isInternationalShippingLabelsOn
         self.isShippingLabelsPaymentMethodCreationOn = isShippingLabelsPaymentMethodCreationOn
         self.isShippingLabelsPackageCreationOn = isShippingLabelsPackageCreationOn
         self.isShippingLabelsMultiPackageOn = isShippingLabelsMultiPackageOn
         self.isPushNotificationsForAllStoresOn = isPushNotificationsForAllStoresOn
-        self.isFilterProductsByCategoryOn = isFilterProductsByCategoryOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -40,8 +37,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isShippingLabelsMultiPackageOn
         case .pushNotificationsForAllStores:
             return isPushNotificationsForAllStoresOn
-        case .filterProductsByCategory:
-            return isFilterProductsByCategoryOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -30,8 +30,7 @@ final class FilterProductListViewModelTests: XCTestCase {
                                                          numberOfActiveFilters: 4)
 
         // When
-        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: true)
-        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0)
 
         // Then
         let expectedCriteria = filters
@@ -47,8 +46,7 @@ final class FilterProductListViewModelTests: XCTestCase {
                                                          numberOfActiveFilters: 4)
 
         // When
-        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: true)
-        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0)
         viewModel.clearAll()
 
         // Then
@@ -58,45 +56,5 @@ final class FilterProductListViewModelTests: XCTestCase {
                                                                   productCategory: nil,
                                                                   numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
-    }
-
-    func test_criteria_with_non_nil_filters_and_isFilterProductsByCategoryOff_then_it_returns_all_active_filters_minus_filterProductCategory() {
-        // Given
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
-                                                         productStatus: .draft,
-                                                         productType: .grouped,
-                                                         productCategory: filterProductCategory,
-                                                         numberOfActiveFilters: 4)
-
-        // When
-        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: false)
-        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
-
-        // Then
-        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: filters.stockStatus,
-                                                                  productStatus: filters.productStatus,
-                                                                  productType: filters.productType,
-                                                                  productCategory: nil,
-                                                                  numberOfActiveFilters: 3)
-        XCTAssertEqual(viewModel.criteria, expectedCriteria)
-    }
-
-    func test_viewModels_when_isFilterProductsByCategoryOff_then_it_returns_viewModels_except_filterProductCategory() {
-        // Given
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
-                                                         productStatus: .draft,
-                                                         productType: .grouped,
-                                                         productCategory: filterProductCategory,
-                                                         numberOfActiveFilters: 4)
-
-        // When
-        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: false)
-        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
-
-        // Then
-        let productCategoryFilterTypeViewModels = viewModel.filterTypeViewModels.compactMap { $0.selectedValue as? ProductCategory }
-
-        XCTAssertTrue(productCategoryFilterTypeViewModels.isEmpty)
-        XCTAssertEqual(viewModel.filterTypeViewModels.count, 3)
     }
 }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/5159

## Description

In the scope of this PR we prepare the already implemented issue https://github.com/woocommerce/woocommerce-ios/issues/5159 for release. For that, we remove the feature flag so the feature is exposed in any build configuration, we include the product category filter in the tracked event with analytics, and update the Release notes file (`RELEASE-NOTES.txt`)

## Changes

- Remove the feature flag
- Add the `ProductCategory` `slug` to the Analytics event information when the products list is filtered. This is implemented in the same way as Android, where also the slug is added to the filters information. See `getFilterString` in https://github.com/woocommerce/woocommerce-android/blob/da7e069f12f46d18280327a1be72d39981d9d198/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt , that uses the `productFilterOptions` map property, being the values of that map _the slug associated with the property_.  This `getFilterString` function is called from` ProductFilterListFragment.kt` and `ProductFilterOptionListFragment.kt` to track the tap of the show products button.
- Update unit tests to remove the feature flag
- Update release notes

## Testing
### Feature flag removal
The functionality should behave in the `appStore` `BuildConfiguration` in the same way as it was already tested in `localDeveloper` or `alpha`:
- Open app
- Go to Products
- Press the Filter button
- A menu filter entry with the title _Product Category_ should be shown

<img src="https://user-images.githubusercontent.com/1864060/138415960-8b36e51e-af52-467b-9bad-4e3b6db889a4.png" width="320" height="693">

- If there was a Product Category filter persisted, it should be shown when opening there the menu:

<img src="https://user-images.githubusercontent.com/1864060/141122830-09000cc6-0b37-4d48-acf3-712fe2726e68.png" width="320" height="693">

- If the button with title "Clear all" is pressed, it should clear also the Product Category filter:

<img src="https://user-images.githubusercontent.com/1864060/138415960-8b36e51e-af52-467b-9bad-4e3b6db889a4.png" width="320" height="693">

The rest of the issue implementation remains unaffected by the removal of the feature flag.

### Analytics tracking
In order to check that the event is tracked with the right information when showing products with filters:
- Open app
- Go to Products
- Press the Filter button
- Go to Product Category filter
- Select a category
- Press the Show Products button

Product category should be included in the event filters information. This can be checked in the Xcode console:

`WooCommerce[50427:8085398] 🔵 Tracked product_filter_list_show_products_button_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("filters"): "clothing", AnyHashable("blog_id"): 171745248]`

You can also check that it works fine when other filter is selected:

`WooCommerce[50427:8085398] 🔵 Tracked product_filter_list_show_products_button_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("filters"): "variable,clothing", AnyHashable("blog_id"): 171745248]`

### Release notes
Please check the `RELEASE-NOTES.txt` file changes 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
