### PR TITLE
Simple Payments: Create  Order with Taxes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -85,10 +85,6 @@ struct SimplePaymentsAmount: View {
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsAmountViewModel
 
-    /// Tracks if the summary view should be presented.
-    ///
-    @State private var showSummaryView: Bool = false
-
     var body: some View {
         VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
 
@@ -110,11 +106,7 @@ struct SimplePaymentsAmount: View {
 
             // Done button
             Button(Localization.buttonTitle()) {
-                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplePaymentsPrototype) {
-                    showSummaryView.toggle()
-                } else {
-                    viewModel.createSimplePaymentsOrder()
-                }
+                viewModel.createSimplePaymentsOrder()
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -134,7 +134,6 @@ struct SimplePaymentsAmount: View {
         Group {
             if let summaryViewModel = viewModel.summaryViewModel {
                 SimplePaymentsSummary(viewModel: summaryViewModel)
-
             }
             EmptyView()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -119,7 +119,7 @@ struct SimplePaymentsAmount: View {
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)
 
-            LazyNavigationLink(destination: SimplePaymentsSummary(viewModel: viewModel.createSummaryViewModel()), isActive: $showSummaryView) {
+            LazyNavigationLink(destination: summaryView(), isActive: $viewModel.navigateToSummary) {
                 EmptyView()
             }
         }
@@ -134,6 +134,18 @@ struct SimplePaymentsAmount: View {
             }
         }
         .wooNavigationBarStyle()
+    }
+
+    /// Returns a `SimplePaymentsSummary` instance when the view model is available.
+    ///
+    private func summaryView() -> some View {
+        Group {
+            if let summaryViewModel = viewModel.summaryViewModel {
+                SimplePaymentsSummary(viewModel: summaryViewModel)
+
+            }
+            EmptyView()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -24,6 +24,17 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     @Published var presentNotice: Notice?
 
+    /// Defines if the view should navigate to the summary view.
+    /// Setting it to `false` will `nil` the summary view model.
+    ///
+    @Published var navigateToSummary: Bool = false {
+        didSet {
+            if !navigateToSummary {
+                summaryViewModel = nil
+            }
+        }
+    }
+
     /// Assign this closure to be notified when a new order is created
     ///
     var onOrderCreated: (Order) -> Void = { _ in }
@@ -41,6 +52,15 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
         // TODO: We are appending the currency symbol always to the left, we should use `CurrencyFormatter` when releasing to more countries.
         storeCurrencySymbol + "0" + storeCurrencySettings.decimalSeparator + "00"
     }()
+
+    /// Retains the SummaryViewModel.
+    /// Assigning it will set `navigateToSummary`.
+    ///
+    private(set) var summaryViewModel: SimplePaymentsSummaryViewModel? {
+        didSet {
+            navigateToSummary = summaryViewModel != nil
+        }
+    }
 
     /// Current store ID
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -112,12 +112,6 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
 
         loading = true
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            self.loading = false
-            self.summaryViewModel = SimplePaymentsSummaryViewModel(providedAmount: self.amount)
-        }
-        return
-
         // Prototype in production does not support taxes. Development version does.
         let action = OrderAction.createSimplePaymentsOrder(siteID: siteID, amount: amount, taxable: isDevelopmentPrototype) { [weak self] result in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import Experiments
 
 /// View Model for the `SimplePaymentsAmount` view.
 ///
@@ -82,8 +83,12 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     /// Creates a simple payments order.
     ///
     func createSimplePaymentsOrder() {
+
+        // Prototype in production does not support taxes. Development version does.
+        let taxable = ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.simplePaymentsPrototype)
+
         loading = true
-        let action = OrderAction.createSimplePaymentsOrder(siteID: siteID, amount: amount) { [weak self] result in
+        let action = OrderAction.createSimplePaymentsOrder(siteID: siteID, amount: amount, taxable: taxable) { [weak self] result in
             guard let self = self else { return }
             self.loading = false
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -29,7 +29,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     @Published var navigateToSummary: Bool = false {
         didSet {
-            if !navigateToSummary {
+            if !navigateToSummary && oldValue != navigateToSummary {
                 summaryViewModel = nil
             }
         }
@@ -111,6 +111,12 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     func createSimplePaymentsOrder() {
 
         loading = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            self.loading = false
+            self.summaryViewModel = SimplePaymentsSummaryViewModel(providedAmount: self.amount)
+        }
+        return
 
         // Prototype in production does not support taxes. Development version does.
         let action = OrderAction.createSimplePaymentsOrder(siteID: siteID, amount: amount, taxable: isDevelopmentPrototype) { [weak self] result in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -200,5 +200,4 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.presentNotice, .error)
     }
-
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -156,10 +156,56 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         XCTAssertTrue(isLoading)
     }
 
+    func test_order_is_created_with_no_taxes_on_prod_mode() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore, isDevelopmentPrototype: false)
+        viewModel.amount = "$12.30"
+
+        // When
+        let taxable: Bool = waitFor { promise in
+            testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .createSimplePaymentsOrder(_, _, taxable, _):
+                    promise(taxable)
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+            viewModel.createSimplePaymentsOrder()
+        }
+
+        // Then
+        XCTAssertFalse(taxable)
+    }
+
+    func test_order_is_created_with_taxes_on_dev_mode() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore, isDevelopmentPrototype: true)
+        viewModel.amount = "$12.30"
+
+        // When
+        let taxable: Bool = waitFor { promise in
+            testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .createSimplePaymentsOrder(_, _, taxable, _):
+                    promise(taxable)
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+            viewModel.createSimplePaymentsOrder()
+        }
+
+        // Then
+        XCTAssertTrue(taxable)
+    }
+
     func test_view_model_call_onOrderCreated_closure_after_an_order_is_created() {
         // Given
         let testingStore = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore, isDevelopmentPrototype: false)
         testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .createSimplePaymentsOrder(_, _, _, onCompletion):
@@ -179,6 +225,56 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(onOrderCreatedCalled)
+    }
+
+    func test_summaryViewModel_is_created_after_an_order_is_created_in_dev_mode() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore, isDevelopmentPrototype: true)
+
+        // When
+        waitForExpectation { exp in
+            testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .createSimplePaymentsOrder(_, _, _, onCompletion):
+                    onCompletion(.success(.fake()))
+                    exp.fulfill()
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+
+            viewModel.createSimplePaymentsOrder()
+        }
+
+        // Then
+        XCTAssertNotNil(viewModel.summaryViewModel)
+        XCTAssertTrue(viewModel.navigateToSummary)
+    }
+
+    func test_summaryViewModel_is_nilled_after_navigation_is_set_to_false_in_dev_mode() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore, isDevelopmentPrototype: true)
+        waitForExpectation { exp in
+            testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .createSimplePaymentsOrder(_, _, _, onCompletion):
+                    onCompletion(.success(.fake()))
+                    exp.fulfill()
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+
+            viewModel.createSimplePaymentsOrder()
+        }
+
+        // When
+        viewModel.navigateToSummary = false
+
+        // Then
+        XCTAssertNil(viewModel.summaryViewModel)
     }
 
     func test_view_model_attempts_error_notice_presentation_when_failing_to_crete_order() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -162,7 +162,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore)
         testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .createSimplePaymentsOrder(_, _, onCompletion):
