### PR TITLE
[Mobile Payments] Display more specific reasons for payment declines

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		030338102705F7D400764131 /* ReceiptTotalLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0303380F2705F7D400764131 /* ReceiptTotalLine.swift */; };
 		311889EB2653286B0080AEA2 /* PaymentIntentMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */; };
+		317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975BF274EB1F9004357B1 /* DeclineReason.swift */; };
 		55CD4BB4273E617C007686D3 /* ReceiptRendererTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CD4BB3273E617C007686D3 /* ReceiptRendererTest.swift */; };
 		5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */; };
 		8FFAA245E257B9EB98E2FCBD /* Pods_SampleReceiptPrinter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */; };
@@ -133,6 +134,7 @@
 		1CC96A71F2937BCB7432766F /* Pods-HardwareTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HardwareTests.debug.xcconfig"; path = "Target Support Files/Pods-HardwareTests/Pods-HardwareTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleReceiptPrinter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIntentMetadataTests.swift; sourceTree = "<group>"; };
+		317975BF274EB1F9004357B1 /* DeclineReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclineReason.swift; sourceTree = "<group>"; };
 		3CF9348BADD5E0518080A61A /* Pods-Hardware.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.debug.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.debug.xcconfig"; sourceTree = "<group>"; };
 		47BDD50287B7B0CF8D769BFC /* Pods-PrinterPlayground.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrinterPlayground.release-alpha.xcconfig"; path = "Target Support Files/Pods-PrinterPlayground/Pods-PrinterPlayground.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		55CD4BB3273E617C007686D3 /* ReceiptRendererTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptRendererTest.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				E1E125AB26EB582B0068A9B0 /* CardReaderSoftwareUpdateState.swift */,
 				D845BDC1262D98C400A3E40F /* CardBrand.swift */,
 				D845BDD9262DAADB00A3E40F /* PaymentMethod.swift */,
+				317975BF274EB1F9004357B1 /* DeclineReason.swift */,
 			);
 			path = CardReader;
 			sourceTree = "<group>";
@@ -763,6 +766,7 @@
 				E1E125B026EB66EA0068A9B0 /* Cancelable+Stripe.swift in Sources */,
 				D80B4656260E1B290092EDC0 /* CurrencyCode.swift in Sources */,
 				D81AE86425E6B77F00D9CFD3 /* CardReaderServiceError.swift in Sources */,
+				317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */,
 				D8DF5F4E25DD9F91008AFE25 /* CardReaderType+Stripe.swift in Sources */,
 				D89B8F1225DDCBCD0001C726 /* Charge+Stripe.swift in Sources */,
 				E1E4FA2F2653CFD5007B9D4F /* PrintingResult.swift in Sources */,

--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		030338102705F7D400764131 /* ReceiptTotalLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0303380F2705F7D400764131 /* ReceiptTotalLine.swift */; };
 		311889EB2653286B0080AEA2 /* PaymentIntentMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */; };
 		317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975BF274EB1F9004357B1 /* DeclineReason.swift */; };
+		317975C2274EBC1F004357B1 /* DeclineReason+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */; };
+		317975C4274ED591004357B1 /* DeclineReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C3274ED591004357B1 /* DeclineReasonTests.swift */; };
 		55CD4BB4273E617C007686D3 /* ReceiptRendererTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CD4BB3273E617C007686D3 /* ReceiptRendererTest.swift */; };
 		5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */; };
 		8FFAA245E257B9EB98E2FCBD /* Pods_SampleReceiptPrinter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */; };
