### PR TITLE
[Mobile Payments] Prevent error from being displayed when a mandatory update is cancelled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -536,7 +536,11 @@ private extension CardReaderConnectionController {
             return
         }
 
-        if underlyingError == .readerSoftwareUpdateFailedBatteryLow {
+        switch underlyingError {
+        case .readerSoftwareUpdateFailedInterrupted:
+            // Update was cancelled, don't treat this as an error
+            return
+        case .readerSoftwareUpdateFailedBatteryLow:
             alerts.updatingFailedLowBattery(
                 from: from,
                 batteryLevel: batteryLevel,
@@ -544,7 +548,7 @@ private extension CardReaderConnectionController {
                     self.state = .searching
                 }
             )
-        } else {
+        default:
             alerts.updatingFailed(
                 from: from,
                 tryAgain: nil,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5479
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When cancelling a mandatory update, an error would flash up on screen, because the Terminal SDK reports cancellation as a `.readerSoftwareUpdateFailedInterrupted` error. However, as far as the user is concerned this is _not_ an error, so we shouldn't display one, even for a moment.

This change ignores the error, as we [already did for optional updates in `CardReaderSettingsConnectedViewModel`](https://github.com/woocommerce/woocommerce-ios/blob/572107e40b0f80a0d7e630694d48c78079b7352a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift#L73). DRYing this out is the subject of discussion at the moment and will be done in future PRs.

### Testing instructions
#### From `Manage Card Reader`
1. Configure a `.required` test on the simulated reader (see PdfdoF-fr-p2)
2. Navigate to `⚙️ > In-Person Payments > Manage Card Reader`
3. Connect to the reader and observe that an auto-update starts
4. Cancel the update
5. **Observe that no error is shown after the update modal is dismissed**

#### From `Collect Payment`
1. Configure a `.required` test on the simulated reader (see PdfdoF-fr-p2)
2. Navigate to `Orders > Order Details > Collect Payment` (on an order with Pay on Delivery)
3. Connect to the reader and observe that an auto-update starts
4. Cancel the update
5. **Observe that no error is shown after the update modal is dismissed**

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### Before:

https://user-images.githubusercontent.com/2472348/142619003-ca6c0255-9aae-4460-9fba-50a43116e3d1.mp4


#### After:

https://user-images.githubusercontent.com/2472348/142619156-8c702962-7d41-4655-98e1-429919670517.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
