### PR TITLE
Simple Payments: Pay by cash

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -134,7 +134,7 @@ struct SimplePaymentsAmount: View {
     private func summaryView() -> some View {
         Group {
             if let summaryViewModel = viewModel.summaryViewModel {
-                SimplePaymentsSummary(viewModel: summaryViewModel)
+                SimplePaymentsSummary(dismiss: dismiss, viewModel: summaryViewModel)
             }
             EmptyView()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -45,15 +45,23 @@ struct SimplePaymentsMethod: View {
             // Pushes content to the top
             Spacer()
         }
+        .disabled(viewModel.disableViewActions)
         .background(Color(.listBackground).ignoresSafeArea())
         .navigationTitle(viewModel.title)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                ProgressView()
+                    .renderedIf(viewModel.showLoadingIndicator)
+            }
+        }
         .alert(isPresented: $showingCashAlert) {
             Alert(title: Text(Localization.markAsPaidTitle),
                   message: Text(viewModel.payByCashInfo()),
                   primaryButton: .cancel(),
                   secondaryButton: .default(Text(Localization.markAsPaidButton), action: {
-                viewModel.markOrderAsPaid()
-                dismiss()
+                viewModel.markOrderAsPaid {
+                    dismiss()
+                }
             }))
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -5,9 +5,9 @@ import SwiftUI
 ///
 struct SimplePaymentsMethod: View {
 
-    /// Navigation bar title.
+    /// ViewModel to render the view content.
     ///
-    let title: String
+    @ObservedObject var viewModel: SimplePaymentsMethodsViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.noSpacing) {
@@ -38,7 +38,7 @@ struct SimplePaymentsMethod: View {
             Spacer()
         }
         .background(Color(.listBackground).ignoresSafeArea())
-        .navigationTitle(title)
+        .navigationTitle(viewModel.title)
     }
 }
 
@@ -113,21 +113,21 @@ private extension SimplePaymentsMethod {
 struct SimplePaymentsMethod_Preview: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            SimplePaymentsMethod(title: "Take payment ($15.99)")
+            SimplePaymentsMethod(viewModel: .init(formattedTotal: "$15.99"))
                 .navigationBarTitleDisplayMode(.inline)
         }
         .environment(\.colorScheme, .light)
         .previewDisplayName("Light")
 
         NavigationView {
-            SimplePaymentsMethod(title: "Take payment ($15.99)")
+            SimplePaymentsMethod(viewModel: .init(formattedTotal: "$15.99"))
                 .navigationBarTitleDisplayMode(.inline)
         }
         .environment(\.colorScheme, .dark)
         .previewDisplayName("Dark")
 
         NavigationView {
-            SimplePaymentsMethod(title: "Take payment ($15.99)")
+            SimplePaymentsMethod(viewModel: .init(formattedTotal: "$15.99"))
                 .navigationBarTitleDisplayMode(.inline)
         }
         .environment(\.sizeCategory, .accessibilityExtraExtraLarge)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -5,6 +5,10 @@ import SwiftUI
 ///
 struct SimplePaymentsMethod: View {
 
+    /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
+    ///
+    var dismiss: (() -> Void) = {}
+
     /// ViewModel to render the view content.
     ///
     @ObservedObject var viewModel: SimplePaymentsMethodsViewModel
@@ -49,6 +53,7 @@ struct SimplePaymentsMethod: View {
                   primaryButton: .cancel(),
                   secondaryButton: .default(Text(Localization.markAsPaidButton), action: {
                 viewModel.markOrderAsPaid()
+                dismiss()
             }))
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -48,7 +48,7 @@ struct SimplePaymentsMethod: View {
                   message: Text(viewModel.payByCashInfo()),
                   primaryButton: .cancel(),
                   secondaryButton: .default(Text(Localization.markAsPaidButton), action: {
-                print("Tapped marked as pay")
+                viewModel.markOrderAsPaid()
             }))
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -9,6 +9,10 @@ struct SimplePaymentsMethod: View {
     ///
     @ObservedObject var viewModel: SimplePaymentsMethodsViewModel
 
+    /// Determines if the "pay by cash" alert confirmation should be shown.
+    ///
+    @State var showingCashAlert = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.noSpacing) {
 
@@ -20,7 +24,7 @@ struct SimplePaymentsMethod: View {
 
             Group {
                 MethodRow(icon: .priceImage, title: Localization.cash) {
-                    print("Tapped Cash")
+                    showingCashAlert = true
                 }
 
                 Divider()
@@ -39,6 +43,14 @@ struct SimplePaymentsMethod: View {
         }
         .background(Color(.listBackground).ignoresSafeArea())
         .navigationTitle(viewModel.title)
+        .alert(isPresented: $showingCashAlert) {
+            Alert(title: Text(Localization.markAsPaidTitle),
+                  message: Text(viewModel.payByCashInfo()),
+                  primaryButton: .cancel(),
+                  secondaryButton: .default(Text(Localization.markAsPaidButton), action: {
+                print("Tapped marked as pay")
+            }))
+        }
     }
 }
 
@@ -93,6 +105,8 @@ private extension SimplePaymentsMethod {
         static let header = NSLocalizedString("Choose your payment method", comment: "Heading text on the select payment method screen for simple payments")
         static let cash = NSLocalizedString("Cash", comment: "Cash method title on the select payment method screen for simple payments")
         static let card = NSLocalizedString("Card", comment: "Card method title on the select payment method screen for simple payments")
+        static let markAsPaidTitle = NSLocalizedString("Mark as Paid?", comment: "Alert title when selecting the cash payment method for simple payments")
+        static let markAsPaidButton = NSLocalizedString("Mark as Paid", comment: "Alert button when selecting the cash payment method for simple payments")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -38,6 +38,21 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
     func payByCashInfo() -> String {
         Localization.markAsPaidInfo(total: formattedTotal)
     }
+
+    /// Mark an order as paid and dismiss flow
+    ///
+    func markOrderAsPaid() {
+        let action = OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: .completed) { [weak self] error in
+            print("Error: \(error?.localizedDescription ?? "No error")")
+            guard let self = self else {
+                print("Did nothing because self did not exists")
+                return
+            }
+
+            print("Self does exists")
+        }
+        stores.dispatch(action)
+    }
 }
 
 private extension SimplePaymentsMethodsViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -39,7 +39,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
         Localization.markAsPaidInfo(total: formattedTotal)
     }
 
-    /// Mark an order as paid and dismiss flow
+    /// Mark an order as paid and return immediately.
     ///
     func markOrderAsPaid() {
         let action = OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: .completed) { [weak self] error in

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -9,6 +9,18 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
     ///
     let title: String
 
+    /// Defines if the view should show a loading indicator.
+    /// Currently set while marking the order as complete
+    ///
+    @Published private(set) var showLoadingIndicator = false
+
+    /// Defines if the view should be disabled to prevent any further action.
+    /// Useful to prevent any double tap while a network operation is being performed.
+    ///
+    var disableViewActions: Bool {
+        showLoadingIndicator
+    }
+
     /// Store's ID.
     ///
     private let siteID: Int64
@@ -39,17 +51,16 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
         Localization.markAsPaidInfo(total: formattedTotal)
     }
 
-    /// Mark an order as paid and return immediately.
+    /// Mark an order as paid and notify if successful.
     ///
-    func markOrderAsPaid() {
+    func markOrderAsPaid(onSuccess: @escaping () -> ()) {
+        showLoadingIndicator = true
         let action = OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: .completed) { [weak self] error in
-            print("Error: \(error?.localizedDescription ?? "No error")")
-            guard let self = self else {
-                print("Did nothing because self did not exists")
+            guard let self = self, error == nil else {
                 return
             }
-
-            print("Self does exists")
+            self.showLoadingIndicator = false
+            onSuccess()
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -1,7 +1,43 @@
 import Foundation
+import Yosemite
 
 /// ViewModel for the `SimplePaymentsMethods` view.
 ///
 final class SimplePaymentsMethodsViewModel: ObservableObject {
 
+    /// Navigation bar title.
+    ///
+    let title: String
+
+    /// Store's ID.
+    ///
+    private let siteID: Int64
+
+    /// Order's ID to update
+    ///
+    private let orderID: Int64
+
+    /// Formatted total to charge.
+    ///
+    private let formattedTotal: String
+
+    /// Store manager to update order.
+    ///
+    private let stores: StoresManager
+
+    init(siteID: Int64 = 0, orderID: Int64 = 0, formattedTotal: String, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.orderID = orderID
+        self.formattedTotal = formattedTotal
+        self.stores = stores
+        self.title = Localization.title(total: formattedTotal)
+    }
+}
+
+private extension SimplePaymentsMethodsViewModel {
+    enum Localization {
+        static func title(total: String) -> String {
+            NSLocalizedString("Take Payment (\(total))", comment: "Navigation bar title for the Simple Payments Methods screens")
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// ViewModel for the `SimplePaymentsMethods` view.
+///
+final class SimplePaymentsMethodsViewModel: ObservableObject {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -32,12 +32,23 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
         self.stores = stores
         self.title = Localization.title(total: formattedTotal)
     }
+
+    /// Creates the info text when the merchant selects the cash payment method.
+    ///
+    func payByCashInfo() -> String {
+        Localization.markAsPaidInfo(total: formattedTotal)
+    }
 }
 
 private extension SimplePaymentsMethodsViewModel {
     enum Localization {
         static func title(total: String) -> String {
             NSLocalizedString("Take Payment (\(total))", comment: "Navigation bar title for the Simple Payments Methods screens")
+        }
+
+        static func markAsPaidInfo(total: String) -> String {
+            NSLocalizedString("This will mark your order as complete if you received \(total) outside of WooCommerce",
+                              comment: "Alert info when selecting the cash payment method for simple payments")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -36,7 +36,7 @@ struct SimplePaymentsSummary: View {
             TakePaymentSection(viewModel: viewModel)
 
             // Navigation To Payment Methods
-            LazyNavigationLink(destination: SimplePaymentsMethod(title: Localization.takePayment(total: viewModel.total)),
+            LazyNavigationLink(destination: SimplePaymentsMethod(viewModel: viewModel.createMethodsViewModel()),
                                isActive: $viewModel.navigateToPaymentMethods) {
                 EmptyView()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -4,6 +4,10 @@ import SwiftUI
 ///
 struct SimplePaymentsSummary: View {
 
+    /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
+    ///
+    var dismiss: (() -> Void) = {}
+
     /// Defines if the order note screen should be shown or not.
     ///
     @State var showEditNote = false
@@ -36,7 +40,7 @@ struct SimplePaymentsSummary: View {
             TakePaymentSection(viewModel: viewModel)
 
             // Navigation To Payment Methods
-            LazyNavigationLink(destination: SimplePaymentsMethod(viewModel: viewModel.createMethodsViewModel()),
+            LazyNavigationLink(destination: SimplePaymentsMethod(dismiss: dismiss, viewModel: viewModel.createMethodsViewModel()),
                                isActive: $viewModel.navigateToPaymentMethods) {
                 EmptyView()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -166,6 +166,12 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         }
         stores.dispatch(action)
     }
+
+    /// Creates a view model for the `SimplePaymentsMethods` screen.
+    ///
+    func createMethodsViewModel() -> SimplePaymentsMethodsViewModel {
+        SimplePaymentsMethodsViewModel(siteID: siteID, orderID: orderID, formattedTotal: total, stores: stores)
+    }
 }
 
 // MARK: Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -170,7 +170,11 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     /// Creates a view model for the `SimplePaymentsMethods` screen.
     ///
     func createMethodsViewModel() -> SimplePaymentsMethodsViewModel {
-        SimplePaymentsMethodsViewModel(siteID: siteID, orderID: orderID, formattedTotal: total, stores: stores)
+        SimplePaymentsMethodsViewModel(siteID: siteID,
+                                       orderID: orderID,
+                                       formattedTotal: total,
+                                       presentNoticeSubject: presentNoticeSubject,
+                                       stores: stores)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
 		261AA309275178FA009530FE /* SimplePaymentsMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA308275178FA009530FE /* SimplePaymentsMethod.swift */; };
+		261AA30C2753119E009530FE /* SimplePaymentsMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* SimplePaymentsMethodsViewModel.swift */; };
 		262A09812628A8F40033AD20 /* WooStyleModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09802628A8F40033AD20 /* WooStyleModifiers.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -1881,6 +1882,7 @@
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
 		261AA308275178FA009530FE /* SimplePaymentsMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethod.swift; sourceTree = "<group>"; };
+		261AA30B2753119E009530FE /* SimplePaymentsMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethodsViewModel.swift; sourceTree = "<group>"; };
 		262A09802628A8F40033AD20 /* WooStyleModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooStyleModifiers.swift; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -3954,6 +3956,7 @@
 			isa = PBXGroup;
 			children = (
 				261AA308275178FA009530FE /* SimplePaymentsMethod.swift */,
+				261AA30B2753119E009530FE /* SimplePaymentsMethodsViewModel.swift */,
 			);
 			path = Method;
 			sourceTree = "<group>";
@@ -8113,6 +8116,7 @@
 				4520A15E2722BA3E001FA573 /* OrderDateRangeFilter+Utils.swift in Sources */,
 				45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */,
 				2667BFE1252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift in Sources */,
+				261AA30C2753119E009530FE /* SimplePaymentsMethodsViewModel.swift in Sources */,
 				DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */,
 				02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */,
 				D8610BCC256F284700A5DF27 /* ULErrorViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
 		261AA309275178FA009530FE /* SimplePaymentsMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA308275178FA009530FE /* SimplePaymentsMethod.swift */; };
 		261AA30C2753119E009530FE /* SimplePaymentsMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* SimplePaymentsMethodsViewModel.swift */; };
+		261AA30E275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift */; };
 		262A09812628A8F40033AD20 /* WooStyleModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09802628A8F40033AD20 /* WooStyleModifiers.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -1883,6 +1884,7 @@
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
 		261AA308275178FA009530FE /* SimplePaymentsMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethod.swift; sourceTree = "<group>"; };
 		261AA30B2753119E009530FE /* SimplePaymentsMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethodsViewModel.swift; sourceTree = "<group>"; };
+		261AA30D275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		262A09802628A8F40033AD20 /* WooStyleModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooStyleModifiers.swift; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -3979,6 +3981,7 @@
 				262AF3892713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift */,
 				26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */,
 				26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */,
+				261AA30D275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift */,
 			);
 			path = "Simple Payments";
 			sourceTree = "<group>";
@@ -8656,6 +8659,7 @@
 				45AF9DA5265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,
+				261AA30E275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,
 				02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* LedgerTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -8,4 +8,113 @@ import Combine
 final class SimplePaymentsMethodsViewModelTests: XCTestCase {
 
     var subscriptions = Set<AnyCancellable>()
+
+    func test_loading_is_enabled_while_marking_order_as_paid() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrderStatus(_, _, _, onCompletion):
+                onCompletion(nil)
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores)
+
+        // When
+        let loadingStates: [Bool] = waitFor { promise in
+            viewModel.$showLoadingIndicator
+                .dropFirst() // Initial value
+                .collect(2)  // Collect toggle
+                .first()
+                .sink { loadingStates in
+                    promise(loadingStates)
+                }
+                .store(in: &self.subscriptions)
+            viewModel.markOrderAsPaid(onSuccess: {})
+        }
+
+        // Then
+        XCTAssertEqual(loadingStates, [true, false]) // Loading, then not loading.
+    }
+
+    func test_view_is_disabled_while_loading_is_enabled() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores)
+
+        // When
+        let loading: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .updateOrderStatus:
+                    promise(viewModel.showLoadingIndicator)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            viewModel.markOrderAsPaid(onSuccess: {})
+        }
+
+        // Then
+        XCTAssertTrue(loading)
+        XCTAssertTrue(viewModel.disableViewActions)
+    }
+
+    func test_onSuccess_is_invoked_after_order_is_marked_as_paid() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrderStatus(_, _, _, onCompletion):
+                onCompletion(nil)
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        let onSuccessInvoked: Bool = waitFor { promise in
+            viewModel.markOrderAsPaid(onSuccess: {
+                promise(true)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(onSuccessInvoked)
+    }
+
+    func test_view_model_attempts_error_notice_presentation_when_failing_to_mark_order_as_paid() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", presentNoticeSubject: noticeSubject, stores: stores)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrderStatus(_, _, _, onCompletion):
+                onCompletion(NSError(domain: "Error", code: 0))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        let receivedError: Bool = waitFor { promise in
+            noticeSubject.sink { intent in
+                switch intent {
+                case .error:
+                    promise(true)
+                }
+            }
+            .store(in: &self.subscriptions)
+            viewModel.markOrderAsPaid(onSuccess: {})
+        }
+
+        // Then
+        XCTAssertTrue(receivedError)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -1,0 +1,11 @@
+import Foundation
+import XCTest
+import Combine
+
+@testable import WooCommerce
+@testable import Yosemite
+
+final class SimplePaymentsMethodsViewModelTests: XCTestCase {
+
+    var subscriptions = Set<AnyCancellable>()
+}


### PR DESCRIPTION
Closes: #5350 

# Why 

After the Payment Methods UI was done in #5544, this PR adds the pay by cash functionality where the order will be marked as paid upon user confirmation.

# How

- Present an alert after tapping the "Cash" button asking for confirmation.
- Show a loading spinner in the trailing navigation item while the order is being updated.
- Dismiss the view if the network operation completes successfully.
- Show an error notice if there is a problem updating the order.

# Demo

https://user-images.githubusercontent.com/562080/143881625-ecd9a1bb-24af-4b38-adba-e1f4bef792cb.mov

https://user-images.githubusercontent.com/562080/143881641-c0287dc4-4a98-4b5b-a49a-0db04c05495e.mov


# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- Enter an amount & tap next
- Tap next on the summary screen
- Tap the "Cash" row on the Payment Methods screen
- See an alert being presented
- Tap on "Mark as paid"
- See a loading indicator in the trailing navigation bar item
- After success, see the user is navigated to the order list where the order is created and marked as paid.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
