### PR TITLE
Jetpack CP: enable logging in with site address

### DIFF
--- a/WooCommerce/Classes/Extensions/WordPressComSiteInfo+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressComSiteInfo+Woo.swift
@@ -5,8 +5,6 @@ extension WordPressComSiteInfo {
     /// Encapsulates the rules that declare a WordPress site as having a valid
     /// Jetpack installation
     var hasValidJetpack: Bool {
-        return hasJetpack &&
-            isJetpackConnected &&
-            isJetpackActive
+        isJetpackConnected
     }
 }

--- a/WooCommerce/Classes/Extensions/WordPressComSiteInfo+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressComSiteInfo+Woo.swift
@@ -5,6 +5,12 @@ extension WordPressComSiteInfo {
     /// Encapsulates the rules that declare a WordPress site as having a valid
     /// Jetpack installation
     var hasValidJetpack: Bool {
-        isJetpackConnected
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport) {
+            return isJetpackConnected
+        } else {
+            return hasJetpack &&
+                isJetpackConnected &&
+                isJetpackActive
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/WordPressComSiteInfoWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/WordPressComSiteInfoWooTests.swift
@@ -9,16 +9,52 @@ final class WordPressComSiteInfoWooTests: XCTestCase {
         XCTAssertTrue(infoSite.hasValidJetpack)
     }
 
-    func test_is_not_valid_when_site_does_not_have_jetpack() {
+    func test_is_not_valid_when_site_does_not_have_jetpack_with_jcp_feature_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: false)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        // When
         let infoSite = WordPressComSiteInfo(remote: doesNotHaveJetpack())
 
+        // Then
         XCTAssertFalse(infoSite.hasValidJetpack)
     }
 
-    func test_is_not_valid_when_site_has_jetpack_installed_but_not_active() {
+    func test_is_valid_when_site_does_not_have_jetpack_with_jcp_feature_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        // When
+        let infoSite = WordPressComSiteInfo(remote: doesNotHaveJetpack())
+
+        // Then
+        XCTAssertTrue(infoSite.hasValidJetpack)
+    }
+
+    func test_is_not_valid_when_site_has_jetpack_installed_but_not_active_with_jcp_feature_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: false)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        // When
         let infoSite = WordPressComSiteInfo(remote: hasJetpackInactive())
 
+        // Then
         XCTAssertFalse(infoSite.hasValidJetpack)
+    }
+
+    func test_is_not_valid_when_site_has_jetpack_installed_but_not_active_with_jcp_feature_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        // When
+        let infoSite = WordPressComSiteInfo(remote: hasJetpackInactive())
+
+        // Then
+        XCTAssertTrue(infoSite.hasValidJetpack)
     }
 
     func test_is_not_valid_when_site_has_jetpack_installed_but_not_connected() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -8,19 +8,22 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShippingLabelsPackageCreationOn: Bool
     private let isShippingLabelsMultiPackageOn: Bool
     private let isPushNotificationsForAllStoresOn: Bool
+    private let isJetpackConnectionPackageSupportOn: Bool
 
     init(isShippingLabelsM2M3On: Bool = false,
          isInternationalShippingLabelsOn: Bool = false,
          isShippingLabelsPaymentMethodCreationOn: Bool = false,
          isShippingLabelsPackageCreationOn: Bool = false,
          isShippingLabelsMultiPackageOn: Bool = false,
-         isPushNotificationsForAllStoresOn: Bool = false) {
+         isPushNotificationsForAllStoresOn: Bool = false,
+         isJetpackConnectionPackageSupportOn: Bool = false) {
         self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
         self.isInternationalShippingLabelsOn = isInternationalShippingLabelsOn
         self.isShippingLabelsPaymentMethodCreationOn = isShippingLabelsPaymentMethodCreationOn
         self.isShippingLabelsPackageCreationOn = isShippingLabelsPackageCreationOn
         self.isShippingLabelsMultiPackageOn = isShippingLabelsMultiPackageOn
         self.isPushNotificationsForAllStoresOn = isPushNotificationsForAllStoresOn
+        self.isJetpackConnectionPackageSupportOn = isJetpackConnectionPackageSupportOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -37,6 +40,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isShippingLabelsMultiPackageOn
         case .pushNotificationsForAllStores:
             return isPushNotificationsForAllStoresOn
+        case .jetpackConnectionPackageSupport:
+            return isJetpackConnectionPackageSupportOn
         default:
             return false
         }


### PR DESCRIPTION
Fixes #5360 

## Why

When logging in with a site address, we fetch the endpoint `rest/v1.1/connect/site-info` to check the site's different capabilities.

Currently, when we get the `/connect/site-info` response for a site, we check three flags `isJetpackActive`, `hasJetpack` and `isJetpackConnected`. Because of inaccurate values in `isJetpackActive` and `hasJetpack` (p91TBi-6lK-p2), we are going to just use `isJetpackConnected` for determining if a site is connected to Jetpack (either via JCP or Jetpack-the-plugin).

## Changes

When checking whether to display username/password screen after the user logs in with a site address, return `true` based on just `isJetpackConnected` if the JCP feature flag is on.

## Testing

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23) and a Jetpack site (with Jetpack-the-plugin)

### Logging in with site address - JCP site

- Log out from the app
- Tap "Enter Your Store Address"
- Enter the address of a JCP site and tap "Continue" --> it should navigate to the username/password screen
- Complete the login flow with username/password/optional 2FA --> the site picker should be shown with the site selected
- Continue with the selected site --> the Dashboard should be shown

### Logging in with site address - Jetpack site

- Log out from the app
- Tap "Enter Your Store Address"
- Enter the address of a Jetpack site and tap "Continue" --> it should navigate to the username/password screen
- Complete the login flow with username/password/optional 2FA --> the site picker should be shown with the site selected
- Continue with the selected site --> the Dashboard should be shown

## Example screenshots

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.