### PR TITLE
Order Creation: Add new order view model with empty order

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -183,6 +183,35 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   refunds: refunds,
                   fees: fees)
     }
+
+    public static var empty: Order {
+        self.init(siteID: 0,
+              orderID: 0,
+              parentID: 0,
+              customerID: 0,
+              number: "",
+              status: .pending,
+              currency: "",
+              customerNote: "",
+              dateCreated: Date(),
+              dateModified: Date(),
+              datePaid: Date(),
+              discountTotal: "",
+              discountTax: "",
+              shippingTotal: "",
+              shippingTax: "",
+              total: "",
+              totalTax: "",
+              paymentMethodID: "",
+              paymentMethodTitle: "",
+              items: [],
+              billingAddress: nil,
+              shippingAddress: nil,
+              shippingLines: [],
+              coupons: [],
+              refunds: [],
+              fees: [])
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// View to create a new manual order
 ///
 struct NewOrder: View {
+    let viewModel = NewOrderViewModel()
+
     var body: some View {
         ScrollView {
             EmptyView()
@@ -18,6 +20,7 @@ struct NewOrder: View {
                 }, label: {
                     Text(Localization.createButton)
                 })
+                    .renderedIf(viewModel.isCreateButtonEnabled)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -13,7 +13,6 @@ struct NewOrder: View {
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
-        .wooNavigationBarStyle()
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action: {
@@ -24,6 +23,7 @@ struct NewOrder: View {
                     .renderedIf(viewModel.isCreateButtonEnabled)
             }
         }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -13,6 +13,7 @@ struct NewOrder: View {
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
+        .wooNavigationBarStyle()
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -1,0 +1,17 @@
+import Yosemite
+
+/// View model for `NewOrder`.
+///
+final class NewOrderViewModel {
+    /// Order to create remotely
+    ///
+    private var order: Order = .empty {
+        didSet {
+            isCreateButtonEnabled = true
+        }
+    }
+
+    /// Whether to enable the Create button
+    ///
+    private(set) var isCreateButtonEnabled: Bool = false
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 		CC77488E2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
+		CCB366AF274518EC007D437A /* NewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */; };
 		CCCC29DD25E5757C0046B96F /* RenameAttributesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */; };
 		CCCC29E325E576810046B96F /* RenameAttributesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC29E225E576810046B96F /* RenameAttributesViewController.swift */; };
 		CCCC5B1326CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC5B1226CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift */; };
@@ -2525,6 +2526,7 @@
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
+		CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderViewModelTests.swift; sourceTree = "<group>"; };
 		CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RenameAttributesViewController.xib; sourceTree = "<group>"; };
 		CCCC29E225E576810046B96F /* RenameAttributesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewController.swift; sourceTree = "<group>"; };
 		CCCC5B1226CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -4839,6 +4841,7 @@
 				2667BFD5252E5D4C008099D4 /* Issue Refund */,
 				57F2C6C9246DEBB10074063B /* Order Details */,
 				262AF3882713B65700E39AFF /* Simple Payments */,
+				CCB366AD274518CD007D437A /* Order Creation */,
 				570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */,
 				57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */,
 				5767E93F256D9A4A00CFA652 /* OrderListViewModelTests.swift */,
@@ -5700,6 +5703,14 @@
 				CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */,
 			);
 			path = "Payment Methods";
+			sourceTree = "<group>";
+		};
+		CCB366AD274518CD007D437A /* Order Creation */ = {
+			isa = PBXGroup;
+			children = (
+				CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */,
+			);
+			path = "Order Creation";
 			sourceTree = "<group>";
 		};
 		CCD2E68725DD528000BD975D /* Variations */ = {
@@ -8487,6 +8498,7 @@
 				0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */,
 				FEED57FA2686544D00E47FD9 /* RoleErrorViewModelTests.swift in Sources */,
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,
+				CCB366AF274518EC007D437A /* NewOrderViewModelTests.swift in Sources */,
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,
 				773077F3251E954300178696 /* ProductDownloadFileViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1099,6 +1099,7 @@
 		CCFC010D23E9BD5500157A78 /* stats_top_earners-month.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00E723E9BD5500157A78 /* stats_top_earners-month.json */; };
 		CCFC010E23E9BD5500157A78 /* stats_visits-day.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00E823E9BD5500157A78 /* stats_visits-day.json */; };
 		CCFC50552743BC0D001E505F /* NewOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC50542743BC0D001E505F /* NewOrder.swift */; };
+		CCFC50592743E021001E505F /* NewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC50582743E021001E505F /* NewOrderViewModel.swift */; };
 		CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */; };
 		CE0F17D022A8105800964A63 /* ReadMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */; };
 		CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0F17D122A8308900964A63 /* FancyAlertController+PurchaseNote.swift */; };
@@ -2574,6 +2575,7 @@
 		CCFC011023E9E3F400157A78 /* start.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = start.sh; sourceTree = "<group>"; };
 		CCFC011123E9E40B00157A78 /* stop.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = stop.sh; sourceTree = "<group>"; };
 		CCFC50542743BC0D001E505F /* NewOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrder.swift; sourceTree = "<group>"; };
+		CCFC50582743E021001E505F /* NewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderViewModel.swift; sourceTree = "<group>"; };
 		CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMoreTableViewCell.swift; sourceTree = "<group>"; };
 		CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReadMoreTableViewCell.xib; sourceTree = "<group>"; };
 		CE0F17D122A8308900964A63 /* FancyAlertController+PurchaseNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlertController+PurchaseNote.swift"; sourceTree = "<group>"; };
@@ -5904,6 +5906,7 @@
 			isa = PBXGroup;
 			children = (
 				CCFC50542743BC0D001E505F /* NewOrder.swift */,
+				CCFC50582743E021001E505F /* NewOrderViewModel.swift */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -8291,6 +8294,7 @@
 				773077EE251E943700178696 /* ProductDownloadFileViewController.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,
 				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,
+				CCFC50592743E021001E505F /* NewOrderViewModel.swift in Sources */,
 				6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+class NewOrderViewModelTests: XCTestCase {
+
+    func test_view_model_starts_with_create_button_disabled() {
+        // Given
+        let viewModel = NewOrderViewModel()
+
+        // Then
+        XCTAssertFalse(viewModel.isCreateButtonEnabled)
+    }
+}


### PR DESCRIPTION
Part of: #5405

## Description

When a merchant enters Order Creation, it will open a New Order screen with all of the available sections to enter the order details. This PR adds a view model for the New Order screen, which initializes an empty order and only displays the Create button when that order has changed.

A followup PR will add the action to create the order when the Create button is tapped.

## Changes

* Adds an empty order to the `Order` model. This allows us to generate an empty order as the starting point for creating a new order.
* Adds the view model `NewOrderViewModel`. For now, this view model initializes the new (empty) order and handles whether the create button is rendered.
* Adds unit tests for the new view model.

## Testing

This screen is not yet used in the app. For now, confirm that the "Create" button is not displayed by default in the SwiftUI preview.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
