### PR TITLE
Order Creation: Products section UI

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -667,10 +667,16 @@ extension UIImage {
         return UIImage(systemName: "plus", withConfiguration: Configurations.barButtonItemSymbol)!
     }
 
-    /// Minus Icon
+    /// Small Plus Icon
     ///
-    static var minusImage: UIImage {
-        return UIImage.gridicon(.minus)
+    static var plusSmallImage: UIImage {
+        return UIImage.gridicon(.plusSmall)
+    }
+
+    /// Small Minus Icon
+    ///
+    static var minusSmallImage: UIImage {
+        return UIImage.gridicon(.minusSmall)
     }
 
     /// Search Icon - used in `UIBarButtonItem`

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -667,6 +667,12 @@ extension UIImage {
         return UIImage(systemName: "plus", withConfiguration: Configurations.barButtonItemSymbol)!
     }
 
+    /// Minus Icon
+    ///
+    static var minusImage: UIImage {
+        return UIImage.gridicon(.minus)
+    }
+
     /// Search Icon - used in `UIBarButtonItem`
     ///
     static var searchBarButtonItemImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -29,7 +29,7 @@ final class NewOrderHostingController: UIHostingController<NewOrder> {
             .sink { [weak self] notice in
                 switch notice {
                 case .error:
-                    self?.noticePresenter.enqueue(notice: .init(title: Localization.errorMessage, feedbackType: .error))
+                    self?.noticePresenter.enqueue(notice: .init(title: NewOrder.Localization.errorMessage, feedbackType: .error))
                 }
 
                 // Nullify the presentation intent.
@@ -83,13 +83,13 @@ private struct ProductsSection: View {
             Divider()
 
             VStack(alignment: .leading, spacing: NewOrder.Layout.verticalSpacing) {
-                Text(Localization.products)
+                Text(NewOrder.Localization.products)
                     .headlineStyle()
 
                 // TODO: Add a product row for each product added to the order
                 ProductRow()
 
-                AddButton(title: Localization.addProduct) {
+                AddButton(title: NewOrder.Localization.addProduct) {
                     // TODO: Open Add Product modal view
                 }
             }
@@ -196,7 +196,7 @@ private struct ProductsSection: View {
 
 // MARK: Custom Views
 /// Represents a button with a plus icon.
-/// Used for any button that adds items to the order.
+/// Used for any button that adds details to the order.
 ///
 private struct AddButton: View {
     let title: String
@@ -225,14 +225,14 @@ private extension NewOrder {
         static let stepperBorderWidth: CGFloat = 1.0
         static let stepperBorderRadius: CGFloat = 4.0
     }
-}
 
-private enum Localization {
-    static let title = NSLocalizedString("New Order", comment: "Title for the order creation screen")
-    static let createButton = NSLocalizedString("Create", comment: "Button to create an order on the New Order screen")
-    static let errorMessage = NSLocalizedString("Unable to create new order", comment: "Notice displayed when order creation fails")
-    static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating a new order")
-    static let addProduct = NSLocalizedString("Add product", comment: "Title text of the button that adds a product when creating a new order")
+    enum Localization {
+        static let title = NSLocalizedString("New Order", comment: "Title for the order creation screen")
+        static let createButton = NSLocalizedString("Create", comment: "Button to create an order on the New Order screen")
+        static let errorMessage = NSLocalizedString("Unable to create new order", comment: "Notice displayed when order creation fails")
+        static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating a new order")
+        static let addProduct = NSLocalizedString("Add product", comment: "Title text of the button that adds a product when creating a new order")
+    }
 }
 
 struct NewOrder_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -46,7 +46,11 @@ struct NewOrder: View {
 
     var body: some View {
         ScrollView {
-            EmptyView()
+            VStack(spacing: Layout.noSpacing) {
+                Spacer(minLength: Layout.spacerHeight)
+
+                ProductsSection()
+            }
         }
         .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
@@ -70,11 +74,66 @@ struct NewOrder: View {
     }
 }
 
+/// Represents the Products section
+///
+private struct ProductsSection: View {
+    var body: some View {
+        Group {
+            Divider()
+
+            VStack(alignment: .leading, spacing: NewOrder.Layout.verticalSpacing) {
+
+                Text(Localization.products)
+                    .headlineStyle()
+
+                // TODO: Add a list of products added to the order
+
+                AddButton(title: Localization.addProduct) {
+                    // TODO: Open Add Product modal view
+                }
+            }
+            .padding()
+            .background(Color(.listForeground))
+
+            Divider()
+        }
+    }
+}
+
+/// Represents a button with a plus icon.
+/// Used for any button that adds items to the order.
+///
+private struct AddButton: View {
+    let title: String
+    let onButtonTapped: () -> Void
+
+    var body: some View {
+        Button(action: { onButtonTapped() }) {
+            Label {
+                Text(title)
+            } icon: {
+                Image(uiImage: .plusImage)
+            }
+            Spacer()
+        }
+    }
+}
+
 // MARK: Constants
+private extension NewOrder {
+    enum Layout {
+        static let spacerHeight: CGFloat = 16.0
+        static let verticalSpacing: CGFloat = 22.0
+        static let noSpacing: CGFloat = 0.0
+    }
+}
+
 private enum Localization {
     static let title = NSLocalizedString("New Order", comment: "Title for the order creation screen")
     static let createButton = NSLocalizedString("Create", comment: "Button to create an order on the New Order screen")
     static let errorMessage = NSLocalizedString("Unable to create new order", comment: "Notice displayed when order creation fails")
+    static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating a new order")
+    static let addProduct = NSLocalizedString("Add product", comment: "Title text of the button that adds a product when creating a new order")
 }
 
 struct NewOrder_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -108,14 +108,19 @@ private struct ProductsSection: View {
     /// Represent a single product row in the Product section
     ///
     struct ProductRow: View {
+
+        // Tracks the scale of the view due to accessibility changes
+        @ScaledMetric private var scale: CGFloat = 1
+
         var body: some View {
             AdaptiveStack(horizontalAlignment: .leading) {
                 HStack(alignment: .top) {
                     // Product image
                     // TODO: Display actual product image when available
                     Image(uiImage: .productPlaceholderImage)
+                        .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: NewOrder.Layout.productImageSize, height: NewOrder.Layout.productImageSize)
+                        .frame(width: NewOrder.Layout.productImageSize * scale, height: NewOrder.Layout.productImageSize * scale)
                         .foregroundColor(Color(UIColor.listSmallIcon))
                         .accessibilityHidden(true)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -48,7 +48,7 @@ struct NewOrder: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(spacing: Layout.noSpacing) {
-                    Spacer(minLength: Layout.spacing)
+                    Spacer(minLength: Layout.sectionSpacing)
 
                     ProductsSection(geometry: geometry)
                 }
@@ -222,7 +222,7 @@ private struct AddButton: View {
 // MARK: Constants
 private extension NewOrder {
     enum Layout {
-        static let spacing: CGFloat = 16.0
+        static let sectionSpacing: CGFloat = 16.0
         static let verticalSpacing: CGFloat = 22.0
         static let noSpacing: CGFloat = 0.0
         static let productImageSize: CGFloat = 44.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -47,7 +47,7 @@ struct NewOrder: View {
     var body: some View {
         ScrollView {
             VStack(spacing: Layout.noSpacing) {
-                Spacer(minLength: Layout.spacerHeight)
+                Spacer(minLength: Layout.spacing)
 
                 ProductsSection()
             }
@@ -74,6 +74,7 @@ struct NewOrder: View {
     }
 }
 
+// MARK: Order Sections
 /// Represents the Products section
 ///
 private struct ProductsSection: View {
@@ -82,11 +83,11 @@ private struct ProductsSection: View {
             Divider()
 
             VStack(alignment: .leading, spacing: NewOrder.Layout.verticalSpacing) {
-
                 Text(Localization.products)
                     .headlineStyle()
 
-                // TODO: Add a list of products added to the order
+                // TODO: Add a product row for each product added to the order
+                ProductRow()
 
                 AddButton(title: Localization.addProduct) {
                     // TODO: Open Add Product modal view
@@ -98,8 +99,102 @@ private struct ProductsSection: View {
             Divider()
         }
     }
+
+    /// Represent a single product row in the Product section
+    ///
+    struct ProductRow: View {
+        var body: some View {
+            AdaptiveStack(horizontalAlignment: .leading) {
+                HStack(alignment: .top) {
+                    // Product image
+                    // TODO: Display actual product image when available
+                    Image(uiImage: .productPlaceholderImage)
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: NewOrder.Layout.productImageSize, height: NewOrder.Layout.productImageSize)
+                        .foregroundColor(Color(UIColor.listSmallIcon))
+
+                    // Product details
+                    VStack(alignment: .leading) {
+                        Text("Love Ficus") // Fake data - product name
+                        Text("7 in stock • $20.00") // Fake data - stock / price
+                            .subheadlineStyle()
+                        Text("SKU: 123456") // Fake data - SKU
+                            .subheadlineStyle()
+                    }
+                }
+
+                Spacer()
+
+                ProductStepper()
+            }
+
+            Divider()
+        }
+    }
+
+    /// Represents a custom stepper.
+    /// Used to change the product quantity in the order.
+    ///
+    struct ProductStepper: View {
+        @State var textSize: CGSize = .zero
+
+        var body: some View {
+            HStack(spacing: NewOrder.Layout.stepperSpacing) {
+                Button {
+                    // TODO: Decrement the product quantity
+                } label: {
+                    Image(uiImage: .minusImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: textSize.height)
+                }
+                Text("1") // Fake data - quantity
+                    .background(ViewGeometry())
+                    .onPreferenceChange(ViewSizeKey.self) {
+                        textSize = $0
+                    }
+                Button {
+                    // TODO: Increment the product quantity
+                } label: {
+                    Image(uiImage: .plusImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: textSize.height)
+                }
+            }
+            .padding()
+            .overlay(
+                RoundedRectangle(cornerRadius: NewOrder.Layout.stepperBorderRadius)
+                    .stroke(Color(UIColor.separator), lineWidth: NewOrder.Layout.stepperBorderWidth)
+            )
+        }
+
+        /// Custom preference key to get the size of a view
+        ///
+        struct ViewSizeKey: PreferenceKey {
+            static var defaultValue: CGSize = .zero
+
+            static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+                value = nextValue()
+            }
+        }
+
+        /// View that calculates its size and sets ViewSizeKey
+        ///
+        /// Used to ensure that stepper button height matches text height, and overlay border is set correctly at larger text sizes.
+        ///
+        struct ViewGeometry: View {
+            var body: some View {
+                GeometryReader { geometry in
+                    Color.clear
+                        .preference(key: ViewSizeKey.self, value: geometry.size)
+                }
+            }
+        }
+    }
 }
 
+// MARK: Custom Views
 /// Represents a button with a plus icon.
 /// Used for any button that adds items to the order.
 ///
@@ -122,9 +217,13 @@ private struct AddButton: View {
 // MARK: Constants
 private extension NewOrder {
     enum Layout {
-        static let spacerHeight: CGFloat = 16.0
+        static let spacing: CGFloat = 16.0
         static let verticalSpacing: CGFloat = 22.0
         static let noSpacing: CGFloat = 0.0
+        static let productImageSize: CGFloat = 44.0
+        static let stepperSpacing: CGFloat = 20.0
+        static let stepperBorderWidth: CGFloat = 1.0
+        static let stepperBorderRadius: CGFloat = 4.0
     }
 }
 
@@ -143,5 +242,8 @@ struct NewOrder_Previews: PreviewProvider {
         NavigationView {
             NewOrder(viewModel: viewModel)
         }
+
+        NewOrder(viewModel: viewModel)
+            .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -155,7 +155,7 @@ private struct ProductsSection: View {
                 Button {
                     // TODO: Decrement the product quantity
                 } label: {
-                    Image(uiImage: .minusImage)
+                    Image(uiImage: .minusSmallImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(height: textSize.height)
@@ -168,7 +168,7 @@ private struct ProductsSection: View {
                 Button {
                     // TODO: Increment the product quantity
                 } label: {
-                    Image(uiImage: .plusImage)
+                    Image(uiImage: .plusSmallImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(height: textSize.height)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -243,7 +243,22 @@ struct NewOrder_Previews: PreviewProvider {
             NewOrder(viewModel: viewModel)
         }
 
-        NewOrder(viewModel: viewModel)
-            .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
+        NavigationView {
+            NewOrder(viewModel: viewModel)
+        }
+        .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
+        .previewDisplayName("Accessibility")
+
+        NavigationView {
+            NewOrder(viewModel: viewModel)
+        }
+        .environment(\.colorScheme, .dark)
+        .previewDisplayName("Dark")
+
+        NavigationView {
+            NewOrder(viewModel: viewModel)
+        }
+        .environment(\.layoutDirection, .rightToLeft)
+        .previewDisplayName("Right to left")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -144,7 +144,7 @@ private struct ProductsSection: View {
         @State var textSize: CGSize = .zero
 
         var body: some View {
-            HStack(spacing: NewOrder.Layout.stepperSpacing) {
+            HStack(spacing: textSize.height) {
                 Button {
                     // TODO: Decrement the product quantity
                 } label: {
@@ -167,7 +167,7 @@ private struct ProductsSection: View {
                         .frame(height: textSize.height)
                 }
             }
-            .padding()
+            .padding(textSize.height/2)
             .overlay(
                 RoundedRectangle(cornerRadius: NewOrder.Layout.stepperBorderRadius)
                     .stroke(Color(UIColor.separator), lineWidth: NewOrder.Layout.stepperBorderWidth)
@@ -226,7 +226,6 @@ private extension NewOrder {
         static let verticalSpacing: CGFloat = 22.0
         static let noSpacing: CGFloat = 0.0
         static let productImageSize: CGFloat = 44.0
-        static let stepperSpacing: CGFloat = 20.0
         static let stepperBorderWidth: CGFloat = 1.0
         static let stepperBorderRadius: CGFloat = 4.0
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -93,9 +93,10 @@ private struct ProductsSection: View {
                 // TODO: Add a product row for each product added to the order
                 ProductRow()
 
-                AddButton(title: NewOrder.Localization.addProduct) {
+                Button(NewOrder.Localization.addProduct) {
                     // TODO: Open Add Product modal view
                 }
+                .buttonStyle(PlusButtonStyle())
             }
             .padding(.horizontal, insets: geometry.safeAreaInsets)
             .padding()
@@ -192,26 +193,6 @@ private struct ProductsSection: View {
                     break
                 }
             }
-        }
-    }
-}
-
-// MARK: Custom Views
-/// Represents a button with a plus icon.
-/// Used for any button that adds details to the order.
-///
-private struct AddButton: View {
-    let title: String
-    let onButtonTapped: () -> Void
-
-    var body: some View {
-        Button(action: { onButtonTapped() }) {
-            Label {
-                Text(title)
-            } icon: {
-                Image(uiImage: .plusImage)
-            }
-            Spacer()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -117,6 +117,7 @@ private struct ProductsSection: View {
                         .aspectRatio(contentMode: .fill)
                         .frame(width: NewOrder.Layout.productImageSize, height: NewOrder.Layout.productImageSize)
                         .foregroundColor(Color(UIColor.listSmallIcon))
+                        .accessibilityHidden(true)
 
                     // Product details
                     VStack(alignment: .leading) {
@@ -126,6 +127,7 @@ private struct ProductsSection: View {
                         Text("SKU: 123456") // Fake data - SKU
                             .subheadlineStyle()
                     }
+                    .accessibilityElement(children: .combine)
                 }
 
                 Spacer()
@@ -172,6 +174,19 @@ private struct ProductsSection: View {
                 RoundedRectangle(cornerRadius: NewOrder.Layout.stepperBorderRadius)
                     .stroke(Color(UIColor.separator), lineWidth: NewOrder.Layout.stepperBorderWidth)
             )
+            .accessibilityElement(children: .ignore)
+            .accessibility(label: Text("Quantity"))
+            .accessibility(value: Text("1")) // Fake static data - quantity
+            .accessibilityAdjustableAction { direction in
+                switch direction {
+                case .decrement:
+                    break // TODO: Decrement the product quantity
+                case .increment:
+                    break // TODO: Increment the product quantity
+                @unknown default:
+                    break
+                }
+            }
         }
 
         /// Custom preference key to get the size of a view

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -148,33 +148,33 @@ private struct ProductsSection: View {
     /// Used to change the product quantity in the order.
     ///
     struct ProductStepper: View {
-        @State var textSize: CGSize = .zero
+
+        // Tracks the scale of the view due to accessibility changes
+        @ScaledMetric private var scale: CGFloat = 1
 
         var body: some View {
-            HStack(spacing: textSize.height) {
+            HStack(spacing: NewOrder.Layout.stepperSpacing * scale) {
                 Button {
                     // TODO: Decrement the product quantity
                 } label: {
                     Image(uiImage: .minusSmallImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(height: textSize.height)
+                        .frame(height: NewOrder.Layout.stepperButtonSize * scale)
                 }
+
                 Text("1") // Fake data - quantity
-                    .background(ViewGeometry())
-                    .onPreferenceChange(ViewSizeKey.self) {
-                        textSize = $0
-                    }
+
                 Button {
                     // TODO: Increment the product quantity
                 } label: {
                     Image(uiImage: .plusSmallImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(height: textSize.height)
+                        .frame(height: NewOrder.Layout.stepperButtonSize * scale)
                 }
             }
-            .padding(textSize.height/2)
+            .padding(NewOrder.Layout.stepperSpacing/2 * scale)
             .overlay(
                 RoundedRectangle(cornerRadius: NewOrder.Layout.stepperBorderRadius)
                     .stroke(Color(UIColor.separator), lineWidth: NewOrder.Layout.stepperBorderWidth)
@@ -190,29 +190,6 @@ private struct ProductsSection: View {
                     break // TODO: Increment the product quantity
                 @unknown default:
                     break
-                }
-            }
-        }
-
-        /// Custom preference key to get the size of a view
-        ///
-        struct ViewSizeKey: PreferenceKey {
-            static var defaultValue: CGSize = .zero
-
-            static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-                value = nextValue()
-            }
-        }
-
-        /// View that calculates its size and sets ViewSizeKey
-        ///
-        /// Used to ensure that stepper button height matches text height, and overlay border is set correctly at larger text sizes.
-        ///
-        struct ViewGeometry: View {
-            var body: some View {
-                GeometryReader { geometry in
-                    Color.clear
-                        .preference(key: ViewSizeKey.self, value: geometry.size)
                 }
             }
         }
@@ -248,6 +225,8 @@ private extension NewOrder {
         static let productImageSize: CGFloat = 44.0
         static let stepperBorderWidth: CGFloat = 1.0
         static let stepperBorderRadius: CGFloat = 4.0
+        static let stepperButtonSize: CGFloat = 22.0
+        static let stepperSpacing: CGFloat = 22.0
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -45,15 +45,17 @@ struct NewOrder: View {
     @ObservedObject var viewModel: NewOrderViewModel
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: Layout.noSpacing) {
-                Spacer(minLength: Layout.spacing)
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(spacing: Layout.noSpacing) {
+                    Spacer(minLength: Layout.spacing)
 
-                ProductsSection()
+                    ProductsSection(geometry: geometry)
+                }
             }
-        }
-        .background(Color(.listBackground))
+            .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+        }
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -78,6 +80,8 @@ struct NewOrder: View {
 /// Represents the Products section
 ///
 private struct ProductsSection: View {
+    let geometry: GeometryProxy
+
     var body: some View {
         Group {
             Divider()
@@ -93,6 +97,7 @@ private struct ProductsSection: View {
                     // TODO: Open Add Product modal view
                 }
             }
+            .padding(.horizontal, insets: geometry.safeAreaInsets)
             .padding()
             .background(Color(.listForeground))
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -23,6 +23,12 @@ struct LinkButtonStyle: ButtonStyle {
     }
 }
 
+struct PlusButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        return PlusButton(configuration: configuration)
+    }
+}
+
 /// Adds a primary button style while showing a progress view on top of the button when required.
 ///
 struct PrimaryLoadingButtonStyle: PrimitiveButtonStyle {
@@ -191,6 +197,28 @@ private struct LinkButton: View {
     }
 }
 
+private struct PlusButton: View {
+    let configuration: ButtonStyleConfiguration
+    
+    var body: some View {
+        HStack {
+            Label {
+                configuration.label
+            } icon: {
+                Image(uiImage: .plusImage)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .foregroundColor(Color(foregroundColor))
+        .background(Color(.clear))
+    }
+    
+    var foregroundColor: UIColor {
+        configuration.isPressed ? .accentDark : .accent
+    }
+}
+
 private enum Style {
     static let defaultCornerRadius = CGFloat(8.0)
     static let defaultBorderWidth = CGFloat(1.0)
@@ -216,6 +244,9 @@ struct PrimaryButton_Previews: PreviewProvider {
 
             Button("Link button") {}
                 .buttonStyle(LinkButtonStyle())
+
+            Button("Plus button") {}
+                .buttonStyle(PlusButtonStyle())
         }
         .padding()
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -199,7 +199,7 @@ private struct LinkButton: View {
 
 private struct PlusButton: View {
     let configuration: ButtonStyleConfiguration
-    
+
     var body: some View {
         HStack {
             Label {
@@ -213,7 +213,7 @@ private struct PlusButton: View {
         .foregroundColor(Color(foregroundColor))
         .background(Color(.clear))
     }
-    
+
     var foregroundColor: UIColor {
         configuration.isPressed ? .accentDark : .accent
     }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -246,6 +246,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.mailImage)
     }
 
+    func test_minus_image_is_not_nil() {
+        XCTAssertNotNil(UIImage.minusImage)
+    }
+
     func testMoreImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.moreImage)
     }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -246,8 +246,8 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.mailImage)
     }
 
-    func test_minus_image_is_not_nil() {
-        XCTAssertNotNil(UIImage.minusImage)
+    func test_minus_small_image_is_not_nil() {
+        XCTAssertNotNil(UIImage.minusSmallImage)
     }
 
     func testMoreImageIconIsNotNil() {
@@ -320,6 +320,10 @@ final class IconsTests: XCTestCase {
 
     func testPlusBarButtonItemImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.plusBarButtonItemImage)
+    }
+
+    func test_plus_small_image_is_not_nil() {
+        XCTAssertNotNil(UIImage.plusSmallImage)
     }
 
     func testPriceImageIconIsNotNil() {


### PR DESCRIPTION
Part of: #5408

## Description

This adds the Products section UI to the New Order screen in the order creation flow. This section includes:

* A row showing product details and a custom stepper to change the product quantity
* A button to add a new product

For now, the UI is static with temporary, fake data. (Future PRs will add real data and interactions.)

## Changes

* Adds the minus gridicon to `UIImage+Woo`.
* To the `NewOrder` view:
   * Adds a `GeometryReader` to calculate the right edge insets for edge-to-edge backgrounds in landscape.
   * Adds a Products section to the view, including a heading, product row, and add product button.
   * Adds a ProductRow view with a custom stepper for product quantity, to go in the Products section. The custom stepper uses a view preference key to capture the text size, and adjust the stepper layout (button size, padding, spacing) according to that size. This ensures the stepper resizes nicely with dynamic font sizes.
   * Adds a reusable `AddButton` view, since we'll have many similar buttons throughout this screen.

For now, I added these views all within `NewOrder.swift`, but it may make sense to eventually separate them to reuse across different screens.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, confirm you see the expected Products section with a product row and `Add product` button.

Accessibility testing:

* Rotate to landscape mode and confirm the layout has the expected padding.
* Change the text size and confirm the layout responds appropriately.
* Build and run the app on device and confirm the VoiceOver controls work well. (Note: For now, the product quantity stepper is using static data so the quantity won't change if you swipe to increment/decrement.)

## Screenshots

Portrait|Landscape
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-11-25 at 16 33 58](https://user-images.githubusercontent.com/8658164/143477798-335c6ac5-b043-465b-942e-96e527d9bd26.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-11-25 at 16 34 00](https://user-images.githubusercontent.com/8658164/143477802-4d5b8b14-78b9-4942-bfbd-cd2dbc4c2e39.png)

Large font size|Dark mode|Right-to-left
-|-|-
![NewOrder-Products-Accessibility](https://user-images.githubusercontent.com/8658164/143477887-400ae4db-3a31-46f9-acdc-3dd371e5d106.png)|![NewOrder-Products-Dark](https://user-images.githubusercontent.com/8658164/143477885-760652c4-15d7-4977-b400-2dd233409c06.png)|![NewOrder-Products-RTL](https://user-images.githubusercontent.com/8658164/143477882-c8a62e4b-eb9e-4af2-8681-a307ed31bf78.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
