### PR TITLE
Order Filters: display a new empty state when there are no results with filters applied

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -25,6 +25,10 @@ final class FilterOrderListViewModel: FilterListViewModel {
             self.dateRange = dateRange
             self.numberOfActiveFilters = numberOfActiveFilters
         }
+
+        var readableString: String {
+            [orderStatus.description, dateRange.description].compactMap { $0 }.joined(separator: ", ")
+        }
     }
 
     let filterActionTitle = Localization.filterActionTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -63,6 +63,10 @@ final class OrderListViewController: UIViewController {
     ///
     private let emptyStateConfig: EmptyStateViewController.Config
 
+    /// The configuration to use for the view if the list with filters applied is empty.
+    ///
+    private let emptyStateConfigNoFilters: EmptyStateViewController.Config
+
     /// The view shown if the list is empty.
     ///
     private lazy var emptyStateViewController = EmptyStateViewController(style: .list)
@@ -104,10 +108,15 @@ final class OrderListViewController: UIViewController {
 
     /// Designated initializer.
     ///
-    init(siteID: Int64, title: String, viewModel: OrderListViewModel, emptyStateConfig: EmptyStateViewController.Config) {
+    init(siteID: Int64,
+         title: String,
+         viewModel: OrderListViewModel,
+         emptyStateConfig: EmptyStateViewController.Config,
+         emptyStateConfigNoFilters: EmptyStateViewController.Config) {
         self.siteID = siteID
         self.viewModel = viewModel
         self.emptyStateConfig = emptyStateConfig
+        self.emptyStateConfigNoFilters = emptyStateConfigNoFilters
 
         super.init(nibName: nil, bundle: nil)
 
@@ -435,7 +444,7 @@ private extension OrderListViewController {
             return
         }
 
-        childController.configure(emptyStateConfig)
+        childController.configure(createFilterConfig())
 
         // Show Error Loading Data banner if the empty state is caused by a sync error
         if viewModel.hasErrorLoadingData {
@@ -468,6 +477,16 @@ private extension OrderListViewController {
         childController.willMove(toParent: nil)
         childView.removeFromSuperview()
         childController.removeFromParent()
+    }
+
+    /// Empty state config
+    ///
+    func createFilterConfig() ->  EmptyStateViewController.Config {
+        guard let filters = viewModel.filters, filters.numberOfActiveFilters != 0 else {
+            return emptyStateConfig
+        }
+
+        return emptyStateConfigNoFilters
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -485,7 +485,7 @@ private extension OrderListViewController {
 
     /// Creates EmptyStateViewController.Config for no orders matching the filter empty view
     ///
-    private func noOrdersMatchFilterConfig() ->  EmptyStateViewController.Config {
+    func noOrdersMatchFilterConfig() -> EmptyStateViewController.Config {
         let boldSearchKeyword = NSAttributedString(string: viewModel.filters?.readableString ?? String(),
                                                    attributes: [.font: EmptyStateViewController.Config.messageFont.bold])
         let message = NSMutableAttributedString(string: Localization.filteredOrdersEmptyStateMessage)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -65,7 +65,7 @@ final class OrderListViewController: UIViewController {
 
     /// The configuration to use for the view if the list with filters applied is empty.
     ///
-    private let emptyStateConfigNoFilters: EmptyStateViewController.Config
+    private let emptyStateConfigWithFilters: EmptyStateViewController.Config
 
     /// The view shown if the list is empty.
     ///
@@ -112,11 +112,11 @@ final class OrderListViewController: UIViewController {
          title: String,
          viewModel: OrderListViewModel,
          emptyStateConfig: EmptyStateViewController.Config,
-         emptyStateConfigNoFilters: EmptyStateViewController.Config) {
+         emptyStateConfigWithFilters: EmptyStateViewController.Config) {
         self.siteID = siteID
         self.viewModel = viewModel
         self.emptyStateConfig = emptyStateConfig
-        self.emptyStateConfigNoFilters = emptyStateConfigNoFilters
+        self.emptyStateConfigWithFilters = emptyStateConfigWithFilters
 
         super.init(nibName: nil, bundle: nil)
 
@@ -486,7 +486,7 @@ private extension OrderListViewController {
             return emptyStateConfig
         }
 
-        return emptyStateConfigNoFilters
+        return emptyStateConfigWithFilters
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -19,6 +19,10 @@ protocol OrderListViewControllerDelegate: AnyObject {
     /// Called when an order list `UIScrollView`'s `scrollViewDidScroll` event is triggered from the user.
     ///
     func orderListScrollViewDidScroll(_ scrollView: UIScrollView)
+
+    /// Called when a user press a clear filters button. Eg. the clear filters button in the empty screen.
+    ///
+    func clearFilters()
 }
 
 /// OrderListViewController: Displays the list of Orders associated to the active Store / Account.
@@ -496,7 +500,7 @@ private extension OrderListViewController {
             image: .emptySearchResultsImage,
             details: "",
             buttonTitle: Localization.clearButton) { [weak self] button in
-                self?.viewModel.updateFilters(filters: FilterOrderListViewModel.Filters())
+                self?.delegate?.clearFilters()
             }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -63,10 +63,6 @@ final class OrderListViewController: UIViewController {
     ///
     private let emptyStateConfig: EmptyStateViewController.Config
 
-    /// The configuration to use for the view if the list with filters applied is empty.
-    ///
-    private let emptyStateConfigWithFilters: EmptyStateViewController.Config
-
     /// The view shown if the list is empty.
     ///
     private lazy var emptyStateViewController = EmptyStateViewController(style: .list)
@@ -111,12 +107,10 @@ final class OrderListViewController: UIViewController {
     init(siteID: Int64,
          title: String,
          viewModel: OrderListViewModel,
-         emptyStateConfig: EmptyStateViewController.Config,
-         emptyStateConfigWithFilters: EmptyStateViewController.Config) {
+         emptyStateConfig: EmptyStateViewController.Config) {
         self.siteID = siteID
         self.viewModel = viewModel
         self.emptyStateConfig = emptyStateConfig
-        self.emptyStateConfigWithFilters = emptyStateConfigWithFilters
 
         super.init(nibName: nil, bundle: nil)
 
@@ -486,7 +480,24 @@ private extension OrderListViewController {
             return emptyStateConfig
         }
 
-        return emptyStateConfigWithFilters
+        return noOrdersMatchFilterConfig()
+    }
+
+    /// Creates EmptyStateViewController.Config for no orders matching the filter empty view
+    ///
+    private func noOrdersMatchFilterConfig() ->  EmptyStateViewController.Config {
+        let boldSearchKeyword = NSAttributedString(string: viewModel.filters?.readableString ?? String(),
+                                                   attributes: [.font: EmptyStateViewController.Config.messageFont.bold])
+        let message = NSMutableAttributedString(string: Localization.filteredOrdersEmptyStateMessage)
+        message.replaceFirstOccurrence(of: "%@", with: boldSearchKeyword)
+
+        return EmptyStateViewController.Config.withButton(
+            message: message,
+            image: .emptySearchResultsImage,
+            details: "",
+            buttonTitle: Localization.clearButton) { [weak self] button in
+                self?.viewModel.updateFilters(filters: FilterOrderListViewModel.Filters())
+            }
     }
 }
 
@@ -655,9 +666,15 @@ private extension OrderListViewController {
     }
 }
 
-// MARK: - Nested Types
+// MARK: - Constants
 //
 private extension OrderListViewController {
+    enum Localization {
+        static let filteredOrdersEmptyStateMessage = NSLocalizedString("We're sorry, we couldn't find any order that match %@",
+                   comment: "Message for empty Orders filtered results. The %@ is a placeholder for the filters entered by the user.")
+        static let clearButton = NSLocalizedString("Clear Filters",
+                                 comment: "Action to remove filters orders on the placeholder overlay when no orders match the filter on the Order List")
+    }
 
     enum Settings {
         static let estimatedHeaderHeight = CGFloat(43)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -19,7 +19,8 @@ final class OrdersRootViewController: UIViewController {
         emptyStateConfig: .simple(
             message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
             image: .waitingForCustomersImage
-        )
+        ),
+        emptyStateConfigNoFilters: noOrdersMatchFilterConfig()
     )
 
     // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
@@ -288,6 +289,18 @@ private extension OrdersRootViewController {
 
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID, "status": order.status.rawValue])
     }
+
+    /// Creates EmptyStateViewController.Config for no orders matching the filter empty view
+    ///
+    private func noOrdersMatchFilterConfig() ->  EmptyStateViewController.Config {
+        return EmptyStateViewController.Config.withButton(
+            message: .init(string: Localization.filteredOrdersEmptyStateMessage),
+            image: .emptyOrdersImage,
+            details: "",
+            buttonTitle: Localization.clearButton) { [weak self] button in
+                self?.filters = FilterOrderListViewModel.Filters()
+            }
+    }
 }
 
 // MARK: - Constants
@@ -297,6 +310,11 @@ private extension OrdersRootViewController {
         static let allOrdersEmptyStateMessage =
         NSLocalizedString("Waiting for your first order",
                           comment: "The message shown in the Orders → All Orders tab if the list is empty.")
+        static let filteredOrdersEmptyStateMessage =
+        NSLocalizedString("No matching orders found",
+                          comment: "The text on the placeholder overlay when no orders match the filter on the Orders tab")
+        static let clearButton = NSLocalizedString("Clear Filters",
+                                 comment: "Action to remove filters orders on the placeholder overlay when no orders match the filter on the Orders tab")
         static let accessibilityLabelSearchOrders = NSLocalizedString("Search orders", comment: "Search Orders")
         static let accessibilityHintSearchOrders = NSLocalizedString(
             "Retrieves a list of orders that contain a given keyword.",

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -20,7 +20,7 @@ final class OrdersRootViewController: UIViewController {
             message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
             image: .waitingForCustomersImage
         ),
-        emptyStateConfigNoFilters: noOrdersMatchFilterConfig()
+        emptyStateConfigWithFilters: noOrdersMatchFilterConfig()
     )
 
     // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -295,7 +295,7 @@ private extension OrdersRootViewController {
     private func noOrdersMatchFilterConfig() ->  EmptyStateViewController.Config {
         return EmptyStateViewController.Config.withButton(
             message: .init(string: Localization.filteredOrdersEmptyStateMessage),
-            image: .emptyOrdersImage,
+            image: .emptySearchResultsImage,
             details: "",
             buttonTitle: Localization.clearButton) { [weak self] button in
                 self?.filters = FilterOrderListViewModel.Filters()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -19,8 +19,7 @@ final class OrdersRootViewController: UIViewController {
         emptyStateConfig: .simple(
             message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
             image: .waitingForCustomersImage
-        ),
-        emptyStateConfigWithFilters: noOrdersMatchFilterConfig()
+        )
     )
 
     // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
@@ -289,18 +288,6 @@ private extension OrdersRootViewController {
 
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID, "status": order.status.rawValue])
     }
-
-    /// Creates EmptyStateViewController.Config for no orders matching the filter empty view
-    ///
-    private func noOrdersMatchFilterConfig() ->  EmptyStateViewController.Config {
-        return EmptyStateViewController.Config.withButton(
-            message: .init(string: Localization.filteredOrdersEmptyStateMessage),
-            image: .emptySearchResultsImage,
-            details: "",
-            buttonTitle: Localization.clearButton) { [weak self] button in
-                self?.filters = FilterOrderListViewModel.Filters()
-            }
-    }
 }
 
 // MARK: - Constants
@@ -310,11 +297,6 @@ private extension OrdersRootViewController {
         static let allOrdersEmptyStateMessage =
         NSLocalizedString("Waiting for your first order",
                           comment: "The message shown in the Orders → All Orders tab if the list is empty.")
-        static let filteredOrdersEmptyStateMessage =
-        NSLocalizedString("No matching orders found",
-                          comment: "The text on the placeholder overlay when no orders match the filter on the Orders tab")
-        static let clearButton = NSLocalizedString("Clear Filters",
-                                 comment: "Action to remove filters orders on the placeholder overlay when no orders match the filter on the Orders tab")
         static let accessibilityLabelSearchOrders = NSLocalizedString("Search orders", comment: "Search Orders")
         static let accessibilityHintSearchOrders = NSLocalizedString(
             "Retrieves a list of orders that contain a given keyword.",

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -227,6 +227,10 @@ extension OrdersRootViewController: OrderListViewControllerDelegate {
     func orderListScrollViewDidScroll(_ scrollView: UIScrollView) {
         hiddenScrollView.updateFromScrollViewDidScrollEventForLargeTitleWorkaround(scrollView)
     }
+
+    func clearFilters() {
+        filters = FilterOrderListViewModel.Filters()
+    }
 }
 
 // MARK: - Creators

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -129,18 +129,23 @@ private extension OrderSearchStarterViewController {
 
         let title = cellViewModel.name ?? Localization.defaultOrderListTitle
         let emptyStateConfig = EmptyStateViewController.Config.simple(message: emptyStateMessage, image: .emptySearchResultsImage)
+        let noOrdersMatchFilterEmptyStateConfig =
+        EmptyStateViewController.Config.simple(message: .init(string: Localization.filteredOrdersEmptyStateMessage), image: .emptyOrdersImage)
 
-        // TODO-5243: Remove status filters from search view
         return OrderListViewController(
             siteID: siteID,
             title: title,
             viewModel: .init(siteID: siteID, filters: nil),
-            emptyStateConfig: emptyStateConfig
+            emptyStateConfig: emptyStateConfig,
+            emptyStateConfigNoFilters: noOrdersMatchFilterEmptyStateConfig
         )
     }
 
     enum Localization {
         static let defaultOrderListTitle = NSLocalizedString("Orders", comment: "Default title for Orders List shown when tapping on the Search filter.")
+        static let filteredOrdersEmptyStateMessage =
+        NSLocalizedString("No matching orders found",
+                          comment: "The text on the placeholder overlay when no orders match the filter on the Orders Search View")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -140,9 +140,6 @@ private extension OrderSearchStarterViewController {
 
     enum Localization {
         static let defaultOrderListTitle = NSLocalizedString("Orders", comment: "Default title for Orders List shown when tapping on the Search filter.")
-        static let filteredOrdersEmptyStateMessage =
-        NSLocalizedString("No matching orders found",
-                          comment: "The text on the placeholder overlay when no orders match the filter on the Orders Search View")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -137,7 +137,7 @@ private extension OrderSearchStarterViewController {
             title: title,
             viewModel: .init(siteID: siteID, filters: nil),
             emptyStateConfig: emptyStateConfig,
-            emptyStateConfigNoFilters: noOrdersMatchFilterEmptyStateConfig
+            emptyStateConfigWithFilters: noOrdersMatchFilterEmptyStateConfig
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -129,15 +129,12 @@ private extension OrderSearchStarterViewController {
 
         let title = cellViewModel.name ?? Localization.defaultOrderListTitle
         let emptyStateConfig = EmptyStateViewController.Config.simple(message: emptyStateMessage, image: .emptySearchResultsImage)
-        let noOrdersMatchFilterEmptyStateConfig =
-        EmptyStateViewController.Config.simple(message: .init(string: Localization.filteredOrdersEmptyStateMessage), image: .emptySearchResultsImage)
 
         return OrderListViewController(
             siteID: siteID,
             title: title,
             viewModel: .init(siteID: siteID, filters: nil),
-            emptyStateConfig: emptyStateConfig,
-            emptyStateConfigWithFilters: noOrdersMatchFilterEmptyStateConfig
+            emptyStateConfig: emptyStateConfig
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -130,7 +130,7 @@ private extension OrderSearchStarterViewController {
         let title = cellViewModel.name ?? Localization.defaultOrderListTitle
         let emptyStateConfig = EmptyStateViewController.Config.simple(message: emptyStateMessage, image: .emptySearchResultsImage)
         let noOrdersMatchFilterEmptyStateConfig =
-        EmptyStateViewController.Config.simple(message: .init(string: Localization.filteredOrdersEmptyStateMessage), image: .emptyOrdersImage)
+        EmptyStateViewController.Config.simple(message: .init(string: Localization.filteredOrdersEmptyStateMessage), image: .emptySearchResultsImage)
 
         return OrderListViewController(
             siteID: siteID,


### PR DESCRIPTION
Part of #5243 

## Description
As part of Order Filters, now we will display a new empty state when there are no results with filters applied.

## Testing
1. Launch the app, and select the Orders tab.
2. Filter the Order List using some filters where you are sure there are no results.
3. You should be able to see the new empty screen.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro - 2021-11-16 at 15 32 51](https://user-images.githubusercontent.com/495617/142018900-33db4897-3af4-47f5-9eb2-25751fc0dc5a.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-16 at 16 48 59](https://user-images.githubusercontent.com/495617/142018918-1845a5af-286a-4686-a0c9-9a1b3f6ef441.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
