### PR TITLE
[Mobile Payments] My store is not aligned

### DIFF
--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -24,8 +24,6 @@ final class ReceiptRendererTest: XCTestCase {
 
         let renderer = ReceiptRenderer(content: content)
 
-        print(renderer.htmlContent())
-
         XCTAssertEqual(
             Insecure.MD5.hash(data: renderer.htmlContent().data(using: .utf8)!).description,
             expectedResultWithHtmlSymbolsMd5Description

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -430,6 +430,6 @@ private extension DashboardViewController {
     enum Constants {
         static let animationDuration = 0.2
         static let bannerBottomMargin = CGFloat(8)
-        static let horizontalMargin = CGFloat(16)
+        static let horizontalMargin = CGFloat(20)
     }
 }


### PR DESCRIPTION
Closes: #4850 

### Description
Increases horizontal margin to be aligned with the large title. 

The ticket says to make the left margin 16, but if I understood correctly this 20px left margin of the large title is something "standard" and ideally should not be changed. @ctarda could you please confirm that?

![image_2021-11-16_14-53-02](https://user-images.githubusercontent.com/4923871/141987791-21119b99-09ba-43c6-ad7f-c751a4234090.png)



What I don't like is that other tabs have the same problem, and somewhere misalignment is even bigger:

![image](https://user-images.githubusercontent.com/4923871/141987488-7dc24786-ccfe-4772-af1f-cc36afe72ca0.png)
![image](https://user-images.githubusercontent.com/4923871/141987509-08e5fa0a-10f7-49b1-9673-29a96e42819e.png)
![image](https://user-images.githubusercontent.com/4923871/141987562-da006b5b-6acd-40b5-9090-d5aee3ad1eb8.png)


Shell it be also addressed?


### Testing instructions
* Open stat screen
* Notice that title and store name is aligned

### Images/gif

![image](https://user-images.githubusercontent.com/4923871/141987443-98ea8e72-441e-470c-9e2b-e901d28bb35d.png)


![image](https://user-images.githubusercontent.com/4923871/141987343-70c18a4b-3c31-4710-9bfa-73f61ecaf987.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.