### PR TITLE
Simple Payments: Fix iOS 15 regressions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -99,7 +99,7 @@ struct SimplePaymentsAmount: View {
                 .secondaryBodyStyle()
 
             // Amount Textfield
-            TextField(viewModel.amountPlaceholder, text: $viewModel.amount)
+            BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount)
                 .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
                 .foregroundColor(Color(.text))
                 .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -132,6 +132,7 @@ struct SimplePaymentsAmount: View {
                 })
             }
         }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -100,10 +100,11 @@ struct SimplePaymentsAmount: View {
 
             // Amount Textfield
             BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount)
-                .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
-                .foregroundColor(Color(.text))
-                .multilineTextAlignment(.center)
+                .font(.systemFont(ofSize: Layout.amountFontSize(scale: scale), weight: .bold))
+                .foregroundColor(.text)
+                .textAlignment(.center)
                 .keyboardType(.decimalPad)
+                .fixedSize()
 
             Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -5,7 +5,7 @@ import Yosemite
 ///
 final class SimplePaymentsAmountViewModel: ObservableObject {
 
-    /// Stores amount entered by the merchant.
+    /// Stores the amount(formatted) entered by the merchant.
     ///
     @Published var amount: String = "" {
         didSet {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
@@ -15,6 +15,22 @@ struct BindableTextfield: UIViewRepresentable {
     ///
     @Binding var text: String
 
+    /// Textfield font.
+    ///
+    var font = UIFont.body
+
+    /// Textfield keyboard.
+    ///
+    var keyboardType = UIKeyboardType.default
+
+    /// Textfield text color.
+    ///
+    var foregroundColor = UIColor.text
+
+    /// Textfield text alignment.
+    ///
+    var textAlignment = NSTextAlignment.left
+
     init(_ placeholder: String?, text: Binding<String>) {
         self.placeHolder = placeholder
         self._text = text
@@ -24,7 +40,6 @@ struct BindableTextfield: UIViewRepresentable {
     ///
     func makeUIView(context: Context) -> UITextField {
         let textfield = UITextField()
-        textfield.placeholder = placeHolder
         textfield.delegate = context.coordinator
         return textfield
     }
@@ -38,7 +53,12 @@ struct BindableTextfield: UIViewRepresentable {
     /// Updates underlying view.
     ///
     func updateUIView(_ uiView: UITextField, context: Context) {
+        uiView.placeholder = placeHolder
         uiView.text = text
+        uiView.font = font
+        uiView.textColor = foregroundColor
+        uiView.textAlignment = textAlignment
+        uiView.keyboardType = keyboardType
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
@@ -89,3 +89,37 @@ extension BindableTextfield {
         }
     }
 }
+
+
+// MARK: Modifiers
+
+extension BindableTextfield {
+    /// Updates the textfield font.
+    ///
+    func font(_ font: UIFont) -> Self {
+        var copy = self
+        copy.font = font
+        return copy
+    }
+
+    /// Updates the textfield foreground color.
+    func foregroundColor(_ color: UIColor) -> Self {
+        var copy = self
+        copy.foregroundColor = color
+        return copy
+    }
+
+    /// Updates the textfield text alignment.
+    func textAlignment(_ alignment: NSTextAlignment) -> Self {
+        var copy = self
+        copy.textAlignment = alignment
+        return copy
+    }
+
+    /// Updates the textfield keyboard type.
+    func keyboardType(_ type: UIKeyboardType) -> Self {
+        var copy = self
+        copy.keyboardType = type
+        return copy
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftUI
+
+/// `UITextfield` wrapper reads and writes to provided binding value.
+/// Needed because iOS 15 won't allow us to intercept correctly the binding value in the original `SwiftUI` component.
+/// Feel free to add modifiers as it is needed.
+///
+struct BindableTextfield: UIViewRepresentable {
+
+    /// Placeholder of the textfield.
+    ///
+    let placeHolder: String?
+
+    /// Binding to read content from and write content to.
+    ///
+    @Binding var text: String
+
+    init(_ placeholder: String?, text: Binding<String>) {
+        self.placeHolder = placeholder
+        self._text = text
+    }
+
+    /// Creates view with the initial configuration.
+    ///
+    func makeUIView(context: Context) -> UITextField {
+        let textfield = UITextField()
+        textfield.placeholder = placeHolder
+        textfield.delegate = context.coordinator
+        return textfield
+    }
+
+    /// Creates coordinator.
+    ///
+    func makeCoordinator() -> Coordinator {
+        Coordinator(_text)
+    }
+
+    /// Updates underlying view.
+    ///
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        uiView.text = text
+    }
+}
+
+// MARK: Coordinator
+
+extension BindableTextfield {
+    /// Coordinator needed to listen to the `TextField` delegate and relay the input content to the binding value.
+    ///
+    final class Coordinator: NSObject, UITextFieldDelegate {
+
+        /// Binding to set content from the `TextField` delegate.
+        ///
+        @Binding var text: String
+
+        init(_ text: Binding<String>) {
+            self._text = text
+        }
+
+        /// Relays the input value to the binding variable.
+        ///
+        func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            if let currentInput = textField.text, let inputRange = Range(range, in: currentInput) {
+                text = currentInput.replacingCharacters(in: inputRange, with: string)
+            } else {
+                text = string
+            }
+            return false
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -452,6 +452,7 @@
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
 		26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */; };
+		26B3EC642745916F0075EAE6 /* BindableTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC632745916F0075EAE6 /* BindableTextField.swift */; };
 		26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */; };
 		26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */; };
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
@@ -1929,6 +1930,7 @@
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
 		26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModelTests.swift; sourceTree = "<group>"; };
+		26B3EC632745916F0075EAE6 /* BindableTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableTextField.swift; sourceTree = "<group>"; };
 		26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelProtocol.swift; sourceTree = "<group>"; };
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
@@ -4620,6 +4622,7 @@
 				26C6E8E926E8FD3900C7BB0F /* LazyView.swift */,
 				26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */,
 				AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */,
+				26B3EC632745916F0075EAE6 /* BindableTextField.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -8257,6 +8260,7 @@
 				02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */,
 				027D4A8D2526FD1800108626 /* SettingsViewController.swift in Sources */,
 				02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */,
+				26B3EC642745916F0075EAE6 /* BindableTextField.swift in Sources */,
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
 				5783FB3F25D7369F00B9984B /* WooAnalyticsEventPropertyType.swift in Sources */,
 				CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */,


### PR DESCRIPTION
# Why

While working on the "Simple Payments" feature, I noticed that upon compiling the app in Xcode 13 against iOS 15 there were some bugs present. Specifically:

- The Cancel button on the "Enter Amount" screen had the wrong color
- The currency formatter on the "Enter Amount" screen was not working correctly.

This PR fixes those issues.

# How

- Add `.wooNavigationBarStyle()` modifier to the `SimplePaymentsAmount` screen to fix the navigation bar button color

- Creates a new `BindableTextField` which is a `UITextField` wrapper that relays the input content to a bindable value, emulating the current `SwiftUI.Textfield` implementation. 

The problem with the native `SwiftUI` component is that on iOS 15, there seems to be a regression where the content entered by the user is not modified via intercepting the binding value and we end up with two states, the binding value state, and the internal view state. 

I tried several approaches, but none worked, there is an official Formatter API available on iOS15+ but that only formats the text when the return key is pressed. 🤷 

# Demo

## Before

https://user-images.githubusercontent.com/562080/142285715-46f62106-1313-4c5f-a400-ea853fd93643.mov

## After

https://user-images.githubusercontent.com/562080/142285724-a2c9b2a0-c43a-4e72-a6d3-9fd1c3f105c1.mov 

# Testing Steps

- Start the simple payments flow on iOS 15(compiled in Xcode 13)
- See the cancel button rendered with the correct accent color.
- Enter an amount and see that the formatter works correctly. (Not more than two decimals and letters not allowed)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
