### PR TITLE
[Mobile Payments] Maintain reader software update Required/Optional state correctly

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -503,7 +503,12 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
                 error: CardReaderServiceError.softwareUpdate(underlyingError: UnderlyingError(with: error),
                                                              batteryLevel: reader.batteryLevel?.doubleValue))
             )
-            softwareUpdateSubject.send(.available)
+            if let requiredDate = update?.requiredAt,
+               requiredDate > Date() {
+                softwareUpdateSubject.send(.available)
+            } else {
+                softwareUpdateSubject.send(.none)
+            }
         } else {
             softwareUpdateSubject.send(.completed)
             softwareUpdateSubject.send(.none)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -68,7 +68,7 @@ private extension CardReaderSettingsConnectedViewController {
         guard let viewModel = viewModel else {
             return false
         }
-        return viewModel.readerUpdateAvailable == true
+        return viewModel.optionalReaderUpdateAvailable == true
     }
 
     /// Set the title and back button.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -11,7 +11,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     private var connectedReaders = [CardReader]()
     private let knownReaderProvider: CardReaderSettingsKnownReaderProvider?
 
-    private(set) var readerUpdateAvailable: Bool = false
+    private(set) var optionalReaderUpdateAvailable: Bool = false
     var readerUpdateInProgress: Bool {
         readerUpdateProgress != nil
     }
@@ -81,9 +81,9 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                             self?.completeCardReaderUpdate(success: true)
                         }
                     case .available:
-                        self.readerUpdateAvailable = true
+                        self.optionalReaderUpdateAvailable = true
                     case .none:
-                        self.readerUpdateAvailable = false
+                        self.optionalReaderUpdateAvailable = false
                     }
                     self.didUpdate?()
                 }
