### PR TITLE
Jetpack CP: add 2 endpoints `wp/v2/settings` and `wc/v3/settings` for the workaround

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */; };
 		029BA4F4255D72EC006171FD /* ShippingLabelPrintData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */; };
 		029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */; };
+		02A26F1B2744F5FC008E4EDB /* wc-site-settings-partial.json in Resources */ = {isa = PBXBuildFile; fileRef = 02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */; };
+		02A26F1C2744F5FC008E4EDB /* wp-site-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */; };
 		02AAD53F250092A400BA1E26 /* product-add-or-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AAD53E250092A300BA1E26 /* product-add-or-delete.json */; };
 		02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */; };
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
@@ -627,6 +629,8 @@
 		029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemote.swift; sourceTree = "<group>"; };
 		029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintData.swift; sourceTree = "<group>"; };
 		029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintDataMapper.swift; sourceTree = "<group>"; };
+		02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wc-site-settings-partial.json"; sourceTree = "<group>"; };
+		02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wp-site-settings.json"; sourceTree = "<group>"; };
 		02AAD53E250092A300BA1E26 /* product-add-or-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-add-or-delete.json"; sourceTree = "<group>"; };
 		02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-deactivated.json"; sourceTree = "<group>"; };
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
@@ -1740,6 +1744,7 @@
 				74ABA1C7213F19FE00FFAD30 /* top-performers-year.json */,
 				FE28F6E726842D57004465C7 /* user-complete.json */,
 				7495AACE225D366D00801A89 /* variation-as-product.json */,
+				02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */,
 				D800DA0D25EFEC21001E13CE /* wcpay-connection-token.json */,
 				318E8FD626C322EA00F519D7 /* wcpay-customer.json */,
 				318E8FD826C324D900F519D7 /* wcpay-customer-error.json */,
@@ -1770,6 +1775,7 @@
 				31B8D6B526583970008E3DB2 /* wcpay-account-implicitly-not-eligible.json */,
 				31799AFB2705189200D78179 /* wcpay-location.json */,
 				31799AFD270518AD00D78179 /* wcpay-location-error.json */,
+				02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */,
 				077F39D726A58EB600ABEADC /* systemStatus.json */,
 			);
 			path = Responses;
@@ -2152,6 +2158,7 @@
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
 				45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */,
+				02A26F1C2744F5FC008E4EDB /* wp-site-settings.json in Resources */,
 				740211DF2193985A002248DA /* comment-moderate-spam.json in Resources */,
 				B5147876211B9227007562E5 /* broken-orders-mark-2.json in Resources */,
 				3158FE6C26129D2E00E566B9 /* wcpay-account-rejected-terms-of-service.json in Resources */,
@@ -2162,6 +2169,7 @@
 				CE50346721B5DCBE007573C6 /* site-plan.json in Resources */,
 				743E84F322172D0A00FAC9D7 /* shipment_tracking_empty.json in Resources */,
 				B505F6D520BEE4E700BB1B69 /* me.json in Resources */,
+				02A26F1B2744F5FC008E4EDB /* wc-site-settings-partial.json in Resources */,
 				028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */,
 				02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */,
 				CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
 		02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
 		02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */; };
+		02C11276274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C11275274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift */; };
+		02C112782742862600F4F0B4 /* WordPressSiteSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C112772742862600F4F0B4 /* WordPressSiteSettingsMapper.swift */; };
 		02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */; };
 		02C2548425635BD000A04423 /* ShippingLabelPaperSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2548325635BD000A04423 /* ShippingLabelPaperSize.swift */; };
 		02C2549A25636E1500A04423 /* ShippingLabelAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2549925636E1500A04423 /* ShippingLabelAddress.swift */; };
@@ -630,6 +632,8 @@
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
 		02BDB83423EA98C800BCC63E /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
 		02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTMLTests.swift"; sourceTree = "<group>"; };
+		02C11275274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooCommerceAvailabilityMapper.swift; sourceTree = "<group>"; };
+		02C112772742862600F4F0B4 /* WordPressSiteSettingsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteSettingsMapper.swift; sourceTree = "<group>"; };
 		02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationMapper.swift; sourceTree = "<group>"; };
 		02C2548325635BD000A04423 /* ShippingLabelPaperSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSize.swift; sourceTree = "<group>"; };
 		02C2549925636E1500A04423 /* ShippingLabelAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddress.swift; sourceTree = "<group>"; };
@@ -1496,7 +1500,6 @@
 				029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */,
 				D8EDFE1D25EE87F1003D2213 /* WCPayRemote.swift */,
 				FE28F6E5268429B6004465C7 /* UserRemote.swift */,
-				077F39D526A58E4500ABEADC /* SystemPluginsRemote.swift */,
 				077F39D526A58E4500ABEADC /* SystemStatusRemote.swift */,
 				AEF94584272974F2001DCCFB /* TelemetryRemote.swift */,
 			);
