### PR TITLE
[Mobile Payments] Implement didReportBatteryLevel delegate to get battery level updates from readers

### DIFF
--- a/Hardware/Hardware/CardReader/CardReader.swift
+++ b/Hardware/Hardware/CardReader/CardReader.swift
@@ -1,6 +1,6 @@
 /// Models a Card Reader. This is the public struct that clients of
 /// Hardware are expected to consume.
-/// CardReader is meant to be inmutable. 
+/// CardReader is meant to be immutable.
 public struct CardReader {
 
     /// The CardReader serial number

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -521,6 +521,31 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
             break
         }
     }
+
+    /// Receive changes in the reader battery level. Note that the SDK will call this delegate
+    /// not more frequently than every 10 minutes and will not report battery level during payment collection.
+    /// See `https://github.com/stripe/stripe-terminal-ios/issues/121#issuecomment-966589886`
+    ///
+    public func reader(_ reader: Reader, didReportBatteryLevel batteryLevel: Float, status: BatteryStatus, isCharging: Bool) {
+        let connectedReaders = connectedReadersSubject.value
+
+        guard let connectedReader = connectedReaders.first else {
+            return
+        }
+
+        let connectedReaderWithUpdatedBatteryLevel = CardReader(
+            serial: connectedReader.serial,
+            vendorIdentifier: connectedReader.vendorIdentifier,
+            name: connectedReader.name,
+            status: connectedReader.status,
+            softwareVersion: connectedReader.softwareVersion,
+            batteryLevel: batteryLevel,
+            readerType: connectedReader.readerType,
+            locationId: connectedReader.locationId
+        )
+
+        connectedReadersSubject.send([connectedReaderWithUpdatedBatteryLevel])
+    }
 }
 
 // MARK: - Terminal delegate

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -102,6 +102,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         updateReaderID()
         updateBatteryLevel()
         updateSoftwareVersion()
+        didUpdate?()
     }
 
     private func updateReaderID() {


### PR DESCRIPTION
Closes #5333 

Changes:
- Implements `didReportBatteryLevel` which the SDK will call occasionally (roughly every ten minutes)
- Since like most of our objects, `CardReader` is immutable, we construct and publish a new CardReader with the new battery level.

To test:
- I recommend adding a print to `didReportBatteryLevel` to print the batteryLevel as the delegate is called.
- Connect a reader using the settings flow so that you can note the battery level. Also note the current time.
- Wait 10 minutes. Note the new battery level and ensure the settings "connected reader" view shows it as well
- NOTE: The reader batteries decline slowly, sometimes not at all, and sometimes they go up (weird, I know). Over the course of ten minutes, I have never seen the battery level reported change by more than 1%. This might be related to the concern noted below.

Concerns:
- I have had mixed results with this delegate. It appears to fire on Chippers every 10 minutes for the first 30 minutes or so then goes silent until you wake up the reader by initiating (and then you can cancel) payment collection. My M2 reader is worse - I've only seen it call this delegate once (10 minutes after connecting). That said, with this PR, we can at least update the displayed battery level if/when it is reported to us. I will open an issue against the SDK after I collect a little more data.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
