### PR TITLE
Simple payments: Small UX Pmprovements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -104,6 +104,7 @@ struct SimplePaymentsAmount: View {
                 .foregroundColor(.text)
                 .textAlignment(.center)
                 .keyboardType(.decimalPad)
+                .focused()
                 .fixedSize()
 
             Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -96,6 +96,7 @@ private struct EmailSection: View {
                                  placeholder: SimplePaymentsSummary.Localization.emailPlaceHolder,
                                  text: $viewModel.email,
                                  keyboardType: .emailAddress)
+                .autocapitalization(.none)
                 .background(Color(.listForeground))
 
             Divider()


### PR DESCRIPTION
# Why 

This PR just adds a couple of small UX improvements.
1. Autofocus amount text field when initiating the Simple Payments flow
2. Disable autocapitalization on the email text field on the Summary Screen

# Demo
https://user-images.githubusercontent.com/562080/143495468-710353ba-8640-41ce-8162-4c3d80fad001.mov

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- See that the amount text field is focused automatically
- Enter an amount & tap next
- Tap on the email row
- See that the first letter on the keyboard is not capitalized.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
