### PR TITLE
Jetpack CP: add media endpoints for JCP sites

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -50,10 +50,14 @@
 		02A26F1B2744F5FC008E4EDB /* wc-site-settings-partial.json in Resources */ = {isa = PBXBuildFile; fileRef = 02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */; };
 		02A26F1C2744F5FC008E4EDB /* wp-site-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */; };
 		02AAD53F250092A400BA1E26 /* product-add-or-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AAD53E250092A300BA1E26 /* product-add-or-delete.json */; };
+		02AF07EA27492DBC00B2D81E /* WordPressMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AF07E927492DBC00B2D81E /* WordPressMedia.swift */; };
+		02AF07EC27492FDD00B2D81E /* media-library-from-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */; };
+		02AF07EE27493AE700B2D81E /* media-upload-to-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AF07ED27493AE700B2D81E /* media-upload-to-wordpress-site.json */; };
 		02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */; };
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
 		02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
 		02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */; };
+		02BE0A7B274B695F001176D2 /* WordPressMediaMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BE0A7A274B695F001176D2 /* WordPressMediaMapper.swift */; };
 		02C11276274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C11275274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift */; };
 		02C112782742862600F4F0B4 /* WordPressSiteSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C112772742862600F4F0B4 /* WordPressSiteSettingsMapper.swift */; };
 		02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */; };
@@ -632,10 +636,14 @@
 		02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wc-site-settings-partial.json"; sourceTree = "<group>"; };
 		02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wp-site-settings.json"; sourceTree = "<group>"; };
 		02AAD53E250092A300BA1E26 /* product-add-or-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-add-or-delete.json"; sourceTree = "<group>"; };
+		02AF07E927492DBC00B2D81E /* WordPressMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMedia.swift; sourceTree = "<group>"; };
+		02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library-from-wordpress-site.json"; sourceTree = "<group>"; };
+		02AF07ED27493AE700B2D81E /* media-upload-to-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-upload-to-wordpress-site.json"; sourceTree = "<group>"; };
 		02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-deactivated.json"; sourceTree = "<group>"; };
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
 		02BDB83423EA98C800BCC63E /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
 		02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTMLTests.swift"; sourceTree = "<group>"; };
+		02BE0A7A274B695F001176D2 /* WordPressMediaMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMediaMapper.swift; sourceTree = "<group>"; };
 		02C11275274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooCommerceAvailabilityMapper.swift; sourceTree = "<group>"; };
 		02C112772742862600F4F0B4 /* WordPressSiteSettingsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteSettingsMapper.swift; sourceTree = "<group>"; };
 		02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationMapper.swift; sourceTree = "<group>"; };
@@ -1173,6 +1181,7 @@
 			children = (
 				020D07B723D852BB00FD9580 /* Media.swift */,
 				020D07B923D8542000FD9580 /* UploadableMedia.swift */,
+				02AF07E927492DBC00B2D81E /* WordPressMedia.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -1634,7 +1643,9 @@
 				B505F6D420BEE4E600BB1B69 /* me.json */,
 				93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */,
 				02F096C12406691100C0C1D5 /* media-library.json */,
+				02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */,
 				020D07C123D858BB00FD9580 /* media-upload.json */,
+				02AF07ED27493AE700B2D81E /* media-upload-to-wordpress-site.json */,
 				B58D10C92114D22E00107ED4 /* new-order-note.json */,
 				022902D322E2436400059692 /* no_stats_permission_error.json */,
 				B5A24178217F98F600595DEF /* notifications-load-all.json */,
@@ -1854,6 +1865,7 @@
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
 				077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */,
 				02C11275274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift */,
+				02BE0A7A274B695F001176D2 /* WordPressMediaMapper.swift */,
 				02C112772742862600F4F0B4 /* WordPressSiteSettingsMapper.swift */,
 			);
 			path = Mapper;
@@ -2136,6 +2148,7 @@
 				45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */,
 				CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */,
 				31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */,
