### PR TITLE
[Mobile Payments] Clear connected view model update error state on successfully connecting to a reader

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -51,7 +51,6 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
             self.didGetConnectedReaders = true
             self.connectedReaders = readers
             self.updateProperties()
-
             self.reevaluateShouldShow()
         }
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -47,9 +47,11 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
             guard let self = self else {
                 return
             }
+            self.readerUpdateError = nil
             self.didGetConnectedReaders = true
             self.connectedReaders = readers
             self.updateProperties()
+
             self.reevaluateShouldShow()
         }
         ServiceLocator.stores.dispatch(action)


### PR DESCRIPTION
Partially addresses #5327 

This was a tricky one to reproduce. There may be other ways to precipitate 5327, and I will keep looking.

Background of the changes:

As of SDK2 an update may be kicked off while connecting to a reader. Because of this an update error can happen when attempting to connect to a reader if the reader needs a software update but has a low battery. This is different than SDK 1 where updates (and update errors) could not happen until AFTER connection completed.

The card reader settings views have two underlying view models - one for aggregating and formatting state useful for the searching view and one for aggregating and formatting state useful for the connected view. Both view models are contemporary and observe software update events.

Unfortunately, with the change in SDK2, a software update failure (due to low battery) can now occur (and be handled) outside of the connected view controller's purview. When this happens, the connected view model will receive notification of the update failure, but not the clearing that occurs under the purview of the searching view model.

The most appropriate way to remedy this would be to have both the searching and connected views rely on a single source of update state since SDK2 has blurred the lines. I've opened issue #5417 for that. In the mean time, a quick fix will be to clear any update error in the connected view model when the list of connected readers updates.

To test
- You'll need two readers. One requiring an update and with a low battery and another not requiring an update
- Power on just the low battery reader initially
- Attempt to connect to it
- Observe the update fails due to low battery
- Power on the other reader
- Keep searching and connect to the other reader when you see it
- Disconnect from the other reader
- Ensure you do NOT see a update failed due to low battery alert at this point

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
