### PR TITLE
Jetpack CP: image support for JCP sites

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1547,3 +1547,19 @@ extension WCPayPaymentIntentStatusEnum {
         .requiresPaymentMethod
     }
 }
+extension WordPressMedia {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WordPressMedia {
+        .init(
+            mediaID: .fake(),
+            date: .fake(),
+            slug: .fake(),
+            mimeType: .fake(),
+            src: .fake(),
+            alt: .fake(),
+            details: .fake(),
+            title: .fake()
+        )
+    }
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1302,3 +1302,36 @@ extension SystemPlugin {
         )
     }
 }
+
+extension WordPressMedia {
+    public func copy(
+        mediaID: CopiableProp<Int64> = .copy,
+        date: CopiableProp<Date> = .copy,
+        slug: CopiableProp<String> = .copy,
+        mimeType: CopiableProp<String> = .copy,
+        src: CopiableProp<String> = .copy,
+        alt: NullableCopiableProp<String> = .copy,
+        details: NullableCopiableProp<WordPressMedia.MediaDetails> = .copy,
+        title: NullableCopiableProp<WordPressMedia.MediaTitle> = .copy
+    ) -> WordPressMedia {
+        let mediaID = mediaID ?? self.mediaID
+        let date = date ?? self.date
+        let slug = slug ?? self.slug
+        let mimeType = mimeType ?? self.mimeType
+        let src = src ?? self.src
+        let alt = alt ?? self.alt
+        let details = details ?? self.details
+        let title = title ?? self.title
+
+        return WordPressMedia(
+            mediaID: mediaID,
+            date: date,
+            slug: slug,
+            mimeType: mimeType,
+            src: src,
+            alt: alt,
+            details: details,
+            title: title
+        )
+    }
+}

--- a/Networking/Networking/Model/Media/WordPressMedia.swift
+++ b/Networking/Networking/Model/Media/WordPressMedia.swift
@@ -1,5 +1,7 @@
+import Codegen
+
 /// Media from WordPress Site API
-public struct WordPressMedia: Equatable {
+public struct WordPressMedia: Equatable, GeneratedCopiable, GeneratedFakeable {
     public let mediaID: Int64
     public let date: Date
     public let slug: String

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -1,8 +1,30 @@
 import Foundation
 
+/// Protocol for `MediaRemote` mainly used for mocking.
+public protocol MediaRemoteProtocol {
+    func loadMediaLibrary(for siteID: Int64,
+                          pageNumber: Int,
+                          pageSize: Int,
+                          context: String?,
+                          completion: @escaping (Result<[Media], Error>) -> Void)
+    func loadMediaLibraryFromWordPressSite(siteID: Int64,
+                                           pageNumber: Int,
+                                           pageSize: Int,
+                                           completion: @escaping (Result<[WordPressMedia], Error>) -> Void)
+    func uploadMedia(for siteID: Int64,
+                     productID: Int64,
+                     context: String?,
+                     mediaItems: [UploadableMedia],
+                     completion: @escaping (Result<[Media], Error>) -> Void)
+    func uploadMediaToWordPressSite(siteID: Int64,
+                                    productID: Int64,
+                                    mediaItems: [UploadableMedia],
+                                    completion: @escaping (Result<WordPressMedia, Error>) -> Void)
+}
+
 /// Media: Remote Endpoints
 ///
-public class MediaRemote: Remote {
+public class MediaRemote: Remote, MediaRemoteProtocol {
     /// Loads an array of media from the site's WP Media Library.
     /// API reference: https://developer.wordpress.com/docs/api/1.2/get/sites/%24site/media/
     ///
@@ -15,10 +37,10 @@ public class MediaRemote: Remote {
     public func loadMediaLibrary(for siteID: Int64,
                                  pageNumber: Int = Default.pageNumber,
                                  pageSize: Int = 25,
-                                 context: String = Default.context,
+                                 context: String? = Default.context,
                                  completion: @escaping (Result<[Media], Error>) -> Void) {
         let parameters: [String: Any] = [
-            ParameterKey.contextKey: context,
+            ParameterKey.contextKey: context ?? Default.context,
             ParameterKey.pageSize: pageSize,
             ParameterKey.pageNumber: pageNumber,
             ParameterKey.fields: "ID,date,URL,thumbnails,title,alt,extension,mime_type,file",

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */; };
 		0271E1662509CF0100633F7A /* AnyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271E1652509CF0100633F7A /* AnyError.swift */; };
 		028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */; };
+		029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */; };
 		029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */; };
 		029BA557255E0CD4006171FD /* ShippingLabelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA556255E0CD4006171FD /* ShippingLabelStore.swift */; };
 		029BA55B255E0D39006171FD /* ShippingLabelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA55A255E0D39006171FD /* ShippingLabelAction.swift */; };
