### PR TITLE
Jetpack CP: Integrate install Jetpack with UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -225,10 +225,10 @@ private extension DashboardViewController {
             let benefitsController = JetpackBenefitsHostingController()
             benefitsController.setActions { [weak self] in
                 self?.dismiss(animated: true, completion: { [weak self] in
-                    guard let siteURL = ServiceLocator.stores.sessionManager.defaultSite?.url else {
+                    guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
                         return
                     }
-                    let installController = JetpackInstallHostingController(siteURL: siteURL)
+                    let installController = JetpackInstallHostingController(siteID: site.siteID, siteURL: site.url)
                     installController.setDismissAction { [weak self] in
                         self?.dismiss(animated: true, completion: nil)
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallIntroView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallIntroView.swift
@@ -9,6 +9,7 @@ struct JetpackInstallIntroView: View {
     // Closure invoked when Get Started button is tapped
     private let startAction: () -> Void
 
+    // URL of the site to install Jetpack to
     private let siteURL: String
 
     init(siteURL: String, dismissAction: @escaping () -> Void, startAction: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
@@ -78,8 +78,8 @@ struct JetpackInstallStepsView: View {
 
                 // Install steps
                 VStack(alignment: .leading, spacing: Constants.stepItemsVerticalSpacing) {
-                    ForEach(JetpackInstallStep.allCases) { step in
-                        viewModel.currentStep.map { currentStep in
+                    viewModel.currentStep.map { currentStep in
+                        ForEach(JetpackInstallStep.allCases) { step in
                             HStack(spacing: Constants.stepItemHorizontalSpacing) {
                                 if step == currentStep, step != .done {
                                     ActivityIndicator(isAnimating: .constant(true), style: .medium)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
@@ -8,7 +8,7 @@ struct JetpackInstallStepsView: View {
     private let siteURL: String
 
     // View model to handle the installation
-    private let viewModel: JetpackInstallStepsViewModel
+    @ObservedObject private var viewModel: JetpackInstallStepsViewModel
 
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
@@ -34,6 +34,7 @@ struct JetpackInstallStepsView: View {
         self.siteURL = siteURL
         self.viewModel = viewModel
         self.dismissAction = dismissAction
+        viewModel.startInstallation()
     }
 
     var body: some View {
@@ -78,26 +79,28 @@ struct JetpackInstallStepsView: View {
                 // Install steps
                 VStack(alignment: .leading, spacing: Constants.stepItemsVerticalSpacing) {
                     ForEach(JetpackInstallStep.allCases) { step in
-                        HStack(spacing: Constants.stepItemHorizontalSpacing) {
-                            if step == viewModel.currentStep, step != .done {
-                                ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                            } else if step > viewModel.currentStep {
-                                Image(uiImage: .checkEmptyCircleImage)
-                                    .resizable()
-                                    .frame(width: Constants.stepImageSize * scale, height: Constants.stepImageSize * scale)
-                            } else {
-                                Image(uiImage: .checkCircleImage)
-                                    .resizable()
-                                    .frame(width: Constants.stepImageSize * scale, height: Constants.stepImageSize * scale)
-                            }
-
-                            Text(step.title)
-                                .font(.body)
-                                .if(step <= viewModel.currentStep) {
-                                    $0.bold()
+                        viewModel.currentStep.map { currentStep in
+                            HStack(spacing: Constants.stepItemHorizontalSpacing) {
+                                if step == currentStep, step != .done {
+                                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                                } else if step > currentStep {
+                                    Image(uiImage: .checkEmptyCircleImage)
+                                        .resizable()
+                                        .frame(width: Constants.stepImageSize * scale, height: Constants.stepImageSize * scale)
+                                } else {
+                                    Image(uiImage: .checkCircleImage)
+                                        .resizable()
+                                        .frame(width: Constants.stepImageSize * scale, height: Constants.stepImageSize * scale)
                                 }
-                                .foregroundColor(Color(.text))
-                                .opacity(step <= viewModel.currentStep ? 1 : 0.5)
+
+                                Text(step.title)
+                                    .font(.body)
+                                    .if(step <= currentStep) {
+                                        $0.bold()
+                                    }
+                                    .foregroundColor(Color(.text))
+                                    .opacity(step <= currentStep ? 1 : 0.5)
+                            }
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
@@ -7,11 +7,11 @@ struct JetpackInstallStepsView: View {
     /// The site for which Jetpack should be installed
     private let siteURL: String
 
+    // View model to handle the installation
+    private let viewModel: JetpackInstallStepsViewModel
+
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
-
-    /// TODO-5365: Set real step, maybe as an @Published variable from an observable object.
-    @State private var currentStep: JetpackInstallStep = .activation
 
     /// Attributed string for the description text
     private var descriptionAttributedString: NSAttributedString {
@@ -30,8 +30,9 @@ struct JetpackInstallStepsView: View {
         return attributedString
     }
 
-    init(siteURL: String, dismissAction: @escaping () -> Void) {
+    init(siteURL: String, viewModel: JetpackInstallStepsViewModel, dismissAction: @escaping () -> Void) {
         self.siteURL = siteURL
+        self.viewModel = viewModel
         self.dismissAction = dismissAction
     }
 
@@ -78,9 +79,9 @@ struct JetpackInstallStepsView: View {
                 VStack(alignment: .leading, spacing: Constants.stepItemsVerticalSpacing) {
                     ForEach(JetpackInstallStep.allCases) { step in
                         HStack(spacing: Constants.stepItemHorizontalSpacing) {
-                            if step == currentStep, step != .done {
+                            if step == viewModel.currentStep, step != .done {
                                 ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                            } else if step > currentStep {
+                            } else if step > viewModel.currentStep {
                                 Image(uiImage: .checkEmptyCircleImage)
                                     .resizable()
                                     .frame(width: Constants.stepImageSize * scale, height: Constants.stepImageSize * scale)
@@ -92,11 +93,11 @@ struct JetpackInstallStepsView: View {
 
                             Text(step.title)
                                 .font(.body)
-                                .if(step <= currentStep) {
+                                .if(step <= viewModel.currentStep) {
                                     $0.bold()
                                 }
                                 .foregroundColor(Color(.text))
-                                .opacity(step <= currentStep ? 1 : 0.5)
+                                .opacity(step <= viewModel.currentStep ? 1 : 0.5)
                         }
                     }
                 }
@@ -141,11 +142,12 @@ private extension JetpackInstallStepsView {
 
 struct JetpackInstallStepsView_Previews: PreviewProvider {
     static var previews: some View {
-        JetpackInstallStepsView(siteURL: "automattic.com", dismissAction: {})
+        let viewModel = JetpackInstallStepsViewModel(siteID: 123)
+        JetpackInstallStepsView(siteURL: "automattic.com", viewModel: viewModel, dismissAction: {})
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 414, height: 780))
 
-        JetpackInstallStepsView(siteURL: "automattic.com", dismissAction: {})
+        JetpackInstallStepsView(siteURL: "automattic.com", viewModel: viewModel, dismissAction: {})
             .preferredColorScheme(.dark)
             .previewLayout(.fixed(width: 414, height: 780))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -55,8 +55,11 @@ final class JetpackInstallStepsViewModel: ObservableObject {
         stores.dispatch(activationAction)
     }
 
+    /// Check site to make sure connection succeeds.
+    ///
     private func checkSiteConnection() {
-        // TODO:
+        currentStep = .connection
+        // TODO-5365 - update this in the workaround PR
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -38,8 +38,21 @@ final class JetpackInstallStepsViewModel: ObservableObject {
         stores.dispatch(installationAction)
     }
 
+    /// Activates the installed Jetpack plugin.
+    ///
     private func activateJetpack() {
-        // TODO:
+        currentStep = .activation
+        let activationAction = SitePluginAction.activateSitePlugin(siteID: siteID, pluginName: Constants.jetpackPluginName) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success:
+                self.checkSiteConnection()
+            case .failure:
+                // TODO-5365: handle failure with an error message
+                break
+            }
+        }
+        stores.dispatch(activationAction)
     }
 
     private func checkSiteConnection() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -12,7 +12,10 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     /// Stores manager to handle install steps.
     ///
     private let stores: StoresManager
-    
+
+    /// Current step of the installation
+    @Published private(set) var currentStep: JetpackInstallStep = .activation
+
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.stores = stores

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -14,10 +14,42 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     private let stores: StoresManager
 
     /// Current step of the installation
-    @Published private(set) var currentStep: JetpackInstallStep = .activation
+    ///
+    @Published private(set) var currentStep: JetpackInstallStep = .installation
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.stores = stores
+    }
+
+    /// Starts the steps by installing the Jetpack plugin.
+    ///
+    func startInstallation() {
+        let installationAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: Constants.jetpackSlug) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success:
+                self.activateJetpack()
+            case .failure:
+                // TODO-5365: handle failure with an error message
+                break
+            }
+        }
+        stores.dispatch(installationAction)
+    }
+
+    private func activateJetpack() {
+        // TODO:
+    }
+
+    private func checkSiteConnection() {
+        // TODO:
+    }
+}
+
+private extension JetpackInstallStepsViewModel {
+    enum Constants {
+        static let jetpackSlug: String = "jetpack"
+        static let jetpackPluginName: String = "jetpack/jetpack"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -15,7 +15,7 @@ final class JetpackInstallStepsViewModel: ObservableObject {
 
     /// Current step of the installation
     ///
-    @Published private(set) var currentStep: JetpackInstallStep = .installation
+    @Published private(set) var currentStep: JetpackInstallStep?
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
@@ -25,6 +25,7 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     /// Starts the steps by installing the Jetpack plugin.
     ///
     func startInstallation() {
+        currentStep = .installation
         let installationAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: Constants.jetpackSlug) { [weak self] result in
             guard let self = self else { return }
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -1,0 +1,20 @@
+import Combine
+import Foundation
+import Yosemite
+
+/// View model for `JetpackInstallStepsView`
+///
+final class JetpackInstallStepsViewModel: ObservableObject {
+    /// ID of the site to install Jetpack-the-plugin to.
+    ///
+    private let siteID: Int64
+
+    /// Stores manager to handle install steps.
+    ///
+    private let stores: StoresManager
+    
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// Hosting controller wrapper for `JetpackInstallIntroView`
 ///
 final class JetpackInstallHostingController: UIHostingController<JetpackInstallView> {
-    init(siteURL: String) {
-        super.init(rootView: JetpackInstallView(siteURL: siteURL))
+    init(siteID: Int64, siteURL: String) {
+        super.init(rootView: JetpackInstallView(siteID: siteID, siteURL: siteURL))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -22,17 +22,22 @@ struct JetpackInstallView: View {
     // Closure invoked when Close button is tapped
     var dismissAction: () -> Void = {}
 
+    // URL of the site to install Jetpack to
     private let siteURL: String
+
+    // View model for `JetpackInstallStepsView`
+    private let installStepsViewModel: JetpackInstallStepsViewModel
 
     @State private var hasStarted = false
 
-    init(siteURL: String) {
+    init(siteID: Int64, siteURL: String) {
         self.siteURL = siteURL
+        self.installStepsViewModel = JetpackInstallStepsViewModel(siteID: siteID)
     }
 
     var body: some View {
         if hasStarted {
-            JetpackInstallStepsView(siteURL: siteURL, dismissAction: dismissAction)
+            JetpackInstallStepsView(siteURL: siteURL, viewModel: installStepsViewModel, dismissAction: dismissAction)
         } else {
             JetpackInstallIntroView(siteURL: siteURL, dismissAction: dismissAction) {
                 hasStarted = true
@@ -43,7 +48,7 @@ struct JetpackInstallView: View {
 
 struct JetpackInstallView_Previews: PreviewProvider {
     static var previews: some View {
-        JetpackInstallView(siteURL: "automattic.com")
+        JetpackInstallView(siteID: 123, siteURL: "automattic.com")
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 414, height: 780))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -298,10 +298,10 @@ private extension SettingsViewController {
     }
 
     func installJetpackWasPressed() {
-        guard let siteURL = ServiceLocator.stores.sessionManager.defaultSite?.url else {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
             return
         }
-        let installJetpackController = JetpackInstallHostingController(siteURL: siteURL)
+        let installJetpackController = JetpackInstallHostingController(siteID: site.siteID, siteURL: site.url)
         installJetpackController.setDismissAction { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1371,6 +1371,7 @@
 		DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */; };
 		DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962826C20ECB005A056B /* CollapsibleView.swift */; };
 		DEC51A9D274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A9C274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift */; };
+		DEC51AA0274F9922009F3DF4 /* JetpackInstallStepsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A9F274F9922009F3DF4 /* JetpackInstallStepsViewModelTests.swift */; };
 		DEC6C51827466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51727466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift */; };
 		DEC6C51A2747758D006832D3 /* JetpackInstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C5192747758D006832D3 /* JetpackInstallView.swift */; };
 		DEC6C51C27477890006832D3 /* JetpackInstallStepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51B27477890006832D3 /* JetpackInstallStepsView.swift */; };
@@ -2864,6 +2865,7 @@
 		DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelCustomsForm+Localization.swift"; sourceTree = "<group>"; };
 		DEC2962826C20ECB005A056B /* CollapsibleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleView.swift; sourceTree = "<group>"; };
 		DEC51A9C274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepsViewModel.swift; sourceTree = "<group>"; };
+		DEC51A9F274F9922009F3DF4 /* JetpackInstallStepsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepsViewModelTests.swift; sourceTree = "<group>"; };
 		DEC6C51727466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsSiteVisitEmptyView.swift; sourceTree = "<group>"; };
 		DEC6C5192747758D006832D3 /* JetpackInstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallView.swift; sourceTree = "<group>"; };
 		DEC6C51B27477890006832D3 /* JetpackInstallStepsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepsView.swift; sourceTree = "<group>"; };
@@ -3862,6 +3864,7 @@
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				DEC51A9E274F990D009F3DF4 /* JetpackInstall */,
 				E10DFC76267331450083AFF2 /* Settings */,
 				31F21B07263C8E1F0035B50A /* CardReaderSettings */,
 				DEFD6E5F264990DD00E51E0D /* Plugins */,
@@ -6758,6 +6761,14 @@
 			path = Customs;
 			sourceTree = "<group>";
 		};
+		DEC51A9E274F990D009F3DF4 /* JetpackInstall */ = {
+			isa = PBXGroup;
+			children = (
+				DEC51A9F274F9922009F3DF4 /* JetpackInstallStepsViewModelTests.swift */,
+			);
+			path = JetpackInstall;
+			sourceTree = "<group>";
+		};
 		DEE6437426D87C2D00888A75 /* Print Customs Form */ = {
 			isa = PBXGroup;
 			children = (
@@ -8429,6 +8440,7 @@
 				020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
+				DEC51AA0274F9922009F3DF4 /* JetpackInstallStepsViewModelTests.swift in Sources */,
 				26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */,
 				3190D61D26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1370,6 +1370,7 @@
 		DEC2962526C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962426C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift */; };
 		DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */; };
 		DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962826C20ECB005A056B /* CollapsibleView.swift */; };
+		DEC51A9D274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A9C274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift */; };
 		DEC6C51827466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51727466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift */; };
 		DEC6C51A2747758D006832D3 /* JetpackInstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C5192747758D006832D3 /* JetpackInstallView.swift */; };
 		DEC6C51C27477890006832D3 /* JetpackInstallStepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51B27477890006832D3 /* JetpackInstallStepsView.swift */; };
@@ -2862,6 +2863,7 @@
 		DEC2962426C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModel.swift; sourceTree = "<group>"; };
 		DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelCustomsForm+Localization.swift"; sourceTree = "<group>"; };
 		DEC2962826C20ECB005A056B /* CollapsibleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleView.swift; sourceTree = "<group>"; };
+		DEC51A9C274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepsViewModel.swift; sourceTree = "<group>"; };
 		DEC6C51727466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsSiteVisitEmptyView.swift; sourceTree = "<group>"; };
 		DEC6C5192747758D006832D3 /* JetpackInstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallView.swift; sourceTree = "<group>"; };
 		DEC6C51B27477890006832D3 /* JetpackInstallStepsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepsView.swift; sourceTree = "<group>"; };
@@ -6691,6 +6693,7 @@
 				DE23CFF927462D8F003BE54E /* JetpackInstallIntroView.swift */,
 				DEC6C5192747758D006832D3 /* JetpackInstallView.swift */,
 				DEC6C51B27477890006832D3 /* JetpackInstallStepsView.swift */,
+				DEC51A9C274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift */,
 				DEC6C51D27479280006832D3 /* JetpackInstallSteps.swift */,
 			);
 			path = JetpackInstall;
@@ -7711,6 +7714,7 @@
 				AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */,
 				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,
 				45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */,
+				DEC51A9D274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift in Sources */,
 				455DC3A327393C7E00D4644C /* OrderDatesFilterViewController.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
@@ -56,9 +56,12 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
         XCTAssertEqual(activatedPluginName, "jetpack/jetpack")
     }
 
-    func test_currentStep_is_installation_initially() {
+    func test_currentStep_is_installation_on_startInstallation() {
         // Given
         let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID)
+
+        // When
+        viewModel.startInstallation()
 
         // Then
         XCTAssertEqual(viewModel.currentStep, .installation)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class JetpackInstallStepsViewModelTests: XCTestCase {
+
+    private let testSiteID: Int64 = 1232
+
+    func test_startInstallation_dispatches_installSitePlugin_action() {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+
+        // When
+        var installedSiteID: Int64?
+        storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            switch action {
+            case .installSitePlugin(let siteID, _, _):
+                installedSiteID = siteID
+            default:
+                break
+            }
+        }
+        viewModel.startInstallation()
+
+        // Then
+        XCTAssertEqual(installedSiteID, testSiteID)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
@@ -13,10 +13,12 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
 
         // When
         var installedSiteID: Int64?
+        var pluginSlug: String?
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
             switch action {
-            case .installSitePlugin(let siteID, _, _):
+            case .installSitePlugin(let siteID, let slug, _):
                 installedSiteID = siteID
+                pluginSlug = slug
             default:
                 break
             }
@@ -25,6 +27,82 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(installedSiteID, testSiteID)
+        XCTAssertEqual(pluginSlug, "jetpack")
     }
 
+    func test_activateSitePlugin_is_dispatched_when_installSitePlugin_succeeds() {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+
+        // When
+        var activatedSiteID: Int64?
+        var activatedPluginName: String?
+        storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            switch action {
+            case .installSitePlugin(_, _, let onCompletion):
+                onCompletion(.success(()))
+            case .activateSitePlugin(let siteID, let pluginName, _):
+                activatedSiteID = siteID
+                activatedPluginName = pluginName
+            default:
+                break
+            }
+        }
+        viewModel.startInstallation()
+
+        // Then
+        XCTAssertEqual(activatedSiteID, testSiteID)
+        XCTAssertEqual(activatedPluginName, "jetpack/jetpack")
+    }
+
+    func test_currentStep_is_installation_initially() {
+        // Given
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID)
+
+        // Then
+        XCTAssertEqual(viewModel.currentStep, .installation)
+    }
+
+    func test_currentStep_is_activate_when_installation_succeeds() {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+
+        // When
+        storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            switch action {
+            case .installSitePlugin(_, _, let onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        viewModel.startInstallation()
+
+        // Then
+        XCTAssertEqual(viewModel.currentStep, .activation)
+    }
+
+    func test_currentStep_is_connection_when_installation_and_activation_succeeds() {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+
+        // When
+        storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            switch action {
+            case .installSitePlugin(_, _, let onCompletion):
+                onCompletion(.success(()))
+            case .activateSitePlugin(_, _, let onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        viewModel.startInstallation()
+
+        // Then
+        XCTAssertEqual(viewModel.currentStep, .connection)
+    }
 }


### PR DESCRIPTION
Part of #5365 

### Description
This PR integrates the first 2 steps to install and activate Jetpack to a site to show the progress on UI. The last step ("Connecting your site") requires a workaround to fetch the site info from remote for checking connection with WooCommerce, which will be handled in the next PR. Error handling is not included in this PR either.

### Testing instructions
Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23).
- Launch the app and switch to the JCP site.
- Tap on the Jetpack banner at the bottom of My store tab > proceed to Install Jetpack.
- On Jetpack install intro view, tap Get Started.
- You should be navigated to the install steps view, and install steps should be updated from "Installing Jetpack" > "Activating" > "Connecting to your store". The steps will stop here since the connection step hasn't been implemented yet.

Note: after these 2 steps, if you open the store picker you will not see your JCP site again - which is a known issue noted in p91TBi-6EK-p2 - we're waiting for a fix on backend.

### Demo
https://user-images.githubusercontent.com/5533851/143556922-c5fa333a-5476-45b1-9d56-be18b64e705d.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.