### PR TITLE
Simple Payments: Payment Method UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -5,7 +5,112 @@ import SwiftUI
 ///
 struct SimplePaymentsMethod: View {
 
+    /// Navigation bar title.
+    ///
+    let title: String
+
     var body: some View {
-        Text("Payment method")
+        VStack(alignment: .leading, spacing: Layout.noSpacing) {
+
+            Text(Localization.header)
+                .subheadlineStyle()
+                .padding()
+
+            Divider()
+
+            Group {
+                MethodRow(icon: .priceImage, title: Localization.cash) {
+                    print("Tapped Cash")
+                }
+
+                Divider()
+
+                MethodRow(icon: .creditCardImage, title: Localization.card) {
+                    print("Tapped Card")
+                }
+            }
+            .padding(.leading)
+            .background(Color(.listForeground))
+
+            Divider()
+
+            Spacer()
+        }
+        .background(Color(.listBackground).ignoresSafeArea())
+        .navigationTitle(title)
+    }
+}
+
+/// Represents a Payment method row
+///
+private struct MethodRow: View {
+    /// Icon of the row
+    ///
+    let icon: UIImage
+
+    /// Title of the row
+    ///
+    let title: String
+
+    /// Action when the row is selected
+    ///
+    let action: () -> ()
+
+    /// Keeps track of the current screen scale.
+    ///
+    @ScaledMetric private var scale = 1
+
+    var body: some View {
+        HStack(spacing: SimplePaymentsMethod.Layout.noSpacing) {
+            Image(uiImage: icon)
+                .resizable()
+                .frame(width: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale),
+                       height: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale))
+                .foregroundColor(Color(.systemGray))
+
+            TitleAndValueRow(title: title, value: .content(""), selectable: true, action: action)
+        }
+    }
+}
+
+// MARK: Constants
+private extension SimplePaymentsMethod {
+    enum Localization {
+        static let header = NSLocalizedString("Choose your payment method", comment: "Heading text on the select payment method screen for simple payments")
+        static let cash = NSLocalizedString("Cash", comment: "Cash method title on the select payment method screen for simple payments")
+        static let card = NSLocalizedString("Card", comment: "Card method title on the select payment method screen for simple payments")
+    }
+
+    enum Layout {
+        static let noSpacing: CGFloat = 0
+        static func iconWidthHeight(scale: CGFloat) -> CGFloat {
+            24 * scale
+        }
+    }
+}
+
+// MARK: Previews
+struct SimplePaymentsMethod_Preview: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SimplePaymentsMethod(title: "Take payment ($15.99)")
+                .environment(\.colorScheme, .light)
+                .previewDisplayName("Light")
+                .navigationBarTitleDisplayMode(.inline)
+        }
+
+        NavigationView {
+            SimplePaymentsMethod(title: "Take payment ($15.99)")
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark")
+                .navigationBarTitleDisplayMode(.inline)
+        }
+
+        NavigationView {
+            SimplePaymentsMethod(title: "Take payment ($15.99)")
+                .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
+                .previewDisplayName("Accessibility")
+                .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SwiftUI
+
+/// View to choose what payment method will be used with the simple payments order.
+///
+struct SimplePaymentsMethod: View {
+
+    var body: some View {
+        Text("Payment method")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -29,11 +29,12 @@ struct SimplePaymentsMethod: View {
                     print("Tapped Card")
                 }
             }
-            .padding(.leading)
+            .padding(.horizontal)
             .background(Color(.listForeground))
 
             Divider()
 
+            // Pushes content to the top
             Spacer()
         }
         .background(Color(.listBackground).ignoresSafeArea())
@@ -61,14 +62,27 @@ private struct MethodRow: View {
     @ScaledMetric private var scale = 1
 
     var body: some View {
-        HStack(spacing: SimplePaymentsMethod.Layout.noSpacing) {
-            Image(uiImage: icon)
-                .resizable()
-                .frame(width: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale),
-                       height: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale))
-                .foregroundColor(Color(.systemGray))
+        Button(action: action) {
+            HStack {
+                Image(uiImage: icon)
+                    .resizable()
+                    .flipsForRightToLeftLayoutDirection(true)
+                    .frame(width: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale),
+                           height: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale))
+                    .foregroundColor(Color(.systemGray))
 
-            TitleAndValueRow(title: title, value: .content(""), selectable: true, action: action)
+                Text(title)
+                    .bodyStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(uiImage: .chevronImage)
+                    .resizable()
+                    .flipsForRightToLeftLayoutDirection(true)
+                    .frame(width: SimplePaymentsMethod.Layout.chevronWidthHeight(scale: scale),
+                           height: SimplePaymentsMethod.Layout.chevronWidthHeight(scale: scale))
+                    .foregroundColor(Color(.systemGray))
+            }
+            .padding(.vertical, SimplePaymentsMethod.Layout.verticalPadding)
         }
     }
 }
