### PR TITLE
[Mobile Payments] Card reader software update Tracks properties

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -407,7 +407,7 @@ private extension CardReaderConnectionController {
         let cancel = softwareUpdateCancelable.map { cancelable in
             return { [weak self] in
                 self?.state = .cancel
-                let analyticsProperties = ["software_update_type": "Required"]
+                let analyticsProperties = [SoftwareUpdateTypeProperty.name: SoftwareUpdateTypeProperty.required.rawValue]
                 ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCancelTapped, withProperties: analyticsProperties)
                 cancelable.cancel { result in
                     if case .failure(let error) = result {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -407,9 +407,13 @@ private extension CardReaderConnectionController {
         let cancel = softwareUpdateCancelable.map { cancelable in
             return { [weak self] in
                 self?.state = .cancel
+                let analyticsProperties = ["software_update_type": "Required"]
+                ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCancelTapped, withProperties: analyticsProperties)
                 cancelable.cancel { result in
                     if case .failure(let error) = result {
                         print("=== error canceling software update: \(error)")
+                    } else {
+                        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCanceled, withProperties: analyticsProperties)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -205,8 +205,8 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     }
 
     private func track(_ stat: WooAnalyticsStat, error: Error? = nil) {
-        let properties = ["software_update_type": optionalReaderUpdateAvailable ? "Optional" : "Required"]
-        ServiceLocator.analytics.track(stat, properties: properties, error: error)
+        let updateType = optionalReaderUpdateAvailable ? SoftwareUpdateTypeProperty.optional : SoftwareUpdateTypeProperty.required
+        ServiceLocator.analytics.track(stat, properties: [SoftwareUpdateTypeProperty.name: updateType.rawValue], error: error)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -64,7 +64,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                         self.readerUpdateError = nil
                         self.softwareUpdateCancelable = cancelable
                         self.readerUpdateProgress = 0
-                        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateStarted)
+                        self.track(.cardReaderSoftwareUpdateStarted)
                     case .installing(progress: let progress):
                         self.readerUpdateProgress = progress
                     case .failed(error: let error):
@@ -74,12 +74,12 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                             break
                         }
                         self.readerUpdateError = error
+                        self.track(.cardReaderSoftwareUpdateFailed, error: error)
                         self.completeCardReaderUpdate(success: false)
-                        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateFailed)
                     case .completed:
                         self.readerUpdateProgress = 1
                         self.softwareUpdateCancelable = nil
-                        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateSuccess)
+                        self.track(.cardReaderSoftwareUpdateSuccess)
                         // If we were installing a software update, introduce a small delay so the user can
                         // actually see a success message showing the installation was complete
                         DispatchQueue.main.asyncAfter(deadline: .now() + self.delayToShowUpdateSuccessMessage) { [weak self] in
@@ -130,19 +130,19 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     /// Allows the view controller to kick off a card reader update
     ///
     func startCardReaderUpdate() {
-        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateTapped)
+        track(.cardReaderSoftwareUpdateTapped)
         let action = CardPresentPaymentAction.startCardReaderUpdate
         ServiceLocator.stores.dispatch(action)
     }
 
     func cancelCardReaderUpdate() {
-        ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCancelTapped)
+        track(.cardReaderSoftwareUpdateCancelTapped)
         softwareUpdateCancelable?.cancel(completion: { [weak self] result in
             if case .failure(let error) = result {
                 print("=== error canceling software update: \(error)")
             } else {
+                self?.track(.cardReaderSoftwareUpdateCanceled)
                 self?.completeCardReaderUpdate(success: false)
-                ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCanceled)
             }
         })
     }
@@ -162,7 +162,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     /// Dispatch a request to disconnect from a reader
     ///
     func disconnectReader() {
-        ServiceLocator.analytics.track(.cardReaderDisconnectTapped)
+        track(.cardReaderDisconnectTapped)
 
         self.readerDisconnectInProgress = true
         self.didUpdate?()
@@ -202,6 +202,11 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         if didChange {
             didChangeShouldShow?(shouldShow)
         }
+    }
+
+    private func track(_ stat: WooAnalyticsStat, error: Error? = nil) {
+        let properties = ["software_update_type": optionalReaderUpdateAvailable ? "Optional" : "Required"]
+        ServiceLocator.analytics.track(stat, properties: properties, error: error)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SoftwareUpdateTypeProperty.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SoftwareUpdateTypeProperty.swift
@@ -1,0 +1,6 @@
+enum SoftwareUpdateTypeProperty: String {
+    case optional = "Optional"
+    case required = "Required"
+
+    static let name = "software_update_type"
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		02F6800325807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */; };
 		02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800825807CD300C3BAD2 /* GridStackView.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
+		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -1836,6 +1837,7 @@
 		02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionListView.swift; sourceTree = "<group>"; };
 		02F6800825807CD300C3BAD2 /* GridStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridStackView.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
+		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
@@ -4124,6 +4126,7 @@
 				311F827326CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift */,
 				311D21EC264AF0E700102316 /* CardReaderSettingsAlerts.swift */,
 				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
+				035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */,
 				314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */,
 				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
 				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
@@ -7472,6 +7475,7 @@
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,
+				035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */,
 				31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */,
 				26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -65,7 +65,7 @@ public extension MockAnalyticsProvider {
 }
 
 // MARK: - Convenience Keys
-public extension MockAnalyticsProvider {
+extension MockAnalyticsProvider {
     /// WooAnalyticsKeys
     /// Canonically defined in WooAnalytics.swift
     enum WooAnalyticsKeys {

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -63,3 +63,17 @@ public extension MockAnalyticsProvider {
         // no op
     }
 }
+
+// MARK: - Convenience Keys
+public extension MockAnalyticsProvider {
+    /// WooAnalyticsKeys
+    /// Canonically defined in WooAnalytics.swift
+    enum WooAnalyticsKeys {
+        static let errorKeyCode = "error_code"
+        static let errorKeyDomain = "error_domain"
+        static let errorKeyDescription = "error_description"
+        static let propertyKeyTimeInApp = "time_in_app"
+        static let blogIDKey = "blog_id"
+        static let wpcomStoreKey = "is_wpcom_store"
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -156,7 +156,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    func test_startCardReaderUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateTapped() {
+    func test_startCardReaderUpdate_viewModel_logs_tracks_event_cardReaderSoftwareUpdateTapped() {
         // Given
 
         // When
@@ -166,7 +166,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateTapped.rawValue))
     }
 
-    func test_startCardReaderUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateStarted() {
+    func test_card_reader_update_starts_viewModel_logs_tracks_event_cardReaderSoftwareUpdateStarted() {
         // Given
         // .available not sent
 
@@ -180,7 +180,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         }))
     }
 
-    func test_startCardReaderUpdate_Optional_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateStarted_withOptional() {
+    func test_optional_card_reader_update_starts_viewModel_logs_tracks_event_cardReaderSoftwareUpdateStarted_with_optional() {
         // Given
         mockStoresManager.simulateOptionalUpdateAvailable()
 
@@ -194,7 +194,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         }))
     }
 
-    func test_WhenStoreSendsUpdateComplete_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateSuccess() {
+    func test_when_store_sends_update_complete_viewModel_logs_tracks_event_cardReaderSoftwareUpdateSuccess() {
         // Given
 
         // When
@@ -204,7 +204,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateSuccess.rawValue))
     }
 
