### PR TITLE
[Mobile Payments] Adds variations to the receipts

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -110,7 +110,21 @@ private extension ReceiptRenderer {
     private func summaryTable() -> String {
         var summaryContent = "<table>"
         for line in content.lineItems {
-            let stripedTitle = line.title.htmlStripped()
+            var variations = ""
+            if !line.attributes.isEmpty {
+                variations.append(
+                    line.attributes.map {
+                            "\($0.name) \($0.value)".trimmingCharacters(in: .whitespaces)
+                        }
+                        .joined(separator: ", ")
+                )
+            }
+
+            var title = line.title
+            if !variations.isEmpty {
+                title.append(". \(variations.trimmingCharacters(in: .whitespaces))")
+            }
+            let stripedTitle = title.htmlStripped()
             summaryContent += "<tr><td>\(stripedTitle) × \(line.quantity)</td><td>\(line.amount) \(content.parameters.currency.uppercased())</td></tr>"
         }
         summaryContent += totalRows()

--- a/Hardware/Hardware/Printer/ReceiptLineItem.swift
+++ b/Hardware/Hardware/Printer/ReceiptLineItem.swift
@@ -4,11 +4,23 @@ public struct ReceiptLineItem: Codable {
     public let title: String
     public let quantity: String
     public let amount: String
+    public let attributes: [ReceiptLineAttribute]
 
-    public init(title: String, quantity: String, amount: String) {
+    public init(title: String, quantity: String, amount: String, attributes: [ReceiptLineAttribute]) {
         self.title = title
         self.quantity = quantity
         self.amount = amount
+        self.attributes = attributes
+    }
+}
+
+public struct ReceiptLineAttribute: Codable {
+    public let name: String
+    public let value: String
+
+    public init(name: String, value: String) {
+        self.name = name
+        self.value = value
     }
 }
 
@@ -17,5 +29,6 @@ extension ReceiptLineItem {
         case title = "title"
         case quantity = "quantity"
         case amount = "amount"
+        case attributes = "attributes"
     }
 }

--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -29,10 +29,26 @@ final class ReceiptRendererTest: XCTestCase {
             expectedResultWithHtmlSymbolsMd5Description
         )
     }
+
+    func test_TextWithVariationsSymbols() {
+        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: 38cbb17ee811d91928439e1aedd76b73"
+        let attributeOne = ReceiptLineAttribute(name: "name_attr_1", value: "value_attr_1")
+        let attributeTwo = ReceiptLineAttribute(name: "name_attr_2", value: "value_attr_2")
+        let content = generateReceiptContent(attributes: [attributeOne, attributeTwo])
+
+        let renderer = ReceiptRenderer(content: content)
+
+        print(renderer.htmlContent())
+
+        XCTAssertEqual(
+            Insecure.MD5.hash(data: renderer.htmlContent().data(using: .utf8)!).description,
+            expectedResultWithHtmlSymbolsMd5Description
+        )
+    }
 }
 
 private extension ReceiptRendererTest {
-    func generateReceiptContent(stringToAppend: String = "") -> ReceiptContent {
+    func generateReceiptContent(stringToAppend: String = "", attributes: [ReceiptLineAttribute] = []) -> ReceiptContent {
         ReceiptContent(
             parameters: CardPresentReceiptParameters(
                 amount: 1,
@@ -60,7 +76,11 @@ private extension ReceiptRendererTest {
                     emvAuthData: "AD*******"),
                 orderID: 9201
             ),
-            lineItems: [ReceiptLineItem(title: "Sample product #1\(stringToAppend)", quantity: "2", amount: "25")],
+            lineItems: [ReceiptLineItem(
+                title: "Sample product #1\(stringToAppend)",
+                quantity: "2",
+                amount: "25",
+                attributes: attributes)],
             cartTotals: [ReceiptTotalLine(description: "description", amount: "13")],
             orderNote: nil
         )

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -97,8 +97,7 @@ private extension ReceiptStore {
             var attributesText = ""
             if !item.attributes.isEmpty {
                 attributesText.append(
-                    item.attributes.map
-                        {attr in
+                    item.attributes.map {attr in
                             "\(attr.name) \(attr.value)".trimmingCharacters(in: .whitespaces)
                         }
                         .joined(separator: ", ")

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -10,7 +10,7 @@ public class ReceiptStore: Store {
     private let fileStorage: FileStorage
 
     private lazy var sharedDerivedStorage: StorageType = {
-        return storageManager.writerDerivedStorage
+        storageManager.writerDerivedStorage
     }()
 
     private lazy var receiptNumberFormatter: NumberFormatter = {
@@ -93,9 +93,25 @@ private extension ReceiptStore {
     }
 
     func generateLineItems(order: Order) -> [ReceiptLineItem] {
-        order.items.map { item in
-            ReceiptLineItem(
-                title: item.name,
+        order.items.map {item in
+            var attributesText = ""
+            if !item.attributes.isEmpty {
+                attributesText.append(
+                    item.attributes.map
+                        {attr in
+                            "\(attr.name) \(attr.value)".trimmingCharacters(in: .whitespaces)
+                        }
+                        .joined(separator: ", ")
+                        .trimmingCharacters(in: .whitespaces)
+                )
+            }
+
+            var title = item.name
+            if !attributesText.isEmpty {
+                title.append(". \(attributesText)")
+            }
+            return ReceiptLineItem(
+                title: title,
                 quantity: item.quantity.description,
                 amount: item.subtotal
             )

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -94,25 +94,11 @@ private extension ReceiptStore {
 
     func generateLineItems(order: Order) -> [ReceiptLineItem] {
         order.items.map {item in
-            var attributesText = ""
-            if !item.attributes.isEmpty {
-                attributesText.append(
-                    item.attributes.map {attr in
-                            "\(attr.name) \(attr.value)".trimmingCharacters(in: .whitespaces)
-                        }
-                        .joined(separator: ", ")
-                        .trimmingCharacters(in: .whitespaces)
-                )
-            }
-
-            var title = item.name
-            if !attributesText.isEmpty {
-                title.append(". \(attributesText)")
-            }
-            return ReceiptLineItem(
-                title: title,
+            ReceiptLineItem(
+                title: item.name,
                 quantity: item.quantity.description,
-                amount: item.subtotal
+                amount: item.subtotal,
+                attributes: item.attributes.map { ReceiptLineAttribute(name: $0.name, value: $0.value) }
             )
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4642
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds variations to the receipts

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Open a receipt of an order with  variations
* Notice that variations are visible next to the item name

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![image](https://user-images.githubusercontent.com/4923871/143579841-8fa01091-789f-49bf-9192-424dc13652eb.png)
![image](https://user-images.githubusercontent.com/4923871/143579861-e8d5456d-b45f-4ba3-aa6e-7e95a68d2697.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
