### PR TITLE
JCP: Add endpoints for Installing Jetpack plugin from the app

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -545,6 +545,7 @@
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
+		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1132,6 +1133,7 @@
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
+		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1829,6 +1831,7 @@
 				CE50345D21B571A7007573C6 /* SitePlanMapper.swift */,
 				453305E82459DF2100264E50 /* PostMapper.swift */,
 				31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */,
+				DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */,
 				74046E1E217A6B70007DD7BF /* SiteSettingsMapper.swift */,
 				74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */,
 				B53EF53B21814900003E146F /* SuccessResultMapper.swift */,
@@ -2376,6 +2379,7 @@
 				CE430670234B99F50073CBFF /* RefundsRemote.swift in Sources */,
 				B56C1EB620EA757B00D749F9 /* SiteListMapper.swift in Sources */,
 				B50A583921AD861700617455 /* APNSDevice.swift in Sources */,
+				DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */,
 				26455E2425F66982008A1D32 /* ProductAttributeTermRemote.swift in Sources */,
 				7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */,
 				451A97D1260A03900059D135 /* ShippingLabelCustomPackage.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -547,6 +547,7 @@
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
+		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1136,6 +1137,7 @@
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
+		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1956,6 +1958,7 @@
 				2670C3FB270F4E06002FE931 /* SiteListMapperTests.swift */,
 				453305EA2459E01A00264E50 /* PostMapperTests.swift */,
 				311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */,
+				DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */,
 				74A7B4BB217A807400E85A8B /* SiteSettingsMapperTests.swift */,
 				74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */,
 				45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */,
@@ -2688,6 +2691,7 @@
 				AE2D6623272A8F6E004A2C3A /* TelemetryRemoteTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
 				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
+				DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */,
 				CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */,
 				FE28F6EC268436C9004465C7 /* UserRemoteTests.swift in Sources */,
 				020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
+		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1134,6 +1135,7 @@
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
+		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1664,6 +1666,7 @@
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
+				DEC51A96274DD962009F3DF4 /* plugin.json */,
 				31D27C8E2602B553002EDB1D /* plugins.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
 				02AAD53E250092A300BA1E26 /* product-add-or-delete.json */,
@@ -2136,6 +2139,7 @@
 				2670C3FE270F4E6A002FE931 /* sites-malformed.json in Resources */,
 				31B8D6B426583662008E3DB2 /* wcpay-account-not-eligible.json in Resources */,
 				74C8F06C20EEBD5D00B6EDC9 /* broken-order.json in Resources */,
+				DEC51A97274DD962009F3DF4 /* plugin.json in Resources */,
 				45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */,
 				CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */,
 				31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */,

