### PR TITLE
[Mobile Payments] Guard for nil self early when capturing payment

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -178,6 +178,9 @@ private extension PaymentCaptureOrchestrator {
         let action = PaymentGatewayAccountAction.captureOrderPayment(siteID: siteID,
                                                                      orderID: order.orderID,
                                                                      paymentIntentID: paymentIntent.id) { [weak self] result in
+            guard let self = self else {
+                return
+            }
 
             guard let receiptParameters = paymentIntent.receiptParameters() else {
                 let error = CardReaderServiceError.paymentCapture()
@@ -190,8 +193,8 @@ private extension PaymentCaptureOrchestrator {
 
             switch result {
             case .success:
-                self?.celebrate() // plays a sound, haptic
-                self?.saveReceipt(for: order, params: receiptParameters)
+                self.celebrate() // plays a sound, haptic
+                self.saveReceipt(for: order, params: receiptParameters)
                 onCompletion(.success(receiptParameters))
             case .failure(let error):
                 onCompletion(.failure(error))


### PR DESCRIPTION
Fixes #5426 

Changes:
- guard for `nil` `self` early in payment capture to avoid executing parts of the completion (and not others) in the unlikely event that `self` is `nil` during payment capture

To test:
- Ensure you can capture payment, hear celebration sound, see receipt for order after returning to order later (indicating the details were saved)

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