@@ -148,7 +148,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     }
 
     private func completeCardReaderUpdate(success: Bool) {
-        readerUpdateAvailable = !success
+        optionalReaderUpdateAvailable = !success
         readerUpdateProgress = nil
         didUpdate?()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -27,6 +27,8 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     var connectedReaderBatteryLevel: String?
     var connectedReaderSoftwareVersion: String?
 
+    var delayToShowUpdateSuccessMessage: DispatchTimeInterval = .seconds(1)
+
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?, knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil) {
         self.didChangeShouldShow = didChangeShouldShow
         self.knownReaderProvider = knownReaderProvider
@@ -77,7 +79,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                         ServiceLocator.analytics.track(.cardReaderSoftwareUpdateSuccess)
                         // If we were installing a software update, introduce a small delay so the user can
                         // actually see a success message showing the installation was complete
-                        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [weak self] in
+                        DispatchQueue.main.asyncAfter(deadline: .now() + self.delayToShowUpdateSuccessMessage) { [weak self] in
                             self?.completeCardReaderUpdate(success: true)
                         }
                     case .available:
@@ -148,7 +150,8 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     }
 
     private func completeCardReaderUpdate(success: Bool) {
-        optionalReaderUpdateAvailable = !success
+        //Avoids a failed mandatory reader update being shown as optional
+        optionalReaderUpdateAvailable = optionalReaderUpdateAvailable && !success
         readerUpdateProgress = nil
         didUpdate?()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -27,11 +27,14 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     var connectedReaderBatteryLevel: String?
     var connectedReaderSoftwareVersion: String?
 
-    var delayToShowUpdateSuccessMessage: DispatchTimeInterval = .seconds(1)
+    let delayToShowUpdateSuccessMessage: DispatchTimeInterval
 
-    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?, knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil) {
+    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
+         knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil,
+         delayToShowUpdateSuccessMessage: DispatchTimeInterval = .seconds(1)) {
         self.didChangeShouldShow = didChangeShouldShow
         self.knownReaderProvider = knownReaderProvider
+        self.delayToShowUpdateSuccessMessage = delayToShowUpdateSuccessMessage
         beginObservation()
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -111,4 +111,8 @@ extension MockCardPresentPaymentsStoresManager {
     func simulateUpdateStarted() {
         softwareUpdateSubject.send(.started(cancelable: nil))
     }
+
+    func simulateOptionalUpdateAvailable() {
+        softwareUpdateSubject.send(.available)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -20,6 +20,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel.delayToShowUpdateSuccessMessage = .milliseconds(1)
     }
 
     func test_did_change_should_show_returns_false_if_no_connected_readers() {
@@ -231,5 +232,67 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: Constants.expectationTimeout)
         XCTAssertFalse(analytics.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateFailed.rawValue))
+    }
+
+    func test_when_a_mandatory_update_succeeds_optional_updates_are_not_available() {
+        // Given
+        // .available is not sent
+        mockStoresManager.simulateUpdateStarted()
+        let expectation = self.expectation(description: #function)
+        viewModel.didUpdate = { [weak self] in
+            if self?.viewModel.readerUpdateProgress == nil { //ensures that we wait until completeCardReaderUpdate()
+                expectation.fulfill()
+            }
+        }
+
+        // When
+        mockStoresManager.simulateSuccessfulUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        XCTAssertFalse(viewModel.optionalReaderUpdateAvailable)
+    }
+
+    func test_when_an_optional_update_succeeds_optional_updates_are_not_available() {
+        // Given
+        mockStoresManager.simulateOptionalUpdateAvailable()
+        mockStoresManager.simulateUpdateStarted()
+        let expectation = self.expectation(description: #function)
+        viewModel.didUpdate = { [weak self] in
+            if self?.viewModel.readerUpdateProgress == nil { //ensures that we wait until completeCardReaderUpdate()
+                expectation.fulfill()
+            }
+        }
+
+        // When
+        mockStoresManager.simulateSuccessfulUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        XCTAssertFalse(viewModel.optionalReaderUpdateAvailable)
+    }
+
+    func test_when_a_mandatory_update_fails_optional_updates_are_not_available() {
+        // Given
+        // .available is not sent
+        mockStoresManager.simulateUpdateStarted()
+
+        // When
+        mockStoresManager.simulateFailedUpdate(error: CardReaderServiceError.bluetoothDenied)
+
+        // Then
+        XCTAssertFalse(viewModel.optionalReaderUpdateAvailable)
+    }
+
+    func test_when_an_optional_update_fails_optional_updates_are_available() {
+        // Given
+        mockStoresManager.simulateOptionalUpdateAvailable()
+        mockStoresManager.simulateUpdateStarted()
+
+        // When
+        mockStoresManager.simulateFailedUpdate(error: CardReaderServiceError.bluetoothDenied)
+
+        // Then
+        XCTAssertTrue(viewModel.optionalReaderUpdateAvailable)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -19,8 +19,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         analytics = MockAnalyticsProvider()
         ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analytics))
 
-        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
-        viewModel.delayToShowUpdateSuccessMessage = .milliseconds(1)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         delayToShowUpdateSuccessMessage: .milliseconds(1))
     }
 
     func test_did_change_should_show_returns_false_if_no_connected_readers() {
@@ -35,7 +35,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         let _ = CardReaderSettingsConnectedViewModel(didChangeShouldShow: { shouldShow in
             XCTAssertTrue(shouldShow == .isFalse)
             expectation.fulfill()
-        } )
+        },
+                                                     delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
@@ -46,7 +47,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: { shouldShow in
             XCTAssertTrue(shouldShow == .isTrue)
             expectation.fulfill()
-        } )
+        },
+                                                         delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
@@ -64,12 +66,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "Unknown Battery Level")
     }
 
     func test_view_model_correctly_formats_connected_card_reader_software_version() {
-        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                             delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Version: 1.00.03.34-SZZZ_Generic_v45-300001")
     }
 
@@ -81,7 +85,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Unknown Software Version")
     }
 
@@ -125,7 +130,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         var updateDidBegin = false
 


### PR DESCRIPTION
Part of #5300 

## Description
In #5300, we want to Track a property of `software_update_type` with `Required` or `Optional` based on whether the a card reader software update is mandatory or not. To do this, we need to maintain this state accurately, through the flow of updating a reader.

### What's a required update?!
Required updates are communicated by Stripe as updates which start as soon as a reader is connected, without a notification from the Terminal SDK that there's an update available. We were tracking this using the property `CardReaderSettingsConnectedViewModel.readerUpdateAvailable`, however this wasn't clear from the original naming, so I've clarified that naming in 2e4e86c737b0f1d6444c98c2fac7916df612e11b.

Beyond that, I found a bug in our logic which meant that a re-run of a `Required` update which had failed (e.g. for low battery) was marked as `Optional`. This is fixed in f624724c15ead1d192fb878cd36c86611581684e, by checking the required date is in the future before reporting that an (optional) update is available in the failure handler.

## Testing
This is difficult to test in isolation, and might be best tested with #5390. However, it's worth running through some updates, failures, cancellations, and re-runs to check that the flows are unchanged by this work. The bug I found didn't actually manifest in the app in any way, so there are no repro steps to check.

See PdfdoF-fr-p2 for details on simulating different update scenarios.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