--- a/Networking/Networking/Mapper/SitePluginMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginMapper.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-/// Mapper: SitePlugins
+/// Mapper: SitePlugin
 ///
 struct SitePluginMapper: Mapper {
 
-    /// Site Identifier associated to the plugins that will be parsed.
+    /// Site Identifier associated to the plugin that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID in the plugin endpoint.
     ///
     let siteID: Int64
@@ -22,9 +22,9 @@ struct SitePluginMapper: Mapper {
 }
 
 
-/// SitePluginsEnvelope Disposable Entity:
+/// SitePluginEnvelope Disposable Entity:
 /// The plugins endpoint returns the document within a `data` key. This entity
-/// allows us to do parse all the things with JSONDecoder.
+/// allows us to do parse the returned plugin model with JSONDecoder.
 ///
 private struct SitePluginEnvelope: Decodable {
     let plugin: SitePlugin

--- a/Networking/Networking/Mapper/SitePluginMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginMapper.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Mapper: SitePlugins
+///
+struct SitePlugiMapper: Mapper {
+
+    /// Site Identifier associated to the plugins that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID in the plugin endpoint.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into SitePlugin.
+    ///
+    func map(response: Data) throws -> SitePlugin {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(SitePluginEnvelope.self, from: response).plugin
+    }
+}
+
+
+/// SitePluginsEnvelope Disposable Entity:
+/// The plugins endpoint returns the document within a `data` key. This entity
+/// allows us to do parse all the things with JSONDecoder.
+///
+private struct SitePluginEnvelope: Decodable {
+    let plugin: SitePlugin
+
+    private enum CodingKeys: String, CodingKey {
+        case plugin = "data"
+    }
+}

--- a/Networking/Networking/Mapper/SitePluginMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginMapper.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Mapper: SitePlugins
 ///
-struct SitePlugiMapper: Mapper {
+struct SitePluginMapper: Mapper {
 
     /// Site Identifier associated to the plugins that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID in the plugin endpoint.

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -34,6 +34,22 @@ public class SitePluginsRemote: Remote {
         let mapper = SitePluginMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Activate the plugin with the specified name for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the plugins.
+    ///   - pluginName: Name of the plugin (found with "plugin" key in plugin detail).
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func activatePlugin(for siteID: Int64,
+                               pluginName: String,
+                               completion: @escaping (Result<SitePlugin, Error>) -> Void) {
+        let path = String(format: "%@/%@", Constants.sitePluginsPath, pluginName)
+        let request = JetpackRequest(wooApiVersion: .none, method: .post, siteID: siteID, path: path, parameters: [Constants.statusParameter: Constants.statusActive])
+        let mapper = SitePluginMapper(siteID: siteID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -43,5 +59,7 @@ private extension SitePluginsRemote {
     enum Constants {
         static let sitePluginsPath: String = "wp/v2/plugins"
         static let slugParameter: String = "slug"
+        static let statusParameter: String = "status"
+        static let statusActive: String = "active"
     }
 }

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -22,7 +22,7 @@ public class SitePluginsRemote: Remote {
     /// Install the plugin with the specified slug for a given site.
     ///
     /// - Parameters:
-    ///   - siteID: Site for which we'll fetch the plugins.
+    ///   - siteID: Site for which we'll install the plugin.
     ///   - slug: The plugin’s URL slug in the plugin directory.
     ///   - completion: Closure to be executed upon completion.
     ///
@@ -38,7 +38,7 @@ public class SitePluginsRemote: Remote {
     /// Activate the plugin with the specified name for a given site.
     ///
     /// - Parameters:
-    ///   - siteID: Site for which we'll fetch the plugins.
+    ///   - siteID: Site for which we'll activate the plugin.
     ///   - pluginName: Name of the plugin (found with "plugin" key in plugin detail).
     ///   - completion: Closure to be executed upon completion.
     ///
@@ -54,7 +54,7 @@ public class SitePluginsRemote: Remote {
     /// Get details about the plugin with the specified name for a given site.
     ///
     /// - Parameters:
-    ///   - siteID: Site for which we'll fetch the plugins.
+    ///   - siteID: Site for which we'll get detail the plugin.
     ///   - pluginName: Name of the plugin (found with "plugin" key in plugin detail).
     ///   - completion: Closure to be executed upon completion.
     ///

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -50,6 +50,22 @@ public class SitePluginsRemote: Remote {
         let mapper = SitePluginMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Get details about the plugin with the specified name for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the plugins.
+    ///   - pluginName: Name of the plugin (found with "plugin" key in plugin detail).
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func getPluginDetails(for siteID: Int64,
+                                 pluginName: String,
+                                 completion: @escaping (Result<SitePlugin, Error>) -> Void) {
+        let path = String(format: "%@/%@", Constants.sitePluginsPath, pluginName)
+        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: nil)
+        let mapper = SitePluginMapper(siteID: siteID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -18,6 +18,22 @@ public class SitePluginsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Install the plugin with the specified slug for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the plugins.
+    ///   - slug: The plugin’s URL slug in the plugin directory.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func installPlugin(for siteID: Int64,
+                              slug: String,
+                              completion: @escaping (Result<SitePlugin, Error>) -> Void) {
+        let path = Constants.sitePluginsPath
+        let request = JetpackRequest(wooApiVersion: .none, method: .post, siteID: siteID, path: path, parameters: [Constants.slugParameter: slug])
+        let mapper = SitePluginMapper(siteID: siteID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -26,5 +42,6 @@ public class SitePluginsRemote: Remote {
 private extension SitePluginsRemote {
     enum Constants {
         static let sitePluginsPath: String = "wp/v2/plugins"
+        static let slugParameter: String = "slug"
     }
 }

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -46,7 +46,11 @@ public class SitePluginsRemote: Remote {
                                pluginName: String,
                                completion: @escaping (Result<SitePlugin, Error>) -> Void) {
         let path = String(format: "%@/%@", Constants.sitePluginsPath, pluginName)
-        let request = JetpackRequest(wooApiVersion: .none, method: .post, siteID: siteID, path: path, parameters: [Constants.statusParameter: Constants.statusActive])
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: [Constants.statusParameter: Constants.statusActive])
         let mapper = SitePluginMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
@@ -14,15 +14,15 @@ class SitePluginMapperTests: XCTestCase {
     func test_SitePlugin_fields_are_properly_parsed() {
         let plugin = mapPlugin(from: "plugin")
         XCTAssertNotNil(plugin)
-        
         XCTAssertEqual(plugin?.plugin, "jetpack/jetpack")
         XCTAssertEqual(plugin?.siteID, dummySiteID)
         XCTAssertEqual(plugin?.status, .active)
         XCTAssertEqual(plugin?.name, "Jetpack by WordPress.com")
         XCTAssertEqual(plugin?.pluginUri, "https://jetpack.com")
-        XCTAssertEqual(plugin?.authorUri, "Automattic")
-        XCTAssertEqual(plugin?.descriptionRaw, "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.")
-        XCTAssertEqual(plugin?.descriptionRendered, "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>")
+        XCTAssertEqual(plugin?.author, "Automattic")
+        XCTAssertEqual(plugin?.descriptionRaw, "Bring the power of the WordPress.com cloud to your self-hosted WordPress.")
+        XCTAssertEqual(plugin?.descriptionRendered, "Bring the power of the WordPress.com cloud to your self-hosted WordPress. " +
+                       "<cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>")
         XCTAssertEqual(plugin?.version, "9.5")
         XCTAssertEqual(plugin?.textDomain, "jetpack")
     }
@@ -33,7 +33,7 @@ class SitePluginMapperTests: XCTestCase {
 ///
 private extension SitePluginMapperTests {
 
-    /// Returns the SitePluginsMapper output upon receiving `filename` (Data Encoded)
+    /// Returns the SitePluginMapper output upon receiving `filename` (Data Encoded)
     ///
     func mapPlugin(from filename: String) -> SitePlugin? {
         guard let response = Loader.contentsOf(filename) else {

--- a/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// SitePluginMapper Unit Tests
 ///
-class SitePluginMapperTests: XCTestCase {
+final class SitePluginMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///

--- a/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Networking
+
+/// SitePluginMapper Unit Tests
+///
+class SitePluginMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 1112
+
+    /// Verifies the SitePlugin fields are parsed correctly.
+    ///
+    func test_SitePlugin_fields_are_properly_parsed() {
+        let plugin = mapPlugin(from: "plugin")
+        XCTAssertNotNil(plugin)
+        
+        XCTAssertEqual(plugin?.plugin, "jetpack/jetpack")
+        XCTAssertEqual(plugin?.siteID, dummySiteID)
+        XCTAssertEqual(plugin?.status, .active)
+        XCTAssertEqual(plugin?.name, "Jetpack by WordPress.com")
+        XCTAssertEqual(plugin?.pluginUri, "https://jetpack.com")
+        XCTAssertEqual(plugin?.authorUri, "Automattic")
+        XCTAssertEqual(plugin?.descriptionRaw, "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.")
+        XCTAssertEqual(plugin?.descriptionRendered, "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>")
+        XCTAssertEqual(plugin?.version, "9.5")
+        XCTAssertEqual(plugin?.textDomain, "jetpack")
+    }
+}
+
+
+/// Private Methods.
+///
+private extension SitePluginMapperTests {
+
+    /// Returns the SitePluginsMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapPlugin(from filename: String) -> SitePlugin? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? SitePluginMapper(siteID: dummySiteID).map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
@@ -23,7 +23,7 @@ class SitePluginsRemoteTests: XCTestCase {
 
     /// Verifies that loadPlugins properly parses the sample response.
     ///
-    func test_loadPlugins_properly_returns_plugins() {
+    func test_loadPlugins_properly_returns_plugins() throws {
         let remote = SitePluginsRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "plugins", filename: "plugins")
@@ -36,12 +36,8 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugins):
-            XCTAssertEqual(plugins.count, 5)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        let plugins = try XCTUnwrap(result.get())
+        XCTAssertEqual(plugins.count, 5)
     }
 
     /// Verifies that loadPlugins properly relays Networking Layer errors.
@@ -57,19 +53,14 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugins):
-            XCTAssertNil(plugins)
-        case .failure(let error):
-            XCTAssertNotNil(error)
-        }
+        XCTAssertTrue(result.isFailure)
     }
 
     // MARK: - Install plugin tests
 
     /// Verifies that installPlugin properly parses the sample response.
     ///
-    func test_installPlugin_properly_returns_plugins() {
+    func test_installPlugin_properly_returns_plugin() throws {
         let remote = SitePluginsRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "plugins", filename: "plugin")
@@ -82,12 +73,8 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugin):
-            XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        let plugin = try XCTUnwrap(result.get())
+        XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
     }
 
     /// Verifies that installPlugin properly relays Networking Layer errors.
@@ -103,19 +90,14 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugin):
-            XCTAssertNil(plugin)
-        case .failure(let error):
-            XCTAssertNotNil(error)
-        }
+        XCTAssertTrue(result.isFailure)
     }
 
     // MARK: - Activate plugin tests
 
     /// Verifies that activatePlugin properly parses the sample response.
     ///
-    func test_activatePlugin_properly_returns_plugins() {
+    func test_activatePlugin_properly_returns_plugins() throws {
         let remote = SitePluginsRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "plugins/jetpack/jetpack", filename: "plugin")
@@ -128,12 +110,8 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugin):
-            XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        let plugin = try XCTUnwrap(result.get())
+        XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
     }
 
     /// Verifies that activatePlugin properly relays Networking Layer errors.
@@ -149,19 +127,14 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugin):
-            XCTAssertNil(plugin)
-        case .failure(let error):
-            XCTAssertNotNil(error)
-        }
+        XCTAssertTrue(result.isFailure)
     }
 
     // MARK: - Get plugin details tests
 
     /// Verifies that getPluginDetails properly parses the sample response.
     ///
-    func test_getPluginDetails_properly_returns_plugins() {
+    func test_getPluginDetails_properly_returns_plugins() throws {
         let remote = SitePluginsRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "plugins/jetpack/jetpack", filename: "plugin")
@@ -174,12 +147,8 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugin):
-            XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        let plugin = try XCTUnwrap(result.get())
+        XCTAssertEqual(plugin.status, .active)
     }
 
     /// Verifies that getPluginDetails properly relays Networking Layer errors.
@@ -195,11 +164,6 @@ class SitePluginsRemoteTests: XCTestCase {
         }
 
         // Then
-        switch result {
-        case .success(let plugin):
-            XCTAssertNil(plugin)
-        case .failure(let error):
-            XCTAssertNotNil(error)
-        }
+        XCTAssertTrue(result.isFailure)
     }
 }

--- a/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
@@ -110,4 +110,96 @@ class SitePluginsRemoteTests: XCTestCase {
             XCTAssertNotNil(error)
         }
     }
+
+    // MARK: - Activate plugin tests
+
+    /// Verifies that activatePlugin properly parses the sample response.
+    ///
+    func test_activatePlugin_properly_returns_plugins() {
+        let remote = SitePluginsRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "plugins/jetpack/jetpack", filename: "plugin")
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.activatePlugin(for: self.sampleSiteID, pluginName: "jetpack/jetpack") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        switch result {
+        case .success(let plugin):
+            XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
+        case .failure(let error):
+            XCTAssertNil(error)
+        }
+    }
+
+    /// Verifies that activatePlugin properly relays Networking Layer errors.
+    ///
+    func test_activatePlugin_properly_relays_netwoking_errors() {
+        let remote = SitePluginsRemote(network: network)
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.activatePlugin(for: self.sampleSiteID, pluginName: "jetpack/jetpack") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        switch result {
+        case .success(let plugin):
+            XCTAssertNil(plugin)
+        case .failure(let error):
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - Get plugin details tests
+
+    /// Verifies that getPluginDetails properly parses the sample response.
+    ///
+    func test_getPluginDetails_properly_returns_plugins() {
+        let remote = SitePluginsRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "plugins/jetpack/jetpack", filename: "plugin")
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.getPluginDetails(for: self.sampleSiteID, pluginName: "jetpack/jetpack") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        switch result {
+        case .success(let plugin):
+            XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
+        case .failure(let error):
+            XCTAssertNil(error)
+        }
+    }
+
+    /// Verifies that getPluginDetails properly relays Networking Layer errors.
+    ///
+    func test_getPluginDetails_properly_relays_netwoking_errors() {
+        let remote = SitePluginsRemote(network: network)
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.getPluginDetails(for: self.sampleSiteID, pluginName: "jetpack/jetpack") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        switch result {
+        case .success(let plugin):
+            XCTAssertNil(plugin)
+        case .failure(let error):
+            XCTAssertNotNil(error)
+        }
+    }
 }

--- a/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
@@ -64,4 +64,50 @@ class SitePluginsRemoteTests: XCTestCase {
             XCTAssertNotNil(error)
         }
     }
+
+    // MARK: - Install plugin tests
+
+    /// Verifies that installPlugin properly parses the sample response.
+    ///
+    func test_installPlugin_properly_returns_plugins() {
+        let remote = SitePluginsRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "plugins", filename: "plugin")
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.installPlugin(for: self.sampleSiteID, slug: "jetpack") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        switch result {
+        case .success(let plugin):
+            XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
+        case .failure(let error):
+            XCTAssertNil(error)
+        }
+    }
+
+    /// Verifies that installPlugin properly relays Networking Layer errors.
+    ///
+    func test_installPlugin_properly_relays_netwoking_errors() {
+        let remote = SitePluginsRemote(network: network)
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.installPlugin(for: self.sampleSiteID, slug: "jetpack") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        switch result {
+        case .success(let plugin):
+            XCTAssertNil(plugin)
+        case .failure(let error):
+            XCTAssertNotNil(error)
+        }
+    }
 }

--- a/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// SitePluginsRemote Unit Tests
 ///
-class SitePluginsRemoteTests: XCTestCase {
+final class SitePluginsRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///

--- a/Networking/NetworkingTests/Responses/plugin.json
+++ b/Networking/NetworkingTests/Responses/plugin.json
@@ -1,0 +1,26 @@
+{
+    "data": {
+        "plugin": "jetpack/jetpack",
+        "status": "active",
+        "name": "Jetpack by WordPress.com",
+        "plugin_uri": "https://jetpack.com",
+        "author": "Automattic",
+        "author_uri": "https://jetpack.com",
+        "description": {
+            "raw": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.",
+            "rendered": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>"
+        },
+        "version": "9.5",
+        "network_only": false,
+        "requires_wp": "5.6",
+        "requires_php": "5.6",
+        "textdomain": "jetpack",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wp/v2/plugins/jetpack/jetpack"
+                }
+            ]
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/plugin.json
+++ b/Networking/NetworkingTests/Responses/plugin.json
@@ -7,8 +7,8 @@
         "author": "Automattic",
         "author_uri": "https://jetpack.com",
         "description": {
-            "raw": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.",
-            "rendered": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>"
+            "raw": "Bring the power of the WordPress.com cloud to your self-hosted WordPress.",
+            "rendered": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>"
         },
         "version": "9.5",
         "network_only": false,


### PR DESCRIPTION
Part of #5365

### Description
This PR adds the 3 endpoints for the 3 steps of installing Jetpack. As discussed in p91TBi-6EK-p2, there might be a workaround to make the installation really works, but I figure these 3 steps are mandatory anyway.

The 3 endpoints are generalized just in case we want to install other plugins in the future:
- Install plugin: needs plugin slug as input to install the specified plugin to a site.
- Activate plugin: needs plugin name as input to activate the specified plugin in a site.
- Get plugin details: Also needs plugin name, returns status of a plugin in a site.

### Testing instructions
These endpoints haven't been integrated yet, so CI should just pass for the unit tests added.

### Screenshots
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.