### PR TITLE
[Mobile Payments] Remove reference to led colours when connecting to a card reader

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -47,7 +47,7 @@ private extension CardPresentModalScanningForReader {
         )
 
         static let instruction = NSLocalizedString(
-            "To turn on your card reader, briefly press its power button. When powered on, the power LED will blink blue.",
+            "To turn on your card reader, briefly press its power button.",
             comment: "Label within the modal dialog that appears when searching for a card reader"
         )
 


### PR DESCRIPTION
Closes: #5464 

### Description
* Remove references to the led colours when connecting to a reader, as the current message is specific only to the BBPOS Chipper

### Testing instructions
* Check out the branch, build and run, attempt to connect to a card reader

### Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/143283877-d0026d5d-e1b5-4ba8-b595-61f59a47594f.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/143283887-e8e98834-fdcd-4192-947e-6c8cb6e3ef41.png" width="350"/> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
