### PR TITLE
Simple Payments: Render taxes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -127,7 +127,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
             switch result {
             case .success(let order):
                 if self.isDevelopmentPrototype {
-                    self.summaryViewModel = SimplePaymentsSummaryViewModel(providedAmount: self.amount)
+                    self.summaryViewModel = SimplePaymentsSummaryViewModel(order: order, providedAmount: self.amount)
                 } else {
                     self.onOrderCreated(order)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -269,23 +269,24 @@ private extension SimplePaymentsSummary {
 // MARK: Previews
 struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "40.0", totalWithTaxes: "$42.3"))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "40.0", totalWithTaxes: "$42.3", taxAmount: "$2.3"))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
         SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(
             providedAmount: "$40.0",
             totalWithTaxes: "$42.3",
+            taxAmount: "$2.3",
             noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."
         ))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3"))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3", taxAmount: "$2.3"))
             .environment(\.colorScheme, .dark)
             .previewDisplayName("Dark")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3"))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3", taxAmount: "$2.3"))
             .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
             .previewDisplayName("Accessibility")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -269,22 +269,23 @@ private extension SimplePaymentsSummary {
 // MARK: Previews
 struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "40.0", totalWithTaxes: "$42.3"))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
         SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(
             providedAmount: "$40.0",
+            totalWithTaxes: "$42.3",
             noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."
         ))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3"))
             .environment(\.colorScheme, .dark)
             .previewDisplayName("Dark")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0"))
+        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3"))
             .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
             .previewDisplayName("Accessibility")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -124,7 +124,18 @@ private struct PaymentsSection: View {
                 TitleAndValueRow(title: SimplePaymentsSummary.Localization.subtotal, value: .content(viewModel.providedAmount), selectable: false) {}
 
                 TitleAndToggleRow(title: SimplePaymentsSummary.Localization.chargeTaxes, isOn: $viewModel.enableTaxes)
-                    .padding([.leading, .trailing])
+                    .padding(.horizontal)
+
+                Group {
+                    Text(SimplePaymentsSummary.Localization.taxesDisclaimer)
+                        .footnoteStyle()
+                        .padding(.horizontal)
+
+                    TitleAndValueRow(title: SimplePaymentsSummary.Localization.taxRate(viewModel.taxRate),
+                                     value: .content(viewModel.taxAmount),
+                                     selectable: false) {}
+                }
+                .renderedIf(viewModel.enableTaxes)
 
                 TitleAndValueRow(title: SimplePaymentsSummary.Localization.total, value: .content(viewModel.total), bold: true, selectable: false) {}
             }
@@ -258,6 +269,12 @@ private extension SimplePaymentsSummary {
                                                comment: "Title text of the button that adds a note when creating a simple payment")
         static let editNote = NSLocalizedString("Edit",
                                                comment: "Title text of the button that edits a note when creating a simple payment")
