### PR TITLE
Simple Payments: Add Summary View Interactions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -118,7 +118,7 @@ struct SimplePaymentsAmount: View {
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)
 
-            LazyNavigationLink(destination: SimplePaymentsSummary(), isActive: $showSummaryView) {
+            LazyNavigationLink(destination: SimplePaymentsSummary(viewModel: viewModel.createSummaryViewModel()), isActive: $showSummaryView) {
                 EmptyView()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -106,6 +106,10 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     func userDidCancelFlow() {
         analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowCanceled())
     }
+
+    func createSummaryViewModel() -> SimplePaymentsSummaryViewModel {
+        SimplePaymentsSummaryViewModel(providedAmount: amount)
+    }
 }
 
 // MARK: Helpers

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -12,11 +12,6 @@ struct SimplePaymentsSummary: View {
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
 
-    /// `ViewModel` to drive the `EditOrderNote` view
-    /// Temporarily here, to be moved to `SimplePaymentsSummaryViewModel` when available.
-    ///
-    @StateObject var noteViewModel = SimplePaymentsNoteViewModel()
-
     var body: some View {
         VStack {
             ScrollView {
@@ -34,7 +29,7 @@ struct SimplePaymentsSummary: View {
 
                     Spacer(minLength: Layout.spacerHeight)
 
-                    NoteSection(content: noteViewModel.newNote, showEditNote: $showEditNote)
+                    NoteSection(viewModel: viewModel, showEditNote: $showEditNote)
                 }
             }
 
@@ -45,7 +40,8 @@ struct SimplePaymentsSummary: View {
         .sheet(isPresented: $showEditNote) {
             EditCustomerNote(dismiss: {
                 showEditNote.toggle()
-            }, viewModel: noteViewModel)
+                viewModel.reloadContent()
+                }, viewModel: viewModel.noteViewModel)
         }
     }
 }
