### PR TITLE
Jetpack CP: workaround to call `wp/v2/settings` and `wc/v3/settings` for JCP sites for accurate site info

### DIFF
--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -1,9 +1,23 @@
 import Combine
 import Foundation
 
+/// Protocol for `AccountRemote` mainly used for mocking.
+///
+/// The required methods are intentionally incomplete. Feel free to add the other ones.
+///
+public protocol AccountRemoteProtocol {
+    func loadAccount(completion: @escaping (Result<Account, Error>) -> Void)
+    func loadAccountSettings(for userID: Int64, completion: @escaping (Result<AccountSettings, Error>) -> Void)
+    func updateAccountSettings(for userID: Int64, tracksOptOut: Bool, completion: @escaping (Result<AccountSettings, Error>) -> Void)
+    func loadSites() -> AnyPublisher<Result<[Site], Error>, Never>
+    func checkIfWooCommerceIsActive(for siteID: Int64) -> AnyPublisher<Result<Bool, Error>, Never>
+    func fetchWordPressSiteSettings(for siteID: Int64) -> AnyPublisher<Result<WordPressSiteSettings, Error>, Never>
+    func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void)
+}
+
 /// Account: Remote Endpoints
 ///
-public class AccountRemote: Remote {
+public class AccountRemote: Remote, AccountRemoteProtocol {
 
     /// Loads the Account Details associated with the Credential's authToken.
     ///

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		029BA557255E0CD4006171FD /* ShippingLabelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA556255E0CD4006171FD /* ShippingLabelStore.swift */; };
 		029BA55B255E0D39006171FD /* ShippingLabelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA55A255E0D39006171FD /* ShippingLabelAction.swift */; };
 		02A098242480D0D8002F8C7A /* MockCrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A098232480D0D8002F8C7A /* MockCrashLogger.swift */; };
+		02A26F1E2744FE97008E4EDB /* MockAccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */; };
 		02BA23C222EEEABC009539E7 /* AvailabilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */; };
 		02BA23C422EEEB3B009539E7 /* AvailabilityAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C322EEEB3B009539E7 /* AvailabilityAction.swift */; };
 		02BA23C622EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C522EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift */; };
@@ -437,6 +438,7 @@
 		029BA556255E0CD4006171FD /* ShippingLabelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStore.swift; sourceTree = "<group>"; };
 		029BA55A255E0D39006171FD /* ShippingLabelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAction.swift; sourceTree = "<group>"; };
 		02A098232480D0D8002F8C7A /* MockCrashLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCrashLogger.swift; sourceTree = "<group>"; };
+		02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAccountRemote.swift; sourceTree = "<group>"; };
 		02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityStore.swift; sourceTree = "<group>"; };
 		02BA23C322EEEB3B009539E7 /* AvailabilityAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityAction.swift; sourceTree = "<group>"; };
 		02BA23C522EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV4AvailabilityStoreTests.swift; sourceTree = "<group>"; };
@@ -1077,6 +1079,7 @@
 				020C908024C7D71D001E2BEB /* MockProductVariationsRemote.swift */,
 				02E7FFD82562234F00C53030 /* MockShippingLabelRemote.swift */,
 				D4CBAE5F26D440FA00BBE6D1 /* MockAnnouncementsRemote.swift */,
+				02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1990,6 +1993,7 @@
 				02A098242480D0D8002F8C7A /* MockCrashLogger.swift in Sources */,
 				02FF055F23D985710058E6E7 /* URL+MediaTests.swift in Sources */,
 				D87F27DB25E7E8EA006EC8C9 /* MockCardReader.swift in Sources */,