@@ -434,6 +435,7 @@
 		026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationStoreTests.swift; sourceTree = "<group>"; };
 		0271E1652509CF0100633F7A /* AnyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyError.swift; sourceTree = "<group>"; };
 		028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsStoreErrorTests.swift; sourceTree = "<group>"; };
+		029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaRemote.swift; sourceTree = "<group>"; };
 		029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeTests.swift; sourceTree = "<group>"; };
 		029BA556255E0CD4006171FD /* ShippingLabelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStore.swift; sourceTree = "<group>"; };
 		029BA55A255E0D39006171FD /* ShippingLabelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAction.swift; sourceTree = "<group>"; };
@@ -1080,6 +1082,7 @@
 				02E7FFD82562234F00C53030 /* MockShippingLabelRemote.swift */,
 				D4CBAE5F26D440FA00BBE6D1 /* MockAnnouncementsRemote.swift */,
 				02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */,
+				029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1998,6 +2001,7 @@
 				025CA2D0238F54E800B05C81 /* ProductShippingClassStoreTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				D8652E322630741000350F37 /* PaymentIntent+ReceiptParametersTests.swift in Sources */,
+				029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */,
 				022F00C72472963E008CD97F /* NotificationCountStoreTests.swift in Sources */,
 				578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */,
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -8,21 +8,30 @@ public final class MediaStore: Store {
     private let remote: MediaRemoteProtocol
     private lazy var mediaExportService: MediaExportService = DefaultMediaExportService()
 
-    public override convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+    public convenience override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         let remote = MediaRemote(network: network)
         self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
     }
 
