### PR TITLE
Simple Payments: Update pending order from Summary screen

### DIFF
--- a/Networking/Networking/Model/OrderFeeLine.swift
+++ b/Networking/Networking/Model/OrderFeeLine.swift
@@ -41,6 +41,7 @@ extension OrderFeeLine {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
+        try container.encode(feeID, forKey: .feeID)
         try container.encode(name, forKey: .name)
         try container.encode(taxClass, forKey: .taxClass)
         try container.encode(taxStatus, forKey: .taxStatus)

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -184,7 +184,7 @@ public class OrdersRemote: Remote {
                         let billingAddressEncoded = try order.billingAddress?.toDictionary()
                         params[Order.CodingKeys.billingAddress.rawValue] = billingAddressEncoded
                     case .fees:
-                        let feesEncoded = try order.fees.toDictionary()
+                        let feesEncoded = try order.fees.map { try $0.toDictionary() }
                         params[Order.CodingKeys.feeLines.rawValue] = feesEncoded
                     }
                 }

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -183,6 +183,9 @@ public class OrdersRemote: Remote {
                     case .billingAddress:
                         let billingAddressEncoded = try order.billingAddress?.toDictionary()
                         params[Order.CodingKeys.billingAddress.rawValue] = billingAddressEncoded
+                    case .fees:
+                        let feesEncoded = try order.fees.toDictionary()
+                        params[Order.CodingKeys.feeLines.rawValue] = feesEncoded
                     }
                 }
             }()
