### PR TITLE
Order Creation: Add feature flag and experimental features switch for order creation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -27,6 +27,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .jetpackConnectionPackageSupport:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .orderCreation:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -53,4 +53,8 @@ public enum FeatureFlag: Int {
     /// Allows sites with plugins that include Jetpack Connection Package and without Jetpack-the-plugin to connect to the app
     ///
     case jetpackConnectionPackageSupport
+
+    /// Allows new orders to be manually created
+    ///
+    case orderCreation
 }

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -10,6 +10,7 @@ extension GeneralAppSettings {
         feedbacks: CopiableProp<[FeedbackType: FeedbackSettings]> = .copy,
         isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy,
         isSimplePaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
+        isOrderCreationSwitchEnabled: CopiableProp<Bool> = .copy,
         knownCardReaders: CopiableProp<[String]> = .copy,
         lastEligibilityErrorInfo: NullableCopiableProp<EligibilityErrorInfo> = .copy
     ) -> GeneralAppSettings {
@@ -17,6 +18,7 @@ extension GeneralAppSettings {
         let feedbacks = feedbacks ?? self.feedbacks
         let isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled ?? self.isViewAddOnsSwitchEnabled
         let isSimplePaymentsSwitchEnabled = isSimplePaymentsSwitchEnabled ?? self.isSimplePaymentsSwitchEnabled
+        let isOrderCreationSwitchEnabled = isOrderCreationSwitchEnabled ?? self.isOrderCreationSwitchEnabled
         let knownCardReaders = knownCardReaders ?? self.knownCardReaders
         let lastEligibilityErrorInfo = lastEligibilityErrorInfo ?? self.lastEligibilityErrorInfo
 
@@ -25,6 +27,7 @@ extension GeneralAppSettings {
             feedbacks: feedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
             isSimplePaymentsSwitchEnabled: isSimplePaymentsSwitchEnabled,
+            isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -28,6 +28,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isSimplePaymentsSwitchEnabled: Bool
 
+    /// The state(`true` or `false`) for the Order Creation feature switch.
+    ///
+    public let isOrderCreationSwitchEnabled: Bool
+
     /// A list (possibly empty) of known card reader IDs - i.e. IDs of card readers that should be reconnected to automatically
     /// e.g. ["CHB204909005931"]
     ///
@@ -41,12 +45,14 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
                 isSimplePaymentsSwitchEnabled: Bool,
+                isOrderCreationSwitchEnabled: Bool,
                 knownCardReaders: [String],
                 lastEligibilityErrorInfo: EligibilityErrorInfo? = nil) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
         self.isSimplePaymentsSwitchEnabled = isSimplePaymentsSwitchEnabled
+        self.isOrderCreationSwitchEnabled = isOrderCreationSwitchEnabled
         self.knownCardReaders = knownCardReaders
         self.lastEligibilityErrorInfo = lastEligibilityErrorInfo
     }
@@ -73,6 +79,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             feedbacks: updatedFeedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
             isSimplePaymentsSwitchEnabled: isSimplePaymentsSwitchEnabled,
+            isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )
@@ -90,6 +97,7 @@ extension GeneralAppSettings {
         self.feedbacks = try container.decodeIfPresent([FeedbackType: FeedbackSettings].self, forKey: .feedbacks) ?? [:]
         self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
         self.isSimplePaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSimplePaymentsSwitchEnabled) ?? false
+        self.isOrderCreationSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isOrderCreationSwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
         self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)
 

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -10,6 +10,7 @@ class GeneralAppSettingsTests: XCTestCase {
                                           feedbacks: [.general: feedback],
                                           isViewAddOnsSwitchEnabled: false,
                                           isSimplePaymentsSwitchEnabled: false,
+                                          isOrderCreationSwitchEnabled: false,
                                           knownCardReaders: [])
 
         // When
@@ -25,6 +26,7 @@ class GeneralAppSettingsTests: XCTestCase {
                                           feedbacks: [:],
                                           isViewAddOnsSwitchEnabled: false,
                                           isSimplePaymentsSwitchEnabled: false,
+                                          isOrderCreationSwitchEnabled: false,
                                           knownCardReaders: [])
 
         // When
@@ -42,6 +44,7 @@ class GeneralAppSettingsTests: XCTestCase {
             feedbacks: [.general: existingFeedback],
             isViewAddOnsSwitchEnabled: false,
             isSimplePaymentsSwitchEnabled: false,
+            isOrderCreationSwitchEnabled: false,
             knownCardReaders: []
         )
 
@@ -59,6 +62,7 @@ class GeneralAppSettingsTests: XCTestCase {
                                           feedbacks: [:],
                                           isViewAddOnsSwitchEnabled: false,
                                           isSimplePaymentsSwitchEnabled: false,
+                                          isOrderCreationSwitchEnabled: false,
                                           knownCardReaders: [])
 
         // When
