### PR TITLE
Add local settings docs

### DIFF
--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -24,6 +24,8 @@ The Storage module also exposes a protocol, called [`FileStorage`](../Storage/St
 
 The default implementation of this protocol, [`PListFileStorage`](../Storage/Storage/Tools/PListFileStorage.swift) provides support for `.plist` files.  
 
+File storage is used mostly for [local app settings](app-local-settings.md).
+
 ## Model objects
 This module also provides extensions to make the model objects declared in the `Networking` module coredata-compliant.  
 

--- a/docs/app-local-settings.md
+++ b/docs/app-local-settings.md
@@ -1,0 +1,27 @@
+# App Local Settings
+
+Small amount of data is currently stored in plist files.
+Initial goals were:
+
+- prevent complexity overhead of Core Data
+- prevent data loss when we auto-create the database (if a migration fails)
+- make data typed
+- inject storage layer as dependency.
+
+Retreiving and storing the data is done via [`AppSettingsAction`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Actions/AppSettingsAction.swift) and most of logic happens in [`AppSettingsStore`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Stores/AppSettingsStore.swift).
+There are few data models + plist files separated for specific features and use cases.
+
+## General use cases
+
+- [`GeneralAppSettings`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Storage/Storage/Model/GeneralAppSettings.swift) handles settings universal to all stores.
+- [`GeneralStoreSettings`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Storage/Storage/Model/GeneralStoreSettings.swift) handles settings unique for each store. Cleared on logout.
+- [`StoredProductSettings`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Model/Product/StoredProductSettings.swift) handles products-specific settings, unique for each store. Cleared on logout.
+
+## How to add new property
+
+Example for store settings use case:
+
+1. Add property to data model (`GeneralStoreSettings.swift`).
+2. Run `rake generate` to update `Copiable` implementation.
+3. Add get and set actions in `AppSettingsAction.swift`.
+4. Implement new actions in `AppSettingsStore.swift`. Use existing `getStoreSettings(for:)` and `setStoreSettings(settings:, for:)` helpers + `storeSettings.copy(...)` to update non-mutable settings struct.

--- a/docs/app-local-settings.md
+++ b/docs/app-local-settings.md
@@ -1,6 +1,6 @@
 # App Local Settings
 
-Small amount of data is currently stored in plist files.
+A small amount of data is currently stored in plist files.
 Initial goals were:
 
 - prevent complexity overhead of Core Data
@@ -8,8 +8,8 @@ Initial goals were:
 - make data typed
 - inject storage layer as dependency.
 
-Retreiving and storing the data is done via [`AppSettingsAction`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Actions/AppSettingsAction.swift) and most of logic happens in [`AppSettingsStore`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Stores/AppSettingsStore.swift).
-There are few data models + plist files separated for specific features and use cases.
+Retrieving and storing the data is done via [`AppSettingsAction`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Actions/AppSettingsAction.swift) and most of the logic happens in [`AppSettingsStore`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Stores/AppSettingsStore.swift).
+There are a few data models + plist files separated for specific features and use cases.
 
 ## General use cases
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -256,7 +256,7 @@ The Experiments framework allows us to experiment features in any of our framewo
 
 More on [Experiments](EXPERIMENTS.md)
 
-### Main Flows
+## Main Flows
 
     1.  Performing Tasks
 


### PR DESCRIPTION
## Description

This PR adds documentation for different types of local data stored in `AppSettingsStore`.
Internal discussion ref: p91TBi-6pI-p2.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.