### PR TITLE
[Mobile Payments] Add Stripe Terminal license to licenses

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
@@ -34,7 +34,7 @@ private extension LicensesViewController {
     /// Set the title and back button.
     ///
     func configureNavigation() {
-        title = NSLocalizedString("Software Licenses", comment: "Software Licenses (information page title)")
+        title = NSLocalizedString("Third Party Licenses", comment: "Software Licenses (information page title)")
     }
 
     /// Setup the main view

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
@@ -34,7 +34,7 @@ private extension LicensesViewController {
     /// Set the title and back button.
     ///
     func configureNavigation() {
-        title = NSLocalizedString("Licenses", comment: "Licenses (information page title)")
+        title = NSLocalizedString("Software Licenses", comment: "Software Licenses (information page title)")
     }
 
     /// Setup the main view

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -192,7 +192,7 @@ private extension SettingsViewController {
     func configureLicenses(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Open Source Licenses", comment: "Navigates to screen about open source licenses")
+        cell.textLabel?.text = NSLocalizedString("Software Licenses", comment: "Navigates to screen with third party software licenses")
     }
 
     func configureAppSettings(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -192,7 +192,7 @@ private extension SettingsViewController {
     func configureLicenses(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Software Licenses", comment: "Navigates to screen with third party software licenses")
+        cell.textLabel?.text = NSLocalizedString("Third Party Licenses", comment: "Navigates to screen with third party software licenses")
     }
 
     func configureAppSettings(cell: BasicTableViewCell) {

--- a/WooCommerce/Resources/HTML/licenses.html
+++ b/WooCommerce/Resources/HTML/licenses.html
@@ -35,16 +35,17 @@
 
         <h3>Additional Libraries</h3>
 
-        <p>WooCommerce for iOS is made possible with the help of many fantastic open source libraries!</p>
+        <p>WooCommerce for iOS is made possible with the help of many fantastic libraries!</p>
 
         <h4>The following libraries are licensed under <a href="https://opensource.org/licenses/MIT">MIT</a>:</h4>
         <ul>
             <li><a href="https://github.com/Alamofire/Alamofire">Alamofire</a> by <a href="http://alamofire.org/">Alamofire Software Foundation</a></li>
-            <li><a href="https://github.com/kishikawakatsumi/KeychainAccess">KeychainAccess</a> by <a href="https://github.com/kishikawakatsumi">Kishikawa Katsumi</a></li>
-            <li><a href="https://github.com/xmartlabs/XLPagerTabStrip">XLPagerTabStrip</a> by <a href="https://xmartlabs.com/">XMARTLABS</a></li>
-            <li><a href="https://github.com/onevcat/Kingfisher">Kingfisher</a> by <a href="https://github.com/onevcat">Wei Wang</a></li>
-            <li><a href="https://github.com/pmusolino/Wormholy">Wormholy</a> by <a href="https://github.com/pmusolino">Paolo Musolino</a></li>
             <li><a href="https://github.com/gonzalezreal/AttributedText">AttributedText</a> by <a href="https://github.com/gonzalezreal">Guille Gonzalez</a></li>
+            <li><a href="https://github.com/kishikawakatsumi/KeychainAccess">KeychainAccess</a> by <a href="https://github.com/kishikawakatsumi">Kishikawa Katsumi</a></li>
+            <li><a href="https://github.com/onevcat/Kingfisher">Kingfisher</a> by <a href="https://github.com/onevcat">Wei Wang</a></li>
+            <li><a href="https://github.com/stripe/stripe-terminal-ios">StripeTerminal</a> by <a href="https://github.com/stripe">Stripe</a></li>
+            <li><a href="https://github.com/pmusolino/Wormholy">Wormholy</a> by <a href="https://github.com/pmusolino">Paolo Musolino</a></li>
+            <li><a href="https://github.com/xmartlabs/XLPagerTabStrip">XLPagerTabStrip</a> by <a href="https://xmartlabs.com/">XMARTLABS</a></li>
         </ul>
 
         <h4>The following libraries are licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0">The Apache License, Version 2.0</a>:</h4>


### PR DESCRIPTION
Closes #5376 

- Adds StripeTerminal to the Licenses we display
- **Renames** link from "Open Source Licenses" to "Software Licenses" since StripeTerminal is not open source
- Alphabetizes libraries in MIT section

To test:
- Note the changes under Settings and under Software Licenses
- Ensure that tapping on the Terminal link or Stripe link takes you to the expected repo or organization

<img src="https://user-images.githubusercontent.com/1595739/142457274-8caf9ff3-a317-41dd-b791-f698d9a81a49.PNG" width=50% />

<img src="https://user-images.githubusercontent.com/1595739/142457283-6194a7cd-fbc9-4363-8261-179514e8ad9f.PNG" width=50% />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