-    func test_WhenStoreSendsUpdateFailed_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateFailed() {
+    func test_when_store_sends_update_failed_viewModel_logs_tracks_event_cardReaderSoftwareUpdateFailed() {
         // Given
         // .available not sent
 
@@ -225,7 +225,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         }))
     }
 
-    func test_WhenUserCancelsUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateCancelTapped() {
+    func test_when_user_cancels_update_viewModel_logs_tracks_event_cardReaderSoftwareUpdateCancelTapped() {
         // Given
 
         // When
@@ -235,7 +235,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateCancelTapped.rawValue))
     }
 
-    func test_WhenUpdateIsSuccessfullyCanceled_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateCanceled() {
+    func test_when_update_is_successfully_canceled_viewModel_logs_tracks_event_cardReaderSoftwareUpdateCanceled() {
         // Given
         let expectation = self.expectation(description: #function)
 
@@ -251,7 +251,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateCanceled.rawValue))
     }
 
-    func test_WhenUpdateIsSuccessfullyCanceled_ViewModel_DoesNotLogTracksEvent_cardReaderSoftwareUpdateFailed() {
+    func test_when_update_is_successfully_canceled_viewModel_does_not_log_tracks_event_cardReaderSoftwareUpdateFailed() {
         // Given
         let expectation = self.expectation(description: #function)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -168,12 +168,30 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_startCardReaderUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateStarted() {
         // Given
+        // .available not sent
 
         // When
         mockStoresManager.simulateUpdateStarted()
 
         // Then
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateStarted.rawValue))
+        XCTAssert(analytics.receivedProperties.contains(where: {
+            $0["software_update_type"] as! String == "Required"
+        }))
+    }
+
+    func test_startCardReaderUpdate_Optional_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateStarted_withOptional() {
+        // Given
+        mockStoresManager.simulateOptionalUpdateAvailable()
+
+        // When
+        mockStoresManager.simulateUpdateStarted()
+
+        // Then
+        XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateStarted.rawValue))
+        XCTAssert(analytics.receivedProperties.contains(where: {
+            $0["software_update_type"] as! String == "Optional"
+        }))
     }
 
     func test_WhenStoreSendsUpdateComplete_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateSuccess() {
@@ -188,6 +206,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     func test_WhenStoreSendsUpdateFailed_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateFailed() {
         // Given
+        // .available not sent
 
         // When
         let expectedError = CardReaderServiceError.softwareUpdate(underlyingError: .readerSoftwareUpdateFailedBatteryLow,
@@ -195,7 +214,15 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         mockStoresManager.simulateFailedUpdate(error: expectedError)
 
         // Then
+        let expectedErrorDescription = "Hardware.CardReaderServiceError.softwareUpdate(underlyingError: " +
+            "Hardware.UnderlyingError.readerSoftwareUpdateFailedBatteryLow, batteryLevel: Optional(0.4))"
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateFailed.rawValue))
+        XCTAssert(analytics.receivedProperties.contains(where: {
+            $0["software_update_type"] as! String == "Required"
+        }))
+        XCTAssert(analytics.receivedProperties.contains(where: {
+            $0[MockAnalyticsProvider.WooAnalyticsKeys.errorKeyDescription] as! String == expectedErrorDescription
+        }))
     }
 
     func test_WhenUserCancelsUpdate_ViewModel_LogsTracksEvent_cardReaderSoftwareUpdateCancelTapped() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -176,7 +176,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Then
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateStarted.rawValue))
         XCTAssert(analytics.receivedProperties.contains(where: {
-            $0["software_update_type"] as! String == "Required"
+            $0["software_update_type"] as? String == "Required"
         }))
     }
 
