### PR TITLE
[Mobile Payments] Simplify reader update check

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -64,11 +64,11 @@ private extension CardReaderSettingsConnectedViewController {
         configureUpdateView()
     }
 
+    /// Returns `false` if no reader update is available or if  `viewModel` is `nil`.
+    /// Returns `true` otherwise.
+    ///
     func isReaderUpdateAvailable() -> Bool {
-        guard let viewModel = viewModel else {
-            return false
-        }
-        return viewModel.optionalReaderUpdateAvailable == true
+        viewModel?.optionalReaderUpdateAvailable == true
     }
 
     /// Set the title and back button.


### PR DESCRIPTION
Closes #5427 

Changes:
- Simplifies reader update function by testing `Bool` property on optional for truthiness and using that for an implicit return

To test:
- Inspection is probably sufficient, but if you want a gold star, ensure that readers needing updates continue to show they need an update and vice versa

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
