### PR TITLE
Issue/4861 Payments Services cleanup

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -10,15 +10,6 @@ public protocol CardReaderService {
     /// The Publisher that emits the connected readers
     var connectedReaders: AnyPublisher<[CardReader], Never> { get }
 
-    /// The Publisher that emits the service status
-    var serviceStatus: AnyPublisher<CardReaderServiceStatus, Never> { get }
-
-    /// The Publisher that emits the service discovery status
-    var discoveryStatus: AnyPublisher<CardReaderServiceDiscoveryStatus, Never> { get }
-
-    /// The Publisher that emits the payment status
-    var paymentStatus: AnyPublisher<PaymentStatus, Never> { get }
-
     /// The Publisher that emits reader events
     var readerEvents: AnyPublisher<CardReaderEvent, Never> { get }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -46,19 +46,6 @@ extension StripeCardReaderService: CardReaderService {
         connectedReadersSubject.eraseToAnyPublisher()
     }
 
-    public var serviceStatus: AnyPublisher<CardReaderServiceStatus, Never> {
-        serviceStatusSubject.eraseToAnyPublisher()
-    }
-
-    public var discoveryStatus: AnyPublisher<CardReaderServiceDiscoveryStatus, Never> {
-        discoveryStatusSubject.removeDuplicates().eraseToAnyPublisher()
-    }
-
-    /// The Publisher that emits the payment status
-    public var paymentStatus: AnyPublisher<PaymentStatus, Never> {
-        paymentStatusSubject.eraseToAnyPublisher()
-    }
-
     /// The Publisher that emits reader events
     public var readerEvents: AnyPublisher<CardReaderEvent, Never> {
         readerEventsSubject.eraseToAnyPublisher()

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -10,9 +10,7 @@ public final class StripeCardReaderService: NSObject {
 
     private var discoveredReadersSubject = CurrentValueSubject<[CardReader], Error>([])
     private let connectedReadersSubject = CurrentValueSubject<[CardReader], Never>([])
-    private let serviceStatusSubject = CurrentValueSubject<CardReaderServiceStatus, Never>(.ready)
     private let discoveryStatusSubject = CurrentValueSubject<CardReaderServiceDiscoveryStatus, Never>(.idle)
-    private let paymentStatusSubject = CurrentValueSubject<PaymentStatus, Never>(.notReady)
     private let readerEventsSubject = PassthroughSubject<CardReaderEvent, Never>()
     private let softwareUpdateSubject = CurrentValueSubject<CardReaderSoftwareUpdateState, Never>(.none)
 

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -12,18 +12,6 @@ final class MockCardReaderService: CardReaderService {
         connectedReadersSubject.eraseToAnyPublisher()
     }
 
-    var serviceStatus: AnyPublisher<CardReaderServiceStatus, Never> {
-        CurrentValueSubject<CardReaderServiceStatus, Never>(.ready).eraseToAnyPublisher()
-    }
-
-    var discoveryStatus: AnyPublisher<CardReaderServiceDiscoveryStatus, Never> {
-        discoveryStatusSubject.eraseToAnyPublisher()
-    }
-
-    var paymentStatus: AnyPublisher<PaymentStatus, Never> {
-        CurrentValueSubject<PaymentStatus, Never>(.notReady).eraseToAnyPublisher()
-    }
-
     var readerEvents: AnyPublisher<CardReaderEvent, Never> {
         PassthroughSubject<CardReaderEvent, Never>().eraseToAnyPublisher()
     }


### PR DESCRIPTION
Closes #4861 

### Description

The PR removes unused publishers from:
* StripeCardReaderService
* MockCardReaderService
* StripeCardReaderService
* CardReaderService