+				02AF07EE27493AE700B2D81E /* media-upload-to-wordpress-site.json in Resources */,
 				45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */,
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,
 				3158A4A32729F42500C3CFA8 /* wcpay-account-dev-test.json in Resources */,
@@ -2145,6 +2158,7 @@
 				4599FC5C24A6276F0056157A /* product-tags-all.json in Resources */,
 				74A7B4BE217A841400E85A8B /* broken-settings-general.json in Resources */,
 				026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */,
+				02AF07EC27492FDD00B2D81E /* media-library-from-wordpress-site.json in Resources */,
 				CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
@@ -2439,6 +2453,7 @@
 				26B2F74524C5573F0065CCC8 /* LeaderboardListMapper.swift in Sources */,
 				24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */,
 				31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */,
+				02BE0A7B274B695F001176D2 /* WordPressMediaMapper.swift in Sources */,
 				45150A9A268340D2006922EA /* Country.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
 				CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */,
@@ -2482,6 +2497,7 @@
 				74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */,
 				029BA4F4255D72EC006171FD /* ShippingLabelPrintData.swift in Sources */,
 				24F98C562502EA4800F49B68 /* FeatureFlag.swift in Sources */,
+				02AF07EA27492DBC00B2D81E /* WordPressMedia.swift in Sources */,
 				B557DA1D20979E7D005962F4 /* Order.swift in Sources */,
 				74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */,
 				26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */,

--- a/Networking/Networking/Mapper/WordPressMediaMapper.swift
+++ b/Networking/Networking/Mapper/WordPressMediaMapper.swift
@@ -1,0 +1,25 @@
+/// Mapper: WordPressMedia
+///
+struct WordPressMediaMapper: Mapper {
+    /// (Attempts) to convert data into a WordPressMedia.
+    func map(response: Data) throws -> WordPressMedia {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(Constants.dateFormatterForDecoding)
+        return try decoder.decode(WordPressMedia.self, from: response)
+    }
+}
+
+/// Mapper: WordPressMedia List
+///
+struct WordPressMediaListMapper: Mapper {
+    /// (Attempts) to convert data into a WordPressMedia list.
+    func map(response: Data) throws -> [WordPressMedia] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(Constants.dateFormatterForDecoding)
+        return try decoder.decode([WordPressMedia].self, from: response)
+    }
+}
+
+private enum Constants {
+    static let dateFormatterForDecoding = DateFormatter.Defaults.dateTimeFormatter
+}

--- a/Networking/Networking/Model/Media/WordPressMedia.swift
+++ b/Networking/Networking/Model/Media/WordPressMedia.swift
@@ -1,0 +1,112 @@
+import Codegen
+
+/// Media from WordPress Site API
+public struct WordPressMedia: Equatable {
+    public let mediaID: Int64
+    public let date: Date
+    public let slug: String
+    public let mimeType: String
+    public let src: String
+    public let alt: String?
+    public let details: MediaDetails?
+    public let title: MediaTitle?
+
+    /// Media initializer.
+    public init(mediaID: Int64,
+                date: Date,
+                slug: String,
+                mimeType: String,
+                src: String,
+                alt: String?,
+                details: MediaDetails?,
+                title: MediaTitle?) {
+        self.mediaID = mediaID
+        self.date = date
+        self.slug = slug
+        self.mimeType = mimeType
+        self.src = src
+        self.alt = alt
+        self.details = details
+        self.title = title
+    }
+}
+
+extension WordPressMedia: Decodable {
+    /// Decodable Initializer.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let mediaID = try container.decode(Int64.self, forKey: .mediaID)
+        let date = try container.decodeIfPresent(Date.self, forKey: .date) ?? Date()
+        let slug = try container.decodeIfPresent(String.self, forKey: .slug) ?? ""
+        let mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""
+        let src = try container.decodeIfPresent(String.self, forKey: .src) ?? ""
+        let alt = try container.decodeIfPresent(String.self, forKey: .alt)
+        let details = try container.decodeIfPresent(MediaDetails.self, forKey: .details)
+        let title = try container.decodeIfPresent(MediaTitle.self, forKey: .title)
+
+        self.init(mediaID: mediaID,
+                  date: date,
+                  slug: slug,
+                  mimeType: mimeType,
+                  src: src,
+                  alt: alt,
+                  details: details,
+                  title: title)
+    }
+}
+
+public extension WordPressMedia {
+    /// Details about a WordPress site media.
+    struct MediaDetails: Decodable, Equatable {
+        public let width: Double
+        public let height: Double
+        public let fileName: String
+        public let sizes: [String: MediaSizeDetails]
+
+        enum CodingKeys: String, CodingKey {
+            case width
+            case height
+            case fileName = "file"
+            case sizes
+        }
+    }
+
+    /// Details about a size of WordPress site media (e.g. `thumbnail`, `medium`, `2048x2048`).
+    struct MediaSizeDetails: Decodable, Equatable {
+        public let fileName: String
+        public let src: String
+        public let width: Double
+        public let height: Double
+
+        enum CodingKeys: String, CodingKey {
+            case fileName = "file"
+            case src = "source_url"
+            case width
+            case height
+        }
+    }
+
+    /// Title of the WordPress site media.
+    struct MediaTitle: Decodable, Equatable {
+        /// `GET` media list request's `title` field only contains `rendered`, while `POST` media request includes both `raw` and `rendered`.
+        let rendered: String
+
+        enum CodingKeys: String, CodingKey {
+            case rendered
+        }
+    }
+}
+
+private extension WordPressMedia {
+    enum CodingKeys: String, CodingKey {
+        case mediaID  = "id"
+        case date = "date_gmt"
+        case slug
+        case mimeType = "mime_type"
+        case src = "source_url"
+        case alt = "alt_text"
+        case details = "media_details"
+        case title
+    }
+}

