### PR TITLE
Order Filters: tracking order filters event when the flow starts

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -226,6 +226,10 @@ public enum WooAnalyticsStat: String {
     case orderTrackingDeleteSuccess = "order_tracking_delete_success"
     case orderTrackingProvidersLoaded = "order_tracking_providers_loaded"
 
+    // MARK: Order List Sorting/Filtering
+    //
+    case orderListViewFilterOptionsTapped = "order_list_view_filter_options_tapped"
+    
     // MARK: Shipping Labels Events
     //
     case shippingLabelRefundRequested = "shipping_label_refund_requested"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -229,7 +229,7 @@ public enum WooAnalyticsStat: String {
     // MARK: Order List Sorting/Filtering
     //
     case orderListViewFilterOptionsTapped = "order_list_view_filter_options_tapped"
-    
+
     // MARK: Shipping Labels Events
     //
     case shippingLabelRefundRequested = "shipping_label_refund_requested"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -115,15 +115,12 @@ final class OrdersRootViewController: UIViewController {
     /// Present `FilterListViewController`
     ///
     private func filterButtonTapped() {
-        //TODO-5243: add event for tracking the filter tapped
+        ServiceLocator.analytics.track(.orderListViewFilterOptionsTapped)
         let viewModel = FilterOrderListViewModel(filters: filters)
         let filterOrderListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in
-            //TODO-5243: add event for tracking filter list show
             self?.filters = filters
         }, onClearAction: {
-            //TODO-5243: add event for tracking clear action
         }, onDismissAction: {
-            //TODO-5243: add event for tracking dismiss action
         })
         present(filterOrderListViewController, animated: true, completion: nil)
     }


### PR DESCRIPTION
Part of #5243 

In this PR I just added a new event when we present the order filters screen. We decided to not add the other events related to the comments removed on the code because they do not add anything for us, and we already track the filters applied to the order list in another place of the app.

## Testing
Make sure you are able to see the event `order_list_view_filter_options_tapped` in the console when you tap the "Filters" button in the order list tab.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
