### PR TITLE
Remove PR list generation at code-freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,8 +98,6 @@ platform :ios do
       extracted_notes_file_path: File.join('WooCommerce', 'Resources', 'release_notes.txt')
     )
     ios_update_release_notes(new_version: new_version)
-    get_prs_list(repository: GHHELPER_REPO, milestone: new_version,
-                 report_path: File.join(File.expand_path('~'), "wcios_prs_list_#{old_version}_#{new_version}.txt"))
     setbranchprotection(repository: GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository: GHHELPER_REPO, milestone: new_version)
     ios_check_beta_deps(podfile: 'Podfile')
@@ -807,12 +805,6 @@ platform :ios do
   ########################################################################
   # Helper Lanes
   ########################################################################
-  desc 'Get a list of pull requests from the `milestone`'
-  lane :get_pullrequests_list do |options|
-    get_prs_list(repository: GHHELPER_REPO, milestone: (options[:milestone]).to_s,
-                 report_path: "#{File.expand_path('~')}/wcios_prs_list.txt")
-  end
-
   desc 'Run release preflight checks'
   lane :release_preflight do |_options|
     configure_validate


### PR DESCRIPTION
This PR removes the step in Fastlane's `code_freeze` lane that generates a text file with a list of the PRs that made it to the new version. With the current process to generate the release notes and the new tooling we built to generate the draft of the release announcement, this file is not used anymore.

This is also removing the `get_pullrequests_list` lane.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
