### PR TITLE
Order Creation: Add action to create a manual order in Yosemite layer

### DIFF
--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -68,4 +68,8 @@ public enum OrderAction: Action {
     /// Creates a simple payments order with a specific amount value and no tax.
     ///
     case createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: (Result<Order, Error>) -> Void)
+
+    /// Creates a manual order with the provided order details.
+    ///
+    case createOrder(siteID: Int64, order: Order, onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -64,6 +64,8 @@ public class OrderStore: Store {
 
         case let .createSimplePaymentsOrder(siteID, amount, onCompletion):
             createSimplePaymentsOrder(siteID: siteID, amount: amount, onCompletion: onCompletion)
+        case let .createOrder(siteID, order, onCompletion):
+            createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
         }
     }
 }
@@ -252,6 +254,21 @@ private extension OrderStore {
     func createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: @escaping (Result<Order, Error>) -> Void) {
         let order = OrderFactory.simplePaymentsOrder(amount: amount)
         remote.createOrder(siteID: siteID, order: order, fields: [.feeLines]) { [weak self] result in
+            switch result {
+            case .success(let order):
+                self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
+                    onCompletion(result)
+                })
+            case .failure:
+                onCompletion(result)
+            }
+        }
+    }
+
+    /// Creates a manual order with the provided order details.
+    ///
+    func createOrder(siteID: Int64, order: Order, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        remote.createOrder(siteID: siteID, order: order, fields: []) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -671,6 +671,24 @@ final class OrderStoreTests: XCTestCase {
         // Then
         XCTAssertNotNil(storedOrder)
     }
+
+    func test_create_order_stores_orders_correctly() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "order")
+
+        // When
+        let storedOrder: Yosemite.Order? = waitFor { promise in
+            let action = OrderAction.createOrder(siteID: self.sampleSiteID, order: self.sampleOrder()) { _ in
+                let order = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)?.toReadOnly()
+                promise(order)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertNotNil(storedOrder)
+    }
 }
 
 


### PR DESCRIPTION
Part of: #5405

## Description

This PR has the Yosemite layer changes from https://github.com/woocommerce/woocommerce-ios/pull/5458, to add an action to create a complete manual order. This action will be used in the new order creation flow.

## Changes

* Adds a `createOrder` action in the Yosemite layer, to create a complete order.
* Unit tests for the new method in `orderStore`.

## Testing

* Confirm tests pass.
* You can test firing this action with an order and confirm the new order is created on your store.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
