### PR TITLE
Order Filters: enable feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -24,7 +24,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .simplePaymentsPrototype:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderListFilters:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .jetpackConnectionPackageSupport:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderCreation:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 8.1
 -----
+- [***] Not it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab.
 - [*] Login: Password AutoFill will suggest wordpress.com accounts. [https://github.com/woocommerce/woocommerce-ios/pull/5399]
 - [internal] Migrated Settings screen to MVVM [https://github.com/woocommerce/woocommerce-ios/pull/5393]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.1
 -----
-- [***] Not it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab. [https://github.com/woocommerce/woocommerce-ios/pull/5491]
+- [***] Now it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab. [https://github.com/woocommerce/woocommerce-ios/pull/5491]
 - [*] Login: Password AutoFill will suggest wordpress.com accounts. [https://github.com/woocommerce/woocommerce-ios/pull/5399]
 - [internal] Migrated Settings screen to MVVM [https://github.com/woocommerce/woocommerce-ios/pull/5393]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.1
 -----
-- [***] Not it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab.
+- [***] Not it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab. [https://github.com/woocommerce/woocommerce-ios/pull/5491]
 - [*] Login: Password AutoFill will suggest wordpress.com accounts. [https://github.com/woocommerce/woocommerce-ios/pull/5399]
 - [internal] Migrated Settings screen to MVVM [https://github.com/woocommerce/woocommerce-ios/pull/5393]
 


### PR DESCRIPTION
Part of #5243 

### Description
This should be the last PR before enabling the functionality for order filters. This PR will be merged inside https://github.com/woocommerce/woocommerce-ios/pull/5400 where I did a massive refactoring of the order list, removing old code and the top tabs for "All orders" and "Processing". In the end, I'll merge that PR in `develop`.

### Testing instructions
You should be able to load the order list, and to filter orders by statuses and date ranges. Plus, you should be able to use the "search" functionality.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