@@ -1844,6 +1847,8 @@
 				CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
 				077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */,
+				02C11275274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift */,
+				02C112772742862600F4F0B4 /* WordPressSiteSettingsMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -2439,6 +2444,7 @@
 				743E84EC22171F4600FAC9D7 /* ShipmentTracking.swift in Sources */,
 				B56C1EB820EA76F500D749F9 /* Site.swift in Sources */,
 				26615473242D596B00A31661 /* ProductCategoriesRemote.swift in Sources */,
+				02C112782742862600F4F0B4 /* WordPressSiteSettingsMapper.swift in Sources */,
 				26615475242D7C9500A31661 /* ProductCategoryListMapper.swift in Sources */,
 				3178A49F2703E5CF00A8B4CA /* WCPayReaderLocationMapper.swift in Sources */,
 				45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */,
@@ -2517,6 +2523,7 @@
 				45152809257A7C6E0076B03C /* ProductAttributesRemote.swift in Sources */,
 				D8FBFF2222D5266E006E3336 /* OrderStatsV4Interval.swift in Sources */,
 				4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */,
+				02C11276274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift in Sources */,
 				CC0786C5267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift in Sources */,
 				4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */,
 				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,

--- a/Networking/Networking/Mapper/WooCommerceAvailabilityMapper.swift
+++ b/Networking/Networking/Mapper/WooCommerceAvailabilityMapper.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Mapper: From WooCommerce site settings response to a boolean that indicates whether WooCommerce is active on the site
+///
+struct WooCommerceAvailabilityMapper: Mapper {
+
+    /// Any store with valid WooCommerce site settings response data is considered to have an active WooCommerce plugin.
+    ///
+    func map(response: Data) throws -> Bool {
+        true
+    }
+}

--- a/Networking/Networking/Mapper/WordPressSiteSettingsMapper.swift
+++ b/Networking/Networking/Mapper/WordPressSiteSettingsMapper.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Mapper: WordPress Site Settings
+///
+struct WordPressSiteSettingsMapper: Mapper {
+    /// (Attempts) to convert a dictionary into `WordPressSiteSettings`.
+    func map(response: Data) throws -> WordPressSiteSettings {
+        let decoder = JSONDecoder()
+        return try decoder.decode(WordPressSiteSettings.self, from: response)
+    }
+}
+
+/// Represents a WordPress Site Settings response.
+///
+public struct WordPressSiteSettings: Decodable, Equatable {
+    /// Site's Name.
+    public let name: String
+
+    /// Site's Description.
+    public let description: String
+
+    /// Site's URL.
+    public let url: String
+
+    private enum CodingKeys: String, CodingKey {
+        case name = "title"
+        case description
+        case url
+    }
+}

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -64,6 +64,29 @@ public class AccountRemote: Remote {
         return enqueue(request, mapper: mapper)
     }
 
