### PR TITLE
[Mobile Payments] Present incomplete store address error to user

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
+++ b/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
@@ -3,14 +3,25 @@
 /// It is meant to abstract an implementation of the [adapter pattern](https://en.wikipedia.org/wiki/Adapter_pattern)
 
 public protocol ReaderTokenProvider {
-    func fetchToken(completion: @escaping(Result<String, Error>) -> Void)
+    func fetchToken(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
 }
 
 public protocol ReaderLocationProvider {
-    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void)
+    func fetchDefaultLocationID(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
 }
 
 public protocol CardReaderConfigProvider: ReaderLocationProvider, ReaderTokenProvider {
-    func fetchToken(completion: @escaping(Result<String, Error>) -> Void)
-    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void)
+    func fetchToken(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
+    func fetchDefaultLocationID(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
+}
+
+/// An error that occurs while configuring a reader
+///
+/// - incompleteStoreAddress: The location could not be created because the Store address configured for the site failed validation.
+///     May include URL for wp-admin page to update address.
+/// - unknown: other error cases.
+///
+public enum CardReaderConfigError: Error, LocalizedError {
+    case incompleteStoreAddress(adminUrl: URL?)
+    case unknown(error: Error)
 }

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -10,7 +10,7 @@ public enum CardReaderServiceError: Error {
     case discovery(underlyingError: UnderlyingError = .internalServiceError)
 
     /// Error thrown while connecting to a reader
-    case connection(underlyingError: LocalizedError = UnderlyingError.internalServiceError)
+    case connection(underlyingError: UnderlyingError = .internalServiceError)
 
     /// Error thrown while disonnecting from a reader
     case disconnection(underlyingError: UnderlyingError = .internalServiceError)
@@ -192,6 +192,19 @@ public enum UnderlyingError: Error {
     /// Catch-all error case. Indicates there is something wrong with the
     /// internal state of the CardReaderService.
     case internalServiceError
+
+    case locationIdMissing
+}
+
+extension UnderlyingError {
+    init(with configurationError: CardReaderConfigError) {
+        switch configurationError {
+        case .incompleteStoreAddress(_):
+            self =  .locationIdMissing
+        case .unknown(let error):
+            self  = UnderlyingError(with: error)
+        }
+    }
 }
 
 extension UnderlyingError {
@@ -208,6 +221,10 @@ extension UnderlyingError {
         default:
             return false
         }
+    }
+
+    public var isLocationIDMissingError: Bool {
+        return self == .locationIdMissing
     }
 }
 
@@ -331,6 +348,10 @@ updating the application or using a different reader
         case .internalServiceError:
             return NSLocalizedString("Sorry, this payment couldn’t be processed",
                                      comment: "Error message when the card reader service experiences an unexpected internal service error.")
+
+        case .locationIdMissing:
+            return NSLocalizedString("Location Id missing",
+                                     comment: "Error message when it is not possible to get a location id.")
         }
     }
 }

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -10,7 +10,7 @@ public enum CardReaderServiceError: Error {
     case discovery(underlyingError: UnderlyingError = .internalServiceError)
 
     /// Error thrown while connecting to a reader
-    case connection(underlyingError: UnderlyingError = .internalServiceError)
+    case connection(underlyingError: LocalizedError = UnderlyingError.internalServiceError)
 
     /// Error thrown while disonnecting from a reader
     case disconnection(underlyingError: UnderlyingError = .internalServiceError)

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -281,23 +281,11 @@ extension StripeCardReaderService: CardReaderService {
                 case .success(let locationId):
                     return promise(.success(BluetoothConnectionConfiguration(locationId: locationId)))
                 case .failure(let error):
-                    let underlyingError = self.underlyingError(from: error)
+                    let underlyingError = UnderlyingError(with: error)
                     return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                 }
             }
         }
-    }
-
-    private func underlyingError(from rawError: LocalizedError) -> LocalizedError {
-        if let configError = rawError as? CardReaderConfigError {
-            switch configError {
-            case .incompleteStoreAddress(_):
-                return configError
-            case .unknown(let error):
-                return UnderlyingError(with: error)
-            }
-        }
-        return UnderlyingError(with: rawError)
     }
 
     public func connect(_ reader: StripeTerminal.Reader, configuration: BluetoothConnectionConfiguration) -> Future <CardReader, Error> {

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -281,11 +281,23 @@ extension StripeCardReaderService: CardReaderService {
                 case .success(let locationId):
                     return promise(.success(BluetoothConnectionConfiguration(locationId: locationId)))
                 case .failure(let error):
-                    let underlyingError = UnderlyingError(with: error)
+                    let underlyingError = self.underlyingError(from: error)
                     return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                 }
             }
         }
