### PR TITLE
Shipping Labels: Fix crash when saving label after opening order from push notification

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+8.2
+-----
+- [*] Shipping Labels: Fixes a crash when saving a new shipping label after opening the order from a push notification. [https://github.com/woocommerce/woocommerce-ios/pull/5549]
+
 8.1
 -----
 - [***] Now it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab. [https://github.com/woocommerce/woocommerce-ios/pull/5491]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -547,8 +547,15 @@ private extension OrderDetailsViewController {
             }
         }
         shippingLabelFormVC.onLabelSave = { [weak self] in
-            guard let self = self else { return }
-            self.navigationController?.popToViewController(self, animated: true)
+            guard let self = self, let navigationController = self.navigationController, navigationController.viewControllers.contains(self) else {
+                // Navigate back to order details when presented from push notification
+                if let orderLoaderVC = self?.parent as? OrderLoaderViewController {
+                    self?.navigationController?.popToViewController(orderLoaderVC, animated: true)
+                }
+                return
+            }
+
+            navigationController.popToViewController(self, animated: true)
         }
         shippingLabelFormVC.hidesBottomBarWhenPushed = true
         navigationController?.show(shippingLabelFormVC, sender: self)


### PR DESCRIPTION
Fixes: #5543

## Description

If you opened an order from a push notification, and then created a new shipping label, tapping the "Save for Later" button on the shipping label print screen caused a crash. This fixes the crash so the "Save for Later" button navigates back to the order detail even when the order was opened from a push notification.

## Changes

Adds a check that `OrderDetailsViewController` is on the navigation stack before navigating back to it. If it isn't, checks if `OrderDetailsViewController` is a child of `OrderLoaderViewController` and navigates back to that VC instead.

## Testing

1. Receive a push notification for a new order.
2. Tap the notification to open the order detail.
3. From the order detail, choose to create a shipping label.
4. On shipping label form, enter all the label details and purchase the label.
5. On the print shipping label screen, choose to save the label.
6. Confirm you are taken back to the order detail for that order.

You can also test the same steps but opening an order from the order list (instead of a push notification) and confirm it still works as expected in that case.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
