### PR TITLE
[Mobile Payments] Use ARC to avoid a retain cycle

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -64,7 +64,7 @@ final class CardReaderConnectionController {
             didSetState()
         }
     }
-    private var fromController: UIViewController?
+    private weak var fromController: UIViewController?
     private var siteID: Int64
     private var knownCardReaderProvider: CardReaderSettingsKnownReaderProvider
     private var alerts: CardReaderSettingsAlertsProvider
@@ -572,7 +572,6 @@ private extension CardReaderConnectionController {
     private func returnSuccess(connected: Bool) {
         self.alerts.dismiss()
         self.onCompletion?(.success(connected))
-        self.fromController = nil
         self.state = .idle
     }
 
@@ -581,7 +580,6 @@ private extension CardReaderConnectionController {
     private func returnFailure(error: Error) {
         self.alerts.dismiss()
         self.onCompletion?(.failure(error))
-        self.fromController = nil
         self.state = .idle
     }
 }


### PR DESCRIPTION
### Description
A retain cycle was fixed in #4721, however the fix relied on explicitly setting `CardReaderConnectionController:fromController` to nil. This happened on the successful or failed completion of a connection flow.

I wasn't able to reproduce a leak here, but if the `CardReaderConnectionController` were to be removed before it called the completion methods, this implementation would leak. The most likely way this could happen is a future regression, where an engineer could add another exit path without realising that the design relies on the `fromController` being set to nil.

Fortunately, we can resolve this a little more simply by relying on ARC and `deinit` behaviour, by making the `fromController` a weak reference.

### Testing instructions
Tricky really. I removed the `fromController = nil` statements from `returnSuccess()` and `returnFailure()`, and confirmed the leak in the Leaks instrument that way, and that there is no leak after making `fromController` a weak reference. Surprisingly though, it didn't seem to leak 100% of the time even in that scenario.

### Screenshots
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
