### PR TITLE
[Mobile Payments] Bump Stripe Terminal SDK to 2.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -62,7 +62,7 @@ target 'WooCommerce' do
   pod 'XLPagerTabStrip', '~> 9.0'
   pod 'Charts', '~> 3.6.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
-  pod 'StripeTerminal', '~> 2.3'
+  pod 'StripeTerminal', '~> 2.4'
   pod 'Kingfisher', '~> 6.0.0'
   pod 'Wormholy', '~> 1.6.5', configurations: ['Debug']
 
@@ -79,7 +79,7 @@ end
 #
 def yosemite_pods
   pod 'Alamofire', '~> 4.8'
-  pod 'StripeTerminal', '~> 2.3'
+  pod 'StripeTerminal', '~> 2.4'
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 
@@ -167,7 +167,7 @@ end
 # =================
 #
 def hardware_pods
-  pod 'StripeTerminal', '~> 2.3'
+  pod 'StripeTerminal', '~> 2.4'
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -43,7 +43,7 @@ PODS:
   - Sentry/Core (6.2.1)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (2.3.0)
+  - StripeTerminal (2.4.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.7.1)
   - WordPress-Aztec-iOS (1.11.0)
@@ -100,7 +100,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 6.0.0)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 2.3)
+  - StripeTerminal (~> 2.4)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.42.0)
   - WordPressKit (~> 4.40.0)
@@ -176,7 +176,7 @@ SPEC CHECKSUMS:
   Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: c53f6bc71c11b11867992478b1806a7c6ec16c0f
+  StripeTerminal: da566fa62a4e7bbf0510dd27614f3087293cd79e
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: d0fee204f467dacf8808b7ac14ce43affeb271a5
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -197,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 1905144529d4d224bebb1e178da8509f9934af25
+PODFILE CHECKSUM: f0f2a1a361d8c0e253b703da6a333ecb1cce7fff
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Closes #5459 

## Changes
* Bump the dependency with the Stripe Terminal SDK to 2.4.x, releases yesterday as 2.4.0

## How to test
* Check the I didn't commit anything I should not have
* Check whether CI is ✅ 
* For extra credit, checkout the branch, build and run locally

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
