### PR TITLE
Jetpack CP: present install Jetpack screen from Settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -297,6 +297,17 @@ private extension SettingsViewController {
         show(viewController, sender: self)
     }
 
+    func installJetpackWasPressed() {
+        guard let siteURL = ServiceLocator.stores.sessionManager.defaultSite?.url else {
+            return
+        }
+        let installJetpackController = JetpackInstallHostingController(siteURL: siteURL)
+        installJetpackController.setDismissAction { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+        }
+        present(installJetpackController, animated: true, completion: nil)
+    }
+
     func privacyWasPressed() {
         ServiceLocator.analytics.track(.settingsPrivacySettingsTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
@@ -441,6 +452,8 @@ extension SettingsViewController: UITableViewDelegate {
             supportWasPressed()
         case .inPersonPayments:
             inPersonPaymentsWasPressed()
+        case .installJetpack:
+            installJetpackWasPressed()
         case .privacy:
             privacyWasPressed()
         case .betaFeatures:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5370 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the last entry point to install Jetpack in the app for JCP sites - Settings > "Install Jetpack." All changes are in `SettingsViewController`. The settings row is behind the JCP feature flag.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app and log in to a JCP site if needed
- Go to Settings
- Tap on "Install Jetpack" row --> the install screen should be presented, like when tapping on the Jetpack benefits banner in the My store tab

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