@@ -83,8 +97,14 @@ private extension SimplePaymentsMethod {
 
     enum Layout {
         static let noSpacing: CGFloat = 0
+        static let verticalPadding: CGFloat = 11
+
         static func iconWidthHeight(scale: CGFloat) -> CGFloat {
             24 * scale
+        }
+
+        static func chevronWidthHeight(scale: CGFloat) -> CGFloat {
+            22 * scale
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -94,23 +94,23 @@ struct SimplePaymentsMethod_Preview: PreviewProvider {
     static var previews: some View {
         NavigationView {
             SimplePaymentsMethod(title: "Take payment ($15.99)")
-                .environment(\.colorScheme, .light)
-                .previewDisplayName("Light")
                 .navigationBarTitleDisplayMode(.inline)
         }
+        .environment(\.colorScheme, .light)
+        .previewDisplayName("Light")
 
         NavigationView {
             SimplePaymentsMethod(title: "Take payment ($15.99)")
-                .environment(\.colorScheme, .dark)
-                .previewDisplayName("Dark")
                 .navigationBarTitleDisplayMode(.inline)
         }
+        .environment(\.colorScheme, .dark)
+        .previewDisplayName("Dark")
 
         NavigationView {
             SimplePaymentsMethod(title: "Take payment ($15.99)")
-                .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
-                .previewDisplayName("Accessibility")
                 .navigationBarTitleDisplayMode(.inline)
         }
+        .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
+        .previewDisplayName("Accessibility")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -34,6 +34,12 @@ struct SimplePaymentsSummary: View {
             }
 
             TakePaymentSection(viewModel: viewModel)
+
+            // Navigation To Payment Methods
+            LazyNavigationLink(destination: SimplePaymentsMethod(title: Localization.takePayment(total: viewModel.total)),
+                               isActive: $viewModel.navigateToPaymentMethods) {
+                EmptyView()
+            }
         }
         .background(Color(.listBackground).ignoresSafeArea())
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -26,6 +26,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     @Published var enableTaxes: Bool = false
 
+    /// Defines when to navigate to the payments method screen.
+    ///
+    @Published var navigateToPaymentMethods = false
+
     /// Defines if a loading indicator should be shown.
     ///
     @Published private(set) var showLoadingIndicator = false
@@ -152,7 +156,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
 
             switch result {
             case .success:
-                // TODO: Navigate to Payment Method
+                self.navigateToPaymentMethods = true
                 // TODO: Analytics
                 break
             case .failure:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -391,6 +391,7 @@
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
+		261AA309275178FA009530FE /* SimplePaymentsMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA308275178FA009530FE /* SimplePaymentsMethod.swift */; };
 		262A09812628A8F40033AD20 /* WooStyleModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09802628A8F40033AD20 /* WooStyleModifiers.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -1879,6 +1880,7 @@
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
+		261AA308275178FA009530FE /* SimplePaymentsMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethod.swift; sourceTree = "<group>"; };
 		262A09802628A8F40033AD20 /* WooStyleModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooStyleModifiers.swift; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -3948,6 +3950,14 @@
 			path = "Variations/Add Attributes";
 			sourceTree = "<group>";
 		};
+		261AA30A27517907009530FE /* Method */ = {
+			isa = PBXGroup;
+			children = (
+				261AA308275178FA009530FE /* SimplePaymentsMethod.swift */,
+			);
+			path = Method;
+			sourceTree = "<group>";
+		};
 		262A097F2628A8BF0033AD20 /* View Modifiers */ = {
 			isa = PBXGroup;
 			children = (
@@ -4042,6 +4052,7 @@
 				26100B1D2721BAD800473045 /* SimplePaymentsTopBannerFactory.swift */,
 				26B9875A273C6A520090E8CA /* Amount */,
 				26B9875B273C6A670090E8CA /* Summary */,
+				261AA30A27517907009530FE /* Method */,
 			);
 			path = "Simple Payments";
 			sourceTree = "<group>";
@@ -7853,6 +7864,7 @@
 				02F6800325807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift in Sources */,
 				02E8B17723E2C49000A43403 /* InProgressProductImageCollectionViewCell.swift in Sources */,
 				CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */,
+				261AA309275178FA009530FE /* SimplePaymentsMethod.swift in Sources */,
 				0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */,
 				D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */,
 				02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -142,4 +142,25 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(receivedError)
     }
+
+    func test_when_order_is_updated_navigation_to_payments_method_is_triggered() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(Order.fake()))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        XCTAssertFalse(viewModel.navigateToPaymentMethods)
+
+        // When
+        viewModel.updateOrder()
+
+        // Then
+        XCTAssertTrue(viewModel.navigateToPaymentMethods)
+    }
 }


### PR DESCRIPTION
closes #5349 

# Why

After the simple payment order was properly updated in #5516, now it's time to choose the payment method that we will use for the order.

This PR adds the UI for the payment method screen and adds navigation from the summary screen.

# How

- Added `SimplePaymentsMethods` view with nothing crazy or quirks to explain 😅 
- Added a `navigateToPaymentMethods` property in `SimplePaymentsSummaryViewModel` that is set to true after the order is updated.

# Screenshots

Light | Dark | Accessibility 
---- | ---- | ----
<img  width="250" alt="light" src="https://user-images.githubusercontent.com/562080/143659090-69f0c66e-e410-4756-b1e7-274167609cf4.png"> | <img  width="250" alt="bdark" src="https://user-images.githubusercontent.com/562080/143659094-2915b730-446e-4a48-9f64-e9217782e7e9.png"> | <img  width="250" alt="accessibility" src="https://user-images.githubusercontent.com/562080/143659092-d3820c56-1a09-43fc-a7b5-ef69c82f8230.png">

# Demo

https://user-images.githubusercontent.com/562080/143659116-2dbe0c45-9860-40c2-91cc-a2df8358f293.mov

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- Enter an amount & tap next
- Tap next on the summary screen
- After the order is updated see that the app navigates to the payment method screen.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
