### PR TITLE
Update internal release notes for #5393

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 8.1
 -----
+- [internal] Migrated Settings screen to MVVM [https://github.com/woocommerce/woocommerce-ios/pull/5393]
 
 
 8.0


### PR DESCRIPTION
# Description
When reviewing #5393 I forgot that we should update the release notes with an internal update. This PR adds that to make sure that Settings screen gets tested during code freeze.

(I'm not sure which label to add to this PR so I'm leaving it empty).

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