@@ -264,6 +267,7 @@ public extension OrdersRemote {
         case customerNote
         case shippingAddress
         case billingAddress
+        case fees
     }
 
     /// Order fields supported for create

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -252,7 +252,7 @@ final class OrdersRemoteTests: XCTestCase {
     func test_create_order_properly_encodes_fee_lines() throws {
         // Given
         let remote = OrdersRemote(network: network)
-        let fee = OrderFeeLine(feeID: 0, name: "Line", taxClass: "", taxStatus: .none, total: "12.34", totalTax: "", taxes: [], attributes: [])
+        let fee = OrderFeeLine(feeID: 333, name: "Line", taxClass: "", taxStatus: .none, total: "12.34", totalTax: "", taxes: [], attributes: [])
         let order = Order.fake().copy(fees: [fee])
 
         // When
@@ -260,8 +260,9 @@ final class OrdersRemoteTests: XCTestCase {
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
-        let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: String]]).first
-        let expected = [
+        let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: AnyHashable]]).first
+        let expected: [String: AnyHashable] = [
+            "id": fee.feeID,
             "name": fee.name,
             "tax_status": fee.taxStatus.rawValue,
             "tax_class": fee.taxClass,

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -227,9 +227,9 @@ private struct TakePaymentSection: View {
             Divider()
 
             Button(SimplePaymentsSummary.Localization.takePayment(total: viewModel.total), action: {
-                print("Take payment pressed")
+                viewModel.updateOrder()
             })
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
             .padding()
 
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -140,6 +140,17 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                                                            email: email) { [weak self] result in
             guard let self = self else { return }
             self.showLoadingIndicator = false
+
+            switch result {
+            case .success:
+                // TODO: Navigate to Payment Method
+                // TODO: Analytics
+                break
+            case .failure:
+                // TODO: Present notice
+                // TODO: Analytics
+                break
+            }
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -25,6 +25,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     @Published var enableTaxes: Bool = false
 
+    /// Defines if a loading indicator should be shown.
+    ///
+    @Published private(set) var showLoadingIndicator = false
+
     /// Total to charge. With or without taxes.
     ///
     var total: String {
@@ -45,6 +49,22 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     private let currencyFormatter: CurrencyFormatter
 
+    /// Store ID
+    ///
+    private let siteID: Int64
+
+    /// Order ID to update.
+    ///
+    private let orderID: Int64
+
+    /// Fee ID to update.
+    ///
+    private let feeID: Int64
+
+    /// Stores Manager.
+    ///
+    private let stores: StoresManager
+
     /// ViewModel for the edit order note view.
     ///
     lazy private(set) var noteViewModel = SimplePaymentsNoteViewModel()
@@ -53,8 +73,16 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
          totalWithTaxes: String,
          taxAmount: String,
          noteContent: String? = nil,
-         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+         siteID: Int64 = 0,
+         orderID: Int64 = 0,
+         feeID: Int64 = 0,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.orderID = orderID
+        self.feeID = feeID
         self.currencyFormatter = currencyFormatter
+        self.stores = stores
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
         self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? totalWithTaxes
         self.taxAmount = currencyFormatter.formatAmount(taxAmount) ?? taxAmount
@@ -81,16 +109,38 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
 
     convenience init(order: Order,
                      providedAmount: String,
-                     currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+                     currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                     stores: StoresManager = ServiceLocator.stores) {
         self.init(providedAmount: providedAmount,
                   totalWithTaxes: order.total,
                   taxAmount: order.totalTax,
-                  currencyFormatter: currencyFormatter)
+                  siteID: order.siteID,
+                  orderID: order.orderID,
+                  feeID: order.fees.first?.feeID ?? 0,
+                  currencyFormatter: currencyFormatter,
+                  stores: stores)
     }
 
     /// Sends a signal to reload the view. Needed when coming back from the `EditNote` view.
     ///
     func reloadContent() {
         objectWillChange.send()
+    }
+
+    /// Updates the order remotely with the information entered by the merchant.
+    ///
+    func updateOrder() {
+        showLoadingIndicator = true
+        let action = OrderAction.updateSimplePaymentsOrder(siteID: siteID,
+                                                           orderID: orderID,
+                                                           feeID: feeID,
+                                                           amount: providedAmount,
+                                                           taxable: enableTaxes,
+                                                           orderNote: noteContent,
+                                                           email: email) { [weak self] result in
+            guard let self = self else { return }
+            self.showLoadingIndicator = false
+        }
+        stores.dispatch(action)
     }
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -65,11 +65,22 @@ public enum OrderAction: Action {
     ///
     case updateOrder(siteID: Int64, order: Order, fields: [OrderUpdateField], onCompletion: (Result<Order, Error>) -> Void)
 
-    /// Creates a simple payments order with a specific amount value and no tax.
+    /// Creates a simple payments order with a specific amount value and  tax status.
     ///
     case createSimplePaymentsOrder(siteID: Int64, amount: String, taxable: Bool, onCompletion: (Result<Order, Error>) -> Void)
 
     /// Creates a manual order with the provided order details.
     ///
     case createOrder(siteID: Int64, order: Order, onCompletion: (Result<Order, Error>) -> Void)
+
+    /// Updates a simple payments order with the specified values.
+    ///
+    case updateSimplePaymentsOrder(siteID: Int64,
+                                   orderID: Int64,
+                                   feeID: Int64,
+                                   amount: String,
+                                   taxable: Bool,
+                                   orderNote: String?,
+                                   email: String?,
+                                   onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -33,13 +33,19 @@ enum OrderFactory {
               shippingLines: [],
               coupons: [],
               refunds: [],
-              fees: [.init(feeID: 0,
-                           name: "Simple Payments",
-                           taxClass: "",
-                           taxStatus: taxable ? .taxable : .none,
-                           total: amount,
-                           totalTax: "",
-                           taxes: [],
-                           attributes: [])])
+              fees: [simplePaymentFee(feeID: 0, amount: amount, taxable: taxable)])
+    }
+
+    /// Creates a fee line suitable to be used within a simple payments order.
+    ///
+    static func simplePaymentFee(feeID: Int64, amount: String, taxable: Bool) -> OrderFeeLine {
+        .init(feeID: feeID,
+              name: "Simple Payments",
+              taxClass: "",
+              taxStatus: taxable ? .taxable : .none,
+              total: amount,
+              totalTax: "",
+              taxes: [],
+              attributes: [])
     }
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -66,6 +66,16 @@ public class OrderStore: Store {
             createSimplePaymentsOrder(siteID: siteID, amount: amount, taxable: taxable, onCompletion: onCompletion)
         case let .createOrder(siteID, order, onCompletion):
             createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
+
+        case let .updateSimplePaymentsOrder(siteID, orderID, feeID, amount, taxable, orderNote, email, onCompletion):
+            updateSimplePaymentsOrder(siteID: siteID,
+                                      orderID: orderID,
+                                      feeID: feeID,
+                                      amount: amount,
+                                      taxable: taxable,
+                                      orderNote: orderNote,
+                                      email: email,
+                                      onCompletion: onCompletion)
         }
     }
 }