+    /// Checks the WooCommerce site settings endpoint to confirm if the WooCommerce plugin is available or not.
+    /// We pass an empty `_fields` just to reduce the response payload size, as we don't care about the contents.
+    /// The current use case is for a workaround for Jetpack Connection Package sites.
+    /// - Parameter siteID: Site for which we will fetch the site settings.
+    /// - Returns: A publisher that emits a boolean which indicates if WooCommerce plugin is active.
+    public func checkIfWooCommerceIsActive(for siteID: Int64) -> AnyPublisher<Result<Bool, Error>, Never> {
+        let parameters = ["_fields": ""]
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: Constants.wooCommerceSiteSettingsPath, parameters: parameters)
+        let mapper = WooCommerceAvailabilityMapper()
+        return enqueue(request, mapper: mapper)
+    }
+
+    /// Fetches WordPress site settings for site metadata (e.g. name, description, URL).
+    /// The current use case is for a workaround for Jetpack Connection Package sites.
+    /// - Parameter siteID: Site for which we will fetch the site settings.
+    /// - Returns: A publisher that emits the WordPress site settings.
+    public func fetchWordPressSiteSettings(for siteID: Int64) -> AnyPublisher<Result<WordPressSiteSettings, Error>, Never> {
+        let path = "sites/\(siteID)/settings"
+        let request = DotcomRequest(wordpressApiVersion: .wpMark2, method: .get, path: path, parameters: nil)
+        let mapper = WordPressSiteSettingsMapper()
+        return enqueue(request, mapper: mapper)
+    }
+
     /// Loads the site plan for the default site associated with the WordPress.com user.
     ///
     public func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void) {
@@ -76,5 +99,13 @@ public class AccountRemote: Remote {
         let mapper = SitePlanMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+// MARK: - Constants
+//
+private extension AccountRemote {
+    enum Constants {
+        static let wooCommerceSiteSettingsPath: String = "settings"
     }
 }

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -81,4 +81,65 @@ final class AccountRemoteTests: XCTestCase {
         XCTAssertEqual(jcpSites.count, 1)
         XCTAssertEqual(nonJCPSites.count, 1)
     }
+
+    // MARK: - `checkIfWooCommerceIsActive`
+
+    func test_checkIfWooCommerceIsActive_emits_true_when_response_is_valid() throws {
+        // Given
+        let siteID = Int64(277)
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "settings", filename: "wc-site-settings-partial")
+
+        // When
+        let result = waitFor { promise in
+            remote.checkIfWooCommerceIsActive(for: siteID).sink { result in
+                promise(result)
+            }.store(in: &self.cancellables)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let isWooCommerceActive = try XCTUnwrap(result.get())
+        XCTAssertTrue(isWooCommerceActive)
+    }
+
+    func test_checkIfWooCommerceIsActive_emits_false_when_error_is_returned() throws {
+        // Given
+        let siteID = Int64(277)
+        let remote = AccountRemote(network: network)
+        network.simulateError(requestUrlSuffix: "settings", error: NetworkError.notFound)
+
+        // When
+        let result = waitFor { promise in
+            remote.checkIfWooCommerceIsActive(for: siteID).sink { result in
+                promise(result)
+            }.store(in: &self.cancellables)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertEqual(error, .notFound)
+    }
+
+    // MARK: - `fetchWordPressSiteSettings`
+
+    func test_fetchWordPressSiteSettings_emits_settings_in_response() throws {
+        // Given
+        let siteID = Int64(277)
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "sites/\(siteID)/settings", filename: "wp-site-settings")
+
+        // When
+        let result = waitFor { promise in
+            remote.fetchWordPressSiteSettings(for: siteID).sink { result in
+                promise(result)
+            }.store(in: &self.cancellables)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let siteSettings = try XCTUnwrap(result.get())
+        XCTAssertEqual(siteSettings.name, "Zucchini recipes")
+    }
 }

--- a/Networking/NetworkingTests/Responses/wc-site-settings-partial.json
+++ b/Networking/NetworkingTests/Responses/wc-site-settings-partial.json
@@ -1,0 +1,74 @@
+{
+    "data": [
+        {
+            "id": "wc_admin",
+            "label": "WooCommerce Admin",
+            "description": "Settings for WooCommerce admin reporting.",
+            "parent_id": "",
+            "sub_groups": [],
+            "_links": {
+                "options": [
+                    {
+                        "href": "https://toma.to/wp-json/wc/v3/settings/wc_admin"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "general",
+            "label": "General",
+            "description": "",
+            "parent_id": "",
+            "sub_groups": [],
+            "_links": {
+                "options": [
+                    {
+                        "href": "https://toma.to/wp-json/wc/v3/settings/general"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "products",
+            "label": "Products",
+            "description": "",
+            "parent_id": "",
+            "sub_groups": [],
+            "_links": {
+                "options": [
+                    {
+                        "href": "https://toma.to/wp-json/wc/v3/settings/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "shipping",
+            "label": "Shipping",
+            "description": "",
+            "parent_id": "",
+            "sub_groups": [],
+            "_links": {
+                "options": [
+                    {
+                        "href": "https://toma.to/wp-json/wc/v3/settings/shipping"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "account",
+            "label": "Accounts &amp; Privacy",
+            "description": "",
+            "parent_id": "",
+            "sub_groups": [],
+            "_links": {
+                "options": [
+                    {
+                        "href": "https://toma.to/wp-json/wc/v3/settings/account"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/wp-site-settings.json
+++ b/Networking/NetworkingTests/Responses/wp-site-settings.json
@@ -1,0 +1,18 @@
+{
+    "title": "Zucchini recipes",
+    "description": "All things zucchini and more",
+    "url": "https://zucchini.mystagingwebsite.com",
+    "email": "zuc.chini@automattic.com",
+    "timezone": "America/New_York",
+    "date_format": "F j, Y",
+    "time_format": "H:i",
+    "start_of_week": 1,
+    "language": "",
+    "use_smilies": true,
+    "default_category": 1,
+    "default_post_format": "0",
+    "posts_per_page": 10,
+    "default_ping_status": "open",
+    "default_comment_status": "open",
+    "site_logo": null
+}


### PR DESCRIPTION
Part of #5364 

## Why

To implement the workaround to support JCP sites (p91TBi-6lK-p2), we need to make two extra API requests to the remote site for JCP sites in `me/sites` result:
- `wc/v3/settings?_fields=""` to check if WooCommerce is installed
- `/wp/v2/settings` to get the updated site metadata (the site name/description/URL might not be up to date in `me/sites` response for JCP sites)
This PR only includes the two endpoints in the Networking layer for easier review. Their usage will be in a separate PR.

## Changes

- Added two endpoints to `AccountRemote` with their own mappers with unit tests

## Testing

These endpoints aren't used in the app yet, just CI is sufficient!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