+    }
+
+    private func underlyingError(from rawError: LocalizedError) -> LocalizedError {
+        if let configError = rawError as? CardReaderConfigError {
+            switch configError {
+            case .incompleteStoreAddress(_):
+                return configError
+            case .unknown(let error):
+                return UnderlyingError(with: error)
+            }
+        }
+        return UnderlyingError(with: rawError)
     }
 
     public func connect(_ reader: StripeTerminal.Reader, configuration: BluetoothConnectionConfiguration) -> Future <CardReader, Error> {

--- a/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
@@ -3,8 +3,11 @@ import StripeTerminal
 /// the mapping is done according to the error codes documented here:
 /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html
 extension UnderlyingError {
-    init(with stripeError: Error) {
+    init?(withStripeError stripeError: Error) {
         let error = stripeError as NSError
+        guard error.domain == ErrorDomain else {
+            return nil
+        }
 
         switch error.code {
         case ErrorCode.Code.busy.rawValue:
@@ -82,7 +85,7 @@ extension UnderlyingError {
         case ErrorCode.Code.stripeAPIError.rawValue:
             self = .processorAPIError
         default:
-            self = .internalServiceError
+            return nil
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -16,7 +16,7 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
 
     let image: UIImage = .paymentErrorImage
 
-    let primaryButtonTitle: String? = Localization.tryAgain
+    let primaryButtonTitle: String? = Localization.retry
 
     let secondaryButtonTitle: String? = Localization.cancel
 
@@ -46,17 +46,20 @@ private extension CardPresentModalConnectingFailedUpdateAddress {
     enum Localization {
         static let title = NSLocalizedString(
             "Please update your store address to proceed.",
-            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails due to address problems"
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to address problems"
         )
 
-        static let tryAgain = NSLocalizedString(
-            "Try again",
-            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This allows the search to continue."
+        static let retry = NSLocalizedString(
+            "Retry After Updating",
+            comment: "Button to try again after connecting to a specific reader fails due to address problems. " +
+            "Intended for use after the merchant corrects the address in the store admin pages."
         )
 
         static let cancel = NSLocalizedString(
             "Cancel",
-            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This also cancels searching."
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails due to address " +
+            "problems. This also cancels searching."
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -1,0 +1,62 @@
+import UIKit
+import Yosemite
+
+/// Modal presented when an error occurs while connecting to a reader due to problems with the address
+///
+final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsModalViewModel {
+    private let continueSearchAction: () -> Void
+    private let cancelSearchAction: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedTopInfo
+    let actionsMode: PaymentsModalActionsMode = .twoAction
+
+    let topTitle: String = Localization.title
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage = .paymentErrorImage
+
+    let primaryButtonTitle: String? = Localization.tryAgain
+
+    let secondaryButtonTitle: String? = Localization.cancel
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? = nil
+
+    let bottomSubtitle: String? = nil
+
+    init(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        self.continueSearchAction = continueSearch
+        self.cancelSearchAction = cancelSearch
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        continueSearchAction()
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        cancelSearchAction()
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalConnectingFailedUpdateAddress {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Please update your store address to proceed.",
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails due to address problems"
+        )
+
+        static let tryAgain = NSLocalizedString(
+            "Try again",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This allows the search to continue."
+        )
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This also cancels searching."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -562,10 +562,17 @@ private extension CardReaderConnectionController {
             self.state = .cancel
         }
 
-        if case CardReaderServiceError.connection(underlyingError: let underlyingError as? CardReaderConfigError) = error,
-           case .incompleteStoreAddress(adminUrl: _) = underlyingError {
+        guard let connectionError = error as? CardReaderConfigError else {
+            alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+            return
+        }
+
+        switch connectionError {
+        case .incompleteStoreAddress(adminUrl: _):
+            // I figure we'd like to pass the store url to the error alert?
             alerts.connectingFailedMissingAddress(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
-        } else {
+        case .unknown(error: _):
+            
             alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -562,17 +562,15 @@ private extension CardReaderConnectionController {
             self.state = .cancel
         }
 
-        guard let connectionError = error as? CardReaderConfigError else {
-            alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
-            return
+        guard case CardReaderServiceError.connection(let underlyingError) = error else {
+            return alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }
 
-        switch connectionError {
+        switch underlyingError {
         case .incompleteStoreAddress(adminUrl: _):
             // I figure we'd like to pass the store url to the error alert?
             alerts.connectingFailedMissingAddress(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
-        case .unknown(error: _):
-            
+        default:
             alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -25,6 +25,12 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         setViewModelAndPresent(from: from, viewModel: connectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch))
     }
 
+    func connectingFailedMissingAddress(from: UIViewController,
+                                        continueSearch: @escaping () -> Void,
+                                        cancelSearch: @escaping () -> Void) {
+        setViewModelAndPresent(from: from, viewModel: connectingFailedUpdateAddress(continueSearch: continueSearch, cancelSearch: cancelSearch))
+    }
+
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) {
         setViewModelAndPresent(from: from, viewModel: updatingFailedLowBattery(from: from, batteryLevel: batteryLevel, close: close))
     }
@@ -158,6 +164,10 @@ private extension CardReaderSettingsAlerts {
 
     func connectingFailed(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch)
+    }
+
+    func connectingFailedUpdateAddress(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalConnectingFailedUpdateAddress(continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -45,6 +45,13 @@ protocol CardReaderSettingsAlertsProvider {
                           continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void)
 
+    /// Defines an alert indicating connecting failed because their address needs updating.
+    /// The user may try again or cancel
+    ///
+    func connectingFailedMissingAddress(from: UIViewController,
+                                        continueSearch: @escaping () -> Void,
+                                        cancelSearch: @escaping () -> Void)
+
     /// Defines an alert indicating an update couldn't be installed because the reader is low on battery.
     ///
     func updatingFailedLowBattery(from: UIViewController,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800825807CD300C3BAD2 /* GridStackView.swift */; };
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
+		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
@@ -1863,6 +1864,7 @@
 		02F6800825807CD300C3BAD2 /* GridStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridStackView.swift; sourceTree = "<group>"; };
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
+		031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectionFailedUpdateAddress.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -6604,6 +6606,7 @@
 				E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */,
 				31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */,
 				31AD0B1026E9575F000B6391 /* CardPresentModalConnectingFailed.swift */,
+				031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */,
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 				D8752EF6265E60F4008ACC80 /* PaymentCaptureCelebration.swift */,
 				03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */,
@@ -8202,6 +8205,7 @@
 				02BA12852461674B008D8325 /* Optional+String.swift in Sources */,
 				744F00D221B582A9007EFA93 /* StarRatingView.swift in Sources */,
 				45F627B9253603AE00894B86 /* ProductDownloadSettingsViewModel.swift in Sources */,
+				031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */,
 				318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */,
 				AEA622B2274669D3002A9B57 /* AddOrderCoordinator.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -83,6 +83,18 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         }
     }
 
+    func connectingFailedMissingAddress(from: UIViewController,
+                                        continueSearch: @escaping () -> Void,
+                                        cancelSearch: @escaping () -> Void) {
+        if mode == .continueSearchingAfterConnectionFailure {
+            continueSearch()
+        }
+
+        if mode == .cancelSearchingAfterConnectionFailure {
+            cancelSearch()
+        }
+    }
+
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) {
         close()
     }

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -112,11 +112,11 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
 
 private final class MockTokenProvider: CardReaderConfigProvider {
-    func fetchToken(completion: @escaping(Result<String, Error>) -> Void) {
+    func fetchToken(completion: @escaping(Result<String, CardReaderConfigError>) -> Void) {
         completion(.success("a token"))
     }
 
-    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void) {
+    func fetchDefaultLocationID(completion: @escaping(Result<String, CardReaderConfigError>) -> Void) {
         completion(.success("a location ID"))
     }
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -128,6 +128,7 @@ public typealias CardReaderEvent = Hardware.CardReaderEvent
 public typealias CardReaderSoftwareUpdateState = Hardware.CardReaderSoftwareUpdateState
 public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDiscoveryStatus
 public typealias CardReaderServiceError = Hardware.CardReaderServiceError
+public typealias CardReaderConfigError = Hardware.CardReaderConfigError
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
 public typealias PaymentIntent = Hardware.PaymentIntent
 public typealias PrintingResult = Hardware.PrintingResult


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #5088
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This change will present an error to the user when they need to update their store address in order to connect to a reader. In a further PR, it will include a button with a link to the WP-Admin page where they can make the change.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. With a store set up for In-Person Payments, go to `WP-Admin > WooCommerce > Settings` and delete the contents of `Address line 1`
2. In the app, go to `⚙️ > In-Person Payments > Manage Card Reader`
3. Search for and connect to a reader (or simulated reader)
4. Observe that the error message is shown telling the merchant to update their address.
5. Update the address in WP-Admin to include `Address line 1` again
6. Tap retry, and connect to the reader again.

Unit tests will follow in a future PR. The retry action could use some polish; e.g. just retrying connection to the exact reader which failed would be much nicer than starting a search again... but that can be an iteration on this for after we send the user to the `adminUrl` or something.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/143595235-441c848e-44e8-41c9-a1da-0646599855bb.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