@@ -138,9 +134,9 @@ private struct PaymentsSection: View {
 ///
 private struct NoteSection: View {
 
-    /// Order note content.
+    /// ViewModel to drive the view content.
     ///
-    let content: String
+    @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
 
     /// Defines if the order note screen should be shown or not.
     ///
@@ -162,7 +158,7 @@ private struct NoteSection: View {
                     }
                     .foregroundColor(Color(.accent))
                     .bodyStyle()
-                    .renderedIf(content.isNotEmpty)
+                    .renderedIf(viewModel.noteContent.isNotEmpty)
                 }
 
                 noteContent()
@@ -178,9 +174,9 @@ private struct NoteSection: View {
     /// Builds a button to add a note if no note is present. If there is a note present only displays it
     ///
     @ViewBuilder private func noteContent() -> some View {
-        if content.isNotEmpty {
+        if viewModel.noteContent.isNotEmpty {
 
-            Text(content)
+            Text(viewModel.noteContent)
                 .bodyStyle()
 
         } else {
@@ -273,8 +269,10 @@ struct SimplePaymentsSummary_Preview: PreviewProvider {
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"),
-                              noteViewModel: .init(originalNote: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(
+            providedAmount: "$40.0",
+            noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."
+        ))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -119,15 +119,13 @@ private struct PaymentsSection: View {
                     .headlineStyle()
                     .padding([.horizontal, .top])
 
-                // Temporary data
                 TitleAndValueRow(title: SimplePaymentsSummary.Localization.subtotal, value: .content(viewModel.providedAmount), selectable: false) {}
 
                 // Temporary data
                 TitleAndToggleRow(title: SimplePaymentsSummary.Localization.chargeTaxes, isOn: .constant(false))
                     .padding([.leading, .trailing])
 
-                // Temporary data
-                TitleAndValueRow(title: SimplePaymentsSummary.Localization.total, value: .content("$40.0"), bold: true, selectable: false) {}
+                TitleAndValueRow(title: SimplePaymentsSummary.Localization.total, value: .content(viewModel.total), bold: true, selectable: false) {}
             }
             .background(Color(.listForeground))
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -22,7 +22,7 @@ struct SimplePaymentsSummary: View {
             ScrollView {
                 VStack(spacing: Layout.noSpacing) {
 
-                    CustomAmountSection()
+                    CustomAmountSection(viewModel: viewModel)
 
                     Spacer(minLength: Layout.spacerHeight)
 
@@ -53,6 +53,11 @@ struct SimplePaymentsSummary: View {
 /// Represents the Custom amount section
 ///
 private struct CustomAmountSection: View {
+
+    /// ViewModel to drive the view content
+    ///
+    @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
+
     var body: some View {
         Group {
             Divider()
@@ -66,8 +71,7 @@ private struct CustomAmountSection: View {
                 Text(SimplePaymentsSummary.Localization.customAmount)
                     .headlineStyle()
 
-                // Temporary data
-                Text("$40.00")
+                Text(viewModel.providedAmount)
                     .headlineStyle()
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
@@ -100,6 +104,7 @@ private struct EmailSection: View {
 /// Represents the Payments Section
 ///
 private struct PaymentsSection: View {
+    
     var body: some View {
         Group {
             Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -123,8 +123,7 @@ private struct PaymentsSection: View {
 
                 TitleAndValueRow(title: SimplePaymentsSummary.Localization.subtotal, value: .content(viewModel.providedAmount), selectable: false) {}
 
-                // Temporary data
-                TitleAndToggleRow(title: SimplePaymentsSummary.Localization.chargeTaxes, isOn: .constant(false))
+                TitleAndToggleRow(title: SimplePaymentsSummary.Localization.chargeTaxes, isOn: $viewModel.enableTaxes)
                     .padding([.leading, .trailing])
 
                 TitleAndValueRow(title: SimplePaymentsSummary.Localization.total, value: .content(viewModel.total), bold: true, selectable: false) {}

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -8,6 +8,10 @@ struct SimplePaymentsSummary: View {
     ///
     @State var showEditNote = false
 
+    /// ViewModel to drive the view content
+    ///
+    @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
+
     /// `ViewModel` to drive the `EditOrderNote` view
     /// Temporarily here, to be moved to `SimplePaymentsSummaryViewModel` when available.
     ///
@@ -253,19 +257,20 @@ private extension SimplePaymentsSummary {
 // MARK: Previews
 struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
-        SimplePaymentsSummary()
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
-        SimplePaymentsSummary(noteViewModel: .init(originalNote: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"),
+                              noteViewModel: .init(originalNote: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
 
-        SimplePaymentsSummary()
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"))
             .environment(\.colorScheme, .dark)
             .previewDisplayName("Dark")
 
-        SimplePaymentsSummary()
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"))
             .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
             .previewDisplayName("Accessibility")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -38,7 +38,7 @@ struct SimplePaymentsSummary: View {
                 }
             }
 
-            TakePaymentSection()
+            TakePaymentSection(viewModel: viewModel)
         }
         .background(Color(.listBackground).ignoresSafeArea())
         .navigationTitle(Localization.title)
@@ -205,12 +205,17 @@ private struct NoteSection: View {
 /// Represents the bottom take payment button
 ///
 private struct TakePaymentSection: View {
+
+    /// ViewModel to drive the view content.
+    ///
+    @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
+
     var body: some View {
         VStack {
             Divider()
 
             // Temporary data
-            Button(SimplePaymentsSummary.Localization.takePayment(total: "$40.0"), action: {
+            Button(SimplePaymentsSummary.Localization.takePayment(total: viewModel.total), action: {
                 print("Take payment pressed")
             })
             .buttonStyle(PrimaryButtonStyle())

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -21,7 +21,7 @@ struct SimplePaymentsSummary: View {
 
                     Spacer(minLength: Layout.spacerHeight)
 
-                    EmailSection()
+                    EmailSection(viewModel: viewModel)
 
                     Spacer(minLength: Layout.spacerHeight)
 
@@ -83,13 +83,19 @@ private struct CustomAmountSection: View {
 /// Represents the email section
 ///
 private struct EmailSection: View {
+
+    /// ViewModel to drive the view content
+    ///
+    @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
+
     var body: some View {
         Group {
             Divider()
 
             TitleAndTextFieldRow(title: SimplePaymentsSummary.Localization.email,
                                  placeholder: SimplePaymentsSummary.Localization.emailPlaceHolder,
-                                 text: .constant("")) // Temporary data
+                                 text: $viewModel.email,
+                                 keyboardType: .emailAddress)
                 .background(Color(.listForeground))
 
             Divider()
@@ -210,7 +216,6 @@ private struct TakePaymentSection: View {
         VStack {
             Divider()
 
-            // Temporary data
             Button(SimplePaymentsSummary.Localization.takePayment(total: viewModel.total), action: {
                 print("Take payment pressed")
             })

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -30,7 +30,7 @@ struct SimplePaymentsSummary: View {
 
                     Spacer(minLength: Layout.spacerHeight)
 
-                    PaymentsSection()
+                    PaymentsSection(viewModel: viewModel)
 
                     Spacer(minLength: Layout.spacerHeight)
 
@@ -54,7 +54,7 @@ struct SimplePaymentsSummary: View {
 ///
 private struct CustomAmountSection: View {
 
-    /// ViewModel to drive the view content
+    /// ViewModel to drive the view content.
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
 
@@ -104,7 +104,11 @@ private struct EmailSection: View {
 /// Represents the Payments Section
 ///
 private struct PaymentsSection: View {
-    
+
+    /// ViewModel to drive the view content.
+    ///
+    @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
+
     var body: some View {
         Group {
             Divider()
@@ -116,7 +120,7 @@ private struct PaymentsSection: View {
                     .padding([.horizontal, .top])
 
                 // Temporary data
-                TitleAndValueRow(title: SimplePaymentsSummary.Localization.subtotal, value: .content("$40.0"), selectable: false) {}
+                TitleAndValueRow(title: SimplePaymentsSummary.Localization.subtotal, value: .content(viewModel.providedAmount), selectable: false) {}
 
                 // Temporary data
                 TitleAndToggleRow(title: SimplePaymentsSummary.Localization.chargeTaxes, isOn: .constant(false))

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -30,12 +30,20 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     lazy private(set) var noteViewModel = SimplePaymentsNoteViewModel()
 
-    init(providedAmount: String, noteContent: String? = nil) {
-        self.providedAmount = providedAmount
+    /// Formatter to properly format the provided amount.
+    ///
+    private let currencyFormatter: CurrencyFormatter
 
-        // TODO: Add taxes calculation
-        self.total = providedAmount
+    init(providedAmount: String,
+         noteContent: String? = nil,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        self.currencyFormatter = currencyFormatter
 
+        let formattedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
+        self.providedAmount = formattedAmount
+        self.total = formattedAmount // TODO: Add taxes calculation
+
+        // Used mostly in previews
         if let noteContent = noteContent {
             noteViewModel = SimplePaymentsNoteViewModel(originalNote: noteContent)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -12,6 +12,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     let total: String
 
+    /// Email of the costumer. To be used as the billing address email.
+    ///
+    @Published var email: String = ""
+
     /// Accessor for the note content of the `noteViewModel`
     ///
     var noteContent: String {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// `ViewModel` to drive the content of the `SimplePaymentsSummary` view.
+///
+final class SimplePaymentsSummaryViewModel: ObservableObject {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -4,4 +4,11 @@ import Foundation
 ///
 final class SimplePaymentsSummaryViewModel: ObservableObject {
 
+    /// Initial amount to charge. Without taxes.
+    ///
+    let providedAmount: String
+
+    init(providedAmount: String) {
+        self.providedAmount = providedAmount
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -16,6 +16,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     @Published var email: String = ""
 
+    /// Determines if taxes should be added to the provided amount.
+    ///
+    @Published var enableTaxes: Bool = false
+
     /// Accessor for the note content of the `noteViewModel`
     ///
     var noteContent: String {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -12,10 +12,30 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     let total: String
 
-    init(providedAmount: String) {
+    /// Accessor for the note content of the `noteViewModel`
+    ///
+    var noteContent: String {
+        noteViewModel.newNote
+    }
+
+    /// ViewModel for the edit order note view.
+    ///
+    lazy private(set) var noteViewModel = SimplePaymentsNoteViewModel()
+
+    init(providedAmount: String, noteContent: String? = nil) {
         self.providedAmount = providedAmount
 
         // TODO: Add taxes calculation
         self.total = providedAmount
+
+        if let noteContent = noteContent {
+            noteViewModel = SimplePaymentsNoteViewModel(originalNote: noteContent)
+        }
+    }
+
+    /// Sends a signal to reload the view. Needed when coming back from the `EditNote` view.
+    ///
+    func reloadContent() {
+        objectWillChange.send()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -8,7 +8,14 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     let providedAmount: String
 
+    /// Total to charge.
+    ///
+    let total: String
+
     init(providedAmount: String) {
         self.providedAmount = providedAmount
+
+        // TODO: Add taxes calculation
+        self.total = providedAmount
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -451,6 +451,7 @@
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
+		26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */; };
 		26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */; };
 		26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */; };
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
@@ -1925,6 +1926,7 @@
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
+		26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelProtocol.swift; sourceTree = "<group>"; };
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
@@ -3945,6 +3947,7 @@
 			isa = PBXGroup;
 			children = (
 				262AF3892713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift */,
+				26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */,
 				26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */,
 			);
 			path = "Simple Payments";
@@ -8524,6 +8527,7 @@
 				E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,
+				26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */,
 				D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */,
 				025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */,
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
+		26ED9660274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */; };
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
 		26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */; };
@@ -1942,6 +1943,7 @@
 		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
+		26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModel.swift; sourceTree = "<group>"; };
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
 		26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewController.swift; sourceTree = "<group>"; };
@@ -4090,6 +4092,7 @@
 			isa = PBXGroup;
 			children = (
 				26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */,
+				26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */,
 				26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */,
 			);
 			path = Summary;
@@ -7511,6 +7514,7 @@
 				CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */,
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,
 				B5DB01B52114AB2D00A4F797 /* WooCrashLoggingStack.swift in Sources */,
+				26ED9660274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift in Sources */,
 				024DF31E23743045006658FE /* TextList+AztecFormatting.swift in Sources */,
 				0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */,
 				7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+import Combine
+
+@testable import WooCommerce
+
+final class SimplePaymentsSummaryViewModelTests: XCTestCase {
+
+    var subscriptions = Set<AnyCancellable>()
+
+    func test_updating_noteViewModel_updates_noteContent_property() {
+        // Given
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.0")
+
+        // When
+        viewModel.noteViewModel.newNote = "Updated note"
+
+        // Then
+        assertEqual(viewModel.noteContent, viewModel.noteViewModel.newNote)
+    }
+
+    func test_calling_reloadContent_triggers_viewModel_update() {
+        // Given
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.0")
+
+        // When
+        let triggeredUpdate: Bool = waitFor { promise in
+            viewModel.objectWillChange.sink {
+                promise(true)
+            }
+            .store(in: &self.subscriptions)
+
+            viewModel.reloadContent()
+        }
+
+        // Then
+        XCTAssertTrue(triggeredUpdate)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -10,7 +10,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_updating_noteViewModel_updates_noteContent_property() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.0")
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00")
 
         // When
         viewModel.noteViewModel.newNote = "Updated note"
@@ -21,7 +21,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_calling_reloadContent_triggers_viewModel_update() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.0")
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00")
 
         // When
         let triggeredUpdate: Bool = waitFor { promise in
@@ -35,5 +35,15 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(triggeredUpdate)
+    }
+
+    func test_provided_amount_gets_properly_formatted() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", currencyFormatter: currencyFormatter)
+
+        // When & Then
+        XCTAssertEqual(viewModel.providedAmount, "$100.00")
+        XCTAssertEqual(viewModel.total, "$100.00")
     }
 }


### PR DESCRIPTION
closes #5346

# Why

After the UI was introduced in #5377 now it's time to add the correspondent view model so we can properly respond to user interactions.

This PR in particular does:

- Formats the provided amount
- Renders content given in the previous screen
- Adds properties to handle/store values entered by the merchant

# How

- Create `SimplePaymentsSummaryViewModel`
- Pass view model through all the summary views 
- Move `OrderNoteViewModel` out of the summary view and add it into the summary view model.

# Demo

https://user-images.githubusercontent.com/562080/142086195-2b1cf434-d071-463c-8466-0e3bc49bc95f.mov

# Testing Steps

- Use an IPP eligible store with the simple payments feature activated
- On the order list tap the plus button
- Enter an amount
- Tap Next
- On The summary screen:
    - See the amount formatted
    - See the amount rendered in all necessary fields
    - Make sure you can add an email
    - Make sure you can toggle the taxes switch
    - Make sure you can add a note
    - Make sure you can edit a note
    
    
## Known issues
- Dismissing the edit note screen via a drag gesture does not work correctly https://github.com/woocommerce/woocommerce-ios/projects/40#card-73015716

- Done button in edit note screen is enabled when editing an existing note by default https://github.com/woocommerce/woocommerce-ios/projects/40#card-73015397

- Provided amount textfield is not working properly on iOS 15 https://github.com/woocommerce/woocommerce-ios/projects/40#card-72655207

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