@@ -265,6 +275,41 @@ private extension OrderStore {
                 onCompletion(result)
             }
         }
+    }
+
+    /// Updates a simple payment order with the specified values.
+    ///
+    func updateSimplePaymentsOrder(siteID: Int64,
+                                   orderID: Int64,
+                                   feeID: Int64,
+                                   amount: String,
+                                   taxable: Bool,
+                                   orderNote: String?,
+                                   email: String?,
+                                   onCompletion: @escaping (Result<Order, Error>) -> Void) {
+
+        // Recreate the original order
+        let originalOrder = OrderFactory.simplePaymentsOrder(amount: amount, taxable: taxable)
+
+        // Create updated fields
+        let newFee = OrderFactory.simplePaymentFee(feeID: feeID, amount: amount, taxable: taxable)
+        let newBillingAddress = Address(firstName: "",
+                                        lastName: "",
+                                        company: nil,
+                                        address1: "",
+                                        address2: nil,
+                                        city: "",
+                                        state: "",
+                                        postcode: "",
+                                        country: "",
+                                        phone: nil,
+                                        email: email)
+
+        // Set new fields
+        let updatedOrder = originalOrder.copy(orderID: orderID, customerNote: orderNote, billingAddress: newBillingAddress, fees: [newFee])
+        let updateFields: [OrderUpdateField] = [.customerNote, .billingAddress, .fees]
+
+        updateOrder(siteID: siteID, order: updatedOrder, fields: updateFields, onCompletion: onCompletion)
     }
 
     /// Creates a manual order with the provided order details.

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -644,8 +644,9 @@ final class OrderStoreTests: XCTestCase {
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
-        let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: String]]).first
-        let expected = [
+        let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: AnyHashable]]).first
+        let expected: [String: AnyHashable] = [
+            "id": 0,
             "name": "Simple Payments",
             "tax_status": "none",
             "tax_class": "",
@@ -665,8 +666,9 @@ final class OrderStoreTests: XCTestCase {
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
-        let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: String]]).first
-        let expected = [
+        let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: AnyHashable]]).first
+        let expected: [String: AnyHashable] = [
+            "id": 0,
             "name": "Simple Payments",
             "tax_status": "taxable",
             "tax_class": "",


### PR DESCRIPTION
part of #5483 

# Why

Previous PR #5502 took care of rendering proper taxes on the summary screen, this PR takes care of updating the order remotely with the user selection.

PS: This PR just updates the order, does not navigate to any new screen, and does not handle errors yet.

# How

- Updates `OrderFeeLine` to encode its ID. In order to be able to update the simple payment fee with taxable or not taxable status

- Updates `OrdersRemote` to support encoding fee lines when updating an order

- Updates `OrderStore` with an action to update a simple payments order.

- Update `SummaryViewModel`:
    - Receive via DI all the necessary fields in order to update an order
    - Call the update order action
    - Provide a `loadingIndicator` property
    
- Update `SummaryView` to consume the new values from its VM

# Demo

https://user-images.githubusercontent.com/562080/143479568-8e43b563-46e5-48e6-83d3-3e245300d0c9.mov

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- Enter an amount & tap next
- Enter email, modify taxes, edit note
- Tap "Take Payment Button"
- See a loading spinner on the button
- After it finishes, dismiss the flow and check the order detail to corroborate the changes have been correctly made

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
