### PR TITLE
Order Filters: allow multiple status selection

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -8,7 +8,7 @@ public class OrdersRemote: Remote {
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch remote orders.
-    ///     - status: Filters the Orders by the specified Status, if any.
+    ///     - statuses: Filters the Orders by the specified Status, if any.
     ///     - after: If given, limit response to orders published after a given compliant date.  Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - before: If given, limit response to resources published before a given compliant date.. Passing a local date is fine. This
@@ -18,7 +18,7 @@ public class OrdersRemote: Remote {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllOrders(for siteID: Int64,
-                              statusKey: String? = nil,
+                              statuses: [String]? = nil,
                               after: Date? = nil,
                               before: Date? = nil,
                               pageNumber: Int = Defaults.pageNumber,
@@ -26,11 +26,12 @@ public class OrdersRemote: Remote {
                               completion: @escaping (Result<[Order], Error>) -> Void) {
         let utcDateFormatter = DateFormatter.Defaults.iso8601
 
+        let statusesString: String? = statuses?.isEmpty == true ? Defaults.statusAny : statuses?.joined(separator: ",")
         let parameters: [String: Any] = {
             var parameters = [
                 ParameterKeys.page: String(pageNumber),
                 ParameterKeys.perPage: String(pageSize),
-                ParameterKeys.statusKey: statusKey ?? Defaults.statusAny,
+                ParameterKeys.statusKey: statusesString ?? Defaults.statusAny,
                 ParameterKeys.fields: ParameterValues.listFieldValues,
             ]
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -132,7 +132,7 @@ extension WooAnalyticsEvent {
 
     static func ordersListLoaded(totalDuration: TimeInterval, pageNumber: Int, filters: FilterOrderListViewModel.Filters?) -> WooAnalyticsEvent {
         WooAnalyticsEvent(statName: .ordersListLoaded, properties: [
-            "status": filters?.orderStatus?.rawValue ?? String(),
+            "status": (filters?.orderStatus ?? []).map { $0.rawValue }.joined(separator: ","),
             "page_number": Int64(pageNumber),
             "total_duration": Double(totalDuration),
             "date_range": filters?.dateRange?.analyticsDescription ?? String()

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -226,6 +226,10 @@ public enum WooAnalyticsStat: String {
     case orderTrackingDeleteSuccess = "order_tracking_delete_success"
     case orderTrackingProvidersLoaded = "order_tracking_providers_loaded"
 
+    // MARK: Order List Sorting/Filtering
+    //
+    case orderListViewFilterOptionsTapped = "order_list_view_filter_options_tapped"
+    
     // MARK: Shipping Labels Events
     //
     case shippingLabelRefundRequested = "shipping_label_refund_requested"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -229,7 +229,7 @@ public enum WooAnalyticsStat: String {
     // MARK: Order List Sorting/Filtering
     //
     case orderListViewFilterOptionsTapped = "order_list_view_filter_options_tapped"
-    
+
     // MARK: Shipping Labels Events
     //
     case shippingLabelRefundRequested = "shipping_label_refund_requested"

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -54,6 +54,8 @@ enum FilterListValueSelectorConfig {
     case staticOptions(options: [FilterType])
     // Filter list selector for categories linked to that site id, retrieved dynamically
     case productCategories(siteID: Int64)
+    // Filter list selector for order statuses
+    case ordersStatuses
     // Filter list selector for date range
     case ordersDateRange
 }
@@ -236,6 +238,14 @@ private extension FilterListViewController {
                                                                                                       selectedCategory: selectedProductCategory,
                                                                                                       onProductCategorySelection: selectedValueAction)
                 self.listSelector.navigationController?.pushViewController(filterProductCategoryListViewController, animated: true)
+            case .ordersStatuses:
+                let selectedOrderFilters = selected.selectedValue as? Array<OrderStatusEnum> ?? []
+                let statusesFilterVC = OrderStatusFilterViewController(selected: selectedOrderFilters) { statuses in
+                    selected.selectedValue = statuses
+                    self.updateUI(numberOfActiveFilters: self.viewModel.filterTypeViewModels.numberOfActiveFilters)
+                    self.listSelector.reloadData()
+                }
+                self.listSelector.navigationController?.pushViewController(statusesFilterVC, animated: true)
             case .ordersDateRange:
                 let selectedOrderFilter = selected.selectedValue as? OrderDateRangeFilter
                 let datesFilterVC = OrderDatesFilterViewController(selected: selectedOrderFilter) { dateRangeFilter in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -7,7 +7,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
 
     /// Aggregates the filter values that can be updated in the Filter Order UI.
     struct Filters: Equatable {
-        let orderStatus: OrderStatusEnum?
+        let orderStatus: [OrderStatusEnum]?
         let dateRange: OrderDateRangeFilter?
 
         let numberOfActiveFilters: Int
@@ -18,7 +18,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
             numberOfActiveFilters = 0
         }
 
-        init(orderStatus: OrderStatusEnum?,
+        init(orderStatus: [OrderStatusEnum]?,
              dateRange: OrderDateRangeFilter?,
              numberOfActiveFilters: Int) {
             self.orderStatus = orderStatus
@@ -48,7 +48,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
     }
 
     var criteria: Filters {
-        let orderStatus = orderStatusFilterViewModel.selectedValue as? OrderStatusEnum ?? nil
+        let orderStatus = orderStatusFilterViewModel.selectedValue as? [OrderStatusEnum] ?? nil
         let dateRange = dateRangeFilterViewModel.selectedValue as? OrderDateRangeFilter ?? nil
         let numberOfActiveFilters = filterTypeViewModels.numberOfActiveFilters
         return Filters(orderStatus: orderStatus,
@@ -89,9 +89,8 @@ extension FilterOrderListViewModel.OrderListFilter {
     func createViewModel(filters: FilterOrderListViewModel.Filters) -> FilterTypeViewModel {
         switch self {
         case .orderStatus:
-            let options: [OrderStatusEnum?] = [nil, .pending, .processing, .onHold, .failed, .cancelled, .completed, .refunded]
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .staticOptions(options: options),
+                                       listSelectorConfig: .ordersStatuses,
                                        selectedValue: filters.orderStatus)
         case .dateRange:
             return FilterTypeViewModel(title: title,
@@ -127,6 +126,26 @@ extension OrderStatusEnum: FilterType {
             return NSLocalizedString("Refunded", comment: "Display label for refunded order status.")
         case .custom(let payload):
             return payload // unable to localize at runtime.
+        }
+    }
+}
+
+extension Array: FilterType where Element == OrderStatusEnum {
+    var isActive: Bool {
+        return true
+    }
+
+    /// Returns the localized text version of the array
+    ///
+    var description: String {
+        if self.count == 0 {
+            return NSLocalizedString("Any", comment: "Display label for all order statuses selected in Order Filters")
+        }
+        else if self.count == 1 {
+            return self.first?.description ?? ""
+        }
+        else {
+            return "\(self.count)"
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -27,7 +27,14 @@ final class FilterOrderListViewModel: FilterListViewModel {
         }
 
         var readableString: String {
-            [orderStatus.description, dateRange.description].compactMap { $0 }.joined(separator: ", ")
+            var readable: [String] = []
+            if let orderStatus = orderStatus, orderStatus.count > 0 {
+                readable = orderStatus.map { $0.rawValue.capitalized }
+            }
+            if let dateRange = dateRange {
+                readable.append(dateRange.description)
+            }
+            return readable.joined(separator: ", ")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -109,13 +109,11 @@ extension OrderStatusFilterViewController: UITableViewDelegate {
         case .any:
             selected = []
             onCompletion(selected)
-            tableView.reloadData()
         default:
             selectOrDelesectRow(rows[indexPath.row])
             onCompletion(selected)
-            tableView.reloadData()
-            return
         }
+        tableView.reloadData()
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -1,30 +1,206 @@
-//
-//  OrderStatusFilterViewController.swift
-//  WooCommerce
-//
-//  Created by Paolo Musolino on 17/11/21.
-//  Copyright © 2021 Automattic. All rights reserved.
-//
-
 import UIKit
+import Yosemite
 
-class OrderStatusFilterViewController: UIViewController {
+// MARK: - OrderStatusFilterViewController
+// Display a list of options for filtering orders by different type of status.
+// Multiples selection allowed.
+//
+final class OrderStatusFilterViewController: UIViewController {
+
+    @IBOutlet private weak var tableView: UITableView!
+
+    // Completion callback
+    //
+    typealias Completion = ([OrderStatusEnum]) -> Void
+    private let onCompletion: Completion
+
+    private var rows: [Row] = []
+
+    private var selected: [OrderStatusEnum]
+
+    /// Init
+    ///
+    init(selected: [OrderStatusEnum],
+         completion: @escaping Completion) {
+        self.selected = selected
+        onCompletion = completion
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationBar()
+        configureMainView()
+        configureRows()
+        configureTableView()
+    }
+}
 
-        // Do any additional setup after loading the view.
+// MARK: - View Configuration
+//
+private extension OrderStatusFilterViewController {
+
+    func configureNavigationBar() {
+        title = Localization.navigationBarTitle
     }
 
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    func configureMainView() {
+        view.backgroundColor = .listBackground
     }
-    */
 
+    func configureTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        /// Registers all of the available TableViewCells
+        ///
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+
+        tableView.backgroundColor = .listBackground
+        tableView.removeLastCellSeparator()
+    }
+
+    func configureRows() {
+        rows = [.any, .pending, .processing, .onHold, .failed, .cancelled, .completed, .refunded]
+    }
+
+    func selectOrDelesectRow(_ row: Row) {
+        guard let status = row.status else {
+            return
+        }
+        if selected.contains(status) {
+            selected.removeAll { $0 == status }
+        }
+        else {
+            selected.append(status)
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension OrderStatusFilterViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension OrderStatusFilterViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch rows[indexPath.row] {
+        case .any:
+            selected = []
+            onCompletion(selected)
+            tableView.reloadData()
+        default:
+            selectOrDelesectRow(rows[indexPath.row])
+            onCompletion(selected)
+            tableView.reloadData()
+            return
+        }
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+}
+
+// MARK: - Cell configuration
+//
+private extension OrderStatusFilterViewController {
+    enum Row: CaseIterable {
+        case any
+        case pending
+        case processing
+        case onHold
+        case failed
+        case cancelled
+        case completed
+        case refunded
+
+        var status: OrderStatusEnum? {
+            switch self {
+            case .any:
+                return nil
+            case .pending:
+                return .pending
+            case .processing:
+                return .processing
+            case .onHold:
+                return .onHold
+            case .failed:
+                return .failed
+            case .cancelled:
+                return .cancelled
+            case .completed:
+                return .completed
+            case .refunded:
+                return .refunded
+            }
+        }
+
+        var type: UITableViewCell.Type {
+            BasicTableViewCell.self
+        }
+
+        var reuseIdentifier: String {
+            type.reuseIdentifier
+        }
+    }
+
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as BasicTableViewCell:
+            configureStatus(cell: cell, row: row)
+        default:
+            fatalError()
+        }
+    }
+
+    func configureStatus(cell: BasicTableViewCell, row: Row) {
+        switch row {
+        case .any:
+            cell.textLabel?.text = Localization.anyStatusCase
+            cell.accessoryType = selected.isEmpty ? .checkmark : .none
+        default:
+            cell.textLabel?.text = row.status.description
+            if selected.contains(where: { $0 == row.status }) {
+                cell.accessoryType = .checkmark
+            }
+            else {
+                cell.accessoryType = .none
+            }
+        }
+
+        cell.selectionStyle = .none
+    }
+}
+
+private extension OrderStatusFilterViewController {
+    enum Localization {
+        static let anyStatusCase = NSLocalizedString("Any",
+                                                     comment: "Case Any in Order Filters for Order Statuses")
+        static let navigationBarTitle = NSLocalizedString("Order Status",
+                                                          comment: "Navigation title of the orders filter selector screen for order statuses")
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -171,7 +171,7 @@ private extension OrderStatusFilterViewController {
         case let cell as BasicTableViewCell:
             configureStatus(cell: cell, row: row)
         default:
-            fatalError()
+            assertionFailure("The type of cell (\(type(of: cell)) does not match the type (\(row.type)) for row: \(row)")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -1,0 +1,30 @@
+//
+//  OrderStatusFilterViewController.swift
+//  WooCommerce
+//
+//  Created by Paolo Musolino on 17/11/21.
+//  Copyright © 2021 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class OrderStatusFilterViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.xib
@@ -1,22 +1,44 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrderStatusFilterViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrderStatusFilterViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="RrU-ZV-37P" id="SgL-Lj-jEV"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="RrU-ZV-37P">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="RrU-ZV-37P" secondAttribute="bottom" id="6lN-iV-2AF"/>
+                <constraint firstItem="RrU-ZV-37P" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="mq6-E8-aRG"/>
+                <constraint firstItem="RrU-ZV-37P" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="vqv-9H-5Ai"/>
+                <constraint firstItem="RrU-ZV-37P" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="wFx-Mg-ckI"/>
+            </constraints>
+            <point key="canvasLocation" x="131.8840579710145" y="93.75"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrderStatusFilterViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -56,7 +56,7 @@ struct OrderListSyncActionUseCase {
                    pageSize: Int,
                    reason: SyncReason?,
                    completionHandler: @escaping (TimeInterval, Error?) -> Void) -> OrderAction {
-        let statusKey = filters?.orderStatus?.rawValue
+        let statuses = (filters?.orderStatus ?? []).map { $0.rawValue }
         let startDate = filters?.dateRange?.computedStartDate
         let endDate = filters?.dateRange?.computedEndDate
 
@@ -65,7 +65,7 @@ struct OrderListSyncActionUseCase {
 
             return OrderAction.fetchFilteredOrders(
                 siteID: siteID,
-                statusKey: statusKey,
+                statuses: statuses,
                 after: startDate,
                 before: endDate,
                 deleteAllBeforeSaving: deleteAllBeforeSaving,
@@ -76,7 +76,7 @@ struct OrderListSyncActionUseCase {
 
         return OrderAction.synchronizeOrders(
             siteID: siteID,
-            statusKey: statusKey,
+            statuses: statuses,
             after: startDate,
             before: endDate,
             pageNumber: pageNumber,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -180,7 +180,7 @@ final class OrderListViewModel {
     private func createQuery() -> FetchResultSnapshotsProvider<StorageOrder>.Query {
         let predicateStatus: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
-            let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey = %@", $0.rawValue) }
+            let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey IN %@", $0) }
 
             let predicates = [excludeSearchCache, excludeNonMatchingStatus].compactMap { $0 }
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -180,7 +180,7 @@ final class OrderListViewModel {
     private func createQuery() -> FetchResultSnapshotsProvider<StorageOrder>.Query {
         let predicateStatus: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
-            let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey IN %@", $0) }
+            let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey IN %@", $0.map { $0.rawValue }) }
 
             let predicates = [excludeSearchCache, excludeNonMatchingStatus].compactMap { $0 }
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -115,15 +115,12 @@ final class OrdersRootViewController: UIViewController {
     /// Present `FilterListViewController`
     ///
     private func filterButtonTapped() {
-        //TODO-5243: add event for tracking the filter tapped
+        ServiceLocator.analytics.track(.orderListViewFilterOptionsTapped)
         let viewModel = FilterOrderListViewModel(filters: filters)
         let filterOrderListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in
-            //TODO-5243: add event for tracking filter list show
             self?.filters = filters
         }, onClearAction: {
-            //TODO-5243: add event for tracking clear action
         }, onDismissAction: {
-            //TODO-5243: add event for tracking dismiss action
         })
         present(filterOrderListViewController, animated: true, completion: nil)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -642,6 +642,8 @@
 		456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F3247D5434001203F6 /* UITableView+Helpers.swift */; };
 		456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */; };
 		456738972743DE9A00743054 /* OrderDateRangeFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456738962743DE9A00743054 /* OrderDateRangeFilterTests.swift */; };
+		4567389D2745497C00743054 /* OrderStatusFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4567389B2745497C00743054 /* OrderStatusFilterViewController.swift */; };
+		4567389E2745497C00743054 /* OrderStatusFilterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4567389C2745497C00743054 /* OrderStatusFilterViewController.xib */; };
 		4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4569317E2653E82B009ED69D /* ShippingLabelCarriers.swift */; };
 		456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456931832653E9F1009ED69D /* ShippingLabelCarrierRow.swift */; };
 		45693189265403A1009ED69D /* ShippingLabelCarriersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45693188265403A1009ED69D /* ShippingLabelCarriersViewModel.swift */; };
@@ -2083,6 +2085,8 @@
 		456417F3247D5434001203F6 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
 		456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HelpersTests.swift"; sourceTree = "<group>"; };
 		456738962743DE9A00743054 /* OrderDateRangeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDateRangeFilterTests.swift; sourceTree = "<group>"; };
+		4567389B2745497C00743054 /* OrderStatusFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusFilterViewController.swift; sourceTree = "<group>"; };
+		4567389C2745497C00743054 /* OrderStatusFilterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderStatusFilterViewController.xib; sourceTree = "<group>"; };
 		4569317E2653E82B009ED69D /* ShippingLabelCarriers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriers.swift; sourceTree = "<group>"; };
 		456931832653E9F1009ED69D /* ShippingLabelCarrierRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarrierRow.swift; sourceTree = "<group>"; };
 		45693188265403A1009ED69D /* ShippingLabelCarriersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriersViewModel.swift; sourceTree = "<group>"; };
@@ -4342,6 +4346,7 @@
 				4546E098271F0942003836F3 /* FilteredOrdersHeaderBar.swift */,
 				4546E099271F0942003836F3 /* FilteredOrdersHeaderBar.xib */,
 				4520A15B2721B2A9001FA573 /* FilterOrderListViewModel.swift */,
+				4567389A2745456C00743054 /* Order Status Filter */,
 				45F931F6272AE6690098375D /* Date Range Filter */,
 			);
 			path = "Order Filters";
@@ -4382,6 +4387,15 @@
 				45FDDD64267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		4567389A2745456C00743054 /* Order Status Filter */ = {
+			isa = PBXGroup;
+			children = (
+				4567389B2745497C00743054 /* OrderStatusFilterViewController.swift */,
+				4567389C2745497C00743054 /* OrderStatusFilterViewController.xib */,
+			);
+			path = "Order Status Filter";
 			sourceTree = "<group>";
 		};
 		4569317A2653E7F9009ED69D /* Carriers and Rates */ = {
@@ -7197,6 +7211,7 @@
 				456396A825C81C9A001F1A26 /* ShippingLabelFormViewController.xib in Resources */,
 				CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */,
 				CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */,
+				4567389E2745497C00743054 /* OrderStatusFilterViewController.xib in Resources */,
 				D8915DBF23729CFB00F63762 /* ColorPalette.xcassets in Resources */,
 				CE24BCD0212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib in Resources */,
 				B559EBB020A0BF8F00836CD4 /* LICENSE in Resources */,
@@ -7884,6 +7899,7 @@
 				26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */,
 				26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */,
 				7421344A210A323C00C13890 /* WooAnalyticsStat.swift in Sources */,
+				4567389D2745497C00743054 /* OrderStatusFilterViewController.swift in Sources */,
 				02A275BA23FE50AA005C560F /* ProductUIImageLoader.swift in Sources */,
 				02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */,
 				B5D6DC54214802740003E48A /* SyncCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
@@ -16,7 +16,7 @@ final class FilterOrderListViewModelTests: XCTestCase {
 
     func test_criteria_with_non_nil_filters() {
         // Given
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .processing, dateRange: OrderDateRangeFilter(filter: .today), numberOfActiveFilters: 2)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.processing], dateRange: OrderDateRangeFilter(filter: .today), numberOfActiveFilters: 2)
 
         // When
         let viewModel = FilterOrderListViewModel(filters: filters)
@@ -28,7 +28,7 @@ final class FilterOrderListViewModelTests: XCTestCase {
 
     func test_criteria_after_clearing_all_non_nil_filters() {
         // Given
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .completed, dateRange: OrderDateRangeFilter(filter: .last7Days), numberOfActiveFilters: 2)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.completed], dateRange: OrderDateRangeFilter(filter: .last7Days), numberOfActiveFilters: 2)
 
         // When
         let viewModel = FilterOrderListViewModel(filters: filters)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -24,7 +24,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     //
     func test_pulling_to_refresh_on_filtered_list_it_deletes_and_performs_fetch() {
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .processing, dateRange: nil, numberOfActiveFilters: 1)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.processing], dateRange: nil, numberOfActiveFilters: 1)
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
                                                  filters: filters)
 
@@ -35,13 +35,13 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
         XCTAssertTrue(deleteAllBeforeSaving)
-        XCTAssertEqual(statusKey, OrderStatusEnum.processing.rawValue)
+        XCTAssertEqual(statuses, [OrderStatusEnum.processing.rawValue])
     }
 
     // Test that when fetching the first page of a filtered list for reasons
@@ -49,7 +49,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     //
     func test_first_page_load_on_filtered_list_with_non_pull_to_refresh_reasons_will_only_perform_fetch() {
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .processing, dateRange: nil, numberOfActiveFilters: 1)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.processing], dateRange: nil, numberOfActiveFilters: 1)
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
                                                  filters: filters)
 
@@ -60,13 +60,13 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
         XCTAssertFalse(deleteAllBeforeSaving)
-        XCTAssertEqual(statusKey, OrderStatusEnum.processing.rawValue)
+        XCTAssertEqual(statuses, [OrderStatusEnum.processing.rawValue])
     }
 
     // Test that when pulling to refresh, the action returned will be for:
@@ -86,13 +86,13 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
         XCTAssertTrue(deleteAllBeforeSaving)
-        XCTAssertNil(statusKey, "No filtered list will be fetched.")
+        XCTAssertNil(statuses?.first)
     }
 
     // Test when fetching the first page of order list for reasons other than
@@ -110,18 +110,18 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
         XCTAssertFalse(deleteAllBeforeSaving)
-        XCTAssertNil(statusKey, "No filtered list will be fetched.")
+        XCTAssertNil(statuses?.first)
     }
 
     func test_subsequent_page_loads_on_filtered_list_will_fetch_the_given_page_on_that_list() {
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .pending, dateRange: nil, numberOfActiveFilters: 1)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.pending], dateRange: nil, numberOfActiveFilters: 1)
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
                                                  filters: filters)
 
@@ -132,12 +132,12 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statusKey, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
-        XCTAssertEqual(statusKey, OrderStatusEnum.pending.rawValue)
+        XCTAssertEqual(statuses, [OrderStatusEnum.pending.rawValue])
         XCTAssertEqual(pageNumber, Defaults.pageFirstIndex + 3)
         XCTAssertEqual(pageSize, self.pageSize)
     }
@@ -154,12 +154,12 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statusKey, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
-        XCTAssertNil(statusKey)
+        XCTAssertNil(statuses?.first)
         XCTAssertEqual(pageNumber, Defaults.pageFirstIndex + 5)
         XCTAssertEqual(pageSize, self.pageSize)
     }
@@ -172,7 +172,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     //
     func test_refresh_with_new_filters_applied_deletes_and_performs_single_fetch() {
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .processing, dateRange: nil, numberOfActiveFilters: 1)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.processing], dateRange: nil, numberOfActiveFilters: 1)
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
                                                  filters: filters)
 
@@ -183,13 +183,13 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
         XCTAssertTrue(deleteAllBeforeSaving)
-        XCTAssertEqual(statusKey, OrderStatusEnum.processing.rawValue)
+        XCTAssertEqual(statuses, [OrderStatusEnum.processing.rawValue])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -38,7 +38,7 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() throws {
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .processing, dateRange: nil, numberOfActiveFilters: 1)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.processing], dateRange: nil, numberOfActiveFilters: 1)
         let viewModel = OrderListViewModel(siteID: siteID,
                                            storageManager: storageManager,
                                            filters: filters)
@@ -84,7 +84,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_it_also_loads_future_orders_from_the_DB() throws {
 
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .pending, dateRange: nil, numberOfActiveFilters: 1)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.pending], dateRange: nil, numberOfActiveFilters: 1)
         let viewModel = OrderListViewModel(siteID: siteID,
                                            storageManager: storageManager,
                                            filters: filters)
@@ -116,7 +116,7 @@ final class OrderListViewModelTests: XCTestCase {
     /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
     func test_it_groups_future_orders_in_upcoming_section() throws {
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .failed, dateRange: nil, numberOfActiveFilters: 1)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.failed], dateRange: nil, numberOfActiveFilters: 1)
         let viewModel = OrderListViewModel(siteID: siteID,
                                            storageManager: storageManager,
                                            filters: filters)
@@ -415,7 +415,7 @@ final class OrderListViewModelTests: XCTestCase {
         viewModel.activate()
 
         // Act
-        viewModel.updateFilters(filters: FilterOrderListViewModel.Filters(orderStatus: .completed, dateRange: nil, numberOfActiveFilters: 1))
+        viewModel.updateFilters(filters: FilterOrderListViewModel.Filters(orderStatus: [.completed], dateRange: nil, numberOfActiveFilters: 1))
 
         // Assert
         XCTAssertTrue(resynchronizeRequested)
@@ -423,7 +423,7 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_given_identical_filters_it_does_not_request_a_resynchronization() {
         // Arrange
-        let filters = FilterOrderListViewModel.Filters(orderStatus: .pending, dateRange: nil, numberOfActiveFilters: 0)
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.pending], dateRange: nil, numberOfActiveFilters: 0)
         let notificationCenter = NotificationCenter()
         let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, filters: filters)
 

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -14,7 +14,7 @@ public enum OrderAction: Action {
     /// Performs the fetch for the first pages of order list.
     ///
     /// - Parameters:
-    ///     - statusKey: The status to use for the filtered list. If this is not provided, only the
+    ///     - statuses: The statuses to use for the filtered list. If this is not provided, only the
     ///                  all orders list will be fetched. See `OrderStatusEnum` for possible values.
     ///     - deleteAllBeforeSaving: If true, all the orders in the db will be deleted before any
     ///                  order from the fetch requests will be saved.
@@ -25,7 +25,7 @@ public enum OrderAction: Action {
     ///
     case fetchFilteredOrders(
         siteID: Int64,
-        statusKey: String?,
+        statuses: [String]?,
         after: Date? = nil,
         before: Date? = nil,
         deleteAllBeforeSaving: Bool,
@@ -42,7 +42,7 @@ public enum OrderAction: Action {
     ///               doesn't matter. It will be converted to UTC later.
     ///
     case synchronizeOrders(siteID: Int64,
-                           statusKey: String?,
+                           statuses: [String]?,
                            after: Date? = nil,
                            before: Date? = nil,
                            pageNumber: Int,

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests+FetchFilteredAndAllOrders.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests+FetchFilteredAndAllOrders.swift
@@ -36,7 +36,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
 
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
-                             statusKey: OrderStatusEnum.processing.rawValue,
+                             statuses: [OrderStatusEnum.processing.rawValue],
                              deleteAllBeforeSaving: true)
 
         // Assert
@@ -58,7 +58,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
 
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
-                             statusKey: OrderStatusEnum.processing.rawValue,
+                             statuses: [OrderStatusEnum.processing.rawValue],
                              deleteAllBeforeSaving: false)
 
         // Assert
@@ -75,7 +75,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
 
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
-                             statusKey: OrderStatusEnum.completed.rawValue,
+                             statuses: [OrderStatusEnum.completed.rawValue],
                              deleteAllBeforeSaving: true)
 
         // Assert
@@ -90,7 +90,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
 
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
-                             statusKey: nil,
+                             statuses: nil,
                              deleteAllBeforeSaving: true)
 
         // Assert
@@ -106,7 +106,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
 
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
-                             statusKey: OrderStatusEnum.processing.rawValue,
+                             statuses: [OrderStatusEnum.processing.rawValue],
                              deleteAllBeforeSaving: true)
 
         // Assert
@@ -123,12 +123,12 @@ private extension OrderStoreTests_FetchFilteredAndAllOrders {
         OrderStore(dispatcher: Dispatcher(), storageManager: storageManager, network: network)
     }
 
-    func executeActionAndWait(using store: OrderStore, statusKey: String?, deleteAllBeforeSaving: Bool) {
+    func executeActionAndWait(using store: OrderStore, statuses: [String]?, deleteAllBeforeSaving: Bool) {
         let expectation = self.expectation(description: "fetch")
 
         let action = OrderAction.fetchFilteredOrders(
             siteID: Fixtures.siteID,
-            statusKey: statusKey,
+            statuses: statuses,
             deleteAllBeforeSaving: deleteAllBeforeSaving,
             pageSize: 50) { _, _  in
                 expectation.fulfill()

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -66,7 +66,7 @@ final class OrderStoreTests: XCTestCase {
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
-        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statusKey: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
+        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statuses: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 4)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderRefundCondensed.self), 4)
@@ -88,7 +88,7 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderRefundCondensed.self), 0)
 
-        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statusKey: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
+        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statuses: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 4)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderRefundCondensed.self), 4)
             XCTAssertNil(error)
@@ -112,7 +112,7 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderRefundCondensed.self), 0)
 
-        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statusKey: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
+        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statuses: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
             XCTAssertNil(error)
 
             let predicate = NSPredicate(format: "orderID = %ld", remoteOrder.orderID)
@@ -140,7 +140,7 @@ final class OrderStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders", filename: "broken-orders-mark-2")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
 
-        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statusKey: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
+        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statuses: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 6)
 
@@ -158,7 +158,7 @@ final class OrderStoreTests: XCTestCase {
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "orders", filename: "generic_error")
-        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statusKey: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
+        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statuses: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
             XCTAssertNotNil(error)
 
             expectation.fulfill()
@@ -174,7 +174,7 @@ final class OrderStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve orders empty response")
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statusKey: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
+        let action = OrderAction.synchronizeOrders(siteID: sampleSiteID, statuses: nil, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { _, error in
             XCTAssertNotNil(error)
 
             expectation.fulfill()


### PR DESCRIPTION
Part of #5243 

## Description
Now we allow merchants to filter orders not only by single order status but also by multiple statuses, so now the endpoints will take a list of statuses instead of only one. I updated our unit tests and I also implemented a new view controller `OrderStatusFilterViewController` which will be present the order statuses and allow you to select multiple statuses at the same time or just the status `Any`.

## Testing
1. Tap the orders tab.
2. Tap the filters button.
3. You should be able to filter orders selecting multiple statuses, or just the status `Any`.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/142253295-a828aa1c-034b-4b7a-8185-53fbfe45c9e3.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