@@ -79,6 +83,7 @@ class GeneralAppSettingsTests: XCTestCase {
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
                                                   isSimplePaymentsSwitchEnabled: true,
+                                                  isOrderCreationSwitchEnabled: true,
                                                   knownCardReaders: readers,
                                                   lastEligibilityErrorInfo: eligibilityInfo)
 
@@ -97,5 +102,6 @@ class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
         assertEqual(newSettings.isSimplePaymentsSwitchEnabled, true)
+        assertEqual(newSettings.isOrderCreationSwitchEnabled, true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -264,12 +264,14 @@ private enum Row: CaseIterable {
     // Orders.
     case simplePayments
     case simplePaymentsDescription
+    case orderCreation
+    case orderCreationDescription
 
     var type: UITableViewCell.Type {
         switch self {
-        case .orderAddOns, .simplePayments:
+        case .orderAddOns, .simplePayments, .orderCreation:
             return SwitchTableViewCell.self
-        case .orderAddOnsDescription, .simplePaymentsDescription:
+        case .orderAddOnsDescription, .simplePaymentsDescription, .orderCreationDescription:
             return BasicTableViewCell.self
         }
     }
@@ -289,5 +291,8 @@ private extension BetaFeaturesViewController {
                                                            comment: "Cell title on the beta features screen to enable the Simple Payments feature")
         static let simplePaymentsDescription = NSLocalizedString("Test out creating orders with minimal information as we get ready to launch",
                                                               comment: "Cell description on the beta features screen to enable the Simple Payments feature")
+        static let orderCreationTitle = NSLocalizedString("Order Creation", comment: "Cell title on the beta features screen to enable creating new orders")
+        static let orderCreationDescription = NSLocalizedString("Test out creating new manual orders as we get ready to launch",
+                                                                comment: "Cell description on the beta features screen to enable creating new orders")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -78,7 +78,8 @@ private extension BetaFeaturesViewController {
     func configureSections() {
         self.sections = [
             productsSection(),
-            ordersSection()
+            ordersSection(),
+            orderCreationSection()
         ].compactMap { $0 }
     }
 
@@ -96,6 +97,15 @@ private extension BetaFeaturesViewController {
 
         return Section(rows: [.simplePayments,
                               .simplePaymentsDescription])
+    }
+
+    func orderCreationSection() -> Section? {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) else {
+            return nil
+        }
+
+        return Section(rows: [.orderCreation,
+                              .orderCreationDescription])
     }
 
     /// Register table cells.
@@ -125,6 +135,10 @@ private extension BetaFeaturesViewController {
             configureSimplePaymentsSwitch(cell: cell)
         case let cell as BasicTableViewCell where row == .simplePaymentsDescription:
             configureSimplePaymentsDescription(cell: cell)
+        case let cell as SwitchTableViewCell where row == .orderCreation:
+            configureOrderCreationSwitch(cell: cell)
+        case let cell as BasicTableViewCell where row == .orderCreationDescription:
+            configureOrderCreationDescription(cell: cell)
         default:
             fatalError()
         }
@@ -196,6 +210,17 @@ private extension BetaFeaturesViewController {
     func configureSimplePaymentsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
         cell.textLabel?.text = Localization.simplePaymentsDescription
+    }
+
+    func configureOrderCreationSwitch(cell: SwitchTableViewCell) {
+        configureCommonStylesForSwitchCell(cell)
+        cell.title = Localization.orderCreationTitle
+        cell.accessibilityIdentifier = "beta-features-order-order-creation-cell"
+    }
+
+    func configureOrderCreationDescription(cell: BasicTableViewCell) {
+        configureCommonStylesForDescriptionCell(cell)
+        cell.textLabel?.text = Localization.orderCreationDescription
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -215,6 +215,26 @@ private extension BetaFeaturesViewController {
     func configureOrderCreationSwitch(cell: SwitchTableViewCell) {
         configureCommonStylesForSwitchCell(cell)
         cell.title = Localization.orderCreationTitle
+
+        // Fetch switch's state stored value.
+        let action = AppSettingsAction.loadOrderCreationSwitchState() { result in
+            guard let isEnabled = try? result.get() else {
+                return cell.isOn = false
+            }
+            cell.isOn = isEnabled
+        }
+        ServiceLocator.stores.dispatch(action)
+
+        // Change switch's state stored value
+        cell.onChange = { isSwitchOn in
+            let action = AppSettingsAction.setOrderCreationFeatureSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
+                // Roll back toggle if an error occurred
+                if result.isFailure {
+                    cell.isOn.toggle()
+                }
+            })
+            ServiceLocator.stores.dispatch(action)
+        }
         cell.accessibilityIdentifier = "beta-features-order-order-creation-cell"
     }
 

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -110,6 +110,14 @@ public enum AppSettingsAction: Action {
     ///
     case setSimplePaymentsFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
 
+    /// Loads the most recent state for the Order Creation beta feature switch
+    ///
+    case loadOrderCreationSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Sets the state for the Order Creation beta feature switch.
+    ///
+    case setOrderCreationFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
+
     /// Remember the given card reader (to support automatic reconnection)
     /// where `cardReaderID` is a String e.g. "CHB204909005931"
     ///

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -146,6 +146,10 @@ public class AppSettingsStore: Store {
             setSimplePaymentsFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .loadSimplePaymentsSwitchState(onCompletion: let onCompletion):
             loadSimplePaymentsSwitchState(onCompletion: onCompletion)
+        case .setOrderCreationFeatureSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
+            setOrderCreationFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
+        case .loadOrderCreationSwitchState(onCompletion: let onCompletion):
+            loadOrderCreationSwitchState(onCompletion: onCompletion)
         case .rememberCardReader(cardReaderID: let cardReaderID, onCompletion: let onCompletion):
             rememberCardReader(cardReaderID: cardReaderID, onCompletion: onCompletion)
         case .forgetCardReader(onCompletion: let onCompletion):
@@ -261,6 +265,26 @@ private extension AppSettingsStore {
 
     }
 
+    /// Loads the current Order Creation beta feature switch state from `GeneralAppSettings`
+    ///
+    func loadOrderCreationSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
+        let settings = loadOrCreateGeneralAppSettings()
+        onCompletion(.success(settings.isOrderCreationSwitchEnabled))
+    }
+
+    /// Sets the provided Order Creation beta feature switch state into `GeneralAppSettings`
+    ///
+    func setOrderCreationFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            let settings = loadOrCreateGeneralAppSettings().copy(isOrderCreationSwitchEnabled: isEnabled)
+            try saveGeneralAppSettings(settings)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+
+    }
+
     /// Loads the last persisted eligibility error information from `GeneralAppSettings`
     ///
     func loadEligibilityErrorInfo(onCompletion: (Result<EligibilityErrorInfo, Error>) -> Void) {
@@ -290,6 +314,7 @@ private extension AppSettingsStore {
                                       feedbacks: [:],
                                       isViewAddOnsSwitchEnabled: false,
                                       isSimplePaymentsSwitchEnabled: false,
+                                      isOrderCreationSwitchEnabled: false,
                                       knownCardReaders: [],
                                       lastEligibilityErrorInfo: nil)
         }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -160,6 +160,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         let settings = GeneralAppSettings(installationDate: nil,
                                           feedbacks: [:], isViewAddOnsSwitchEnabled: false,
                                           isSimplePaymentsSwitchEnabled: false,
+                                          isOrderCreationSwitchEnabled: false,
                                           knownCardReaders: [])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
@@ -225,6 +226,7 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
             isSimplePaymentsSwitchEnabled: false,
+            isOrderCreationSwitchEnabled: false,
             knownCardReaders: []
         )
         return settings

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -483,6 +483,42 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(isEnabled)
     }
 
