### PR TITLE
Jetpack CP: only perform JCP workaround behind a feature flag

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -274,7 +274,10 @@ private extension StorePickerViewController {
 //
 private extension StorePickerViewController {
     func synchronizeSites(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = AccountAction.synchronizeSites(selectedSiteID: currentlySelectedSite?.siteID, onCompletion: onCompletion)
+        let action = AccountAction
+            .synchronizeSites(selectedSiteID: currentlySelectedSite?.siteID,
+                              isJetpackConnectionPackageSupported: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport),
+                              onCompletion: onCompletion)
         ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -284,7 +284,10 @@ private extension DefaultStoresManager {
     /// Synchronizes the WordPress.com Sites, associated with the current credentials.
     ///
     func synchronizeSites(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = AccountAction.synchronizeSites(selectedSiteID: sessionManager.defaultStoreID, onCompletion: onCompletion)
+        let action = AccountAction
+            .synchronizeSites(selectedSiteID: sessionManager.defaultStoreID,
+                              isJetpackConnectionPackageSupported: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport),
+                              onCompletion: onCompletion)
         dispatch(action)
     }
 
@@ -449,7 +452,10 @@ private extension DefaultStoresManager {
     /// If the site does not exist in storage, it synchronizes the site asynchronously.
     ///
     func restoreSessionSiteAndSynchronizeIfNeeded(with siteID: Int64) {
-        let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: siteID) { [weak self] result in
+        let isJCPEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport)
+        let action = AccountAction
+            .loadAndSynchronizeSiteIfNeeded(siteID: siteID,
+                                            isJetpackConnectionPackageSupported: isJCPEnabled) { [weak self] result in
             guard let self = self else { return }
             guard case .success(let site) = result else {
                 return

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -7,10 +7,10 @@ import Networking
 //
 public enum AccountAction: Action {
     case loadAccount(userID: Int64, onCompletion: (Account?) -> Void)
-    case loadAndSynchronizeSiteIfNeeded(siteID: Int64, onCompletion: (Result<Site, Error>) -> Void)
+    case loadAndSynchronizeSiteIfNeeded(siteID: Int64, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Site, Error>) -> Void)
     case synchronizeAccount(onCompletion: (Result<Account, Error>) -> Void)
     case synchronizeAccountSettings(userID: Int64, onCompletion: (Result<AccountSettings, Error>) -> Void)
-    case synchronizeSites(selectedSiteID: Int64?, onCompletion: (Result<Void, Error>) -> Void)
+    case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Void, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
 }


### PR DESCRIPTION
Closes #5364 

## Why

After implementing the workaround in https://github.com/woocommerce/woocommerce-ios/pull/5466, I realized that it should be behind a feature flag since it takes a few sprints to release JCP support. This PR checks for the JCP feature flag when making extra network requests for the JCP workaround.

## Changes

- Added `isJetpackConnectionPackageSupported` boolean to `AccountAction.synchronizeSites and `AccountAction.loadAndSynchronizeSiteIfNeeded` (which also calls `me/sites` endpoint) in Yosemite layer and passed the JCP feature flag from the app layer
- In `AccountStore`, only performed the JCP workaround if `isJetpackConnectionPackageSupported` is `true` 

## Testing

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23) and a Jetpack site (with Jetpack-the-plugin)

### Feature flag on

- Launch the app in logged-in state
- Go to Settings > Switch Store --> the JCP site should show up in the site picker

### Feature flag off

- In `DefaultFeatureFlagService`, return `false` for `jetpackConnectionPackageSupport` feature flag
- Launch the app in logged-in state
- Go to Settings > Switch Store --> the JCP site should not show up in the site picker

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