--- a/Networking/Networking/Model/Media/WordPressMedia.swift
+++ b/Networking/Networking/Model/Media/WordPressMedia.swift
@@ -1,5 +1,3 @@
-import Codegen
-
 /// Media from WordPress Site API
 public struct WordPressMedia: Equatable {
     public let mediaID: Int64

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -46,12 +46,11 @@ public class MediaRemote: Remote {
     public func loadMediaLibraryFromWordPressSite(siteID: Int64,
                                                   pageNumber: Int = Default.pageNumber,
                                                   pageSize: Int = 25,
-                                                  context: String = Default.context,
                                                   completion: @escaping (Result<[WordPressMedia], Error>) -> Void) {
         let parameters: [String: Any] = [
             ParameterKey.pageSize: pageSize,
             ParameterKey.pageNumber: pageNumber,
-            ParameterKey.fieldsWordPressSite: Default.wordPressMediaFields,
+            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
             ParameterKey.mimeType: "image"
         ]
 
@@ -123,8 +122,8 @@ public class MediaRemote: Remote {
                                            mediaItems: [UploadableMedia],
                                            completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
         let formParameters: [String: String] = [
-            "post": "\(productID)",
-            ParameterKey.fieldsWordPressSite: Default.wordPressMediaFields,
+            ParameterKey.wordPressMediaPostID: "\(productID)",
+            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
         ]
         let path = "sites/\(siteID)/media"
         let request = DotcomRequest(wordpressApiVersion: .wpMark2, method: .post, path: path, parameters: nil)
@@ -152,12 +151,12 @@ public extension MediaRemote {
     enum Default {
         public static let context: String = "display"
         public static let pageNumber = 1
-        fileprivate static let wordPressMediaFields = "id,date_gmt,slug,mime_type,source_url,alt_text,media_details,title"
     }
 
     private enum ParameterKey {
         static let pageNumber: String = "page"
         static let pageSize: String   = "number"
+        static let wordPressMediaPostID: String = "post"
         static let fields: String     = "fields"
         static let fieldsWordPressSite: String = "_fields"
         static let mimeType: String   = "mime_type"
@@ -166,5 +165,6 @@ public extension MediaRemote {
 
     private enum ParameterValue {
         static let mediaUploadName: String = "file"
+        static let wordPressMediaFields = "id,date_gmt,slug,mime_type,source_url,alt_text,media_details,title"
     }
 }

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -152,13 +152,19 @@ public extension MediaRemote {
     enum Default {
         public static let context: String = "display"
         public static let pageNumber = 1
+        fileprivate static let wordPressMediaFields = "id,date_gmt,slug,mime_type,source_url,alt_text,media_details,title"
     }
 
     private enum ParameterKey {
         static let pageNumber: String = "page"
         static let pageSize: String   = "number"
         static let fields: String     = "fields"
+        static let fieldsWordPressSite: String = "_fields"
         static let mimeType: String   = "mime_type"
         static let contextKey: String = "context"
+    }
+
+    private enum ParameterValue {
+        static let mediaUploadName: String = "file"
     }
 }

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -35,6 +35,36 @@ public class MediaRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Loads an array of media from the site's WP Media Library via WordPress site API.
+    /// API reference: https://developer.wordpress.org/rest-api/reference/media/#list-media
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll load the media from.
+    ///   - pageNumber: The index of the page of media data to load from, starting from 1.
+    ///   - pageSize: The number of media items to return.
+    ///   - completion: Closure to be executed upon completion.
+    public func loadMediaLibraryFromWordPressSite(siteID: Int64,
+                                                  pageNumber: Int = Default.pageNumber,
+                                                  pageSize: Int = 25,
+                                                  context: String = Default.context,
+                                                  completion: @escaping (Result<[WordPressMedia], Error>) -> Void) {
+        let parameters: [String: Any] = [
+            ParameterKey.pageSize: pageSize,
+            ParameterKey.pageNumber: pageNumber,
+            ParameterKey.fieldsWordPressSite: Default.wordPressMediaFields,
+            ParameterKey.mimeType: "image"
+        ]
+
+        let path = "sites/\(siteID)/media"
+        let request = DotcomRequest(wordpressApiVersion: .wpMark2,
+                                    method: .get,
+                                    path: path,
+                                    parameters: parameters)
+        let mapper = WordPressMediaListMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Uploads an array of media in the local file system.
     /// API reference: https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/new/
     ///
@@ -74,6 +104,40 @@ public class MediaRemote: Remote {
             mediaItems.forEach { mediaItem in
                 multipartFormData.append(mediaItem.localURL,
                                          withName: "media[]",
+                                         fileName: mediaItem.filename,
+                                         mimeType: mediaItem.mimeType)
+            }
+        }, completion: completion)
+    }
+
+    /// Uploads an array of media in the local file system to the WordPress site.via WordPress site API
+    /// API reference: https://developer.wordpress.org/rest-api/reference/media/#create-a-media-item
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll upload the media to.
+    ///   - productID: Product for which the media items are first added to.
+    ///   - mediaItems: An array of uploadable media items.
+    ///   - completion: Closure to be executed upon completion.
+    public func uploadMediaToWordPressSite(siteID: Int64,
+                                           productID: Int64,
+                                           mediaItems: [UploadableMedia],
+                                           completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+        let formParameters: [String: String] = [
+            "post": "\(productID)",
+            ParameterKey.fieldsWordPressSite: Default.wordPressMediaFields,
+        ]
+        let path = "sites/\(siteID)/media"
+        let request = DotcomRequest(wordpressApiVersion: .wpMark2, method: .post, path: path, parameters: nil)
+        let mapper = WordPressMediaMapper()
+
+        enqueueMultipartFormDataUpload(request, mapper: mapper, multipartFormData: { multipartFormData in
+            formParameters.forEach { (key, value) in
+                multipartFormData.append(Data(value.utf8), withName: key)
+            }
+
+            mediaItems.forEach { mediaItem in
+                multipartFormData.append(mediaItem.localURL,
+                                         withName: ParameterValue.mediaUploadName,
                                          fileName: mediaItem.filename,
                                          mimeType: mediaItem.mimeType)
             }

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -59,6 +59,60 @@ final class MediaRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    // MARK: - Load Media From Media Library `loadMediaLibrary` via WordPress Site API
+
+    /// Verifies that `loadMediaLibraryFromWordPressSite` properly parses the `media-library-from-wordpress-site` sample response.
+    ///
+    func test_loadMediaLibraryFromWordPressSite_properly_returns_parsed_media_list() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "media", filename: "media-library-from-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.loadMediaLibraryFromWordPressSite(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let mediaItems = try XCTUnwrap(result.get())
+        XCTAssertEqual(mediaItems.count, 2)
+        let uploadedMedia = try XCTUnwrap(mediaItems.first)
+        XCTAssertEqual(uploadedMedia.mediaID, 22)
+        XCTAssertEqual(uploadedMedia.date, Date(timeIntervalSince1970: 1637546157))
+        XCTAssertEqual(uploadedMedia.slug, "img_0111-2")
+        XCTAssertEqual(uploadedMedia.mimeType, "image/jpeg")
+        XCTAssertEqual(uploadedMedia.src, "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.alt, "Floral")
+        XCTAssertEqual(uploadedMedia.details?.width, 2560)
+        XCTAssertEqual(uploadedMedia.details?.height, 1920)
+        XCTAssertEqual(uploadedMedia.details?.fileName, "2021/11/img_0111-2-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.title, .init(rendered: "img_0111-2"))
+        XCTAssertEqual(uploadedMedia.details?.sizes["thumbnail"],
+                       .init(fileName: "img_0111-2-150x150.jpeg",
+                             src: "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-150x150.jpeg",
+                             width: 150,
+                             height: 150))
+    }
+
+    /// Verifies that `loadMediaLibraryFromWordPressSite` properly relays Networking Layer errors.
+    ///
+    func test_loadMediaLibraryFromWordPressSite_properly_relays_networking_errors() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.loadMediaLibraryFromWordPressSite(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     // MARK: - uploadMedia
 
     /// Verifies that `uploadMedia` properly parses the `media-upload` sample response.
@@ -94,6 +148,61 @@ final class MediaRemoteTests: XCTestCase {
             remote.uploadMedia(for: self.sampleSiteID,
                                   productID: self.sampleProductID,
                                   mediaItems: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    /// Verifies that `uploadMediaToWordPressSite` properly parses the `media-upload-to-wordpress-site` sample response.
+    ///
+    func test_uploadMediaToWordPressSite_properly_returns_parsed_media() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        let path = "sites/\(sampleSiteID)/media"
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-upload-to-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.uploadMediaToWordPressSite(siteID: self.sampleSiteID,
+                                              productID: self.sampleProductID,
+                                              mediaItems: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let uploadedMedia = try XCTUnwrap(result.get())
+        XCTAssertEqual(uploadedMedia.mediaID, 23)
+        XCTAssertEqual(uploadedMedia.date, Date(timeIntervalSince1970: 1637477423))
+        XCTAssertEqual(uploadedMedia.slug, "img_0005-1")
+        XCTAssertEqual(uploadedMedia.mimeType, "image/jpeg")
+        XCTAssertEqual(uploadedMedia.src, "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.alt, "Floral")
+        XCTAssertEqual(uploadedMedia.details?.width, 2560)
+        XCTAssertEqual(uploadedMedia.details?.height, 1708)
+        XCTAssertEqual(uploadedMedia.details?.fileName, "2021/11/img_0005-1-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.title, .init(rendered: "img_0005-1"))
+        XCTAssertEqual(uploadedMedia.details?.sizes["thumbnail"],
+                       .init(fileName: "img_0005-1-150x150.jpeg",
+                             src: "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-150x150.jpeg",
+                             width: 150,
+                             height: 150))
+    }
+
+    /// Verifies that `uploadMedia` properly relays Networking Layer errors.
+    ///
+    func test_uploadMediaToWordPressSite_properly_relays_networking_errors() {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.uploadMediaToWordPressSite(siteID: self.sampleSiteID,
+                                              productID: self.sampleProductID,
+                                              mediaItems: []) { result in
                 promise(result)
             }
         }

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -192,7 +192,7 @@ final class MediaRemoteTests: XCTestCase {
                              height: 150))
     }
 
-    /// Verifies that `uploadMedia` properly relays Networking Layer errors.
+    /// Verifies that `uploadMediaToWordPressSite` properly relays Networking Layer errors.
     ///
     func test_uploadMediaToWordPressSite_properly_relays_networking_errors() {
         // Given

--- a/Networking/NetworkingTests/Responses/media-library-from-wordpress-site.json
+++ b/Networking/NetworkingTests/Responses/media-library-from-wordpress-site.json
@@ -1,0 +1,266 @@
+[
+    {
+        "id": 22,
+        "date_gmt": "2021-11-22T01:55:57",
+        "slug": "img_0111-2",
+        "title": {
+            "rendered": "img_0111-2"
+        },
+        "alt_text": "Floral",
+        "mime_type": "image/jpeg",
+        "media_details": {
+            "width": 2560,
+            "height": 1920,
+            "file": "2021/11/img_0111-2-scaled.jpeg",
+            "sizes": {
+                "medium": {
+                    "file": "img_0111-2-300x225.jpeg",
+                    "width": 300,
+                    "height": 225,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-300x225.jpeg"
+                },
+                "large": {
+                    "file": "img_0111-2-1024x768.jpeg",
+                    "width": 1024,
+                    "height": 768,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-1024x768.jpeg"
+                },
+                "thumbnail": {
+                    "file": "img_0111-2-150x150.jpeg",
+                    "width": 150,
+                    "height": 150,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-150x150.jpeg"
+                },
+                "medium_large": {
+                    "file": "img_0111-2-768x576.jpeg",
+                    "width": 768,
+                    "height": 576,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-768x576.jpeg"
+                },
+                "1536x1536": {
+                    "file": "img_0111-2-1536x1152.jpeg",
+                    "width": 1536,
+                    "height": 1152,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-1536x1152.jpeg"
+                },
+                "2048x2048": {
+                    "file": "img_0111-2-2048x1536.jpeg",
+                    "width": 2048,
+                    "height": 1536,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-2048x1536.jpeg"
+                },
+                "post-thumbnail": {
+                    "file": "img_0111-2-1568x1176.jpeg",
+                    "width": 1568,
+                    "height": 1176,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-1568x1176.jpeg"
+                },
+                "woocommerce_thumbnail": {
+                    "file": "img_0111-2-450x450.jpeg",
+                    "width": 450,
+                    "height": 450,
+                    "uncropped": false,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-450x450.jpeg"
+                },
+                "woocommerce_single": {
+                    "file": "img_0111-2-600x450.jpeg",
+                    "width": 600,
+                    "height": 450,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-600x450.jpeg"
+                },
+                "woocommerce_gallery_thumbnail": {
+                    "file": "img_0111-2-100x100.jpeg",
+                    "width": 100,
+                    "height": 100,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-100x100.jpeg"
+                },
+                "shop_catalog": {
+                    "file": "img_0111-2-450x450.jpeg",
+                    "width": 450,
+                    "height": 450,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-450x450.jpeg"
+                },
+                "shop_single": {
+                    "file": "img_0111-2-600x450.jpeg",
+                    "width": 600,
+                    "height": 450,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-600x450.jpeg"
+                },
+                "shop_thumbnail": {
+                    "file": "img_0111-2-100x100.jpeg",
+                    "width": 100,
+                    "height": 100,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-100x100.jpeg"
+                },
+                "full": {
+                    "file": "img_0111-2-scaled.jpeg",
+                    "width": 2560,
+                    "height": 1920,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg"
+                }
+            },
+            "image_meta": {
+                "aperture": "2.4",
+                "credit": "",
+                "camera": "iPhone X",
+                "caption": "",
+                "created_timestamp": "1522412059",
+                "copyright": "",
+                "focal_length": "6",
+                "iso": "16",
+                "shutter_speed": "0.0047846889952153",
+                "title": "",
+                "orientation": "1",
+                "keywords": []
+            },
+            "original_image": "img_0111-2.jpeg"
+        },
+        "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg"
+    },
+    {
+        "id": 20,
+        "date_gmt": "2021-11-21T14:14:56",
+        "slug": "godafoss",
+        "title": {
+            "rendered": "godafoss"
+        },
+        "alt_text": "",
+        "mime_type": "image/jpeg",
+        "media_details": {
+            "width": 2560,
+            "height": 1708,
+            "file": "2021/11/img_0003-scaled.jpeg",
+            "sizes": {
+                "medium": {
+                    "file": "img_0003-300x200.jpeg",
+                    "width": 300,
+                    "height": 200,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-300x200.jpeg"
+                },
+                "large": {
+                    "file": "img_0003-1024x683.jpeg",
+                    "width": 1024,
+                    "height": 683,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-1024x683.jpeg"
+                },
+                "thumbnail": {
+                    "file": "img_0003-150x150.jpeg",
+                    "width": 150,
+                    "height": 150,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-150x150.jpeg"
+                },
+                "medium_large": {
+                    "file": "img_0003-768x513.jpeg",
+                    "width": 768,
+                    "height": 513,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-768x513.jpeg"
+                },
+                "1536x1536": {
+                    "file": "img_0003-1536x1025.jpeg",
+                    "width": 1536,
+                    "height": 1025,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-1536x1025.jpeg"
+                },
+                "2048x2048": {
+                    "file": "img_0003-2048x1367.jpeg",
+                    "width": 2048,
+                    "height": 1367,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-2048x1367.jpeg"
+                },
+                "post-thumbnail": {
+                    "file": "img_0003-1568x1046.jpeg",
+                    "width": 1568,
+                    "height": 1046,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-1568x1046.jpeg"
+                },
+                "woocommerce_thumbnail": {
+                    "file": "img_0003-450x450.jpeg",
+                    "width": 450,
+                    "height": 450,
+                    "uncropped": false,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-450x450.jpeg"
+                },
+                "woocommerce_single": {
+                    "file": "img_0003-600x400.jpeg",
+                    "width": 600,
+                    "height": 400,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-600x400.jpeg"
+                },
+                "woocommerce_gallery_thumbnail": {
+                    "file": "img_0003-100x100.jpeg",
+                    "width": 100,
+                    "height": 100,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-100x100.jpeg"
+                },
+                "shop_catalog": {
+                    "file": "img_0003-450x450.jpeg",
+                    "width": 450,
+                    "height": 450,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-450x450.jpeg"
+                },
+                "shop_single": {
+                    "file": "img_0003-600x400.jpeg",
+                    "width": 600,
+                    "height": 400,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-600x400.jpeg"
+                },
+                "shop_thumbnail": {
+                    "file": "img_0003-100x100.jpeg",
+                    "width": 100,
+                    "height": 100,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-100x100.jpeg"
+                },
+                "full": {
+                    "file": "img_0003-scaled.jpeg",
+                    "width": 2560,
+                    "height": 1708,
+                    "mime_type": "image/jpeg",
+                    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-scaled.jpeg"
+                }
+            },
+            "image_meta": {
+                "aperture": "10",
+                "credit": "Nicolas Cornet",
+                "camera": "NIKON D800E",
+                "caption": "",
+                "created_timestamp": "1344426731",
+                "copyright": "Nicolas Cornet",
+                "focal_length": "24",
+                "iso": "200",
+                "shutter_speed": "4",
+                "title": "Godafoss",
+                "orientation": "1",
+                "keywords": []
+            },
+            "original_image": "img_0003.jpeg"
+        },
+        "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0003-scaled.jpeg"
+    }
+]

--- a/Networking/NetworkingTests/Responses/media-upload-to-wordpress-site.json
+++ b/Networking/NetworkingTests/Responses/media-upload-to-wordpress-site.json
@@ -1,0 +1,133 @@
+{
+    "id": 23,
+    "date_gmt": "2021-11-21T06:50:23",
+    "slug": "img_0005-1",
+    "title": {
+        "raw": "img_0005-1",
+        "rendered": "img_0005-1"
+    },
+    "alt_text": "Floral",
+    "mime_type": "image/jpeg",
+    "media_details": {
+        "width": 2560,
+        "height": 1708,
+        "file": "2021/11/img_0005-1-scaled.jpeg",
+        "sizes": {
+            "medium": {
+                "file": "img_0005-1-300x200.jpeg",
+                "width": 300,
+                "height": 200,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-300x200.jpeg"
+            },
+            "large": {
+                "file": "img_0005-1-1024x683.jpeg",
+                "width": 1024,
+                "height": 683,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-1024x683.jpeg"
+            },
+            "thumbnail": {
+                "file": "img_0005-1-150x150.jpeg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-150x150.jpeg"
+            },
+            "medium_large": {
+                "file": "img_0005-1-768x513.jpeg",
+                "width": 768,
+                "height": 513,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-768x513.jpeg"
+            },
+            "1536x1536": {
+                "file": "img_0005-1-1536x1025.jpeg",
+                "width": 1536,
+                "height": 1025,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-1536x1025.jpeg"
+            },
+            "2048x2048": {
+                "file": "img_0005-1-2048x1367.jpeg",
+                "width": 2048,
+                "height": 1367,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-2048x1367.jpeg"
+            },
+            "post-thumbnail": {
+                "file": "img_0005-1-1568x1046.jpeg",
+                "width": 1568,
+                "height": 1046,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-1568x1046.jpeg"
+            },
+            "woocommerce_thumbnail": {
+                "file": "img_0005-1-450x450.jpeg",
+                "width": 450,
+                "height": 450,
+                "uncropped": false,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-450x450.jpeg"
+            },
+            "woocommerce_single": {
+                "file": "img_0005-1-600x400.jpeg",
+                "width": 600,
+                "height": 400,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-600x400.jpeg"
+            },
+            "woocommerce_gallery_thumbnail": {
+                "file": "img_0005-1-100x100.jpeg",
+                "width": 100,
+                "height": 100,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-100x100.jpeg"
+            },
+            "shop_catalog": {
+                "file": "img_0005-1-450x450.jpeg",
+                "width": 450,
+                "height": 450,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-450x450.jpeg"
+            },
+            "shop_single": {
+                "file": "img_0005-1-600x400.jpeg",
+                "width": 600,
+                "height": 400,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-600x400.jpeg"
+            },
+            "shop_thumbnail": {
+                "file": "img_0005-1-100x100.jpeg",
+                "width": 100,
+                "height": 100,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-100x100.jpeg"
+            },
+            "full": {
+                "file": "img_0005-1-scaled.jpeg",
+                "width": 2560,
+                "height": 1708,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-scaled.jpeg"
+            }
+        },
+        "image_meta": {
+            "aperture": "10",
+            "credit": "Nicolas Cornet",
+            "camera": "NIKON D800E",
+            "caption": "",
+            "created_timestamp": "1344437730",
+            "copyright": "Nicolas Cornet",
+            "focal_length": "16",
+            "iso": "200",
+            "shutter_speed": "20",
+            "title": "",
+            "orientation": "1",
+            "keywords": []
+        },
+        "original_image": "img_0005-1.jpeg"
+    },
+    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-scaled.jpeg"
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5363 

- [x] ⚠️ Make sure https://github.com/woocommerce/woocommerce-ios/pull/5489 is merged before this PR is merged ⚠️ 

### Description

Notes: Sorry about the PR size, 399 lines are from the sample JSON files!

For JCP sites, we cannot use the WordPress.com endpoints to update media or fetch media from the site media library. As in p91TBi-67H-p2, we are using WP core endpoints to upload/download media to/from the site directly for JCP sites.

Documentation for the two WP core endpoints:
- [Image upload](https://developer.wordpress.org/rest-api/reference/media/#create-a-media-item)
- [Media library](https://developer.wordpress.org/rest-api/reference/media/#list-media)

### Changes

All changes are in the Networking layer since the PR is already big:

- Added a new model `WordPressMedia` since the data format is very different from `Media` from WP.com endpoints
- Added two new mappers for upload and download endpoints: `WordPressMediaMapper` and `WordPressMediaListMapper`
- Added two endpoints to `MediaRemote` with unit tests: `loadMediaLibraryFromWordPressSite` and `uploadMediaToWordPressSite`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The new endpoints aren't used yet, just CI is good!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
