### PR TITLE
Store picker: pre-select currently selected store instead of the store from login with store address flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] Now it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab. [https://github.com/woocommerce/woocommerce-ios/pull/5491]
 - [*] Login: Password AutoFill will suggest wordpress.com accounts. [https://github.com/woocommerce/woocommerce-ios/pull/5399]
+- [*] Store picker: after logging in with store address, the pre-selected store is now the currently selected store instead of the store from login flow. [https://github.com/woocommerce/woocommerce-ios/pull/5508]
 - [internal] Migrated Settings screen to MVVM [https://github.com/woocommerce/woocommerce-ios/pull/5393]
 
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -334,15 +334,15 @@ private extension StorePickerViewController {
             return
         }
 
-        // If a site address was passed in credentials, select it
-        if let siteAddress = ServiceLocator.stores.sessionManager.defaultCredentials?.siteAddress,
-            let site = sites.filter({ $0.url == siteAddress }).first {
+        // If there is a defaultSite already set, select it
+        if let site = ServiceLocator.stores.sessionManager.defaultSite {
             currentlySelectedSite = site
             return
         }
 
-        // If there is a defaultSite already set, select it
-        if let site = ServiceLocator.stores.sessionManager.defaultSite {
+        // If a site address was passed in credentials, select it
+        if let siteAddress = ServiceLocator.stores.sessionManager.defaultCredentials?.siteAddress,
+            let site = sites.filter({ $0.url == siteAddress }).first {
             currentlySelectedSite = site
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5493 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the store picker, we previously pre-select a store in the following order:
- Store from login with store address flow (if the user didn't log in with store address, skip to the next one)
- Currently selected store, if available (during the login flow, skip to the next one)
- The first store on the list

This means that if the user logs in with store address, that same store is always pre-selected in the store picker. This PR fixes it by swapping the first two checks so that the currently selected store is pre-selected after logging in.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the WP.com account is connected to multiple WC stores

- Log out from the app
- Tap "Enter Your Store Address"
- Enter a store address and continue
- Enter WP.com credentials to log in --> when reaching the store picker, the store from the previous step should be pre-selected
- In the store picker, tap "Continue"
- Go to Settings > Switch Store --> the pre-selected store should be the current store
- Switch to a different store
- Go to Settings > Switch Store --> the pre-selected store should be the newly selected store

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
