### PR TITLE
Jetpack CP: Fetch site to check for successful Jetpack installation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -60,7 +60,24 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     ///
     private func checkSiteConnection() {
         currentStep = .connection
-        // TODO-5365 - update this in the workaround PR
+        let siteFetch = AccountAction.loadAndSynchronizeSite(siteID: siteID,
+                                                             forcedUpdate: true,
+                                                             isJetpackConnectionPackageSupported: true) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let site):
+                print("😛 \(site.isWooCommerceActive)")
+                guard site.isWooCommerceActive, !site.isJetpackCPConnected else {
+                    // TODO-5365: handle failure with an error message
+                    return
+                }
+                self.currentStep = .done
+            case .failure(let error):
+                // TODO-5365: handle failure with an error message
+                print(error)
+            }
+        }
+        stores.dispatch(siteFetch)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -66,15 +66,14 @@ final class JetpackInstallStepsViewModel: ObservableObject {
             guard let self = self else { return }
             switch result {
             case .success(let site):
-                print("😛 \(site.isWooCommerceActive)")
                 guard site.isWooCommerceActive, !site.isJetpackCPConnected else {
                     // TODO-5365: handle failure with an error message
                     return
                 }
                 self.currentStep = .done
-            case .failure(let error):
+            case .failure:
                 // TODO-5365: handle failure with an error message
-                print(error)
+                break
             }
         }
         stores.dispatch(siteFetch)

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -454,8 +454,9 @@ private extension DefaultStoresManager {
     func restoreSessionSiteAndSynchronizeIfNeeded(with siteID: Int64) {
         let isJCPEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport)
         let action = AccountAction
-            .loadAndSynchronizeSiteIfNeeded(siteID: siteID,
-                                            isJetpackConnectionPackageSupported: isJCPEnabled) { [weak self] result in
+            .loadAndSynchronizeSite(siteID: siteID,
+                                    forcedUpdate: false,
+                                    isJetpackConnectionPackageSupported: isJCPEnabled) { [weak self] result in
             guard let self = self else { return }
             guard case .success(let site) = result else {
                 return

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -7,7 +7,7 @@ import Networking
 //
 public enum AccountAction: Action {
     case loadAccount(userID: Int64, onCompletion: (Account?) -> Void)
-    case loadAndSynchronizeSiteIfNeeded(siteID: Int64, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Site, Error>) -> Void)
+    case loadAndSynchronizeSite(siteID: Int64, forcedUpdate: Bool, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Site, Error>) -> Void)
     case synchronizeAccount(onCompletion: (Result<Account, Error>) -> Void)
     case synchronizeAccountSettings(userID: Int64, onCompletion: (Result<AccountSettings, Error>) -> Void)
     case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Void, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -43,8 +43,11 @@ public class AccountStore: Store {
         switch action {
         case .loadAccount(let userID, let onCompletion):
             loadAccount(userID: userID, onCompletion: onCompletion)
-        case .loadAndSynchronizeSiteIfNeeded(let siteID, let isJetpackConnectionPackageSupported, let onCompletion):
-            loadAndSynchronizeSiteIfNeeded(siteID: siteID, isJetpackConnectionPackageSupported: isJetpackConnectionPackageSupported, onCompletion: onCompletion)
+        case .loadAndSynchronizeSite(let siteID, let forcedUpdate, let isJetpackConnectionPackageSupported, let onCompletion):
+            loadAndSynchronizeSite(siteID: siteID,
+                                   forcedUpdate: forcedUpdate,
+                                   isJetpackConnectionPackageSupported: isJetpackConnectionPackageSupported,
+                                   onCompletion: onCompletion)
         case .synchronizeAccount(let onCompletion):
             synchronizeAccount(onCompletion: onCompletion)
         case .synchronizeAccountSettings(let userID, let onCompletion):
@@ -92,10 +95,14 @@ private extension AccountStore {
         }
     }
 
-    /// Returns the site if it exists in storage already. Otherwise, it synchronizes the WordPress.com sites and returns the site if it exists.
+    /// Returns the site if it exists in storage already and if forced update is not required.
+    /// Otherwise, it synchronizes the WordPress.com sites and returns the site if it exists.
     ///
-    func loadAndSynchronizeSiteIfNeeded(siteID: Int64, isJetpackConnectionPackageSupported: Bool, onCompletion: @escaping (Result<Site, Error>) -> Void) {
-        if let site = storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly() {
+    func loadAndSynchronizeSite(siteID: Int64,
+                                forcedUpdate: Bool,
+                                isJetpackConnectionPackageSupported: Bool,
+                                onCompletion: @escaping (Result<Site, Error>) -> Void) {
+        if let site = storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly(), !forcedUpdate {
             onCompletion(.success(site))
         } else {
             synchronizeSites(selectedSiteID: siteID, isJetpackConnectionPackageSupported: isJetpackConnectionPackageSupported) { [weak self] result in

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -531,9 +531,9 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertNil(account)
     }
 
-    // MARK: - AccountAction.loadAndSynchronizeSiteIfNeeded
+    // MARK: - AccountAction.loadAndSynchronizeSite
 
-    func test_loadAndSynchronizeSiteIfNeeded_returns_site_already_in_storage_without_making_network_request() throws {
+    func test_loadAndSynchronizeSite_returns_site_already_in_storage_without_making_network_request_if_forcedUpdate_is_false() throws {
         // Given
         let network = MockNetwork()
         let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
@@ -551,7 +551,7 @@ final class AccountStoreTests: XCTestCase {
         // When
         let result: Result<Yosemite.Site, Error> = waitFor { promise in
             group.notify(queue: .main) {
-                let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: siteID, isJetpackConnectionPackageSupported: false) { result in
+                let action = AccountAction.loadAndSynchronizeSite(siteID: siteID, forcedUpdate: false, isJetpackConnectionPackageSupported: false) { result in
                     XCTAssertTrue(Thread.isMainThread)
                     promise(result)
                 }
@@ -565,7 +565,7 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(network.requestsForResponseData.count, 0)
     }
 
-    func test_loadAndSynchronizeSiteIfNeeded_returns_unknown_site_error_after_syncing_failure() throws {
+    func test_loadAndSynchronizeSite_returns_unknown_site_error_after_syncing_failure() throws {
         // Given
         let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let group = DispatchGroup()
@@ -580,7 +580,7 @@ final class AccountStoreTests: XCTestCase {
         // When
         let result: Result<Yosemite.Site, Error> = waitFor { promise in
             group.notify(queue: .main) {
-                let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: 9999, isJetpackConnectionPackageSupported: false) { result in
+                let action = AccountAction.loadAndSynchronizeSite(siteID: 9999, forcedUpdate: false, isJetpackConnectionPackageSupported: false) { result in
                     XCTAssertTrue(Thread.isMainThread)
                     promise(result)
                 }
@@ -595,7 +595,7 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertTrue(((network.requestsForResponseData.first?.urlRequest?.url?.absoluteString.contains("me/sites")) == true))
     }
 
-    func test_loadAndSynchronizeSiteIfNeeded_returns_site_after_syncing_success() throws {
+    func test_loadAndSynchronizeSite_returns_site_after_syncing_success() throws {
         // Given
         let network = MockNetwork()
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
@@ -614,8 +614,9 @@ final class AccountStoreTests: XCTestCase {
         let siteIDInSimulatedResponse = Int64(1112233334444555)
         let result: Result<Yosemite.Site, Error> = waitFor { promise in
             group.notify(queue: .main) {
-                let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: siteIDInSimulatedResponse,
-                                                                          isJetpackConnectionPackageSupported: false) { result in
+                let action = AccountAction.loadAndSynchronizeSite(siteID: siteIDInSimulatedResponse,
+                                                                  forcedUpdate: true,
+                                                                  isJetpackConnectionPackageSupported: false) { result in
                     XCTAssertTrue(Thread.isMainThread)
                     promise(result)
                 }
@@ -628,7 +629,7 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(site.siteID, siteIDInSimulatedResponse)
     }
 
-    func test_loadAndSynchronizeSiteIfNeeded_makes_3_network_requests_when_one_site_is_jetpack_cp_connected() throws {
+    func test_loadAndSynchronizeSite_makes_3_network_requests_when_one_site_is_jetpack_cp_connected() throws {
         // Given
         let network = MockNetwork()
         let remote = MockAccountRemote()
@@ -643,7 +644,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let _: Void = waitFor { promise in
-            let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: 123, isJetpackConnectionPackageSupported: true) { result in
+            let action = AccountAction.loadAndSynchronizeSite(siteID: 123, forcedUpdate: true, isJetpackConnectionPackageSupported: true) { result in
                 promise(())
             }
             accountStore.onAction(action)
@@ -654,7 +655,7 @@ final class AccountStoreTests: XCTestCase {
                        [.loadSites, .checkIfWooCommerceIsActive(siteID: siteIDOfJCPSite), .fetchWordPressSiteSettings(siteID: siteIDOfJCPSite)])
     }
 
-    func test_loadAndSynchronizeSiteIfNeeded_makes_1_network_request_when_one_site_is_jetpack_cp_connected_with_jcp_feature_off() throws {
+    func test_loadAndSynchronizeSite_makes_1_network_request_when_one_site_is_jetpack_cp_connected_with_jcp_feature_off() throws {
         // Given
         let network = MockNetwork()
         let remote = MockAccountRemote()
@@ -666,7 +667,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let _: Void = waitFor { promise in
-            let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: 123, isJetpackConnectionPackageSupported: false) { result in
+            let action = AccountAction.loadAndSynchronizeSite(siteID: 123, forcedUpdate: true, isJetpackConnectionPackageSupported: false) { result in
                 promise(())
             }
             accountStore.onAction(action)
@@ -676,7 +677,7 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(remote.invocations, [.loadSites])
     }
 
-    func test_loadAndSynchronizeSiteIfNeeded_makes_1_network_requests_when_all_sites_have_jetpack_plugin() throws {
+    func test_loadAndSynchronizeSite_makes_1_network_requests_when_all_sites_have_jetpack_plugin() throws {
         // Given
         let network = MockNetwork()
         let remote = MockAccountRemote()
@@ -689,7 +690,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let _: Void = waitFor { promise in
-            let action = AccountAction.loadAndSynchronizeSiteIfNeeded(siteID: 123, isJetpackConnectionPackageSupported: true) { result in
+            let action = AccountAction.loadAndSynchronizeSite(siteID: 123, forcedUpdate: true, isJetpackConnectionPackageSupported: true) { result in
                 promise(())
             }
             accountStore.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5365
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a check for site's properties to make sure that everything is synced correctly and that Jetpack-the-plugin has been installed. 

This check makes use of `AccountAction`'s `loadAndSynchronizeSite` - this action is updated with `forcedUpdate` to add the option forced-fetch the site from remote instead of fetching from local storage if the site was stored earlier. This makes sure that all the site's properties are up-to-date.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Due to the site sync issue mentioned in p91TBi-6EK-p2 - the check currently fails after installing and activating Jetpack. Without error handling (which will be implemented in the next PR), we cannot test this on UI - so CI passing should be sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->