### PR TITLE
Jetpack CP: display Install Jetpack row in Settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -193,7 +193,8 @@ private extension SettingsViewModel {
         // Store settings
         let storeSettingsSection: Section = {
             let rows: [Row]
-            if featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport) {
+            if stores.sessionManager.defaultSite?.isJetpackCPConnected == true,
+                featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport) {
                 rows = [.inPersonPayments, .installJetpack]
             } else {
                 rows = [.inPersonPayments]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -1,4 +1,6 @@
+import Codegen
 import XCTest
+import Yosemite
 
 import protocol Storage.StorageType
 import protocol Storage.StorageManagerType
@@ -15,15 +17,19 @@ final class SettingsViewModelTests: XCTestCase {
     ///
     private var stores: MockStoresManager!
 
+    private var sessionManager: SessionManager!
+
     override func setUp() {
         super.setUp()
         storageManager = MockStorageManager()
-        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        sessionManager = .makeForTesting(authenticated: true)
+        stores = MockStoresManager(sessionManager: sessionManager)
     }
 
     override func tearDown() {
         storageManager = nil
         stores = nil
+        sessionManager = nil
         super.tearDown()
     }
 
@@ -38,9 +44,11 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.sections.count > 0)
     }
 
-    func test_sections_contain_install_jetpack_row_when_JCP_support_feature_flag_is_on() {
+    func test_sections_contain_install_jetpack_row_when_JCP_support_feature_flag_is_on_and_default_site_is_jcp() {
         // Given
         let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: true)
+        let site = Site.fake().copy(isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        sessionManager.defaultSite = site
         let viewModel = SettingsViewModel(
             stores: stores,
             storageManager: storageManager,
@@ -51,6 +59,23 @@ final class SettingsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.installJetpack) })
+    }
+
+    func test_sections_do_not_contain_install_jetpack_row_when_JCP_support_feature_flag_is_on_and_default_site_is_not_jcp() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: true)
+        let site = Site.fake().copy(isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        sessionManager.defaultSite = site
+        let viewModel = SettingsViewModel(
+            stores: stores,
+            storageManager: storageManager,
+            featureFlagService: featureFlagService)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.installJetpack) })
     }
 
     func test_sections_do_not_contain_install_jetpack_row_when_JCP_support_feature_flag_is_off() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5371 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Before this PR, "Install Jetpack" row is shown behind the JCP feature flag in Settings. This PR updated the display logic so that the row is only shown when:
- The selected site is Jetpack CP connected (no Jetpack-the-plugin)
- JCP feature flag is enabled

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23) and a Jetpack site (with Jetpack-the-plugin)

#### Jetpack site

- Launch the app and switch to a Jetpack site if needed
- Go to Settings --> there should be no "Install Jetpack" row under the STORE SETTINGS section

#### JCP site

- Switch to a JCP site
- Go to Settings --> there should be an "Install Jetpack" row under the STORE SETTINGS section

#### Jetpack site - feature flag off (JCP sites aren't accessible with feature flag off)

- In `DefaultFeatureFlagService.swift`, return `false` for `jetpackConnectionPackageSupport` feature flag
- Switch to a Jetpack site
- Go to Settings --> there should be no "Install Jetpack" row under the STORE SETTINGS section

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
