### PR TITLE
[Mobile Payments] Make CardReaderConfigProvider conformance to ReaderTokenProvider explicit

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
+++ b/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
@@ -10,7 +10,7 @@ public protocol ReaderLocationProvider {
     func fetchDefaultLocationID(completion: @escaping(String?, Error?) -> Void)
 }
 
-public protocol CardReaderConfigProvider: ReaderLocationProvider {
+public protocol CardReaderConfigProvider: ReaderLocationProvider, ReaderTokenProvider {
     func fetchToken(completion: @escaping(String?, Error?) -> Void)
     func fetchDefaultLocationID(completion: @escaping(String?, Error?) -> Void)
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/DefaultConnectionTokenProvider.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/DefaultConnectionTokenProvider.swift
@@ -4,9 +4,9 @@ import StripeTerminal
 /// uses the networking adapter provided by clients of Hardware
 /// to fetch a connection token
 final class DefaultConnectionTokenProvider: ConnectionTokenProvider {
-    private let provider: CardReaderConfigProvider
+    private let provider: ReaderTokenProvider
 
-    init(provider: CardReaderConfigProvider) {
+    init(provider: ReaderTokenProvider) {
         self.provider = provider
     }
 


### PR DESCRIPTION
Closes #5424 

Brought up during the review of #5322 . 

## Changes
* Make CardReaderConfigProvider conform to ReaderTokenProvider explicitly
* Which also makes possible to make DefaultConnectionTokenProvider (the implementation of the protocol Stripe Terminal requires) to depend on ReaderTokenProvider instead of the full configuration provider

## How to test
There are no user facing changes. 
* CI should be ✅ 
* A quick smoke test, attempting to capture a payment.




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
