### PR TITLE
Simple Payments: Notices Refactor

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderCoordinator.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import Combine
 
 final class AddOrderCoordinator: Coordinator {
     var navigationController: UINavigationController
@@ -70,10 +71,11 @@ private extension AddOrderCoordinator {
     /// Presents `SimplePaymentsAmountHostingController`.
     ///
     func presentSimplePaymentsAmountController() {
-        let viewModel = SimplePaymentsAmountViewModel(siteID: siteID)
+        let presentNoticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
+        let viewModel = SimplePaymentsAmountViewModel(siteID: siteID, presentNoticeSubject: presentNoticeSubject)
         viewModel.onOrderCreated = onOrderCreated
 
-        let viewController = SimplePaymentsAmountHostingController(viewModel: viewModel)
+        let viewController = SimplePaymentsAmountHostingController(viewModel: viewModel, presentNoticePublisher: presentNoticeSubject.eraseToAnyPublisher())
         let simplePaymentsNC = WooNavigationController(rootViewController: viewController)
         navigationController.present(simplePaymentsNC, animated: true)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -14,7 +14,7 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
     ///
     private lazy var modalNoticePresenter: NoticePresenter = {
         let presenter = DefaultNoticePresenter()
-        presenter.presentingViewController = self
+        presenter.presentingViewController = self.navigationController ?? self
         return presenter
     }()
 
@@ -30,9 +30,6 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
         presentNoticePublisher
             .compactMap { $0 }
             .sink { [weak self] notice in
-
-                // To prevent keyboard to hide the notice
-                self?.view.endEditing(true)
 
                 switch notice {
                 case .error(let description):

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -146,7 +146,6 @@ private extension SimplePaymentsAmount {
         static let title = NSLocalizedString("Take Payment", comment: "Title for the simple payments screen")
         static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the simple payments screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the simple payments screen")
-        static let error = NSLocalizedString("There was an error creating the order", comment: "Notice text after failing to create a simple payments order.")
 
         static func buttonTitle() -> String {
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplePaymentsPrototype) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -129,7 +129,9 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
             switch result {
             case .success(let order):
                 if self.isDevelopmentPrototype {
-                    self.summaryViewModel = SimplePaymentsSummaryViewModel(order: order, providedAmount: self.amount)
+                    self.summaryViewModel = SimplePaymentsSummaryViewModel(order: order,
+                                                                           providedAmount: self.amount,
+                                                                           presentNoticeSubject: self.presentNoticeSubject)
                 } else {
                     self.onOrderCreated(order)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -116,6 +116,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
 
     convenience init(order: Order,
                      providedAmount: String,
+                     presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      stores: StoresManager = ServiceLocator.stores) {
         self.init(providedAmount: providedAmount,
@@ -124,6 +125,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                   siteID: order.siteID,
                   orderID: order.orderID,
                   feeID: order.fees.first?.feeID ?? 0,
+                  presentNoticeSubject: presentNoticeSubject,
                   currencyFormatter: currencyFormatter,
                   stores: stores)
     }
@@ -156,7 +158,6 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
             case .failure:
                 self.presentNoticeSubject.send(.error(Localization.updateError))
                 // TODO: Analytics
-                break
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import Combine
 
 /// `ViewModel` to drive the content of the `SimplePaymentsSummary` view.
 ///
@@ -61,6 +62,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     private let feeID: Int64
 
+    /// Transmits notice presentation intents.
+    ///
+    private let presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never>
+
     /// Stores Manager.
     ///
     private let stores: StoresManager
@@ -76,11 +81,13 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
          siteID: Int64 = 0,
          orderID: Int64 = 0,
          feeID: Int64 = 0,
+         presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.orderID = orderID
         self.feeID = feeID
+        self.presentNoticeSubject = presentNoticeSubject
         self.currencyFormatter = currencyFormatter
         self.stores = stores
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
@@ -147,11 +154,19 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                 // TODO: Analytics
                 break
             case .failure:
-                // TODO: Present notice
+                self.presentNoticeSubject.send(.error(Localization.updateError))
                 // TODO: Analytics
                 break
             }
         }
         stores.dispatch(action)
+    }
+}
+
+// MARK: Constants
+private extension SimplePaymentsSummaryViewModel {
+    enum Localization {
+        static let updateError = NSLocalizedString("There was an error updating the order",
+                                                   comment: "Notice text after failing to update a simple payments order.")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -108,4 +108,38 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(loadingStates, [true, false]) // Loading, then not loading.
     }
+
+    func test_view_model_attempts_error_notice_presentation_when_failing_to_update_order() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       presentNoticeSubject: noticeSubject,
+                                                       stores: mockStores)
+        mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        let receivedError: Bool = waitFor { promise in
+            noticeSubject.sink { intent in
+                switch intent {
+                case .error:
+                    promise(true)
+                }
+            }
+            .store(in: &self.subscriptions)
+            viewModel.updateOrder()
+        }
+
+        // Then
+        XCTAssertTrue(receivedError)
+    }
 }


### PR DESCRIPTION
closes #5483 

# Why

After updating the order in #5516, we now have the requirement of showing an error notice when the update operation fails.
However, we have the limitation that notices are presented using an UIKit component and these views are made on `SwiftUI`

Previously, I circumvented that limitation by exposing a `@Published` variable on the `AmountViewModel` that was consumed by the hosting controller, and that worked well until now where the requirement is to present an error notice in the Summary screen which is pushed after the amount screen.

This PR fixes that by allowing multiple stacked views and view models to send a notice intent.

# How

The general idea is to create a Combine `PassthroughSubject` at the main `ViewController` level and pass it to the first view model. That view model will pass it along to any sub-view models that it creates. 

View models will send values into that subject and the hosting controller will subscribe to them and show the required notices.

# Demo

https://user-images.githubusercontent.com/562080/143493031-d023027a-4e6b-4d54-b723-f2314258413e.mov

https://user-images.githubusercontent.com/562080/143493028-696dd74c-9915-4d93-952e-9f58736918c4.mov

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- Enter an amount & tap next
- Enter an invalid email & tap the "Take Payment" button
- See an error notice appear

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