@@ -135,6 +137,8 @@
 		2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleReceiptPrinter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIntentMetadataTests.swift; sourceTree = "<group>"; };
 		317975BF274EB1F9004357B1 /* DeclineReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclineReason.swift; sourceTree = "<group>"; };
+		317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeclineReason+Stripe.swift"; sourceTree = "<group>"; };
+		317975C3274ED591004357B1 /* DeclineReasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclineReasonTests.swift; sourceTree = "<group>"; };
 		3CF9348BADD5E0518080A61A /* Pods-Hardware.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.debug.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.debug.xcconfig"; sourceTree = "<group>"; };
 		47BDD50287B7B0CF8D769BFC /* Pods-PrinterPlayground.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrinterPlayground.release-alpha.xcconfig"; path = "Target Support Files/Pods-PrinterPlayground/Pods-PrinterPlayground.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		55CD4BB3273E617C007686D3 /* ReceiptRendererTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptRendererTest.swift; sourceTree = "<group>"; };
@@ -376,6 +380,7 @@
 				D80B4651260E19590092EDC0 /* PaymentIntentParametersTests.swift */,
 				D845BDFE262DDA6A00A3E40F /* ReceiptDetailsTests.swift */,
 				D845BE02262DDBF500A3E40F /* CardBrandTests.swift */,
+				317975C3274ED591004357B1 /* DeclineReasonTests.swift */,
 			);
 			path = HardwareTests;
 			sourceTree = "<group>";
@@ -435,6 +440,7 @@
 				D845BDCF262D9C6C00A3E40F /* ReceiptDetails+Stripe.swift */,
 				D845BDDD262DAB8300A3E40F /* PaymentMethod+Stripe.swift */,
 				E1E125AF26EB66EA0068A9B0 /* Cancelable+Stripe.swift */,
+				317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */,
 			);
 			path = StripeCardReader;
 			sourceTree = "<group>";
@@ -747,6 +753,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D845BE59262ED84000A3E40F /* AirPrintReceiptPrinterService.swift in Sources */,
+				317975C2274EBC1F004357B1 /* DeclineReason+Stripe.swift in Sources */,
 				D845BDB8262D97B300A3E40F /* ReceiptDetails.swift in Sources */,
 				D88FDB2D25DD21B000CB0DBD /* PaymentIntentParameters.swift in Sources */,
 				D89B8F0825DDC8F60001C726 /* Charge.swift in Sources */,
@@ -818,6 +825,7 @@
 				D88303DB25E450E700C877F9 /* PaymentIntentTests.swift in Sources */,
 				D845BE03262DDBF500A3E40F /* CardBrandTests.swift in Sources */,
 				311889EB2653286B0080AEA2 /* PaymentIntentMetadataTests.swift in Sources */,
+				317975C4274ED591004357B1 /* DeclineReasonTests.swift in Sources */,
 				D845BDFB262DD97E00A3E40F /* MockStripeReceiptDetails.swift in Sources */,
 				D845BDF5262DD67E00A3E40F /* MockStripeCardPresentDetails.swift in Sources */,
 				D88303D125E44B2500C877F9 /* ChargeTests.swift in Sources */,

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -311,6 +311,9 @@ updating the application or using a different reader
             return NSLocalizedString("The system experienced an unexpected software error",
                                      comment: "Error message when the card reader service experiences an unexpected software error.")
         case .paymentDeclinedByPaymentProcessorAPI:
