### PR TITLE
Order Creation: Add create order action for new manual orders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -15,17 +15,15 @@ struct NewOrder: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button(action: {
-                    viewModel.createOrder()
-                }, label: {
-                    if viewModel.isLoading {
-                        ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                            .accentColor(Color(.navigationBarLoadingIndicator))
-                    } else {
-                        Text(Localization.createButton)
+                switch viewModel.navigationTrailingItem {
+                case .create(let rendered):
+                    Button(Localization.createButton) {
+                        viewModel.createOrder()
                     }
-                })
-                    .renderedIf(viewModel.isCreateButtonEnabled)
+                        .renderedIf(rendered)
+                case .loading:
+                    ProgressView()
+                }
             }
         }
         .wooNavigationBarStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -40,7 +40,7 @@ private extension NewOrder {
 
 struct NewOrder_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = NewOrderViewModel(siteID: 123) { _ in }
+        let viewModel = NewOrderViewModel(siteID: 123)
 
         NavigationView {
             NewOrder(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// View to create a new manual order
 ///
 struct NewOrder: View {
-    let viewModel = NewOrderViewModel()
+    let viewModel: NewOrderViewModel
 
     var body: some View {
         ScrollView {
@@ -16,7 +16,7 @@ struct NewOrder: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action: {
-                    // TODO-5405 - Add create order action
+                    viewModel.createOrder()
                 }, label: {
                     Text(Localization.createButton)
                 })
@@ -37,8 +37,10 @@ private extension NewOrder {
 
 struct NewOrder_Previews: PreviewProvider {
     static var previews: some View {
+        let viewModel = NewOrderViewModel(siteID: 123) { _ in }
+
         NavigationView {
-            NewOrder()
+            NewOrder(viewModel: viewModel)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// View to create a new manual order
 ///
 struct NewOrder: View {
-    let viewModel: NewOrderViewModel
+    @ObservedObject var viewModel: NewOrderViewModel
 
     var body: some View {
         ScrollView {
@@ -18,7 +18,12 @@ struct NewOrder: View {
                 Button(action: {
                     viewModel.createOrder()
                 }, label: {
-                    Text(Localization.createButton)
+                    if viewModel.isLoading {
+                        ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                            .accentColor(Color(.navigationBarLoadingIndicator))
+                    } else {
+                        Text(Localization.createButton)
+                    }
                 })
                     .renderedIf(viewModel.isCreateButtonEnabled)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -2,7 +2,7 @@ import Yosemite
 
 /// View model for `NewOrder`.
 ///
-final class NewOrderViewModel {
+final class NewOrderViewModel: ObservableObject {
     private let siteID: Int64
     private let stores: StoresManager
 
@@ -22,6 +22,10 @@ final class NewOrderViewModel {
     ///
     private(set) var isCreateButtonEnabled: Bool = false
 
+    /// True while performing the create order operation. False otherwise.
+    ///
+    @Published private(set) var isLoading: Bool = false
+
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, onCompletion: @escaping (Order) -> Void) {
         self.siteID = siteID
         self.stores = stores
@@ -30,8 +34,10 @@ final class NewOrderViewModel {
 
     // MARK: - API Requests
     func createOrder() {
+        isLoading = true
         let action = OrderAction.createOrder(siteID: siteID, order: order) { [weak self] result in
             guard let self = self else { return }
+            self.isLoading = false
 
             switch result {
             case .success(let order):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -3,6 +3,13 @@ import Yosemite
 /// View model for `NewOrder`.
 ///
 final class NewOrderViewModel {
+    private let siteID: Int64
+    private let stores: StoresManager
+
+    /// Closure to be executed when order is created
+    ///
+    private let onCompletion: (Order) -> Void
+
     /// Order to create remotely
     ///
     private var order: Order = .empty {
@@ -14,4 +21,25 @@ final class NewOrderViewModel {
     /// Whether to enable the Create button
     ///
     private(set) var isCreateButtonEnabled: Bool = false
+
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, onCompletion: @escaping (Order) -> Void) {
+        self.siteID = siteID
+        self.stores = stores
+        self.onCompletion = onCompletion
+    }
+
+    // MARK: - API Requests
+    func createOrder() {
+        let action = OrderAction.createOrder(siteID: siteID, order: order) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let order):
+                self.onCompletion(order)
+            case .failure(let error):
+                DDLogError("⛔️ Error creating new order: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -14,17 +14,14 @@ final class NewOrderViewModel: ObservableObject {
     ///
     private var order: Order = .empty {
         didSet {
-            isCreateButtonEnabled = true
+            navigationTrailingItem = .create(rendered: false)
         }
     }
 
-    /// Whether to enable the Create button
+    /// Active navigation bar trailing item.
+    /// Defaults to an hidden (un-rendered) create button.
     ///
-    private(set) var isCreateButtonEnabled: Bool = false
-
-    /// True while performing the create order operation. False otherwise.
-    ///
-    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var navigationTrailingItem: NavigationItem = .create(rendered: false)
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, onCompletion: @escaping (Order) -> Void) {
         self.siteID = siteID
@@ -32,12 +29,19 @@ final class NewOrderViewModel: ObservableObject {
         self.onCompletion = onCompletion
     }
 
+    /// Representation of possible navigation bar trailing buttons
+    ///
+    enum NavigationItem: Equatable {
+        case create(rendered: Bool)
+        case loading
+    }
+
     // MARK: - API Requests
     func createOrder() {
-        isLoading = true
+        navigationTrailingItem = .loading
         let action = OrderAction.createOrder(siteID: siteID, order: order) { [weak self] result in
             guard let self = self else { return }
-            self.isLoading = false
+            self.navigationTrailingItem = .create(rendered: true)
 
             switch result {
             case .success(let order):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -6,10 +6,6 @@ final class NewOrderViewModel: ObservableObject {
     private let siteID: Int64
     private let stores: StoresManager
 
-    /// Closure to be executed when order is created
-    ///
-    private let onCompletion: (Order) -> Void
-
     /// Order to create remotely
     ///
     private var order: Order = .empty {
@@ -23,10 +19,9 @@ final class NewOrderViewModel: ObservableObject {
     ///
     @Published private(set) var navigationTrailingItem: NavigationItem = .create(rendered: false)
 
-    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, onCompletion: @escaping (Order) -> Void) {
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.stores = stores
-        self.onCompletion = onCompletion
     }
 
     /// Representation of possible navigation bar trailing buttons
@@ -44,9 +39,11 @@ final class NewOrderViewModel: ObservableObject {
             self.navigationTrailingItem = .create(rendered: true)
 
             switch result {
-            case .success(let order):
-                self.onCompletion(order)
+            case .success:
+                // TODO: Handle newly created order / remove success logging
+                DDLogInfo("New order created successfully!")
             case .failure(let error):
+                // TODO: Display error in the UI (#5457)
                 DDLogError("⛔️ Error creating new order: \(error)")
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -4,11 +4,55 @@ import Yosemite
 
 class NewOrderViewModelTests: XCTestCase {
 
+    let sampleSiteID: Int64 = 123
+
     func test_view_model_starts_with_create_button_disabled() {
         // Given
-        let viewModel = NewOrderViewModel(siteID: 123, onCompletion: { _ in })
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, onCompletion: { _ in })
 
         // Then
-        XCTAssertFalse(viewModel.isCreateButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .create(rendered: false))
+    }
+
+    func test_loading_indicator_is_enabled_during_network_request() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores, onCompletion: { _ in })
+
+        // When
+        let navigationItem: NewOrderViewModel.NavigationItem = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder:
+                    promise(viewModel.navigationTrailingItem)
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+            viewModel.createOrder()
+        }
+
+        // Then
+        XCTAssertEqual(navigationItem, .loading)
+    }
+
+    func test_loading_indicator_is_disabled_after_the_network_operation_completes() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores, onCompletion: { _ in })
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .createOrder(_, order, onCompletion):
+                onCompletion(.success(order))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+        viewModel.createOrder()
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTrailingItem, .create(rendered: true))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -6,7 +6,7 @@ class NewOrderViewModelTests: XCTestCase {
 
     func test_view_model_starts_with_create_button_disabled() {
         // Given
-        let viewModel = NewOrderViewModel()
+        let viewModel = NewOrderViewModel(siteID: 123, onCompletion: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.isCreateButtonEnabled)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -8,7 +8,7 @@ class NewOrderViewModelTests: XCTestCase {
 
     func test_view_model_starts_with_create_button_disabled() {
         // Given
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, onCompletion: { _ in })
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID)
 
         // Then
         XCTAssertEqual(viewModel.navigationTrailingItem, .create(rendered: false))
@@ -17,7 +17,7 @@ class NewOrderViewModelTests: XCTestCase {
     func test_loading_indicator_is_enabled_during_network_request() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores, onCompletion: { _ in })
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
 
         // When
         let navigationItem: NewOrderViewModel.NavigationItem = waitFor { promise in
@@ -39,7 +39,7 @@ class NewOrderViewModelTests: XCTestCase {
     func test_loading_indicator_is_disabled_after_the_network_operation_completes() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores, onCompletion: { _ in })
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
 
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -68,4 +68,8 @@ public enum OrderAction: Action {
     /// Creates a simple payments order with a specific amount value and no tax.
     ///
     case createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: (Result<Order, Error>) -> Void)
+
+    /// Creates a manual order with the provided order details.
+    ///
+    case createOrder(siteID: Int64, order: Order, onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -64,6 +64,8 @@ public class OrderStore: Store {
 
         case let .createSimplePaymentsOrder(siteID, amount, onCompletion):
             createSimplePaymentsOrder(siteID: siteID, amount: amount, onCompletion: onCompletion)
+        case let .createOrder(siteID, order, onCompletion):
+            createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
         }
     }
 }
@@ -252,6 +254,21 @@ private extension OrderStore {
     func createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: @escaping (Result<Order, Error>) -> Void) {
         let order = OrderFactory.simplePaymentsOrder(amount: amount)
         remote.createOrder(siteID: siteID, order: order, fields: [.feeLines]) { [weak self] result in
+            switch result {
+            case .success(let order):
+                self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
+                    onCompletion(result)
+                })
+            case .failure:
+                onCompletion(result)
+            }
+        }
+    }
+
+    /// Creates a manual order with the provided order details.
+    ///
+    func createOrder(siteID: Int64, order: Order, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        remote.createOrder(siteID: siteID, order: order, fields: []) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {


### PR DESCRIPTION
Fixes: #5405

## Description

To create a new order, we need to send the order to the remote endpoint (`POST /wc/v3/orders`). We already have support for that endpoint in the Networking layer (added for Simple Payments).

This PR adds support at the Yosemite layer for creating a manual order, and connects that action to the Create button on the New Order screen. For now, there aren't any errors displayed in the UI if order creation fails (see https://github.com/woocommerce/woocommerce-ios/issues/5457).

## Changes

* Adds a `createOrder` action in the Yosemite layer, to create a complete order.
* Connects that `createOrder` action with the "Create" button in the New Order screen, which displays a loading indicator while the API request is being made.

![Simulator Screen Recording - iPhone 13 Pro - 2021-11-17 at 14 56 44](https://user-images.githubusercontent.com/8658164/142224368-5049553f-00e1-44a5-9e9f-e1fed2842adc.gif)


## Testing

This is a little tricky to test directly, since this screen isn't yet used in the app and the Create button isn't rendered by default. There are two changes you can make to test this:

1. Add navigation to the NewOrder screen. A quick way to do this is to temporarily change [`presentSimplePaymentsAmountController()` in `OrdersTabbedViewController`](https://github.com/woocommerce/woocommerce-ios/blob/f94dc0ca9417a5f8fdebc142721a1c70f61e56c2/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift#L135) to present the New Order screen when the + button is tapped:
```
let viewModel = NewOrderViewModel(siteID: siteID, onCompletion: { _ in })
let newOrder = NewOrder(viewModel: viewModel)
let hostingVC = UIHostingController(rootView: newOrder)
show(hostingVC, sender: self)
```
2. In `NewOrderViewModel`, set `isCreateButtonEnabled` to true to enable the Create button when the screen is opened.

Then, to test:

1. Make sure Simple Payments is enabled under Settings > Experimental Features (to make the + button appear).
2. Go to the Orders tab and tap the + button.
3. Tap the "Create" button on the New Order screen.
4. Confirm the button behaves as expected and a new (empty) order is created on your store.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
