### PR TITLE
Products: Added the variation number to the variations list and details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,8 @@
 -----
 - [***] Push notifications are now supported for all connected stores. [https://github.com/woocommerce/woocommerce-ios/pull/5299]
 - [*] Fix: in Settings > Switch Store, tapping "Dismiss" after selecting a different store does not switch stores anymore. [https://github.com/woocommerce/woocommerce-ios/pull/5359]
+- [*] Products: Variation number added in variation list and details page
+    [https://github.com/woocommerce/woocommerce-ios/issues/4846]
 
 7.9
 -----

--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -23,13 +23,13 @@
       location = "group:Fakes/Fakes.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Observables">
+      location = "group:CodeGeneration">
    </FileRef>
    <FileRef
       location = "group:TestKit">
    </FileRef>
    <FileRef
-      location = "group:CodeGeneration">
+      location = "group:Observables">
    </FileRef>
    <FileRef
       location = "group:Pods/Pods.xcodeproj">

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -39,6 +39,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let productUIImageLoader: ProductUIImageLoader
 
     private let currency: String
+    private let titleString: String // Navigation title
 
     private lazy var exitForm: () -> Void = {
         presentationStyle.createExitForm(viewController: self)
@@ -58,10 +59,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          eventLogger: ProductFormEventLoggerProtocol,
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
+         titleString: String = String(),
          presentationStyle: ProductFormPresentationStyle) {
         self.viewModel = viewModel
         self.eventLogger = eventLogger
         self.currency = currency
+        self.titleString = titleString
         self.presentationStyle = presentationStyle
         self.productImageActionHandler = productImageActionHandler
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
@@ -410,6 +413,9 @@ private extension ProductFormViewController {
     func configureNavigationBar() {
         updateNavigationBar()
         updateBackButtonTitle()
+        if titleString.isNotEmpty {
+            self.title = titleString
+        }
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -423,10 +423,17 @@ extension ProductVariationsViewController: UITableViewDelegate {
             let updatedProduct = self.product.copy(variations: variationsUpdated)
             self.product = updatedProduct
         }
+
+        // Passing title to set as ProductFormViewController navigation title
+        let titleFormat = NSLocalizedString("Variation #%1$@",
+                                            comment: "Variation title. Parameters: %1$@ - Product variation ID")
+        let titleString = String.localizedStringWithFormat(titleFormat, "\(viewModel.productModel.productVariation.productVariationID)")
+
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductVariationFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
+                                                       titleString: titleString,
                                                        presentationStyle: .navigationStack)
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
@@ -5,7 +5,13 @@ extension ProductsTabProductViewModel {
     init(productVariationModel: EditableProductVariationModel,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         imageUrl = productVariationModel.productVariation.image?.src
-        name = productVariationModel.name
+
+        // Variation number added to variation list.
+        // Here productVariationID concatenated with name
+        // See https://github.com/woocommerce/woocommerce-ios/issues/4846 for more details
+        let number = NSLocalizedString("#%1$@", comment: "Variation number. Parameters: %1$@ - Product variation ID")
+        let variationNumber = String.localizedStringWithFormat(number, "\(productVariationModel.productVariation.productVariationID)")
+        name = "\(variationNumber)\n\(productVariationModel.name)"
         detailsAttributedString = productVariationModel.createDetailsAttributedString(currencySettings: currencySettings)
 
         imageService = ServiceLocator.imageService

--- a/WooCommerce/Resources/ar.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ar.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "تم استرداد أموال 🎉 من المنتجات بنجاح";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "#%1$@ مجموعة";

--- a/WooCommerce/Resources/de.lproj/Localizable.strings
+++ b/WooCommerce/Resources/de.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Produkte erfolgreich rückerstattet";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variante #%1$@";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
+/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
 "#%@ %@" = "#%1$@ %2$@";
 
 /* In Shipping Labels Package Details, the pattern used to show the weight of a product. For example, “1lbs”. */
@@ -4264,3 +4264,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Products successfully refunded";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variation #%1$@";

--- a/WooCommerce/Resources/es.lproj/Localizable.strings
+++ b/WooCommerce/Resources/es.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "Se han reembolsado correctamente 🎉 productos";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variación #%1$@";

--- a/WooCommerce/Resources/fr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/fr.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Produits remboursés avec succès";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variante #%1$@";

--- a/WooCommerce/Resources/he.lproj/Localizable.strings
+++ b/WooCommerce/Resources/he.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "החזר כספי עבור 🎉 מוצרים בוצע בהצלחה";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "#%1$@ סוג";

--- a/WooCommerce/Resources/id.lproj/Localizable.strings
+++ b/WooCommerce/Resources/id.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Pengembalian dana produk berhasil";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variasi #%1$@";

--- a/WooCommerce/Resources/it.lproj/Localizable.strings
+++ b/WooCommerce/Resources/it.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 prodotti rimborsati correttamente";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variante #%1$@";

--- a/WooCommerce/Resources/ja.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ja.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 商品は正常に返金されました";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "バリエーション #%1$@";

--- a/WooCommerce/Resources/ko.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ko.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉개 제품이 환불되었음";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "개 변형 #%1$@";

--- a/WooCommerce/Resources/nl.lproj/Localizable.strings
+++ b/WooCommerce/Resources/nl.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Producten zijn terugbetaald";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variatie #%1$@";

--- a/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
+++ b/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 produtos reembolsados com êxito";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variação #%1$@";

--- a/WooCommerce/Resources/ru.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ru.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Средства за продукты возвращены";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Вариант #%1$@";

--- a/WooCommerce/Resources/sv.lproj/Localizable.strings
+++ b/WooCommerce/Resources/sv.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 produkter återbetalades";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Variation #%1$@";

--- a/WooCommerce/Resources/tr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/tr.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Ürünlerin geri ödemesi başarıyla yapıldı";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "Varyasyon #%1$@";

--- a/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 产品已成功退款";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "个变体 #%1$@";

--- a/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
@@ -4209,3 +4209,5 @@
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 已成功退還商品款項";
 
+/* Format for the variation title with variation number. Reads, `Variation #1422` */
+"Variation #%1$@" = "個款式 #%1$@";

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -102,6 +102,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "id"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Added feature [#4846](https://github.com/woocommerce/woocommerce-ios/issues/4846)

Added variation number in Products -> Variations -> Variations list and details page.

Updated release note:
- [*] Products: Variation number added in variation list and details page

![Variation details page](https://user-images.githubusercontent.com/19687299/141145841-dcbb342e-fb94-443b-8890-732bfc91884a.png)
![Variation list](https://user-images.githubusercontent.com/19687299/141145861-7e012b07-94b8-4359-9507-b5cec3bac500.png)