-    public init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: MediaRemoteProtocol) {
+    init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: MediaRemoteProtocol) {
         self.remote = remote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    convenience init(mediaExportService: MediaExportService,
+         dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         network: Network) {
+        let remote = MediaRemote(network: network)
+        self.init(mediaExportService: mediaExportService, dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
     }
 
     init(mediaExportService: MediaExportService,
          dispatcher: Dispatcher,
          storageManager: StorageManagerType,
-         network: Network) {
-        self.remote = MediaRemote(network: network)
+         network: Network,
+         remote: MediaRemoteProtocol) {
+        self.remote = remote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
         self.mediaExportService = mediaExportService
     }

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -159,6 +159,7 @@ public enum MediaActionError: Error {
 }
 
 extension WordPressMedia {
+    /// Converts a `WordPressMedia` to `Media`.
     func toMedia() -> Media {
         .init(mediaID: mediaID,
               date: date,

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -5,11 +5,16 @@ import Storage
 // MARK: - MediaStore
 //
 public final class MediaStore: Store {
-    private let remote: MediaRemote
+    private let remote: MediaRemoteProtocol
     private lazy var mediaExportService: MediaExportService = DefaultMediaExportService()
 
-    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
-        self.remote = MediaRemote(network: network)
+    public override convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        let remote = MediaRemote(network: network)
+        self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+    }
+
+    public init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: MediaRemoteProtocol) {
+        self.remote = remote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -55,10 +55,20 @@ private extension MediaStore {
                               pageNumber: Int,
                               pageSize: Int,
                               onCompletion: @escaping (Result<[Media], Error>) -> Void) {
-        remote.loadMediaLibrary(for: siteID,
-                                   pageNumber: pageNumber,
-                                   pageSize: pageSize,
-                                   completion: onCompletion)
+        let storage = storageManager.viewStorage
+        if let site = storage.loadSite(siteID: siteID)?.toReadOnly(), site.isJetpackCPConnected {
+            remote.loadMediaLibraryFromWordPressSite(siteID: siteID,
+                                                     pageNumber: pageNumber,
+                                                     pageSize: pageSize) { result in
+                onCompletion(result.map { $0.map { $0.toMedia() } })
+            }
+        } else {
+            remote.loadMediaLibrary(for: siteID,
+                                       pageNumber: pageNumber,
+                                       pageSize: pageSize,
+                                       context: nil,
+                                       completion: onCompletion)
+        }
     }
 
     /// Uploads an exportable media asset to the site's WP Media Library with 2 steps:
@@ -86,26 +96,49 @@ private extension MediaStore {
                      productID: Int64,
                      uploadableMedia media: UploadableMedia,
                      onCompletion: @escaping (Result<Media, Error>) -> Void) {
-        remote.uploadMedia(for: siteID,
-                           productID: productID,
-                           mediaItems: [media]) { result in
-            // Removes local media after the upload API request.
-            do {
-                try MediaFileManager().removeLocalMedia(at: media.localURL)
-            } catch {
-                onCompletion(.failure(error))
-                return
-            }
-
-            switch result {
-            case .success(let uploadedMediaItems):
-                guard let uploadedMedia = uploadedMediaItems.first, uploadedMediaItems.count == 1 else {
-                    onCompletion(.failure(MediaActionError.unexpectedMediaCount(count: uploadedMediaItems.count)))
+        let storage = storageManager.viewStorage
+        if let site = storage.loadSite(siteID: siteID)?.toReadOnly(), site.isJetpackCPConnected {
+            remote.uploadMediaToWordPressSite(siteID: siteID,
+                                              productID: productID,
+                                              mediaItems: [media]) { result in
+                // Removes local media after the upload API request.
+                do {
+                    try MediaFileManager().removeLocalMedia(at: media.localURL)
+                } catch {
+                    onCompletion(.failure(error))
                     return
                 }
-                onCompletion(.success(uploadedMedia))
-            case .failure(let error):
-                onCompletion(.failure(error))
+
+                switch result {
+                case .success(let uploadedMedia):
+                    onCompletion(.success(uploadedMedia.toMedia()))
+                case .failure(let error):
+                    onCompletion(.failure(error))
+                }
+            }
+        } else {
+            remote.uploadMedia(for: siteID,
+                                  productID: productID,
+                                  context: nil,
+                                  mediaItems: [media]) { result in
+                // Removes local media after the upload API request.
+                do {
+                    try MediaFileManager().removeLocalMedia(at: media.localURL)
+                } catch {
+                    onCompletion(.failure(error))
+                    return
+                }
+
+                switch result {
+                case .success(let uploadedMediaItems):
+                    guard let uploadedMedia = uploadedMediaItems.first, uploadedMediaItems.count == 1 else {
+                        onCompletion(.failure(MediaActionError.unexpectedMediaCount(count: uploadedMediaItems.count)))
+                        return
+                    }
+                    onCompletion(.success(uploadedMedia))
+                case .failure(let error):
+                    onCompletion(.failure(error))
+                }
             }
         }
     }
@@ -114,4 +147,27 @@ private extension MediaStore {
 public enum MediaActionError: Error {
     case unexpectedMediaCount(count: Int)
     case unknown
+}
+
+extension WordPressMedia {
+    func toMedia() -> Media {
+        .init(mediaID: mediaID,
+              date: date,
+              fileExtension: fileExtension,
+              filename: details?.fileName ?? "",
+              mimeType: mimeType,
+              src: src,
+              thumbnailURL: details?.sizes["thumbnail"]?.src,
+              name: slug,
+              alt: alt,
+              height: details?.height,
+              width: details?.width)
+    }
+
+    private var fileExtension: String {
+        guard let fileName = details?.fileName else {
+            return ""
+        }
+        return URL(fileURLWithPath: fileName).pathExtension
+    }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import Networking
 
@@ -7,9 +6,6 @@ import XCTest
 /// Mock for `MediaRemote`.
 ///
 final class MockMediaRemote {
-    /// Returns the value as a publisher when `loadSites` is called.
-    var loadSitesResult: Result<[Site], Error> = .success([])
-
     /// Returns the requests that have been made to `MediaRemoteProtocol`.
     var invocations = [Invocation]()
 
@@ -55,7 +51,7 @@ extension MockMediaRemote {
     }
 }
 
-// MARK: - AccountRemoteProtocol
+// MARK: - MediaRemoteProtocol
 
 extension MockMediaRemote: MediaRemoteProtocol {
     func loadMediaLibrary(for siteID: Int64, pageNumber: Int, pageSize: Int, context: String?, completion: @escaping (Result<[Media], Error>) -> Void) {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
@@ -1,0 +1,103 @@
+import Combine
+import Foundation
+import Networking
+
+import XCTest
+
+/// Mock for `MediaRemote`.
+///
+final class MockMediaRemote {
+    /// Returns the value as a publisher when `loadSites` is called.
+    var loadSitesResult: Result<[Site], Error> = .success([])
+
+    /// Returns the requests that have been made to `MediaRemoteProtocol`.
+    var invocations = [Invocation]()
+
+    /// The results to return based on the given site ID in `loadMediaLibrary`
+    private var loadMediaLibraryResultsBySiteID = [Int64: Result<[Media], Error>]()
+
+    /// The results to return based on the given site ID in `loadMediaLibraryFromWordPressSite`
+    private var loadMediaLibraryFromWordPressSiteResultsBySiteID = [Int64: Result<[WordPressMedia], Error>]()
+
+    /// The results to return based on the given site ID in `uploadMedia`
+    private var uploadMediaResultsBySiteID = [Int64: Result<[Media], Error>]()
+
+    /// The results to return based on the given site ID in `uploadMediaToWordPressSite`
+    private var uploadMediaToWordPressSiteResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
+
+    /// Returns the value as a publisher when `loadMediaLibrary` is called.
+    func whenLoadingMediaLibrary(siteID: Int64, thenReturn result: Result<[Media], Error>) {
+        loadMediaLibraryResultsBySiteID[siteID] = result
+    }
+
+    /// Returns the value as a publisher when `loadMediaLibraryFromWordPressSite` is called.
+    func whenLoadingMediaLibraryFromWordPressSite(siteID: Int64, thenReturn result: Result<[WordPressMedia], Error>) {
+        loadMediaLibraryFromWordPressSiteResultsBySiteID[siteID] = result
+    }
+
+    /// Returns the value as a publisher when `uploadMedia` is called.
+    func whenUploadingMedia(siteID: Int64, thenReturn result: Result<[Media], Error>) {
+        uploadMediaResultsBySiteID[siteID] = result
+    }
+
+    /// Returns the value as a publisher when `uploadMediaToWordPressSite` is called.
+    func whenUploadingMediaToWordPressSite(siteID: Int64, thenReturn result: Result<WordPressMedia, Error>) {
+        uploadMediaToWordPressSiteResultsBySiteID[siteID] = result
+    }
+}
+
+extension MockMediaRemote {
+    enum Invocation: Equatable {
+        case loadMediaLibrary(siteID: Int64)
+        case loadMediaLibraryFromWordPressSite(siteID: Int64)
+        case uploadMedia(siteID: Int64)
+        case uploadMediaToWordPressSite(siteID: Int64)
+    }
+}
+
+// MARK: - AccountRemoteProtocol
+
+extension MockMediaRemote: MediaRemoteProtocol {
+    func loadMediaLibrary(for siteID: Int64, pageNumber: Int, pageSize: Int, context: String?, completion: @escaping (Result<[Media], Error>) -> Void) {
+        invocations.append(.loadMediaLibrary(siteID: siteID))
+        guard let result = loadMediaLibraryResultsBySiteID[siteID] else {
+            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func loadMediaLibraryFromWordPressSite(siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping (Result<[WordPressMedia], Error>) -> Void) {
+        invocations.append(.loadMediaLibraryFromWordPressSite(siteID: siteID))
+        guard let result = loadMediaLibraryFromWordPressSiteResultsBySiteID[siteID] else {
+            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func uploadMedia(for siteID: Int64,
+                     productID: Int64,
+                     context: String?,
+                     mediaItems: [UploadableMedia],
+                     completion: @escaping (Result<[Media], Error>) -> Void) {
+        invocations.append(.uploadMedia(siteID: siteID))
+        guard let result = uploadMediaResultsBySiteID[siteID] else {
+            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func uploadMediaToWordPressSite(siteID: Int64,
+                                    productID: Int64,
+                                    mediaItems: [UploadableMedia],
+                                    completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+        invocations.append(.uploadMediaToWordPressSite(siteID: siteID))
+        guard let result = uploadMediaToWordPressSiteResultsBySiteID[siteID] else {
+            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -153,32 +153,102 @@ final class MediaStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    /// Verifies that `MediaAction.retrieveMediaLibrary` invokes `MediaRemoteProtocol.loadMediaLibrary` when there is no corresponding site in storage.
+    func test_retrieveMediaLibrary_without_storage_site_invokes_loadMediaLibrary_remote_call() throws {
+        // Given
+        let remote = MockMediaRemote()
+        remote.whenLoadingMediaLibrary(siteID: sampleSiteID, thenReturn: .success([]))
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network,
+                                    remote: remote)
+
+        // When
+        let _: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.loadMediaLibrary(siteID: sampleSiteID)])
+    }
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` from a JCP site returns the media list from the remote response.
+    func test_retrieveMediaLibrary_from_jcp_site_returns_media_list() throws {
+        // Given
+        let remote = MockMediaRemote()
+        let media = WordPressMedia.fake()
+        remote.whenLoadingMediaLibraryFromWordPressSite(siteID: sampleSiteID, thenReturn: .success([media]))
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network,
+                                    remote: remote)
+
+        insertJCPSiteToStorage(siteID: sampleSiteID)
+
+        // When
+        let result: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.loadMediaLibraryFromWordPressSite(siteID: sampleSiteID)])
+
+        let mediaList = try XCTUnwrap(result.get())
+        XCTAssertEqual(mediaList, [media.toMedia()])
+    }
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` from a JCP site returns an error from the remote response.
+    func test_retrieveMediaLibrary_from_jcp_site_returns_error_upon_empty_response() throws {
+        // Given
+        let remote = MockMediaRemote()
+        remote.whenLoadingMediaLibraryFromWordPressSite(siteID: sampleSiteID, thenReturn: .failure(DotcomError.unauthorized))
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network,
+                                    remote: remote)
+
+        insertJCPSiteToStorage(siteID: sampleSiteID)
+
+        // When
+        let result: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.loadMediaLibraryFromWordPressSite(siteID: sampleSiteID)])
+
+        let error = try XCTUnwrap(result.failure as? DotcomError)
+        XCTAssertEqual(error, .unauthorized)
+    }
+
     // MARK: test cases for `MediaAction.uploadMedia`
 
     func test_uploadMedia_returns_uploaded_media_and_deletes_input_media_file() throws {
         // Given
+        let fileManager = FileManager.default
 
         // Creates a temporary file to simulate a uploadable media file.
-        let filename = "test.txt"
-        let fileManager = FileManager.default
-        let targetURL = fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        let targetURL: URL = {
+            let filename = "test.txt"
+            return fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        }()
 
-        do {
-            try fileManager.createDirectory(at: fileManager.temporaryDirectory, withIntermediateDirectories: true)
-            try "testing".write(toFile: targetURL.path, atomically: true, encoding: String.Encoding.utf8)
-        } catch {
-            XCTFail("Cannot write to target URL: \(targetURL) with error: \(error)")
-        }
-
-        // Verifies that the temporary file exists.
-        XCTAssertTrue(fileManager.fileExists(atPath: targetURL.path))
-
-        let uploadableMedia = createSampleUploadableMedia(targetURL: targetURL)
-        let mediaExportService = MockMediaExportService(uploadableMedia: uploadableMedia)
-        let mediaStore = MediaStore(mediaExportService: mediaExportService,
-                                    dispatcher: dispatcher,
-                                    storageManager: storageManager,
-                                    network: network)
+        let mediaStore = createMediaStoreAndExportableMedia(at: targetURL, fileManager: fileManager)
 
         let path = "sites/\(sampleSiteID)/media/new"
         network.simulateResponse(requestUrlSuffix: path, filename: "media-upload")
@@ -204,27 +274,15 @@ final class MediaStoreTests: XCTestCase {
 
     func test_uploadMedia_returns_error_upon_response_error() {
         // Given
-        // Creates a temporary file to simulate a uploadable media file.
-        let filename = "test.txt"
         let fileManager = FileManager.default
-        let targetURL = fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
 
-        do {
-            try fileManager.createDirectory(at: fileManager.temporaryDirectory, withIntermediateDirectories: true)
-            try "testing".write(toFile: targetURL.path, atomically: true, encoding: String.Encoding.utf8)
-        } catch {
-            XCTFail("Cannot write to target URL: \(targetURL) with error: \(error)")
-        }
+        // Creates a temporary file to simulate a uploadable media file.
+        let targetURL: URL = {
+            let filename = "test.txt"
+            return fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        }()
 
-        // Verifies that the temporary file exists.
-        XCTAssertTrue(fileManager.fileExists(atPath: targetURL.path))
-
-        let uploadableMedia = createSampleUploadableMedia(targetURL: targetURL)
-        let mediaExportService = MockMediaExportService(uploadableMedia: uploadableMedia)
-        let mediaStore = MediaStore(mediaExportService: mediaExportService,
-                                    dispatcher: dispatcher,
-                                    storageManager: storageManager,
-                                    network: network)
+        let mediaStore = createMediaStoreAndExportableMedia(at: targetURL, fileManager: fileManager)
 
         let path = "sites/\(sampleSiteID)/media/new"
 
@@ -248,6 +306,116 @@ final class MediaStoreTests: XCTestCase {
         // Verifies that the temporary file is removed after the media is uploaded.
         XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path))
     }
+
+    /// Verifies that `MediaAction.uploadMedia` invokes `MediaRemoteProtocol.uploadMedia` when there is no corresponding site in storage.
+    func test_uploadMedia_without_storage_site_invokes_uploadMedia_remote_call() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // Creates a temporary file to simulate a uploadable media file.
+        let targetURL: URL = {
+            let filename = "test.txt"
+            return fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        }()
+
+        let remote = MockMediaRemote()
+        remote.whenUploadingMedia(siteID: sampleSiteID, thenReturn: .failure(DotcomError.unauthorized))
+
+        let mediaStore = createMediaStoreAndExportableMedia(at: targetURL, fileManager: fileManager, remote: remote)
+
+        let asset = PHAsset()
+
+        // When
+        let _: Result<Media, Error> = waitFor { promise in
+            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+                                                 productID: self.sampleProductID,
+                                                 mediaAsset: asset) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.uploadMedia(siteID: sampleSiteID)])
+    }
+
+    /// Verifies that `MediaAction.uploadMedia` from a JCP site returns the uploaded media from the remote response.
+    func test_uploadMedia_to_jcp_site_returns_uploaded_media_and_deletes_input_media_file() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // Creates a temporary file to simulate a uploadable media file.
+        let targetURL: URL = {
+            let filename = "test.txt"
+            return fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        }()
+
+        let remote = MockMediaRemote()
+        let media = WordPressMedia.fake()
+        remote.whenUploadingMediaToWordPressSite(siteID: sampleSiteID, thenReturn: .success(media))
+
+        let mediaStore = createMediaStoreAndExportableMedia(at: targetURL, fileManager: fileManager, remote: remote)
+
+        let asset = PHAsset()
+
+        insertJCPSiteToStorage(siteID: sampleSiteID)
+
+        // When
+        let result: Result<Media, Error> = waitFor { promise in
+            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+                                                 productID: self.sampleProductID,
+                                                 mediaAsset: asset) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.uploadMediaToWordPressSite(siteID: sampleSiteID)])
+
+        let mediaList = try XCTUnwrap(result.get())
+        XCTAssertEqual(mediaList, media.toMedia())
+
+        // Verifies that the temporary file is removed after the media is uploaded.
+        XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path))
+    }
+
+    /// Verifies that `MediaAction.uploadMedia` from a JCP site returns an error from the remote response.
+    func test_uploadMedia_to_jcp_site_returns_error_from_remote_response() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // Creates a temporary file to simulate a uploadable media file.
+        let targetURL: URL = {
+            let filename = "test.txt"
+            return fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        }()
+
+        let remote = MockMediaRemote()
+        remote.whenUploadingMediaToWordPressSite(siteID: sampleSiteID, thenReturn: .failure(DotcomError.unauthorized))
+
+        let mediaStore = createMediaStoreAndExportableMedia(at: targetURL, fileManager: fileManager, remote: remote)
+
+        let asset = PHAsset()
+
+        insertJCPSiteToStorage(siteID: sampleSiteID)
+
+        // When
+        let result: Result<Media, Error> = waitFor { promise in
+            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+                                                 productID: self.sampleProductID,
+                                                 mediaAsset: asset) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.uploadMediaToWordPressSite(siteID: sampleSiteID)])
+
+        let error = try XCTUnwrap(result.failure as? DotcomError)
+        XCTAssertEqual(error, .unauthorized)
+    }
 }
 
 private extension MediaStoreTests {
@@ -257,10 +425,43 @@ private extension MediaStoreTests {
                                mimeType: "image/jpeg")
     }
 
+    func createMediaStoreAndExportableMedia(at targetURL: URL, fileManager: FileManager, remote: MediaRemoteProtocol? = nil) -> MediaStore {
+        do {
+            try fileManager.createDirectory(at: fileManager.temporaryDirectory, withIntermediateDirectories: true)
+            try "testing".write(toFile: targetURL.path, atomically: true, encoding: String.Encoding.utf8)
+        } catch {
+            XCTFail("Cannot write to target URL: \(targetURL) with error: \(error)")
+        }
+
+        // Verifies that the temporary file exists.
+        XCTAssertTrue(fileManager.fileExists(atPath: targetURL.path))
+
+        let uploadableMedia = createSampleUploadableMedia(targetURL: targetURL)
+        let mediaExportService = MockMediaExportService(uploadableMedia: uploadableMedia)
+        if let remote = remote {
+            return MediaStore(mediaExportService: mediaExportService,
+                              dispatcher: dispatcher,
+                              storageManager: storageManager,
+                              network: network,
+                              remote: remote)
+        } else {
+            return MediaStore(mediaExportService: mediaExportService,
+                              dispatcher: dispatcher,
+                              storageManager: storageManager,
+                              network: network)
+        }
+    }
+
     func date(with dateString: String) -> Date {
         guard let date = DateFormatter.Defaults.iso8601.date(from: dateString) else {
             return Date()
         }
         return date
+    }
+
+    func insertJCPSiteToStorage(siteID: Int64) {
+        // JCP site determination requires a `Site` in storage.
+        let jcpSite = Site.fake().copy(siteID: siteID, isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        storageManager.insertSampleSite(readOnlySite: jcpSite)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5363 

### Description

Apology for the 500+ diffs, 49 of them are from auto-generated code and the test setup is a big lengthy.

This is the final PR to support media upload/download from JCP sites, with most changes in the Yosemite layer after two media endpoints via WordPress site API were implemented in https://github.com/woocommerce/woocommerce-ios/pull/5490. The changes are not feature-flagged because the JCP sites are only accessible behind a feature flag.

- In `MediaStore`, upload/download media using WordPress site API for a JCP site - this requires fetching the `Site` from storage. If there is no `Site`, or if the site is not a JCP site, we use the WP.com API as before
- For testing, some initializers are added with internal access for `MediaStore` and a protocol `MediaRemoteProtocol` is created to enable mocking with `MockMediaRemote`

### Testing instructions

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23) and a Jetpack site (with Jetpack-the-plugin)

#### Jetpack site

- Launch the app, and log in to a Jetpack site if needed
- Go to the Products tab
- Tap on any editable product or create a product
- Tap on the image header to edit photos
- Tap "Add Photos"
- Tap "WordPress Media Library" --> a grid of images from site media library should appear
- Select one photo from the media library
- Dismiss media library
- Tap "Add Photos"
- Choose a photo or take one with camera --> there should be a spinner cell after picking a photo
- Tap "Publish" or "Save" --> the new image should be saved to the site media library remotely, and two images are added to the product

#### JCP site

- In Settings > Switch Store, switch to a JCP site
- In web, make sure there is at least one image in the site media library
- Go to the Products tab
- Tap on any editable product or create a product
- Tap on the image header to edit photos
- Tap "Add Photos"
- Tap "WordPress Media Library" --> a grid of images from site media library should appear
- Select one photo from the media library
- Dismiss media library
- Tap "Add Photos"
- Choose a photo or take one with camera --> there should be a spinner cell after picking a photo
- Tap "Publish" or "Save" --> the new image should be saved to the site media library remotely, and two images are added to the product

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