+        static let taxesDisclaimer = NSLocalizedString("Taxes are automatically calculated based on your store address.",
+                                                       comment: "Disclaimer in the simple payments summary screen about taxes.")
+
+        static func taxRate(_ rate: String) -> String {
+            NSLocalizedString("Tax (\(rate)%)", comment: "Tax percentage to be applied to the simple payments order")
+        }
 
         static func takePayment(total: String) -> String {
             NSLocalizedString("Take Payment (\(total))",

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -9,6 +9,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     let providedAmount: String
 
+    /// Store tax percentage rate.
+    ///
+    let taxRate: String
+
     /// Email of the costumer. To be used as the billing address email.
     ///
     @Published var email: String = ""
@@ -48,6 +52,12 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.currencyFormatter = currencyFormatter
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
         self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? providedAmount
+        self.taxRate = {
+            let amount = currencyFormatter.convertToDecimal(from: providedAmount)?.decimalValue ?? Decimal.zero
+            let total = currencyFormatter.convertToDecimal(from: totalWithTaxes)?.decimalValue ?? Decimal.zero
+            let rate = ((total / amount) - Decimal(1)) * Decimal(100)
+            return currencyFormatter.localize(rate) ?? "\(rate)"
+        }()
 
         // Used mostly in previews
         if let noteContent = noteContent {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -63,6 +63,12 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.taxRate = {
             let amount = currencyFormatter.convertToDecimal(from: providedAmount)?.decimalValue ?? Decimal.zero
             let tax = currencyFormatter.convertToDecimal(from: taxAmount)?.decimalValue ?? Decimal.zero
+
+            // Prevent dividing by zero
+            guard amount > .zero else {
+                return "0"
+            }
+
             let rate = (tax / amount) * Decimal(100)
             return currencyFormatter.localize(rate) ?? "\(rate)"
         }()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -13,6 +13,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     let taxRate: String
 
+    /// Tax amount to charge.
+    ///
+    let taxAmount: String
+
     /// Email of the costumer. To be used as the billing address email.
     ///
     @Published var email: String = ""
@@ -21,7 +25,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     @Published var enableTaxes: Bool = false
 
-    /// Total to charge. With or Without taxes.
+    /// Total to charge. With or without taxes.
     ///
     var total: String {
         enableTaxes ? totalWithTaxes : providedAmount
@@ -47,15 +51,17 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
 
     init(providedAmount: String,
          totalWithTaxes: String,
+         taxAmount: String,
          noteContent: String? = nil,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.currencyFormatter = currencyFormatter
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
-        self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? providedAmount
+        self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? totalWithTaxes
+        self.taxAmount = currencyFormatter.formatAmount(taxAmount) ?? taxAmount
         self.taxRate = {
             let amount = currencyFormatter.convertToDecimal(from: providedAmount)?.decimalValue ?? Decimal.zero
-            let total = currencyFormatter.convertToDecimal(from: totalWithTaxes)?.decimalValue ?? Decimal.zero
-            let rate = ((total / amount) - Decimal(1)) * Decimal(100)
+            let tax = currencyFormatter.convertToDecimal(from: taxAmount)?.decimalValue ?? Decimal.zero
+            let rate = (tax / amount) * Decimal(100)
             return currencyFormatter.localize(rate) ?? "\(rate)"
         }()
 
@@ -70,6 +76,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.init(providedAmount: providedAmount,
                   totalWithTaxes: order.total,
+                  taxAmount: order.totalTax,
                   currencyFormatter: currencyFormatter)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -58,6 +58,8 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
         self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? totalWithTaxes
         self.taxAmount = currencyFormatter.formatAmount(taxAmount) ?? taxAmount
+
+        // rate_percentage = taxAmount / providedAmount * 100
         self.taxRate = {
             let amount = currencyFormatter.convertToDecimal(from: providedAmount)?.decimalValue ?? Decimal.zero
             let tax = currencyFormatter.convertToDecimal(from: taxAmount)?.decimalValue ?? Decimal.zero

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -59,4 +59,13 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.providedAmount, "$100.00")
         XCTAssertEqual(viewModel.total, "$104.30")
     }
+
+    func test_tax_rate_is_calculated_properly() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", currencyFormatter: currencyFormatter)
+
+        // When & Then
+        XCTAssertEqual(viewModel.taxRate, "4.30")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -10,7 +10,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_updating_noteViewModel_updates_noteContent_property() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30")
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30", taxAmount: "$4.3")
 
         // When
         viewModel.noteViewModel.newNote = "Updated note"
@@ -21,7 +21,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_calling_reloadContent_triggers_viewModel_update() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30")
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30", taxAmount: "$4.3")
 
         // When
         let triggeredUpdate: Bool = waitFor { promise in
@@ -40,7 +40,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_provided_amount_gets_properly_formatted() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", currencyFormatter: currencyFormatter)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "$4.3", currencyFormatter: currencyFormatter)
 
         // When & Then
         XCTAssertEqual(viewModel.providedAmount, "$100.00")
@@ -50,7 +50,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_provided_amount_with_taxes_gets_properly_formatted() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", currencyFormatter: currencyFormatter)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "$4.3", currencyFormatter: currencyFormatter)
 
         // When
         viewModel.enableTaxes = true
@@ -60,10 +60,19 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.total, "$104.30")
     }
 
+    func test_tax_amount_is_properly_formatted() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "4.3", currencyFormatter: currencyFormatter)
+
+        // When & Then
+        XCTAssertEqual(viewModel.taxAmount, "$4.30")
+    }
+
     func test_tax_rate_is_calculated_properly() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", currencyFormatter: currencyFormatter)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "$4.3", currencyFormatter: currencyFormatter)
 
         // When & Then
         XCTAssertEqual(viewModel.taxRate, "4.30")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -10,7 +10,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_updating_noteViewModel_updates_noteContent_property() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00")
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30")
 
         // When
         viewModel.noteViewModel.newNote = "Updated note"
@@ -21,7 +21,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_calling_reloadContent_triggers_viewModel_update() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00")
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30")
 
         // When
         let triggeredUpdate: Bool = waitFor { promise in
@@ -40,10 +40,23 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_provided_amount_gets_properly_formatted() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", currencyFormatter: currencyFormatter)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", currencyFormatter: currencyFormatter)
 
         // When & Then
         XCTAssertEqual(viewModel.providedAmount, "$100.00")
         XCTAssertEqual(viewModel.total, "$100.00")
+    }
+
+    func test_provided_amount_with_taxes_gets_properly_formatted() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", currencyFormatter: currencyFormatter)
+
+        // When
+        viewModel.enableTaxes = true
+
+        // Then
+        XCTAssertEqual(viewModel.providedAmount, "$100.00")
+        XCTAssertEqual(viewModel.total, "$104.30")
     }
 }


### PR DESCRIPTION
closes #5348 

# Why

In #5494 we are creating an order with taxes before navigating to the summary screen. This PR takes care of rendering that order with extra emphasis on the taxes section.

# How

- Update `SummaryViewModel` with the necessary properties to render taxes. `taxRate`, `taxAmount`, `totalWithTaxaes`, and `total`.

- Update the `Summary` view to render the taxes fields when the taxes toggle is enabled.

# Demo

https://user-images.githubusercontent.com/562080/143130842-d6b6e5dd-8457-4f0c-84d9-3309c49d69eb.mov

# Testing instructions
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- Enter an amount & tap next
- See the summary screen with the amount you have provided
- Enable the "Charge Taxes" toggle
- See that the taxes section appears and the total reflects the taxes value.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
