### PR TITLE
Hide cancel button for 100% mandatory updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -455,6 +455,9 @@ private extension CardReaderConnectionController {
                     self.softwareUpdateCancelable = cancelable
                     self.state = .updating(progress: 0)
                 case .installing(progress: let progress):
+                    if progress >= 0.995 {
+                        self.softwareUpdateCancelable = nil
+                    }
                     self.state = .updating(progress: progress)
                 case .completed:
                     self.softwareUpdateCancelable = nil


### PR DESCRIPTION
Fixes #5455 

## Description
This is a naïve fix to duplicate the logic from optional updates over to mandatory updates, hiding the cancel button on both when "100% complete" is displayed.

## Testing
### From `Manage Card Reader`
1. Configure a `.required` test on the simulated reader (see PdfdoF-fr-p2)
2. Navigate to `⚙️ > In-Person Payments > Manage Card Reader`
3. Connect to the reader and observe that an auto-update starts
4. Allow the update to complete, watching for the 100% screen.
5. **Observe that the Cancel button does not show when the update is at 100%** (for a non-simulated update, this stays on screen for 10-15s)

### From `Collect Payment`
1. Configure a `.required` test on the simulated reader (see PdfdoF-fr-p2)
2. Navigate to `Orders > Order Details > Collect Payment` (on an order with Pay on Delivery)
3. Connect to the reader and observe that an auto-update starts
4. Allow the update to complete, watching for the 100% screen.
5. **Observe that the Cancel button does not show when the update is at 100%** (for a non-simulated update, this stays on screen for 10-15s)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
