### PR TITLE
Jetpack CP site detection: add `isJetpackConnected` and `isJetpackThePluginInstalled` attributes to `Networking.Site`

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1314,6 +1314,8 @@ extension Site {
             description: .fake(),
             url: .fake(),
             plan: .fake(),
+            isJetpackThePluginInstalled: .fake(),
+            isJetpackConnected: .fake(),
             isWooCommerceActive: .fake(),
             isWordPressStore: .fake(),
             timezone: .fake(),

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1151,6 +1151,8 @@ extension Site {
         description: CopiableProp<String> = .copy,
         url: CopiableProp<String> = .copy,
         plan: CopiableProp<String> = .copy,
+        isJetpackThePluginInstalled: CopiableProp<Bool> = .copy,
+        isJetpackConnected: CopiableProp<Bool> = .copy,
         isWooCommerceActive: CopiableProp<Bool> = .copy,
         isWordPressStore: CopiableProp<Bool> = .copy,
         timezone: CopiableProp<String> = .copy,
@@ -1161,6 +1163,8 @@ extension Site {
         let description = description ?? self.description
         let url = url ?? self.url
         let plan = plan ?? self.plan
+        let isJetpackThePluginInstalled = isJetpackThePluginInstalled ?? self.isJetpackThePluginInstalled
+        let isJetpackConnected = isJetpackConnected ?? self.isJetpackConnected
         let isWooCommerceActive = isWooCommerceActive ?? self.isWooCommerceActive
         let isWordPressStore = isWordPressStore ?? self.isWordPressStore
         let timezone = timezone ?? self.timezone
@@ -1172,6 +1176,8 @@ extension Site {
             description: description,
             url: url,
             plan: plan,
+            isJetpackThePluginInstalled: isJetpackThePluginInstalled,
+            isJetpackConnected: isJetpackConnected,
             isWooCommerceActive: isWooCommerceActive,
             isWordPressStore: isWordPressStore,
             timezone: timezone,

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -25,6 +25,14 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     ///
     public let plan: String
 
+    /// Whether the site has Jetpack-the-plugin installed.
+    ///
+    public let isJetpackThePluginInstalled: Bool
+
+    /// Whether the site is connected to Jetpack, either through Jetpack-the-plugin or other plugins that include Jetpack Connection Package.
+    ///
+    public let isJetpackConnected: Bool
+
     ///  Indicates if there is a WooCommerce Store Active.
     ///
     public let isWooCommerceActive: Bool
@@ -50,6 +58,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         let name = try siteContainer.decode(String.self, forKey: .name)
         let description = try siteContainer.decode(String.self, forKey: .description)
         let url = try siteContainer.decode(String.self, forKey: .url)
+        let isJetpackThePluginInstalled = try siteContainer.decode(Bool.self, forKey: .isJetpackThePluginInstalled)
+        let isJetpackConnected = try siteContainer.decode(Bool.self, forKey: .isJetpackConnected)
 
         let optionsContainer = try siteContainer.nestedContainer(keyedBy: OptionKeys.self, forKey: .options)
         let isWordPressStore = try optionsContainer.decode(Bool.self, forKey: .isWordPressStore)
@@ -62,6 +72,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                   description: description,
                   url: url,
                   plan: String(), // Not created on init. Added in supplementary API request.
+                  isJetpackThePluginInstalled: isJetpackThePluginInstalled,
+                  isJetpackConnected: isJetpackConnected,
                   isWooCommerceActive: isWooCommerceActive,
                   isWordPressStore: isWordPressStore,
                   timezone: timezone,
@@ -75,6 +87,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                 description: String,
                 url: String,
                 plan: String,
+                isJetpackThePluginInstalled: Bool,
+                isJetpackConnected: Bool,
                 isWooCommerceActive: Bool,
                 isWordPressStore: Bool,
                 timezone: String,
@@ -84,6 +98,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         self.description = description
         self.url = url
         self.plan = plan
+        self.isJetpackThePluginInstalled = isJetpackThePluginInstalled
+        self.isJetpackConnected = isJetpackConnected
         self.isWordPressStore = isWordPressStore
         self.isWooCommerceActive = isWooCommerceActive
         self.timezone = timezone
@@ -91,6 +107,13 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     }
 }
 
+public extension Site {
+    /// Whether the site is connected to Jetpack with Jetpack Connection Package, and not with Jetpack-the-plugin.
+    ///
+    var isJetpackCPConnected: Bool {
+        isJetpackConnected && !isJetpackThePluginInstalled
+    }
+}
 
 /// Defines all of the Site CodingKeys.
 ///
@@ -103,6 +126,8 @@ private extension Site {
         case url            = "URL"
         case options        = "options"
         case plan           = "plan"
+        case isJetpackThePluginInstalled = "jetpack"
+        case isJetpackConnected          = "jetpack_connection"
     }
 
     enum OptionKeys: String, CodingKey {

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -53,7 +53,7 @@ public class AccountRemote: Remote {
     public func loadSites(completion: @escaping (Result<[Site], Error>) -> Void) {
         let path = "me/sites"
         let parameters = [
-            "fields": "ID,name,description,URL,options",
+            "fields": "ID,name,description,URL,options,jetpack,jetpack_connection",
             "options": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset"
         ]
 

--- a/Networking/NetworkingTests/Responses/sites-malformed.json
+++ b/Networking/NetworkingTests/Responses/sites-malformed.json
@@ -6,6 +6,7 @@
       "description": "Testing Tagline",
       "URL": "https:\/\/some-testing-url.testing.blog",
       "jetpack": true,
+      "jetpack_connection": true,
       "updates": {
         "plugins": 3,
         "themes": 1,
@@ -20,6 +21,7 @@
       "description": "Your Favorite Blog",
       "URL": "https:\/\/thoughts.testing.blog",
       "jetpack": false,
+      "jetpack_connection": true,
       "options": {
         "timezone": "",
         "gmt_offset": -4,

--- a/Networking/NetworkingTests/Responses/sites.json
+++ b/Networking/NetworkingTests/Responses/sites.json
@@ -6,6 +6,7 @@
       "description": "Testing Tagline",
       "URL": "https:\/\/some-testing-url.testing.blog",
       "jetpack": true,
+      "jetpack_connection": true,
       "options": {
         "timezone": "",
         "gmt_offset": 3.5,
@@ -144,6 +145,7 @@
       "description": "Your Favorite Blog",
       "URL": "https:\/\/thoughts.testing.blog",
       "jetpack": false,
+      "jetpack_connection": true,
       "options": {
         "timezone": "",
         "gmt_offset": -4,

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -36,6 +36,8 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         description: "",
         url: i18n.DefaultSite.url,
         plan: "",
+        isJetpackThePluginInstalled: true,
+        isJetpackConnected: true,
         isWooCommerceActive: true,
         isWordPressStore: true,
         timezone: "UTC",

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -14,6 +14,8 @@ extension Storage.Site: ReadOnlyConvertible {
         tagline = site.description
         url = site.url
 //        plan = site.plan // We're not assigning the plan here because it's not sent on the intial API request.
+        // TODO: 5364 - update `isJetpackThePluginInstalled`
+        // TODO: 5364 - update `isJetpackConnected`
         isWooCommerceActive = NSNumber(booleanLiteral: site.isWooCommerceActive)
         isWordPressStore = NSNumber(booleanLiteral: site.isWordPressStore)
         timezone = site.timezone
@@ -28,6 +30,8 @@ extension Storage.Site: ReadOnlyConvertible {
                     description: tagline ?? "",
                     url: url ?? "",
                     plan: plan ?? "",
+                    isJetpackThePluginInstalled: true, // TODO: 5364 - persist in storage
+                    isJetpackConnected: true, // TODO: 5364 - persist in storage
                     isWooCommerceActive: isWooCommerceActive?.boolValue ?? false,
                     isWordPressStore: isWordPressStore?.boolValue ?? false,
                     timezone: timezone ?? "",

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -485,14 +485,6 @@ private extension AccountStoreTests {
     /// Sample Site
     ///
     func sampleSitePristine() -> Networking.Site {
-        return Site(siteID: 999,
-                    name: "Awesome Test Site",
-                    description: "Best description ever!",
-                    url: "automattic.com",
-                    plan: String(),
-                    isWooCommerceActive: true,
-                    isWordPressStore: false,
-                    timezone: "Asia/Taipei",
-                    gmtOffset: 0)
+        return Site.fake()
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -351,9 +351,12 @@ final class AccountStoreTests: XCTestCase {
         let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
+        let siteID = Int64(999)
+        // TODO: 5364 - remove `isJetpackThePluginInstalled` and `isJetpackConnected` once they are updated in `Site+ReadOnlyConvertible`
+        let sampleSite = sampleSitePristine().copy(siteID: siteID, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let group = DispatchGroup()
         group.enter()
-        accountStore.upsertStoredSitesInBackground(readOnlySites: [sampleSitePristine()]) {
+        accountStore.upsertStoredSitesInBackground(readOnlySites: [sampleSite]) {
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Site.self), 1)
             group.leave()
         }
@@ -361,7 +364,7 @@ final class AccountStoreTests: XCTestCase {
         // When
         let result: Result<Yosemite.Site, Error> = waitFor { promise in
             group.notify(queue: .main) {
-                let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: 999) { result in
+                let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: siteID) { result in
                     XCTAssertTrue(Thread.isMainThread)
                     promise(result)
                 }
@@ -371,7 +374,7 @@ final class AccountStoreTests: XCTestCase {
 
         // Then
         let site = try XCTUnwrap(result.get())
-        XCTAssertEqual(site, sampleSitePristine())
+        XCTAssertEqual(site, sampleSite)
         XCTAssertEqual(network.requestsForResponseData.count, 0)
     }
 


### PR DESCRIPTION
Part of #5364 

## Why

In order to know if a site is connected to Jetpack via Jetpack Connection Package instead of Jetpack-the-plugin, we are fetching 2 values for each site in the `me/sites` endpoint:

- `isJetpackThePluginInstalled: Bool`: this corresponds to the `jetpack` field in the API response. It indicates whether Jetpack-the-plugin is installed on the site
- `isJetpackConnected: Bool`: this corresponds to the `jetpack_connection` field in the API response. It indicates whether the site is connected to Jetpack, either through Jetpack-the-plugin or other plugins that include Jetpack Connection Package

Then we can know whether a site is a JCP site by the derived value `isJetpackConnected && !isJetpackThePluginInstalled`. As a workaround, there are 2 more API requests to make for each JCP site to get the updated info about whether WooCommerce is active and also the site metadata.

This PR includes changes in the networking layer only for the 2 new attributes, to make it easier for code review. The workaround to make 2 extra API requests and integration with the storage layer will be in separate PRs.

## Changes

- Added `isJetpackThePluginInstalled` and `isJetpackConnected` booleans to `Networking.Site` that correspond to `jetpack` and `jetpack_connection` fields in the API
- Ran `rake generate` for Fakeable and Copiable support
- Updated unit tests: added `jetpack_connection` field to the existing `me/sites` API responses

## Testing

Please test for regression in the site picker (this is where we fetch the sites from `me/sites` endpoint):

- Log out from the app
- Log in to the app --> the site list in the site picker should be the same as before the PR branch
- Go to Settings > Switch Store --> the site list in the site picker should be the same as before

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
