### PR TITLE
Continuous Improvements: Tags loading indicator

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -68,10 +68,10 @@ private extension AddProductCategoryViewController {
         title = Strings.titleView
 
         addCloseNavigationBarButton(title: Strings.cancelButton)
-        configureRightBarButtomitemAsSave()
+        configureRightBarButtonItemAsSave()
     }
 
-    func configureRightBarButtomitemAsSave() {
+    func configureRightBarButtonItemAsSave() {
         navigationItem.setRightBarButton(UIBarButtonItem(title: Strings.saveButton,
                                                          style: .done,
                                                          target: self,
@@ -129,7 +129,7 @@ extension AddProductCategoryViewController {
         let action = ProductCategoryAction.addProductCategory(siteID: siteID,
                                                               name: categoryName,
                                                               parentID: selectedParentCategory?.categoryID) { [weak self] (result) in
-            self?.configureRightBarButtomitemAsSave()
+            self?.configureRightBarButtonItemAsSave()
             switch result {
             case .success(let category):
                 self?.onCompletion(category)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsDataSource.swift
@@ -6,27 +6,6 @@ import UIKit
 protocol ProductTagsDataSource: UITableViewDataSource {
 }
 
-final class LoadingDataSource: NSObject, ProductTagsDataSource {
-
-    private static let cellIdentifier = BasicTableViewCell.reuseIdentifier
-
-    func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
-    }
-
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: LoadingDataSource.cellIdentifier, for: indexPath)
-
-        cell.textLabel?.text = NSLocalizedString("Loading...", comment: "Loading tags in Product Tags screen")
-        cell.selectionStyle = .none
-        return cell
-    }
-}
-
 final class FailureDataSource: NSObject, ProductTagsDataSource {
 
     private static let cellIdentifier = BasicTableViewCell.reuseIdentifier

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -1,12 +1,13 @@
 import UIKit
 import Yosemite
-
+import WordPressUI
 
 /// ProductTagsViewController: Displays the list of ProductTag associated to the active Site and to the specific product.
 ///
 final class ProductTagsViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var ghostTableView: UITableView!
     @IBOutlet private weak var textView: UITextView!
     @IBOutlet private var separatorView: UIView!
 
@@ -19,7 +20,7 @@ final class ProductTagsViewController: UIViewController {
         return resultController.fetchedObjects
     }
 
-    private var dataSource: ProductTagsDataSource = LoadingDataSource() {
+    private var dataSource: ProductTagsDataSource? = nil {
         didSet {
             tableView.dataSource = dataSource
             tableView.reloadData()
@@ -63,7 +64,9 @@ final class ProductTagsViewController: UIViewController {
         configureMainView()
         configureTextView()
         configureSeparator()
+        registerTableViewCells()
         configureTableView()
+        configureGhostTableView()
         startListeningToNotifications()
 
         textView.text = normalizeInitialTags(tags: originalTagNames)
@@ -141,7 +144,6 @@ private extension ProductTagsViewController {
     }
 
     func configureTableView() {
-        registerTableViewCells()
         // The datasource will be dynamically assigned on variable `dataSource`
         tableView.delegate = self
 
@@ -149,10 +151,19 @@ private extension ProductTagsViewController {
         tableView.removeLastCellSeparator()
     }
 
+    func configureGhostTableView() {
+        ghostTableView.translatesAutoresizingMaskIntoConstraints = false
+        ghostTableView.backgroundColor = .listBackground
+        ghostTableView.isScrollEnabled = false
+        ghostTableView.isHidden = true
+        ghostTableView.removeLastCellSeparator()
+    }
+
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells() {
         tableView.registerNib(for: BasicTableViewCell.self)
+        ghostTableView.registerNib(for: WooBasicTableViewCell.self)
     }
 }
 
@@ -203,7 +214,7 @@ extension ProductTagsViewController: KeyboardScrollable {
 //
 private extension ProductTagsViewController {
     func loadTags() {
-        dataSource = LoadingDataSource()
+        displayLoading()
 
         let action = ProductTagAction.synchronizeAllProductTags(siteID: product.siteID) { [weak self] error in
             if let error = error {
@@ -222,6 +233,7 @@ private extension ProductTagsViewController {
     }
 
     func tagsLoaded(tags: [String]) {
+        hideLoading()
         dataSource = SuggestionsDataSource(suggestions: tags,
                                            selectedTags: completeTags,
                                            searchQuery: partialTag)
@@ -251,6 +263,23 @@ private extension ProductTagsViewController {
         ServiceLocator.stores.dispatch(action)
     }
 
+}
+
+// MARK: Loading handling
+//
+private extension ProductTagsViewController {
+    func displayLoading() {
+        let options = GhostOptions(displaysSectionHeader: false,
+            reuseIdentifier: WooBasicTableViewCell.reuseIdentifier,
+            rowsPerSection: [3])
+        ghostTableView.displayGhostContent(options: options, style: .wooDefaultGhostStyle)
+        ghostTableView.isHidden = false
+    }
+
+    func hideLoading() {
+        ghostTableView.removeGhostContent()
+        ghostTableView.isHidden = true
+    }
 }
 
 // MARK: Error handling
@@ -421,8 +450,6 @@ extension ProductTagsViewController: UITableViewDelegate {
         switch tableView.dataSource {
         case is FailureDataSource:
             loadTags()
-        case is LoadingDataSource:
-            return
         case is SuggestionsDataSource:
             suggestionTapped(cell: tableView.cellForRow(at: indexPath))
         default:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,6 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductTagsViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="ghostTableView" destination="iGf-7j-RA7" id="8bf-Qd-2gU"/>
                 <outlet property="separatorView" destination="Yju-A0-WgT" id="Xfk-TL-To5"/>
                 <outlet property="tableView" destination="zVJ-8z-2vs" id="KHA-P7-8J7"/>
                 <outlet property="textView" destination="6Wz-Zl-b7p" id="3gD-hq-Ybw"/>
@@ -58,19 +59,27 @@
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="zVJ-8z-2vs">
                     <rect key="frame" x="0.0" y="113" width="414" height="749"/>
                 </tableView>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="iGf-7j-RA7" userLabel="Ghost Table View">
+                    <rect key="frame" x="0.0" y="113" width="414" height="749"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="top" secondItem="Ip2-5h-wvk" secondAttribute="bottom" id="51P-yI-3FR"/>
                 <constraint firstAttribute="trailing" secondItem="Ip2-5h-wvk" secondAttribute="trailing" id="5AZ-8i-UZP"/>
+                <constraint firstItem="iGf-7j-RA7" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="9at-iB-L88"/>
+                <constraint firstItem="iGf-7j-RA7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="A0R-gI-Qdc"/>
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="Chb-li-7pc"/>
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="ECp-36-O08"/>
+                <constraint firstItem="iGf-7j-RA7" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" constant="-34" id="Q1i-f0-IsN"/>
                 <constraint firstItem="Ip2-5h-wvk" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="24" id="REa-GU-ALk"/>
+                <constraint firstItem="iGf-7j-RA7" firstAttribute="top" secondItem="Ip2-5h-wvk" secondAttribute="bottom" id="RF7-tb-0sL"/>
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="eeY-QK-my7"/>
                 <constraint firstItem="Ip2-5h-wvk" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="oUV-Mg-GkZ"/>
             </constraints>
-            <point key="canvasLocation" x="131.8840579710145" y="135.9375"/>
+            <point key="canvasLocation" x="128.98550724637681" y="98.4375"/>
         </view>
     </objects>
     <resources>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.xib
@@ -60,7 +60,7 @@
                     <rect key="frame" x="0.0" y="113" width="414" height="749"/>
                 </tableView>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="iGf-7j-RA7" userLabel="Ghost Table View">
-                    <rect key="frame" x="0.0" y="113" width="414" height="749"/>
+                    <rect key="frame" x="0.0" y="113" width="414" height="783"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
@@ -70,10 +70,10 @@
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="top" secondItem="Ip2-5h-wvk" secondAttribute="bottom" id="51P-yI-3FR"/>
                 <constraint firstAttribute="trailing" secondItem="Ip2-5h-wvk" secondAttribute="trailing" id="5AZ-8i-UZP"/>
                 <constraint firstItem="iGf-7j-RA7" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="9at-iB-L88"/>
-                <constraint firstItem="iGf-7j-RA7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="A0R-gI-Qdc"/>
+                <constraint firstItem="iGf-7j-RA7" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="A0R-gI-Qdc"/>
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="Chb-li-7pc"/>
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="ECp-36-O08"/>
-                <constraint firstItem="iGf-7j-RA7" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" constant="-34" id="Q1i-f0-IsN"/>
+                <constraint firstItem="iGf-7j-RA7" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="Q1i-f0-IsN"/>
                 <constraint firstItem="Ip2-5h-wvk" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="24" id="REa-GU-ALk"/>
                 <constraint firstItem="iGf-7j-RA7" firstAttribute="top" secondItem="Ip2-5h-wvk" secondAttribute="bottom" id="RF7-tb-0sL"/>
                 <constraint firstItem="zVJ-8z-2vs" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="eeY-QK-my7"/>


### PR DESCRIPTION
Closes: #4294 

### Description
The PR replaces the loading state based on showing the "Loading" cell with the usage of Ghost animation (check the video)

### How to test
* Open a product with tags
* Click tags
* Notice a new loading animation


### Screenshots

https://user-images.githubusercontent.com/4923871/142406347-e14331a0-edce-444b-96bc-5d20277f9ae7.mp4


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
