### PR TITLE
[Mobile Payments] Remove print and log to Lumberjack where needed

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -413,7 +413,7 @@ private extension StripeCardReaderService {
                     }
 
                     if underlyingError == .commandCancelled {
-                        DDLogError("💳 Warning: collect payment error cancelled. We actively ignore this error \(error)")
+                        DDLogWarn("💳 Warning: collect payment error cancelled. We actively ignore this error \(error)")
                     }
 
                 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -408,12 +408,12 @@ private extension StripeCardReaderService {
                     /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:delegate:completion:
 
                     if underlyingError != .commandCancelled {
-                        print("==== collect payment method was not cancelled. this is an actual error ", underlyingError)
+                        DDLogError("💳 Error: collect payment method \(underlyingError)")
                         promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: underlyingError)))
                     }
 
                     if underlyingError == .commandCancelled {
-                        print("==== collect payment method cancelled. this is an error we ignore ", error)
+                        DDLogError("💳 Warning: collect payment error cancelled. We actively ignore this error \(error)")
                     }
 
                 }
@@ -488,12 +488,10 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
     }
 
     public func reader(_ reader: Reader, didStartInstallingUpdate update: ReaderSoftwareUpdate, cancelable: StripeTerminal.Cancelable?) {
-        print("==== started software update")
         softwareUpdateSubject.send(.started(cancelable: cancelable.map(StripeCancelable.init(cancelable:))))
     }
 
     public func reader(_ reader: Reader, didReportReaderSoftwareUpdateProgress progress: Float) {
-        print("==== did repost software update progress ", progress)
         softwareUpdateSubject.send(.installing(progress: progress))
     }
 

--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -24,8 +24,6 @@ final class ReceiptRendererTest: XCTestCase {
 
         let renderer = ReceiptRenderer(content: content)
 
-        print(renderer.htmlContent())
-
         XCTAssertEqual(
             Insecure.MD5.hash(data: renderer.htmlContent().data(using: .utf8)!).description,
             expectedResultWithHtmlSymbolsMd5Description

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -411,7 +411,7 @@ private extension CardReaderConnectionController {
                 ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCancelTapped, withProperties: analyticsProperties)
                 cancelable.cancel { result in
                     if case .failure(let error) = result {
-                        print("=== error canceling software update: \(error)")
+                        DDLogError("💳 Error: canceling software update \(error)")
                     } else {
                         ServiceLocator.analytics.track(.cardReaderSoftwareUpdateCanceled, withProperties: analyticsProperties)
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -148,7 +148,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
             self.track(.cardReaderSoftwareUpdateCancelTapped)
             self.softwareUpdateCancelable?.cancel(completion: { [weak self] result in
                 if case .failure(let error) = result {
-                    print("=== error canceling software update: \(error)")
+                    DDLogError("💳 Error: canceling software update \(error)")
                 } else {
                     self?.track(.cardReaderSoftwareUpdateCanceled)
                     self?.completeCardReaderUpdate(success: false)

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -199,7 +199,6 @@ private extension ReceiptStore {
 
         do {
             try fileStorage.write(content, to: outputURL)
-            Swift.print("new receipt saved: open \(outputURL.path)") // command to open the generated file
         } catch {
             DDLogError("⛔️ Unable to save receipt for order id: \(order.orderID)")
         }


### PR DESCRIPTION
Closes #5428 

Brought up during the review of #5322 

There are a few print statements left around. Some of them can be completely removed, some others (like error messages) are better logged to Lumberjack.

I went through the Hardware project, and updated or removed all the prints I could find. Looked also into view models, view controllers and actions/stores associated with In-Person Payments.

## Changes
* There are no user-facing changes, or changes in behaviour.
* Removed some usages of `print`
* In some cases, the `print` is completely removed, in others, we will log to `DDLog`

## How to test
* Check that CI is still ✅ 
* Capture a payment. Look at the logs, see if there is anything left behind that should not be there.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