+				02A26F1E2744FE97008E4EDB /* MockAccountRemote.swift in Sources */,
 				02124DAC24318D6B00980D74 /* Media+MediaTypeTests.swift in Sources */,
 				025CA2D0238F54E800B05C81 /* ProductShippingClassStoreTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -14,8 +14,8 @@ extension Storage.Site: ReadOnlyConvertible {
         tagline = site.description
         url = site.url
 //        plan = site.plan // We're not assigning the plan here because it's not sent on the intial API request.
-        // TODO: 5364 - update `isJetpackThePluginInstalled`
-        // TODO: 5364 - update `isJetpackConnected`
+        isJetpackThePluginInstalled = site.isJetpackThePluginInstalled
+        isJetpackConnected = site.isJetpackConnected
         isWooCommerceActive = NSNumber(booleanLiteral: site.isWooCommerceActive)
         isWordPressStore = NSNumber(booleanLiteral: site.isWordPressStore)
         timezone = site.timezone
@@ -30,8 +30,8 @@ extension Storage.Site: ReadOnlyConvertible {
                     description: tagline ?? "",
                     url: url ?? "",
                     plan: plan ?? "",
-                    isJetpackThePluginInstalled: true, // TODO: 5364 - persist in storage
-                    isJetpackConnected: true, // TODO: 5364 - persist in storage
+                    isJetpackThePluginInstalled: isJetpackThePluginInstalled,
+                    isJetpackConnected: isJetpackConnected,
                     isWooCommerceActive: isWooCommerceActive?.boolValue ?? false,
                     isWordPressStore: isWordPressStore?.boolValue ?? false,
                     timezone: timezone ?? "",

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -1,0 +1,84 @@
+import Combine
+import Foundation
+import Networking
+
+import XCTest
+
+/// Mock for `AccountRemote`.
+///
+final class MockAccountRemote {
+    /// Returns the value as a publisher when `loadSites` is called.
+    var loadSitesResult: Result<[Site], Error> = .success([])
+
+    /// Returns the requests that have been made to `AccountRemoteProtocol`.
+    var invocations = [Invocation]()
+
+    /// The results to return based on the given site ID in `checkIfWooCommerceIsActive`
+    private var checkIfWooCommerceIsActiveResultsBySiteID = [Int64: Result<Bool, Error>]()
+
+    /// The results to return based on the given site ID in `fetchWordPressSiteSettings`
+    private var fetchWordPressSiteSettingsResultsBySiteID = [Int64: Result<WordPressSiteSettings, Error>]()
+
+    /// Returns the value as a publisher when `checkIfWooCommerceIsActive` is called.
+    func whenCheckingIfWooCommerceIsActive(siteID: Int64, thenReturn result: Result<Bool, Error>) {
+        checkIfWooCommerceIsActiveResultsBySiteID[siteID] = result
+    }
+
+    /// Returns the value as a publisher when `fetchWordPressSiteSettings` is called.
+    func whenFetchingWordPressSiteSettings(siteID: Int64, thenReturn result: Result<WordPressSiteSettings, Error>) {
+        fetchWordPressSiteSettingsResultsBySiteID[siteID] = result
+    }
+}
+
+extension MockAccountRemote {
+    enum Invocation: Equatable {
+        case loadSites
+        case checkIfWooCommerceIsActive(siteID: Int64)
+        case fetchWordPressSiteSettings(siteID: Int64)
+    }
+}
+
+// MARK: - AccountRemoteProtocol
+
+extension MockAccountRemote: AccountRemoteProtocol {
+    func loadAccount(completion: @escaping (Result<Account, Error>) -> Void) {
+        // no-op
+    }
+
+    func loadAccountSettings(for userID: Int64, completion: @escaping (Result<AccountSettings, Error>) -> Void) {
+        // no-op
+    }
+
+    func updateAccountSettings(for userID: Int64, tracksOptOut: Bool, completion: @escaping (Result<AccountSettings, Error>) -> Void) {
+        // no-op
+    }
+
+    func loadSites() -> AnyPublisher<Result<[Site], Error>, Never> {
+        invocations.append(.loadSites)
+        return Just<Result<[Site], Error>>(loadSitesResult).eraseToAnyPublisher()
+    }
+
+    func checkIfWooCommerceIsActive(for siteID: Int64) -> AnyPublisher<Result<Bool, Error>, Never> {
+        invocations.append(.checkIfWooCommerceIsActive(siteID: siteID))
+        if let result = checkIfWooCommerceIsActiveResultsBySiteID[siteID] {
+            return Just<Result<Bool, Error>>(result).eraseToAnyPublisher()
+        } else {
+            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return Empty<Result<Bool, Error>, Never>().eraseToAnyPublisher()
+        }
+    }
+
+    func fetchWordPressSiteSettings(for siteID: Int64) -> AnyPublisher<Result<WordPressSiteSettings, Error>, Never> {
+        invocations.append(.fetchWordPressSiteSettings(siteID: siteID))
+        if let result = fetchWordPressSiteSettingsResultsBySiteID[siteID] {
+            return Just<Result<WordPressSiteSettings, Error>>(result).eraseToAnyPublisher()
+        } else {
+            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return Empty<Result<WordPressSiteSettings, Error>, Never>().eraseToAnyPublisher()
+        }
+    }
+
+    func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void) {
+        // no-op
+    }
+}


### PR DESCRIPTION
Part of #5364 

## Why

To support JCP sites, we need to make two extra API requests to the remote site for JCP sites in `me/sites` result (p91TBi-6lK-p2):
- `wc/v3/settings?_fields=""` to check if WooCommerce is installed
- `/wp/v2/settings` to get the updated site metadata (the site name/description/URL might not be up to date in `me/sites` response for JCP sites)

This PR implements the workaround so that JCP sites are shown in the site picker correctly and fetched on app launch with accurate site info.

## Changes

Most of the changes are in Yosemite layer:
- Updated `AccountStore.synchronizeSites` to make 2 extra network requests for JCP sites, then collect the site list back to the subscriber to upsert the sites into storage
- `Storage.Site`: persisted `isJetpackThePluginInstalled and `isJetpackConnected`
- Added `AccountRemoteProtocol` protocol and `MockAccountRemote` for mocking the remote so that we don't have to rely on JSON files for various API responses

## Testing

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23) and a Jetpack site (with Jetpack-the-plugin)

- Launch the app in logged-in state
- Go to Settings > Switch Store --> the JCP site should show up in the site picker (before this PR, this site isn't shown because `isWooCommerceActive` is `false`)
- In wp-admin, change the name of the JCP site at `/wp-admin/options-general.php`
- In the app, dismiss the site picker and then switch store again --> the JCP site should show the new name after syncing completes

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.