### PR TITLE
Cerry-pick: Use a fixed `Date` in `ReceiptRendererTest` in `release/8.0`

### DIFF
--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -40,7 +40,7 @@ private extension ReceiptRendererTest {
                 amount: 1,
                 formattedAmount: "1",
                 currency: "USD",
-                date: .init(),
+                date: .init(timeIntervalSince1970: 1636970486),
                 storeName: "Test Store",
                 cardDetails: .init(
                     last4: "1234",


### PR DESCRIPTION
See discussion in https://github.com/woocommerce/woocommerce-ios/pull/5433, and https://github.com/woocommerce/woocommerce-ios/pull/5434.

If CI is green, we can merge 👍 