+            case let .createSimplePaymentsOrder(_, _, _, onCompletion):
                 onCompletion(.success(.fake()))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -187,7 +187,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore)
         testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .createSimplePaymentsOrder(_, _, onCompletion):
+            case let .createSimplePaymentsOrder(_, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -67,7 +67,7 @@ public enum OrderAction: Action {
 
     /// Creates a simple payments order with a specific amount value and no tax.
     ///
-    case createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: (Result<Order, Error>) -> Void)
+    case createSimplePaymentsOrder(siteID: Int64, amount: String, taxable: Bool, onCompletion: (Result<Order, Error>) -> Void)
 
     /// Creates a manual order with the provided order details.
     ///

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -5,9 +5,9 @@ import Networking
 ///
 enum OrderFactory {
     /// Creates an order suitable to be used as a simple payments order.
-    /// Under the hood it uses a fee line without taxes to create an order with the desired amount.
+    /// Under the hood it uses a fee line with or without taxes to create an order with the desired amount.
     ///
-    static func simplePaymentsOrder(amount: String) -> Order {
+    static func simplePaymentsOrder(amount: String, taxable: Bool) -> Order {
         Order(siteID: 0,
               orderID: 0,
               parentID: 0,
@@ -33,6 +33,13 @@ enum OrderFactory {
               shippingLines: [],
               coupons: [],
               refunds: [],
-              fees: [.init(feeID: 0, name: "Simple Payments", taxClass: "", taxStatus: .none, total: amount, totalTax: "", taxes: [], attributes: [])])
+              fees: [.init(feeID: 0,
+                           name: "Simple Payments",
+                           taxClass: "",
+                           taxStatus: taxable ? .taxable : .none,
+                           total: amount,
+                           totalTax: "",
+                           taxes: [],
+                           attributes: [])])
     }
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -62,8 +62,8 @@ public class OrderStore: Store {
         case let .updateOrder(siteID, order, fields, onCompletion):
             updateOrder(siteID: siteID, order: order, fields: fields, onCompletion: onCompletion)
 
-        case let .createSimplePaymentsOrder(siteID, amount, onCompletion):
-            createSimplePaymentsOrder(siteID: siteID, amount: amount, onCompletion: onCompletion)
+        case let .createSimplePaymentsOrder(siteID, amount, taxable, onCompletion):
+            createSimplePaymentsOrder(siteID: siteID, amount: amount, taxable: taxable, onCompletion: onCompletion)
         case let .createOrder(siteID, order, onCompletion):
             createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
         }
@@ -251,8 +251,8 @@ private extension OrderStore {
 
     /// Creates a simple payments order with a specific amount value and no tax.
     ///
-    func createSimplePaymentsOrder(siteID: Int64, amount: String, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        let order = OrderFactory.simplePaymentsOrder(amount: amount)
+    func createSimplePaymentsOrder(siteID: Int64, amount: String, taxable: Bool, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        let order = OrderFactory.simplePaymentsOrder(amount: amount, taxable: taxable)
         remote.createOrder(siteID: siteID, order: order, fields: [.feeLines]) { [weak self] result in
             switch result {
             case .success(let order):


### PR DESCRIPTION
Closes: #5482 

# Why

It was decided in p91TBi-6Cg#comment-7404 that in order to not duplicate taxes calculations for **simple payments** we will be creating an order with taxes after entering the amount to allow core to do the tax calculation and then update the order with extra details(email, notes, taxes) in the summary screen.

This PR takes care of creating that order with taxes and then navigating to the summary screen. Note that the created order is not yet connected to the summary screen.

# How

- Update `OrderFactory` and  `OrderStore` to allow to create a simple payments order with taxes.

- Update `AmmountViewModel` to provide 3 new variables:
   - `navigateToSummary`: which will determine when the view needs to navigate to the summary view
   -  `summaryViewModel`: to hold the view model to power the summary view. Setting this value will set `navigateToSummary` to true.
   - `isDevelopmentPrototype `: To know when to maintain the current production behavior and when not.
   
- Update  `SimplePaymentsAmountView` to consume the new properties from the view model.

# Demo

## Production

https://user-images.githubusercontent.com/562080/142961191-61f8d8fb-5520-43be-a17e-e86ee4108e4e.mov

## Development

https://user-images.githubusercontent.com/562080/142961209-9f9f31a5-3c24-4172-82a6-967324af8d53.mov


# Testing instructions

## Prerequisites

- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps

- Start the simple payments flow
- Enter an amount & tap next
- See a loading spinner and then see that you are redirected to the summary screen
- Close the modal screen and navigate to the all orders tab
- See that you have a new order that is charging taxes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