@@ -190,7 +190,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Then
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateStarted.rawValue))
         XCTAssert(analytics.receivedProperties.contains(where: {
-            $0["software_update_type"] as! String == "Optional"
+            $0["software_update_type"] as? String == "Optional"
         }))
     }
 
@@ -218,10 +218,10 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
             "Hardware.UnderlyingError.readerSoftwareUpdateFailedBatteryLow, batteryLevel: Optional(0.4))"
         XCTAssert(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateFailed.rawValue))
         XCTAssert(analytics.receivedProperties.contains(where: {
-            $0["software_update_type"] as! String == "Required"
+            $0["software_update_type"] as? String == "Required"
         }))
         XCTAssert(analytics.receivedProperties.contains(where: {
-            $0[MockAnalyticsProvider.WooAnalyticsKeys.errorKeyDescription] as! String == expectedErrorDescription
+            $0[MockAnalyticsProvider.WooAnalyticsKeys.errorKeyDescription] as? String == expectedErrorDescription
         }))
     }
 


### PR DESCRIPTION
Closes #5300 

## Description
This covers the [remaining software update Tracks work](https://github.com/woocommerce/woocommerce-ios/issues/5300#issuecomment-964052643), i.e. setting the properties for `software_update_type` and those containing error details.

### Relevant events
- `card_reader_software_update_tapped`
- `card_reader_software_update_started`
- `card_reader_software_update_success`
- `card_reader_software_update_failed`
- `card_reader_software_update_cancel_tapped`
- `card_reader_software_update_canceled`

## Testing
- [x] Check that events are logged with `software_update_type: Optional` for optional updates
- [x] Check that events are logged with `software_update_type: Required` for required updates (`cancel` and `update_tapped` events not possible)
- [x] Check that `card_reader_software_update_failed` is logged with properties containing the error details, `error_description`, `error_code`, and `error_domain` in particular.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
