### PR TITLE
Order Editing: Fix iOS 15 navigation bar style

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -85,6 +85,7 @@ struct EditCustomerNote<ViewModel: EditCustomerNoteViewModelProtocol>: View {
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
+                .navigationViewStyle(StackNavigationViewStyle())
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button(Localization.cancel, action: {
@@ -97,7 +98,6 @@ struct EditCustomerNote<ViewModel: EditCustomerNoteViewModelProtocol>: View {
                     }
                 }
         }
-        .navigationViewStyle(StackNavigationViewStyle())
         .wooNavigationBarStyle()
     }
 


### PR DESCRIPTION
# Why 

@ealeksandrov [reported](https://github.com/woocommerce/woocommerce-ios/pull/5396#pullrequestreview-803746084) that on iOS 15, the navigation bar on the order editing flow didn't show any navigation bar button and was using large titles.

This PR fixes that by moving the `.navigationViewStyle(StackNavigationViewStyle())` modifier inside the `NavigationView` content 🤷‍♂️ 

# Screenshots

Before iOS 15 | After iOS 15 | After iOS 14
---- | ---- | ----
![ios-15-bad](https://user-images.githubusercontent.com/562080/141306775-2d78d90f-770b-435b-ab04-6eb010e9a0b1.png) |  ![ios-15-good](https://user-images.githubusercontent.com/562080/141306781-481f540a-e9ca-4242-99b5-746bcb568f86.png) | ![ios-14](https://user-images.githubusercontent.com/562080/141306833-27d3fdbd-d9b4-47b3-bb56-25e9eae3f5d0.jpeg)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
