### PR TITLE
Fix site URL comparison failure in UI tests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -72,7 +72,8 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     /// Main Site's URL
     ///
     var siteUrl: String? {
-        stores.sessionManager.defaultSite?.url as String?
+        let urlString = stores.sessionManager.defaultSite?.url as String?
+        return urlString?.removingPrefix("https://").removingPrefix("http://")
     }
 
     /// Sites pulled from the results controlelr


### PR DESCRIPTION
## Description

Recent [refactoring PR](https://github.com/woocommerce/woocommerce-ios/pull/5393) for `SettingsViewController` changed `siteURL` behaviour.

Before:
```swift
let urlAsString = StoresManager.shared.sessionManager.defaultSite?.url as NSString?
return urlAsString?.hostname() ?? String()
```

After:
```swift
stores.sessionManager.defaultSite?.url as String?
```

Therefore cell for currently selected site changed on settings screen and test expectation now fails.

## How

~~The fix is to change test expectation.~~ I don't think trimming URL to `host` as before is a best way. Because:
- now it's the same URL in both picker and settings screens
- site URL *may* have a path that we lose here.

To align with Android we'll trim scheme, but keep path on settings screen. This won't require any changes on UI tests.
Ref: p1637070882319900-slack-C6H8C3G23

## Test

Check CI status for UI tests or run them locally:
1. Run `rake mocks` in project directory to start API mocks
2. Run UITests test plan in Xcode

## Screenshots

store selector (unchanged) | settings before | settings after
--|--|--
![Simulator Screen Shot - iPhone 13 - 2021-11-16 at 16 29 45](https://user-images.githubusercontent.com/3132438/141996024-b5593c07-e11a-4d90-b5ed-d66533b00561.png)|![Simulator Screen Shot - iPhone 13 - 2021-11-16 at 16 29 55](https://user-images.githubusercontent.com/3132438/141996049-2e41b2ab-c014-4735-a24e-1d85d214aa3a.png)|![Simulator Screen Shot - iPhone 13 - 2021-11-16 at 16 35 19](https://user-images.githubusercontent.com/3132438/141996042-b9243f17-d83c-4e9c-8e08-196527da040a.png)

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.