+    func test_loadOrderCreationSwitchState_returns_false_on_new_generalAppSettings() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadOrderCreationSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_loadOrderCreationSwitchState_returns_true_after_updating_switch_state_to_true() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.setOrderCreationFeatureSwitchState(isEnabled: true, onCompletion: { _ in })
+        subject?.onAction(updateAction)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadOrderCreationSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertTrue(isEnabled)
+    }
+
     // MARK: - General Store Settings
 
     func test_saving_isTelemetryAvailable_works_correctly() throws {
@@ -642,6 +678,7 @@ private extension AppSettingsStoreTests {
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
             isSimplePaymentsSwitchEnabled: false,
+            isOrderCreationSwitchEnabled: false,
             knownCardReaders: []
         )
         return (settings, feedback)


### PR DESCRIPTION
Fixes: #5403

## Description

This PR adds a development feature flag and an Experimental Features switch (behind the flag for now) for Order Creation. As we release parts of the order creation feature, merchants who enable the experimental features toggle can start to create orders.

## Changes

Feature flag:
* Adds the `orderCreation` feature flag, enabled for development and alpha builds in `DefaultFeatureFlagService`.

Experimental Features switch:
* Adds `isOrderCreationSwitchEnabled` to `GeneralAppSettings`, to store the order creation switch state.
* Adds Yosemite actions to load and set the order creation switch state.
* Adds a section for the order creation switch to `BetaFeaturesViewController`, visible when the `orderCreation` feature flag is enabled.
* Updates unit tests (including new tests for the order creation switch state in `AppSettingsStoreTests`).

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-11-15 at 23 38 51](https://user-images.githubusercontent.com/8658164/141869702-937f3ffc-8818-4c4e-b748-8d8b89ad565e.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-11-15 at 22 51 54](https://user-images.githubusercontent.com/8658164/141869709-a5d5f2d2-6a1f-4fdf-a360-335fbb30e987.png)

## Testing

1. Launch the app in debug mode (so the feature flag is enabled).
2. Open app settings > Experimental Features and confirm you can toggle "Order Creation" on and off, and the state is saved when you relaunch the app.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
