### PR TITLE
Stats: Use separate refresh timeouts for periods

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -45,6 +45,21 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         }
     }
 
+    /// Timestamp for last successful data sync
+    var lastFullSyncTimestamp: Date?
+
+    /// Minimal time interval for data refresh
+    var minimalIntervalBetweenSync: TimeInterval {
+        switch timeRange {
+        case .today:
+            return 60
+        case .thisWeek, .thisMonth:
+            return 60*60
+        case .thisYear:
+            return 60*60*12
+        }
+    }
+
     // MARK: Subviews
 
     var refreshControl: UIRefreshControl = {


### PR DESCRIPTION
Part of #5237.

## Description

Previous refresh timeout was 30s for all kinds of data combined. Here we add separated refresh timeouts for stats tabs:
- daily: 60 s
- weekly, monthly: 1 h
- yearly: 12 h

Keep in mind, that first sync after app start will still have all data combined.
Manual pull-to-refresh will also force reload all tabs data.

## Testing

1. Launch app, check 12+ stats requests in proxy/network debugger/Xcode logs.
2. Switch tab to reviews and back to stats within 60 s - verify that only 1 request appears (stats availability check).
3. Switch tab to reviews and back to stats after 60 s - verify that only requests for daily tab appear (3+1).
4. Check that graph footer says "Updated moments ago" for daily tab and "Updated N minutes ago" for other tabs.
5. Reload manually with pull-to-refresh - verify all 12+ requests appear. Footer on all tabs should say "Updated moments ago".

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
