### PR TITLE
[Mobile Payments] Pass tokens and location using Result

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
+++ b/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
@@ -3,14 +3,14 @@
 /// It is meant to abstract an implementation of the [adapter pattern](https://en.wikipedia.org/wiki/Adapter_pattern)
 
 public protocol ReaderTokenProvider {
-    func fetchToken(completion: @escaping(String?, Error?) -> Void)
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void)
 }
 
 public protocol ReaderLocationProvider {
-    func fetchDefaultLocationID(completion: @escaping(String?, Error?) -> Void)
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void)
 }
 
 public protocol CardReaderConfigProvider: ReaderLocationProvider {
-    func fetchToken(completion: @escaping(String?, Error?) -> Void)
-    func fetchDefaultLocationID(completion: @escaping(String?, Error?) -> Void)
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void)
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void)
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/DefaultConnectionTokenProvider.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/DefaultConnectionTokenProvider.swift
@@ -11,6 +11,13 @@ final class DefaultConnectionTokenProvider: ConnectionTokenProvider {
     }
 
     public func fetchConnectionToken(_ completion: @escaping ConnectionTokenCompletionBlock) {
-        provider.fetchToken(completion: completion)
+        provider.fetchToken() { result in
+            switch result {
+            case .success(let token):
+                completion(token, nil)
+            case .failure(let error):
+                completion(nil, error)
+            }
+        }
     }
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -291,17 +291,14 @@ extension StripeCardReaderService: CardReaderService {
 
             // TODO - If we've recently connected to this reader, use the cached locationId from the
             // Terminal SDK instead of making this fetch. See #5116 and #5087
-            self.readerLocationProvider?.fetchDefaultLocationID { (locationId, error) in
-                if let error = error {
+            self.readerLocationProvider?.fetchDefaultLocationID { result in
+                switch result {
+                case .success(let locationId):
+                    return promise(.success(BluetoothConnectionConfiguration(locationId: locationId)))
+                case .failure(let error):
                     let underlyingError = UnderlyingError(with: error)
                     return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                 }
-
-                if let locationId = locationId {
-                    return promise(.success(BluetoothConnectionConfiguration(locationId: locationId)))
-                }
-
-                promise(.failure(CardReaderServiceError.connection()))
             }
         }
     }

--- a/Networking/Networking/Remote/WCPayRemote.swift
+++ b/Networking/Networking/Remote/WCPayRemote.swift
@@ -9,7 +9,7 @@ public class WCPayRemote: Remote {
     ///   - siteID: Site for which we'll fetch the WCPay Connection token.
     ///   - completion: Closure to be executed upon completion.
     public func loadConnectionToken(for siteID: Int64,
-                                    completion: @escaping(WCPayConnectionToken?, Error?) -> Void) {
+                                    completion: @escaping(Result<WCPayConnectionToken, Error>) -> Void) {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: Path.connectionTokens)
 
         let mapper = WCPayConnectionTokenMapper()

--- a/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -37,11 +37,11 @@ final class WCPayRemoteTests: XCTestCase {
         let expectedToken = "a connection token"
 
         network.simulateResponse(requestUrlSuffix: "payments/connection_tokens", filename: "wcpay-connection-token")
-        remote.loadConnectionToken(for: sampleSiteID) { (token, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(token)
-            XCTAssertEqual(token?.token, expectedToken)
-            expectation.fulfill()
+        remote.loadConnectionToken(for: sampleSiteID) { result in
+            if case let .success(token) = result {
+                XCTAssertEqual(token.token, expectedToken)
+                expectation.fulfill()
+            }
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
@@ -53,10 +53,11 @@ final class WCPayRemoteTests: XCTestCase {
         let remote = WCPayRemote(network: network)
         let expectation = self.expectation(description: "Load WCPay token contains errors")
 
-        remote.loadConnectionToken(for: sampleSiteID) { (token, error) in
-            XCTAssertNil(token)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        remote.loadConnectionToken(for: sampleSiteID) { result in
+            if case let .failure(error) = result {
+                XCTAssertNotNil(error)
+                expectation.fulfill()
+            }
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -112,12 +112,12 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
 
 private final class MockTokenProvider: CardReaderConfigProvider {
-    func fetchToken(completion: @escaping(String?, Error?) -> Void) {
-        completion("a token", nil)
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void) {
+        completion(.success("a token"))
     }
 
-    func fetchDefaultLocationID(completion: @escaping(String?, Error?) -> Void) {
-        completion("a location ID", nil)
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void) {
+        completion(.success("a location ID"))
     }
 }
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -242,20 +242,25 @@ private final class WCPayTokenProvider: CardReaderConfigProvider {
         self.remote = remote
     }
 
-    func fetchToken(completion: @escaping(String?, Error?) -> Void) {
-        remote.loadConnectionToken(for: siteID) { token, error in
-            completion(token?.token, error)
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void) {
+        remote.loadConnectionToken(for: siteID) { result in
+            switch result {
+            case .success(let token):
+                completion(.success(token.token))
+            case .failure(let error):
+                completion(.failure(error))
+            }
         }
     }
 
-    func fetchDefaultLocationID(completion: @escaping(String?, Error?) -> Void) {
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void) {
         remote.loadDefaultReaderLocation(for: siteID) { result in
             switch result {
             case .success(let wcpayReaderLocation):
                 let readerLocation = wcpayReaderLocation.toReaderLocation(siteID: self.siteID)
-                completion(readerLocation.id, nil)
+                completion(.success(readerLocation.id))
             case .failure(let error):
-                completion(nil, error)
+                completion(.failure(error))
             }
         }
     }


### PR DESCRIPTION
Closes #5425 

Changes:
- Instead of passing `String?` and `Error?`, pass a `Result<String, Error>` for location and token

To test:
- Ensure unit tests pass
- Ensure you can connect to a reader

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
