### PR TITLE
JCP: Update Yosemite layer with new actions for installing plugins

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -552,6 +552,7 @@
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
 		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
+		DEC51A9B274E3206009F3DF4 /* plugin-inactive.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1145,6 +1146,7 @@
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
 		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
+		DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "plugin-inactive.json"; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1678,6 +1680,7 @@
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
 				DEC51A96274DD962009F3DF4 /* plugin.json */,
+				DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */,
 				31D27C8E2602B553002EDB1D /* plugins.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
 				02AAD53E250092A300BA1E26 /* product-add-or-delete.json */,
@@ -2176,6 +2179,7 @@
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
 				2685C0DE263B5A4200D9EE97 /* add-on-groups.json in Resources */,
+				DEC51A9B274E3206009F3DF4 /* plugin-inactive.json in Resources */,
 				CCF48B382628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json in Resources */,
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,

--- a/Networking/NetworkingTests/Responses/plugin-inactive.json
+++ b/Networking/NetworkingTests/Responses/plugin-inactive.json
@@ -1,0 +1,26 @@
+{
+    "data": {
+        "plugin": "jetpack/jetpack",
+        "status": "inactive",
+        "name": "Jetpack by WordPress.com",
+        "plugin_uri": "https://jetpack.com",
+        "author": "Automattic",
+        "author_uri": "https://jetpack.com",
+        "description": {
+            "raw": "Bring the power of the WordPress.com cloud to your self-hosted WordPress.",
+            "rendered": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>"
+        },
+        "version": "9.5",
+        "network_only": false,
+        "requires_wp": "5.6",
+        "requires_php": "5.6",
+        "textdomain": "jetpack",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wp/v2/plugins/jetpack/jetpack"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Plugins/SitePluginListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Plugins/SitePluginListViewModelTests.swift
@@ -232,6 +232,8 @@ class PluginListViewModelTests: XCTestCase {
             switch action {
             case .synchronizeSitePlugins(let siteID, _):
                 triggeredSiteID = siteID
+            default:
+                break
             }
         }
         let viewModel = PluginListViewModel(siteID: sampleSiteID, storesManager: storesManager)
@@ -250,6 +252,8 @@ class PluginListViewModelTests: XCTestCase {
             switch action {
             case .synchronizeSitePlugins(_, let completion):
                 completion(.success(()))
+            default:
+                break
             }
         }
         let viewModel = PluginListViewModel(siteID: sampleSiteID, storesManager: storesManager)
@@ -272,6 +276,8 @@ class PluginListViewModelTests: XCTestCase {
             switch action {
             case .synchronizeSitePlugins(_, let completion):
                 completion(.failure(MockPluginError.mockError))
+            default:
+                break
             }
         }
         let viewModel = PluginListViewModel(siteID: sampleSiteID, storesManager: storesManager)

--- a/Yosemite/Yosemite/Actions/SitePluginAction.swift
+++ b/Yosemite/Yosemite/Actions/SitePluginAction.swift
@@ -14,5 +14,5 @@ public enum SitePluginAction: Action {
     case activateSitePlugin(siteID: Int64, pluginName: String, onCompletion: (Result<Void, Error>) -> Void)
 
     /// Get details for the plugin with the specified name for a site given its ID
-    case getPluginDetails(siteID: Int64, pluginName: String, onCompletion: (Result<Void, Error>) -> Void)
+    case getPluginDetails(siteID: Int64, pluginName: String, onCompletion: (Result<SitePlugin, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/SitePluginAction.swift
+++ b/Yosemite/Yosemite/Actions/SitePluginAction.swift
@@ -6,4 +6,13 @@ public enum SitePluginAction: Action {
 
     /// Synchronize all plugins for a site given its ID
     case synchronizeSitePlugins(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Install the plugin with the specified slug for a site given its ID
+    case installSitePlugin(siteID: Int64, slug: String, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Activate the plugin with the specified name for a site given its ID
+    case activateSitePlugin(siteID: Int64, pluginName: String, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Get details for the plugin with the specified name for a site given its ID
+    case getPluginDetails(siteID: Int64, pluginName: String, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/SitePluginStore.swift
+++ b/Yosemite/Yosemite/Stores/SitePluginStore.swift
@@ -29,6 +29,12 @@ public final class SitePluginStore: Store {
         switch action {
         case .synchronizeSitePlugins(let siteID, let onCompletion):
             synchronizeSitePlugins(siteID: siteID, completionHandler: onCompletion)
+        case .installSitePlugin(let siteID, let slug, let onCompletion):
+            installSitePlugin(siteID: siteID, slug: slug, onCompletion: onCompletion)
+        case .activateSitePlugin(let siteID, let pluginName, let onCompletion):
+            activateSitePlugin(siteID: siteID, pluginName: pluginName, onCompletion: onCompletion)
+        case .getPluginDetails(let siteID, let pluginName, let onCompletion):
+            getPluginDetails(siteID: siteID, pluginName: pluginName, onCompletion: onCompletion)
         }
     }
 }
@@ -46,6 +52,18 @@ private extension SitePluginStore {
                 completionHandler(.failure(error))
             }
         }
+    }
+
+    func installSitePlugin(siteID: Int64, slug: String, onCompletion: (Result<Void, Error>) -> Void) {
+        // TODO:
+    }
+
+    func activateSitePlugin(siteID: Int64, pluginName: String, onCompletion: (Result<Void, Error>) -> Void) {
+        // TODO:
+    }
+
+    func getPluginDetails(siteID: Int64, pluginName: String, onCompletion: (Result<Void, Error>) -> Void) {
+        // TODO:
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/SitePluginStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SitePluginStoreTests.swift
@@ -124,6 +124,23 @@ final class SitePluginStoreTests: XCTestCase {
         XCTAssertEqual(plugins.first?.status, SitePluginStatusEnum.active.rawValue)
     }
 
+    func test_activateSitePlugin_completes_with_failure_when_receiving_inactive_plugin() {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "plugins/jetpack/jetpack", filename: "plugin-inactive")
+        let store = SitePluginStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = SitePluginAction.activateSitePlugin(siteID: self.sampleSiteID, pluginName: "jetpack/jetpack") { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     func test_getPluginDetails_stores_plugin_correctly() {
         // Given
         network.simulateResponse(requestUrlSuffix: "plugins/jetpack/jetpack", filename: "plugin")


### PR DESCRIPTION
Part of #5365 

### Description
This PR continues integration for installing plugins by updating Yosemite with 3 new actions: Installing, Activating and Getting plugin details.

For each of those actions, plugin details are upserted to keep stored plugins up-to-date.

### Testing instructions
These new actions haven't been integrated to UI, so CI succeeding is enough.

### Screenshots
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
