### PR TITLE
[Analytics] Add Track function combining errors and props

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -80,7 +80,7 @@ public extension WooAnalytics {
     ///   - properties: a collection of properties related to the event
     ///
     func track(_ stat: WooAnalyticsStat, withProperties properties: [AnyHashable: Any]?) {
-        track(stat, properties: properties, withError: nil)
+        track(stat, properties: properties, error: nil)
     }
 
     /// Track a specific event with an associated error (that is translated to properties)
@@ -90,7 +90,7 @@ public extension WooAnalytics {
     ///   - error: the error to track
     ///
     func track(_ stat: WooAnalyticsStat, withError error: Error) {
-        track(stat, properties: nil, withError: error)
+        track(stat, properties: nil, error: error)
     }
 
     /// Track a specific event with associated properties and an associated error (that is translated to properties)
@@ -100,7 +100,7 @@ public extension WooAnalytics {
     ///   - properties: a collection of properties related to the event
     ///   - error: the error to track
     ///
-    func track(_ stat: WooAnalyticsStat, properties passedProperties: [AnyHashable: Any]?, withError error: Error?) {
+    func track(_ stat: WooAnalyticsStat, properties passedProperties: [AnyHashable: Any]?, error: Error?) {
         guard userHasOptedIn == true else {
             return
         }

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -80,15 +80,7 @@ public extension WooAnalytics {
     ///   - properties: a collection of properties related to the event
     ///
     func track(_ stat: WooAnalyticsStat, withProperties properties: [AnyHashable: Any]?) {
-        guard userHasOptedIn == true else {
-            return
-        }
-
-        if let updatedProperties = updatePropertiesIfNeeded(for: stat, properties: properties) {
-            analyticsProvider.track(stat.rawValue, withProperties: updatedProperties)
-        } else {
-            analyticsProvider.track(stat.rawValue)
-        }
+        track(stat, properties: properties, withError: nil)
     }
 
     /// Track a specific event with an associated error (that is translated to properties)
@@ -98,16 +90,52 @@ public extension WooAnalytics {
     ///   - error: the error to track
     ///
     func track(_ stat: WooAnalyticsStat, withError error: Error) {
+        track(stat, properties: nil, withError: error)
+    }
+
+    /// Track a specific event with associated properties and an associated error (that is translated to properties)
+    ///
+    /// - Parameters:
+    ///   - stat: the event name
+    ///   - properties: a collection of properties related to the event
+    ///   - error: the error to track
+    ///
+    func track(_ stat: WooAnalyticsStat, properties passedProperties: [AnyHashable: Any]?, withError error: Error?) {
         guard userHasOptedIn == true else {
             return
         }
 
+        let properties = combinedProperties(from: error, with: passedProperties)
+
+        if let updatedProperties = updatePropertiesIfNeeded(for: stat, properties: properties) {
+            analyticsProvider.track(stat.rawValue, withProperties: updatedProperties)
+        } else {
+            analyticsProvider.track(stat.rawValue)
+        }
+    }
+
+    private func combinedProperties(from error: Error?, with passedProperties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
+        let properties: [AnyHashable: Any]?
+        let errorProperties = errorProperties(from: error)
+
+        if let passedProperties = passedProperties {
+            properties = passedProperties.merging(errorProperties ?? [:], uniquingKeysWith: { current, _ in
+                current
+            })
+        } else {
+            properties = errorProperties
+        }
+        return properties
+    }
+
+    private func errorProperties(from error: Error?) -> [AnyHashable: Any]? {
+        guard let error = error else {
+            return nil
+        }
         let err = error as NSError
-        let errorDictionary = [Constants.errorKeyCode: "\(err.code)",
-                               Constants.errorKeyDomain: err.domain,
-                               Constants.errorKeyDescription: err.description]
-        let updatedProperties = updatePropertiesIfNeeded(for: stat, properties: errorDictionary)
-        analyticsProvider.track(stat.rawValue, withProperties: updatedProperties)
+        return [Constants.errorKeyCode: "\(err.code)",
+                Constants.errorKeyDomain: err.domain,
+                Constants.errorKeyDescription: err.description]
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/Analytics.swift
+++ b/WooCommerce/Classes/ServiceLocator/Analytics.swift
@@ -29,6 +29,15 @@ protocol Analytics {
     ///
     func track(_ stat: WooAnalyticsStat, withError error: Error)
 
+    /// Track a specific event with associated properties and an associated error (that is translated to properties)
+    ///
+    /// - Parameters:
+    ///   - stat: the event name
+    ///   - properties: a collection of properties related to the event
+    ///   - error: the error to track
+    ///
+    func track(_ stat: WooAnalyticsStat, properties: [AnyHashable: Any]?, withError error: Error?)
+
     /// Refresh the tracking metadata for the currently logged-in or anonymous user.
     /// It's good to call this function after a user logs in or out of the app.
     ///

--- a/WooCommerce/Classes/ServiceLocator/Analytics.swift
+++ b/WooCommerce/Classes/ServiceLocator/Analytics.swift
@@ -36,7 +36,7 @@ protocol Analytics {
     ///   - properties: a collection of properties related to the event
     ///   - error: the error to track
     ///
-    func track(_ stat: WooAnalyticsStat, properties: [AnyHashable: Any]?, withError error: Error?)
+    func track(_ stat: WooAnalyticsStat, properties: [AnyHashable: Any]?, error: Error?)
 
     /// Refresh the tracking metadata for the currently logged-in or anonymous user.
     /// It's good to call this function after a user logs in or out of the app.

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -90,6 +90,36 @@ class WooAnalyticsTests: XCTestCase {
         }
     }
 
+    /// Verifies an event with an error and properties is received by the AnalyticsProvider
+    ///
+    func testEventsWithPropertiesAndErrorReceived() {
+        let testError = NSError(domain: Constants.testErrorDomain, code: Constants.testErrorCode, userInfo: Constants.testErrorUserInfo)
+        analytics.track(.applicationOpened, properties: Constants.testProperty1, withError: testError)
+        XCTAssertEqual(testingProvider?.receivedEvents.count, 1)
+        XCTAssertEqual(testingProvider?.receivedProperties.count, 1)
+        XCTAssertEqual(testingProvider?.receivedEvents.first, WooAnalyticsStat.applicationOpened.rawValue)
+
+        guard let receivedProperty1 = testingProvider?.receivedProperties[0] as? [String: String] else {
+            XCTFail()
+            return
+        }
+
+        /// Note: iOS 12 is shuffling several dictionaries (especially when it comes to serializing [:] > URL Parameters).
+        /// For that reason, we'll proceed with a bit of a more lengthy but robust check.
+        ///
+        for (key, value) in Constants.testErrorAndPropertyReceivedProperty {
+            XCTAssertEqual(value, receivedProperty1[key])
+        }
+
+        /// Second note: the error's userInfo, as a string, is getting swizzled. We'll ensure the expected payload is there,
+        /// but the exact position isn't guarranteed!
+        ///
+        let descriptionIncludingUserInfo = receivedProperty1[Constants.testErrorDescriptionKey]
+        for (_, descriptionSubstring) in Constants.testErrorUserInfo {
+            XCTAssert(descriptionIncludingUserInfo?.contains(descriptionSubstring) == true)
+        }
+    }
+
     /// Test user opted out
     ///
     func testUserOptedOut() {
@@ -119,5 +149,7 @@ private extension WooAnalyticsTests {
         static let testErrorDescriptionKey                      = "error_description"
         static let testErrorUserInfo: [String: String]          = ["userinfo-key1": "Here is the value!", "userinfo-key2": "Here is the second value!"]
         static let testErrorReceivedProperty: [String: String]  = ["error_code": "999", "error_domain": "domain"]
+
+        static let testErrorAndPropertyReceivedProperty: [String: String]  = ["error_code": "999", "error_domain": "domain", "prop-key1": "prop-value1"]
     }
 }

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -92,9 +92,14 @@ class WooAnalyticsTests: XCTestCase {
 
     /// Verifies an event with an error and properties is received by the AnalyticsProvider
     ///
-    func testEventsWithPropertiesAndErrorReceived() {
+    func test_events_with_properties_and_error_include_combined_properties() {
+        // Given
         let testError = NSError(domain: Constants.testErrorDomain, code: Constants.testErrorCode, userInfo: Constants.testErrorUserInfo)
-        analytics.track(.applicationOpened, properties: Constants.testProperty1, withError: testError)
+
+        // When
+        analytics.track(.applicationOpened, properties: Constants.testProperty1, error: testError)
+
+        // Then
         XCTAssertEqual(testingProvider?.receivedEvents.count, 1)
         XCTAssertEqual(testingProvider?.receivedProperties.count, 1)
         XCTAssertEqual(testingProvider?.receivedEvents.first, WooAnalyticsStat.applicationOpened.rawValue)
@@ -112,7 +117,7 @@ class WooAnalyticsTests: XCTestCase {
         }
 
         /// Second note: the error's userInfo, as a string, is getting swizzled. We'll ensure the expected payload is there,
-        /// but the exact position isn't guarranteed!
+        /// but the exact position isn't guaranteed!
         ///
         let descriptionIncludingUserInfo = receivedProperty1[Constants.testErrorDescriptionKey]
         for (_, descriptionSubstring) in Constants.testErrorUserInfo {


### PR DESCRIPTION
Supports #5300 

## Description
For Tracks events around card reader software update events, we need to log events with both errors and other properties. To do that, it's convenient to use a track function which accepts both as parameters. This PR does not add any direct use of the combined function, but it is well exercised.

### WooAnalytics changes
Logging events with both properties, and standard error details, required a new `track(_:properties:withError:)` function on WooAnalytics. It's worth calling out here that _all_ tracks events will now go through this function so _all the scrutiny_ is welcomed!

## Testing
Test that events are logged all the way back to Tracks.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