+            if case let .paymentDeclinedByPaymentProcessorAPI(declineReason) = self {
+                return declineReason.localizedDescription
+            }
             return NSLocalizedString("The card was declined by the payment processor - please try another means of payment",
                                      comment: "Error message when the card processor declines the payment.")
         case .paymentDeclinedByCardReader:

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -65,7 +65,7 @@ extension CardReaderServiceError: LocalizedError {
 
 /// Underlying error. Models the specific error that made a given
 /// interaction with the SDK fail.
-public enum UnderlyingError: Error {
+public enum UnderlyingError: Error, Equatable {
     /// The service is busy executing another command. The service can only execute a single command at a time.
     case busy
 
@@ -171,7 +171,7 @@ public enum UnderlyingError: Error {
     case unexpectedSDKError
 
     /// The Stripe API declined the payment
-    case paymentDeclinedByPaymentProcessorAPI
+    case paymentDeclinedByPaymentProcessorAPI(declineReason: DeclineReason)
 
     /// The reader declined the payment. Try another card.
     case paymentDeclinedByCardReader

--- a/Hardware/Hardware/CardReader/DeclineReason.swift
+++ b/Hardware/Hardware/CardReader/DeclineReason.swift
@@ -64,4 +64,52 @@ enum DeclineReason {
     /// payment method.
     ///
     case testCard
+
+    /// The card was declined for an unknown reason. Tell the user this and
+    /// ask them to try another payment method.
+    ///
+    case unknown
+}
+
+extension DeclineReason {
+    public var localizedDescription: String? {
+        switch self {
+        case .temporary:
+            return NSLocalizedString("Trying again may succeed, or try another means of payment",
+                                     comment: "Message when a card is declined due to a potentially temporary problem.")
+        case .fraud:
+            return NSLocalizedString("Try another means of payment",
+                                     comment: "Message when a lost or stolen card is presented for payment. Do NOT disclose fraud.")
+        case .cardNotSupported:
+            return NSLocalizedString("The card does not support this type of purchase. Try another means of payment",
+                                     comment: "Message when the card presented does not allow this type of purchase.")
+        case .currencyNotSupported:
+            return NSLocalizedString("The card does not support this currency. Try another means of payment",
+                                     comment: "Message when the card presented does not support the order currency.")
+        case .duplicateTransaction:
+            return NSLocalizedString("An identical transaction was submitted recently. If you wish to continue, try another means of payment",
+                                     comment: "Message when it looks like a duplicate transaction is being attempted.")
+        case .expiredCard:
+            return NSLocalizedString("The card has expired. Try another means of payment",
+                                     comment: "Message when the presented card is past its expiration date.")
+        case .incorrectPostalCode:
+            return NSLocalizedString("The transaction postal code does not match that of the card presented. Correct the postal code or try another means of payment",
+                                     comment: "Message when the presented card postal code doesn't match the order postal code.")
+        case .insufficientFunds:
+            return NSLocalizedString("Payment declined due to insufficient funds. Try another means of payment",
+                                     comment: "Message when the presented card remaining credit or balance is insufficient for the purchase.")
+        case .invalidAmount:
+            return NSLocalizedString("The payment amount is not allowed for the card presented. Try another means of payment.",
+                                     comment: "Message when the presented card does not allow the purchase amount.")
+        case .pinRequired:
+            return NSLocalizedString("This card requires a PIN code and thus cannot be processed. Try another means of payment",
+                                     comment: "Message when a card requires a PIN code and we have no means of entering such a code.")
+        case .testCard:
+            return NSLocalizedString("System test cards are not permitted for payment. Try another means of payment",
+                                     comment: "Message when attempting to pay for a live transaction with a test card.")
+        case .unknown:
+            return NSLocalizedString("Payment was declined for an unknown reason. Try another means of payment",
+                                     comment: "Message when we don't know exactly why the payment was declined.")
+        }
+    }
 }

--- a/Hardware/Hardware/CardReader/DeclineReason.swift
+++ b/Hardware/Hardware/CardReader/DeclineReason.swift
@@ -13,9 +13,19 @@ enum DeclineReason {
     case temporary
 
     /// The card has been reported lost or stolen. Don't reveal this
-    /// to the user. Just ask them to try another payment method.
+    /// to the user. Treat it like you would a generic decline.
     ///
     case fraud
+
+    /// The payment was declined for an unspecified reason. Ask
+    /// the user to try another payment method.
+    ///
+    case generic
+
+    /// The card, or the account it connects to, is not valid. Ask
+    /// the user to try another payment method.
+    ///
+    case invalidAccount
 
     /// The card presented is not supported. Tell the user this and
     /// ask them to try another payment method.
@@ -59,6 +69,11 @@ enum DeclineReason {
     ///
     case pinRequired
 
+    /// The card presented has had an incorrect PIN entered too many times.
+    /// Tell the user this and ask them to try another payment method.
+    ///
+    case tooManyPinTries
+
     /// The card presented is a system test card and cannot be used to
     /// process a payment. Tell the user this and ask them to try another
     /// payment method.
@@ -80,6 +95,13 @@ extension DeclineReason {
         case .fraud:
             return NSLocalizedString("Try another means of payment",
                                      comment: "Message when a lost or stolen card is presented for payment. Do NOT disclose fraud.")
+        case .generic:
+            return NSLocalizedString("Payment was declined for an unspecified reason. Try another means of payment",
+                                     comment: "Message when payment is declined for a non specific reason.")
+        case .invalidAccount:
+            return NSLocalizedString("The card or card account is invalid. Try another means of payment",
+                                     comment: "Message when payment is declined for a non specific reason.")
+
         case .cardNotSupported:
             return NSLocalizedString("The card does not support this type of purchase. Try another means of payment",
                                      comment: "Message when the card presented does not allow this type of purchase.")
@@ -93,7 +115,7 @@ extension DeclineReason {
             return NSLocalizedString("The card has expired. Try another means of payment",
                                      comment: "Message when the presented card is past its expiration date.")
         case .incorrectPostalCode:
-            return NSLocalizedString("The transaction postal code does not match that of the card presented. Correct the postal code or try another means of payment",
+            return NSLocalizedString("The transaction postal code and card postal code do not match. Try another means of payment",
                                      comment: "Message when the presented card postal code doesn't match the order postal code.")
         case .insufficientFunds:
             return NSLocalizedString("Payment declined due to insufficient funds. Try another means of payment",
@@ -104,6 +126,9 @@ extension DeclineReason {
         case .pinRequired:
             return NSLocalizedString("This card requires a PIN code and thus cannot be processed. Try another means of payment",
                                      comment: "Message when a card requires a PIN code and we have no means of entering such a code.")
+        case .tooManyPinTries:
+            return NSLocalizedString("An incorrect PIN has been entered too many times. Try another means of payment",
+                                     comment: "Message when an incorrect PIN has been entered too many times.")
         case .testCard:
             return NSLocalizedString("System test cards are not permitted for payment. Try another means of payment",
                                      comment: "Message when attempting to pay for a live transaction with a test card.")

--- a/Hardware/Hardware/CardReader/DeclineReason.swift
+++ b/Hardware/Hardware/CardReader/DeclineReason.swift
@@ -80,6 +80,11 @@ public enum DeclineReason {
     ///
     case testCard
 
+    /// The card presented is a live card, but the store/account is in test
+    /// mode. Tell the user this and ask them to use a system test card instead.
+    ///
+    case testModeLiveCard
+
     /// The card was declined for an unknown reason. Tell the user this and
     /// ask them to try another payment method.
     ///
@@ -132,6 +137,9 @@ extension DeclineReason {
         case .testCard:
             return NSLocalizedString("System test cards are not permitted for payment. Try another means of payment",
                                      comment: "Message when attempting to pay for a live transaction with a test card.")
+        case .testModeLiveCard:
+            return NSLocalizedString("A live card was used on a site in test mode. Use a test card instead.",
+                                     comment: "Message when attempting to pay for a test transaction with a live card.")
         case .unknown:
             return NSLocalizedString("Payment was declined for an unknown reason. Try another means of payment",
                                      comment: "Message when we don't know exactly why the payment was declined.")

--- a/Hardware/Hardware/CardReader/DeclineReason.swift
+++ b/Hardware/Hardware/CardReader/DeclineReason.swift
@@ -1,0 +1,67 @@
+/// Defines the distint high level decline reasons we want to handle. Do NOT put
+/// processor specific codes in this file. Use an extension to map
+/// processor specific decline codes to these reasons.
+///
+
+import Foundation
+
+enum DeclineReason {
+    /// A possibly temporary error caused the decline (e.g. the issuing
+    /// bank's servers could not be contacted.) Tell the user this and prompt
+    /// them to try again with the same (or another) payment method.
+    ///
+    case temporary
+
+    /// The card has been reported lost or stolen. Don't reveal this
+    /// to the user. Just ask them to try another payment method.
+    ///
+    case fraud
+
+    /// The card presented is not supported. Tell the user this and
+    /// ask them to try another payment method.
+    ///
+    case cardNotSupported
+
+    /// The currency is not supported by the card presented. Tell the
+    /// user this and ask them to try another payment method.
+    ///
+    case currencyNotSupported
+
+    /// An identical transaction was just completed for the card presented.
+    /// Tell the user this and ask them to try another payment method if they
+    /// really want to do this.
+    ///
+    case duplicateTransaction
+
+    /// The card presented has expired. Tell the user this and ask them
+    /// to try another payment method.
+    ///
+    case expiredCard
+
+    /// The card presented has a different ZIP/postal code than was
+    /// used to place the order. Tell the user this and ask them
+    /// to try another payment method (or correct the order.)
+    ///
+    case incorrectPostalCode
+
+    /// The card presented has insufficient funds for the purchase.
+    /// Tell the user this and ask them to try another payment method.
+    ///
+    case insufficientFunds
+
+    /// The card presented does not allow purchases of the amount
+    /// given. Tell the user this and ask them to try another payment method.
+    ///
+    case invalidAmount
+
+    /// The card presented requires a PIN and the device doesn't support
+    /// PIN entry. Tell the user this and ask them to try another payment method.
+    ///
+    case pinRequired
+
+    /// The card presented is a system test card and cannot be used to
+    /// process a payment. Tell the user this and ask them to try another
+    /// payment method.
+    ///
+    case testCard
+}

--- a/Hardware/Hardware/CardReader/DeclineReason.swift
+++ b/Hardware/Hardware/CardReader/DeclineReason.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum DeclineReason {
+public enum DeclineReason {
     /// A possibly temporary error caused the decline (e.g. the issuing
     /// bank's servers could not be contacted.) Tell the user this and prompt
     /// them to try again with the same (or another) payment method.

--- a/Hardware/Hardware/CardReader/StripeCardReader/DeclineReason+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/DeclineReason+Stripe.swift
@@ -1,0 +1,87 @@
+/// Maps Stripes many decline codes to our decline reasons
+/// See `https://stripe.com/docs/declines/codes`
+///
+
+import Foundation
+import StripeTerminal
+
+extension DeclineReason {
+    init(with stripeDeclineCode: String) {
+        let stripeDeclineCodeDictionary: Dictionary<DeclineReason, [String]> =
+            [
+                .temporary: [
+                    "approve_with_id",
+                    "issuer_not_available",
+                    "processing_error",
+                    "reenter_transaction",
+                    "try_again_later",
+                ],
+                .fraud: [
+                    "call_issuer",
+                    "card_velocity_exceeded",
+                    "do_not_honor",
+                    "do_not_try_again",
+                    "fraudulent",
+                    "lost_card",
+                    "merchant_blacklist",
+                    "pickup_card",
+                    "restricted_card",
+                    "revocation_of_all_authorizations",
+                    "revocation_of_authorization",
+                    "security_violation",
+                    "stolen_card",
+                    "stop_payment_order",
+                ],
+                .generic: [
+                    "generic_decline",
+                    "no_action_taken",
+                    "not_permitted",
+                    "service_not_allowed",
+                    "transaction_not_allowed"
+                ],
+                .invalidAccount: [
+                    "invalid_account",
+                    "new_account_information_available",
+                ],
+                .cardNotSupported: [
+                    "card_not_supported",
+                ],
+                .currencyNotSupported: [
+                    "currency_not_supported",
+                ],
+                .duplicateTransaction: [
+                    "duplicate_transaction",
+                ],
+                .expiredCard: [
+                    "expired_card",
+                ],
+                .incorrectPostalCode: [
+                    "incorrect_zip",
+                ],
+                .insufficientFunds: [
+                    "insufficient_funds",
+                    "withdrawal_count_limit_exceeded",
+                ],
+                .invalidAmount: [
+                    "invalid_amount",
+                ],
+                .pinRequired: [
+                    "invalid_pin",
+                    "offline_pin_required",
+                    "online_or_offline_pin_required",
+                ],
+                .tooManyPinTries: [
+                    "pin_try_exceeded",
+                ],
+                .testCard: [
+                    "testmode_decline",
+                ]
+            ]
+
+        self = stripeDeclineCodeDictionary.first(
+            where: { pair in
+                pair.value.contains(stripeDeclineCode)
+            }
+        )?.key ?? .unknown
+    }
+}

--- a/Hardware/Hardware/CardReader/StripeCardReader/DeclineReason+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/DeclineReason+Stripe.swift
@@ -75,6 +75,9 @@ extension DeclineReason {
                 ],
                 .testCard: [
                     "testmode_decline",
+                ],
+                .testModeLiveCard: [
+                    "test_mode_live_card"
                 ]
             ]
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
@@ -70,7 +70,9 @@ extension UnderlyingError {
         case ErrorCode.Code.unexpectedSdkError.rawValue:
             self = .unexpectedSDKError
         case ErrorCode.Code.declinedByStripeAPI.rawValue:
-            self = .paymentDeclinedByPaymentProcessorAPI
+            let processPaymentError = error as? ProcessPaymentError
+            let declineReason = DeclineReason(with: processPaymentError?.declineCode ?? "")
+            self = .paymentDeclinedByPaymentProcessorAPI(declineReason: declineReason)
         case ErrorCode.Code.declinedByReader.rawValue:
             self = .paymentDeclinedByCardReader
         case ErrorCode.Code.notConnectedToInternet.rawValue:

--- a/Hardware/HardwareTests/DeclineReasonTests.swift
+++ b/Hardware/HardwareTests/DeclineReasonTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import Hardware
+import StripeTerminal
+
+/// Tests the mapping between DeclineReason and Stripe's decline code Strings
+///
+final class DeclineReasonTests: XCTestCase {
+    func test_approve_with_id_maps_to_temporary() {
+        let declineReason = DeclineReason(with: "approve_with_id")
+        XCTAssertEqual(declineReason, .temporary)
+    }
+
+    func test_issuer_not_available_maps_to_temporary() {
+        let declineReason = DeclineReason(with: "issuer_not_available")
+        XCTAssertEqual(declineReason, .temporary)
+    }
+
+    func test_processing_error_maps_to_temporary() {
+        let declineReason = DeclineReason(with: "processing_error")
+        XCTAssertEqual(declineReason, .temporary)
+    }
+
+    func test_reenter_transaction_maps_to_temporary() {
+        let declineReason = DeclineReason(with: "reenter_transaction")
+        XCTAssertEqual(declineReason, .temporary)
+    }
+
+    func test_try_again_later_maps_to_temporary() {
+        let declineReason = DeclineReason(with: "try_again_later")
+        XCTAssertEqual(declineReason, .temporary)
+    }
+
+    func test_call_issuer_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "call_issuer")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_card_velocity_exceeded_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "card_velocity_exceeded")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_do_not_honor_to_fraud() {
+        let declineReason = DeclineReason(with: "do_not_honor")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_do_not_try_again_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "do_not_try_again")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_fraudulent_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "fraudulent")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_lost_card_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "lost_card")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_merchant_blacklist_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "merchant_blacklist")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_pickup_card_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "pickup_card")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_restricted_card_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "restricted_card")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_revocation_of_all_authorizations_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "revocation_of_all_authorizations")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_revocation_of_authorization_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "revocation_of_authorization")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_security_violation_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "security_violation")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_stolen_card_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "stolen_card")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_stop_payment_order_maps_to_fraud() {
+        let declineReason = DeclineReason(with: "stop_payment_order")
+        XCTAssertEqual(declineReason, .fraud)
+    }
+
+    func test_generic_decline_maps_to_generic() {
+        let declineReason = DeclineReason(with: "generic_decline")
+        XCTAssertEqual(declineReason, .generic)
+    }
+
+    func test_no_action_taken_maps_to_generic() {
+        let declineReason = DeclineReason(with: "no_action_taken")
+        XCTAssertEqual(declineReason, .generic)
+    }
+
+    func test_not_permitted_maps_to_generic() {
+        let declineReason = DeclineReason(with: "not_permitted")
+        XCTAssertEqual(declineReason, .generic)
+    }
+
+    func test_service_not_allowed_maps_to_generic() {
+        let declineReason = DeclineReason(with: "service_not_allowed")
+        XCTAssertEqual(declineReason, .generic)
+    }
+
+    func test_new_account_information_available_maps_to_generic() {
+        let declineReason = DeclineReason(with: "generic_decline")
+        XCTAssertEqual(declineReason, .generic)
+    }
+
+    func test_transaction_not_allowed_maps_to_generic() {
+        let declineReason = DeclineReason(with: "transaction_not_allowed")
+        XCTAssertEqual(declineReason, .generic)
+    }
+
+    func test_invalid_account_maps_to_invalidAccount() {
+        let declineReason = DeclineReason(with: "invalid_account")
+        XCTAssertEqual(declineReason, .invalidAccount)
+    }
+
+    func test_new_account_information_available_maps_to_invalidAccount() {
+        let declineReason = DeclineReason(with: "new_account_information_available")
+        XCTAssertEqual(declineReason, .invalidAccount)
+    }
+
+    func test_card_not_supported_maps_to_cardNotSupported() {
+        let declineReason = DeclineReason(with: "card_not_supported")
+        XCTAssertEqual(declineReason, .cardNotSupported)
+    }
+
+    func test_currency_not_supported_maps_to_currencyNotSupported() {
+        let declineReason = DeclineReason(with: "currency_not_supported")
+        XCTAssertEqual(declineReason, .currencyNotSupported)
+    }
+
+    func test_duplicate_transaction_maps_to_duplicateTransaction() {
+        let declineReason = DeclineReason(with: "duplicate_transaction")
+        XCTAssertEqual(declineReason, .duplicateTransaction)
+    }
+
+    func test_expired_card_maps_to_expiredCard() {
+        let declineReason = DeclineReason(with: "expired_card")
+        XCTAssertEqual(declineReason, .expiredCard)
+    }
+
+    func test_incorrect_zip_maps_to_incorrectPostalCode() {
+        let declineReason = DeclineReason(with: "incorrect_zip")
+        XCTAssertEqual(declineReason, .incorrectPostalCode)
+    }
+
+    func test_insufficient_funds_maps_to_insufficientFunds() {
+        let declineReason = DeclineReason(with: "insufficient_funds")
+        XCTAssertEqual(declineReason, .insufficientFunds)
+    }
+
+    func test_withdrawal_count_limit_exceeded_maps_to_insufficientFunds() {
+        let declineReason = DeclineReason(with: "withdrawal_count_limit_exceeded")
+        XCTAssertEqual(declineReason, .insufficientFunds)
+    }
+
+    func test_invalid_amount_maps_to_invalidAmount() {
+        let declineReason = DeclineReason(with: "invalid_amount")
+        XCTAssertEqual(declineReason, .invalidAmount)
+    }
+
+    func test_invalid_pin_maps_to_pinRequired() {
+        let declineReason = DeclineReason(with: "invalid_pin")
+        XCTAssertEqual(declineReason, .pinRequired)
+    }
+
+    func test_offline_pin_required_maps_to_pinRequired() {
+        let declineReason = DeclineReason(with: "offline_pin_required")
+        XCTAssertEqual(declineReason, .pinRequired)
+    }
+
+    func test_online_or_offline_pin_required_maps_to_pinRequired() {
+        let declineReason = DeclineReason(with: "online_or_offline_pin_required")
+        XCTAssertEqual(declineReason, .pinRequired)
+    }
+
+    func test_pin_try_exceeded_maps_to_tooManyPinTries() {
+        let declineReason = DeclineReason(with: "pin_try_exceeded")
+        XCTAssertEqual(declineReason, .tooManyPinTries)
+    }
+
+    func test_testmode_decline_maps_to_testCard() {
+        let declineReason = DeclineReason(with: "testmode_decline")
+        XCTAssertEqual(declineReason, .testCard)
+    }
+}

--- a/Hardware/HardwareTests/DeclineReasonTests.swift
+++ b/Hardware/HardwareTests/DeclineReasonTests.swift
@@ -204,4 +204,9 @@ final class DeclineReasonTests: XCTestCase {
         let declineReason = DeclineReason(with: "testmode_decline")
         XCTAssertEqual(declineReason, .testCard)
     }
+
+    func test_empty_decline_code_maps_to_unknown() {
+        let declineReason = DeclineReason(with: "")
+        XCTAssertEqual(declineReason, .unknown)
+    }
 }

--- a/Hardware/HardwareTests/DeclineReasonTests.swift
+++ b/Hardware/HardwareTests/DeclineReasonTests.swift
@@ -205,6 +205,11 @@ final class DeclineReasonTests: XCTestCase {
         XCTAssertEqual(declineReason, .testCard)
     }
 
+    func test_test_mode_live_card_decline_maps_to_testModeLiveCard() {
+        let declineReason = DeclineReason(with: "test_mode_live_card")
+        XCTAssertEqual(declineReason, .testModeLiveCard)
+    }
+
     func test_empty_decline_code_maps_to_unknown() {
         let declineReason = DeclineReason(with: "")
         XCTAssertEqual(declineReason, .unknown)

--- a/Hardware/HardwareTests/ErrorCodesTests.swift
+++ b/Hardware/HardwareTests/ErrorCodesTests.swift
@@ -135,7 +135,7 @@ final class CardReaderServiceErrorTests: XCTestCase {
     }
 
     func test_stripe_payment_declined_by_processor_api_maps_to_expected_error() {
-        XCTAssertEqual(.paymentDeclinedByPaymentProcessorAPI, domainError(stripeCode: 6000))
+        XCTAssertEqual(.paymentDeclinedByPaymentProcessorAPI(declineReason: .unknown), domainError(stripeCode: 6000))
     }
 
     func test_stripe_payment_declined_by_card_reader_maps_to_expected_error() {


### PR DESCRIPTION
Partially Addresses: #4558

READY FOR REVIEW

### Description
- Payments may be declined for a variety of reasons. And those reasons beg different responses from buyers and merchants (e.g. expired card -> try another card, unable to connect to issuing bank -> just try again)
- Stripe has dozens of decline codes https://stripe.com/docs/declines/codes
- We don't want to hard code support to stripe directly, and many of their codes are highly similar and beg the same responses, so I've added an intermediate layer that groups them into roughly a half dozen DeclineReasons
- We then use that as an associated value for the `paymentDeclinedByPaymentProcessorAPI` `UnderlyingError` case
- We then can display a more appropriate error message to the user

### Testing instructions
- Use a payment amount ending in .05 to trigger a `generic` decline and make sure you get the `Payment was declined for an unspecified reason. Try another means of payment` message
- Use a real credit card on a test site to trigger a `testModeLiveCard` decline and make sure you get the `A live card was used on a site in test mode. Use a test card instead.` message
- Try other amounts on https://stripe.com/docs/terminal/references/testing#physical-test-cards like .55, .65, and .75

### Screenshots

Generic:
<img src="https://user-images.githubusercontent.com/1595739/143320973-bcfa9ccb-529c-4706-af7c-df29de626fbe.PNG" width=50% />

Live Card:
<img src="https://user-images.githubusercontent.com/1595739/143320967-6e14b27f-267b-4855-b1e4-af9e3df3b313.PNG" width=50% />
---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
