### PR TITLE
5548 Provide admin link on incomplete address card reader connection error

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// Modal presented when an error occurs while connecting to a reader due to problems with the address
 ///
 final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsModalViewModel {
-    private let continueSearchAction: () -> Void
+    private let retrySearchAction: () -> Void
     private let cancelSearchAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedTopInfo
@@ -26,13 +26,13 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
 
     let bottomSubtitle: String? = nil
 
-    init(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
-        self.continueSearchAction = continueSearch
+    init(retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        self.retrySearchAction = retrySearch
         self.cancelSearchAction = cancelSearch
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        continueSearchAction()
+        retrySearchAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -4,6 +4,7 @@ import Yosemite
 /// Modal presented when an error occurs while connecting to a reader due to problems with the address
 ///
 final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsModalViewModel {
+    private let adminUrl: URL?
     private let retrySearchAction: () -> Void
     private let cancelSearchAction: () -> Void
 
@@ -26,7 +27,8 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
 
     let bottomSubtitle: String? = nil
 
-    init(retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+    init(adminUrl: URL?, retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        self.adminUrl = adminUrl
         self.retrySearchAction = retrySearch
         self.cancelSearchAction = cancelSearch
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -5,7 +5,8 @@ import Yosemite
 /// Modal presented when an error occurs while connecting to a reader due to problems with the address
 ///
 final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsModalViewModel {
-    private let adminUrl: URL?
+    private var adminUrl: URL?
+    private let openUrlInSafariAction: (_ url: URL) -> Void
     private let retrySearchAction: () -> Void
     private let cancelSearchAction: () -> Void
     private let site: Site?
@@ -36,9 +37,14 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
 
     let bottomSubtitle: String? = nil
 
-    init(adminUrl: URL?, site: Site?, retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+    init(adminUrl: URL?,
+         site: Site?,
+         openUrlInSafari: @escaping (URL) -> Void,
+         retrySearch: @escaping () -> Void,
+         cancelSearch: @escaping () -> Void) {
         self.adminUrl = adminUrl
         self.site = site
+        self.openUrlInSafariAction = openUrlInSafari
         self.retrySearchAction = retrySearch
         self.cancelSearchAction = cancelSearch
     }
@@ -52,8 +58,7 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
         case true:
             presentAuthenticatedWebview(url: adminUrl, from: viewController)
         default:
-            UIApplication.shared.open(adminUrl)
-            // TODO: Replace button with refresh? Dismiss the alert? Do the retry when the user returns to the app?
+            self.openUrlInSafariAction(adminUrl)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -17,7 +17,12 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
 
     let image: UIImage = .paymentErrorImage
 
-    let primaryButtonTitle: String? = Localization.retry
+    var primaryButtonTitle: String? {
+        guard adminUrl != nil else {
+            return Localization.retry
+        }
+        return Localization.openAdmin
+    }
 
     let secondaryButtonTitle: String? = Localization.cancel
 
@@ -34,7 +39,11 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        retrySearchAction()
+        guard let adminUrl = adminUrl,
+              let viewController = viewController else {
+            return retrySearchAction()
+        }
+        WebviewHelper.launch(adminUrl, with: viewController)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
@@ -50,6 +59,12 @@ private extension CardPresentModalConnectingFailedUpdateAddress {
             "Please update your store address to proceed.",
             comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
             "due to address problems"
+        )
+
+        static let openAdmin = NSLocalizedString(
+            "Enter Address",
+            comment: "Button to open a webview at the admin pages, so that the merchant can update their store address " +
+            "to continue setting up In Person Payments"
         )
 
         static let retry = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -593,6 +593,7 @@ private extension CardReaderConnectionController {
             }
             alerts.connectingFailedMissingAddress(from: from,
                                                   adminUrl: adminUrl,
+                                                  site: ServiceLocator.stores.sessionManager.defaultSite,
                                                   openUrlInSafari: openUrlInSafari,
                                                   retrySearch: continueSearch,
                                                   cancelSearch: cancelSearch)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -584,7 +584,7 @@ private extension CardReaderConnectionController {
 
         switch underlyingError {
         case .incompleteStoreAddress(adminUrl: _):
-            alerts.connectingFailedMissingAddress(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+            alerts.connectingFailedMissingAddress(from: from, retrySearch: continueSearch, cancelSearch: cancelSearch)
         default:
             alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -584,10 +584,25 @@ private extension CardReaderConnectionController {
 
         switch underlyingError {
         case .incompleteStoreAddress(let adminUrl):
-            alerts.connectingFailedMissingAddress(from: from, adminUrl: adminUrl, retrySearch: continueSearch, cancelSearch: cancelSearch)
+            let openUrlInSafari = { [weak self] (url: URL?) -> Void in
+                guard let adminUrl = url else {
+                    return
+                }
+                UIApplication.shared.open(adminUrl)
+                self?.showIncompleteAddressErrorWithRefreshButton()
+            }
+            alerts.connectingFailedMissingAddress(from: from,
+                                                  adminUrl: adminUrl,
+                                                  openUrlInSafari: openUrlInSafari,
+                                                  retrySearch: continueSearch,
+                                                  cancelSearch: cancelSearch)
         default:
             alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }
+    }
+
+    private func showIncompleteAddressErrorWithRefreshButton() {
+        showConnectionFailed(error: CardReaderServiceError.connection(underlyingError: .incompleteStoreAddress(adminUrl: nil)))
     }
 
     /// An error occurred during discovery

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -583,8 +583,8 @@ private extension CardReaderConnectionController {
         }
 
         switch underlyingError {
-        case .incompleteStoreAddress(adminUrl: _):
-            alerts.connectingFailedMissingAddress(from: from, retrySearch: continueSearch, cancelSearch: cancelSearch)
+        case .incompleteStoreAddress(let adminUrl):
+            alerts.connectingFailedMissingAddress(from: from, adminUrl: adminUrl, retrySearch: continueSearch, cancelSearch: cancelSearch)
         default:
             alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -170,7 +170,8 @@ private extension CardReaderSettingsAlerts {
     func connectingFailedUpdateAddress(adminUrl: URL?,
                                        retrySearch: @escaping () -> Void,
                                        cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailedUpdateAddress(adminUrl: adminUrl, retrySearch: retrySearch, cancelSearch: cancelSearch)
+        let site = ServiceLocator.stores.sessionManager.defaultSite
+        return CardPresentModalConnectingFailedUpdateAddress(adminUrl: adminUrl, site: site, retrySearch: retrySearch, cancelSearch: cancelSearch)
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -26,9 +26,9 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedMissingAddress(from: UIViewController,
-                                        continueSearch: @escaping () -> Void,
+                                        retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
-        setViewModelAndPresent(from: from, viewModel: connectingFailedUpdateAddress(continueSearch: continueSearch, cancelSearch: cancelSearch))
+        setViewModelAndPresent(from: from, viewModel: connectingFailedUpdateAddress(retrySearch: retrySearch, cancelSearch: cancelSearch))
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) {
@@ -166,8 +166,8 @@ private extension CardReaderSettingsAlerts {
         CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
-    func connectingFailedUpdateAddress(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailedUpdateAddress(continueSearch: continueSearch, cancelSearch: cancelSearch)
+    func connectingFailedUpdateAddress(retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalConnectingFailedUpdateAddress(retrySearch: retrySearch, cancelSearch: cancelSearch)
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -26,9 +26,10 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedMissingAddress(from: UIViewController,
+                                        adminUrl: URL?,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
-        setViewModelAndPresent(from: from, viewModel: connectingFailedUpdateAddress(retrySearch: retrySearch, cancelSearch: cancelSearch))
+        setViewModelAndPresent(from: from, viewModel: connectingFailedUpdateAddress(adminUrl: adminUrl, retrySearch: retrySearch, cancelSearch: cancelSearch))
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) {
@@ -166,8 +167,10 @@ private extension CardReaderSettingsAlerts {
         CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
-    func connectingFailedUpdateAddress(retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailedUpdateAddress(retrySearch: retrySearch, cancelSearch: cancelSearch)
+    func connectingFailedUpdateAddress(adminUrl: URL?,
+                                       retrySearch: @escaping () -> Void,
+                                       cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalConnectingFailedUpdateAddress(adminUrl: adminUrl, retrySearch: retrySearch, cancelSearch: cancelSearch)
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -27,9 +27,14 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
 
     func connectingFailedMissingAddress(from: UIViewController,
                                         adminUrl: URL?,
+                                        openUrlInSafari: @escaping (URL) -> Void,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
-        setViewModelAndPresent(from: from, viewModel: connectingFailedUpdateAddress(adminUrl: adminUrl, retrySearch: retrySearch, cancelSearch: cancelSearch))
+        setViewModelAndPresent(from: from,
+                               viewModel: connectingFailedUpdateAddress(adminUrl: adminUrl,
+                                                                        openUrlInSafari: openUrlInSafari,
+                                                                        retrySearch: retrySearch,
+                                                                        cancelSearch: cancelSearch))
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) {
@@ -168,10 +173,15 @@ private extension CardReaderSettingsAlerts {
     }
 
     func connectingFailedUpdateAddress(adminUrl: URL?,
+                                       openUrlInSafari: @escaping (URL) -> Void,
                                        retrySearch: @escaping () -> Void,
                                        cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         let site = ServiceLocator.stores.sessionManager.defaultSite
-        return CardPresentModalConnectingFailedUpdateAddress(adminUrl: adminUrl, site: site, retrySearch: retrySearch, cancelSearch: cancelSearch)
+        return CardPresentModalConnectingFailedUpdateAddress(adminUrl: adminUrl,
+                                                             site: site,
+                                                             openUrlInSafari: openUrlInSafari,
+                                                             retrySearch: retrySearch,
+                                                             cancelSearch: cancelSearch)
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -27,11 +27,13 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
 
     func connectingFailedMissingAddress(from: UIViewController,
                                         adminUrl: URL?,
+                                        site: Site?,
                                         openUrlInSafari: @escaping (URL) -> Void,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
         setViewModelAndPresent(from: from,
                                viewModel: connectingFailedUpdateAddress(adminUrl: adminUrl,
+                                                                        site: site,
                                                                         openUrlInSafari: openUrlInSafari,
                                                                         retrySearch: retrySearch,
                                                                         cancelSearch: cancelSearch))
@@ -173,10 +175,10 @@ private extension CardReaderSettingsAlerts {
     }
 
     func connectingFailedUpdateAddress(adminUrl: URL?,
+                                       site: Site?,
                                        openUrlInSafari: @escaping (URL) -> Void,
                                        retrySearch: @escaping () -> Void,
                                        cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        let site = ServiceLocator.stores.sessionManager.defaultSite
         return CardPresentModalConnectingFailedUpdateAddress(adminUrl: adminUrl,
                                                              site: site,
                                                              openUrlInSafari: openUrlInSafari,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -49,6 +49,7 @@ protocol CardReaderSettingsAlertsProvider {
     /// The user may try again or cancel
     ///
     func connectingFailedMissingAddress(from: UIViewController,
+                                        adminUrl: URL?,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -49,7 +49,7 @@ protocol CardReaderSettingsAlertsProvider {
     /// The user may try again or cancel
     ///
     func connectingFailedMissingAddress(from: UIViewController,
-                                        continueSearch: @escaping () -> Void,
+                                        retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void)
 
     /// Defines an alert indicating an update couldn't be installed because the reader is low on battery.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -50,6 +50,7 @@ protocol CardReaderSettingsAlertsProvider {
     ///
     func connectingFailedMissingAddress(from: UIViewController,
                                         adminUrl: URL?,
+                                        openUrlInSafari: @escaping (URL) -> Void,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Yosemite
 
 /// Defines a protocol for card reader alert providers to conform to - defining what
 /// alerts such a provider is expected to provide over the course of searching for
@@ -50,6 +51,7 @@ protocol CardReaderSettingsAlertsProvider {
     ///
     func connectingFailedMissingAddress(from: UIViewController,
                                         adminUrl: URL?,
+                                        site: Site?,
                                         openUrlInSafari: @escaping (URL) -> Void,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void)

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Yosemite
 @testable import WooCommerce
 
 enum MockCardReaderSettingsAlertsMode {
@@ -84,10 +85,11 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedMissingAddress(from: UIViewController,
-                                   adminUrl: URL?,
-                                   openUrlInSafari: @escaping (URL) -> Void,
-                                   retrySearch: @escaping () -> Void,
-                                   cancelSearch: @escaping () -> Void) {
+                                        adminUrl: URL?,
+                                        site: Site?,
+                                        openUrlInSafari: @escaping (URL) -> Void,
+                                        retrySearch: @escaping () -> Void,
+                                        cancelSearch: @escaping () -> Void) {
         if mode == .continueSearchingAfterConnectionFailure {
             retrySearch()
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -84,6 +84,7 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedMissingAddress(from: UIViewController,
+                                        adminUrl: URL?,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
         if mode == .continueSearchingAfterConnectionFailure {

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -84,10 +84,10 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedMissingAddress(from: UIViewController,
-                                        continueSearch: @escaping () -> Void,
+                                        retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
         if mode == .continueSearchingAfterConnectionFailure {
-            continueSearch()
+            retrySearch()
         }
 
         if mode == .cancelSearchingAfterConnectionFailure {

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -84,9 +84,10 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedMissingAddress(from: UIViewController,
-                                        adminUrl: URL?,
-                                        retrySearch: @escaping () -> Void,
-                                        cancelSearch: @escaping () -> Void) {
+                                   adminUrl: URL?,
+                                   openUrlInSafari: @escaping (URL) -> Void,
+                                   retrySearch: @escaping () -> Void,
+                                   cancelSearch: @escaping () -> Void) {
         if mode == .continueSearchingAfterConnectionFailure {
             retrySearch()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5548
<!-- Id number of the GitHub issue this PR addresses. -->
Merge #5547 before this

### Description
This changes the behaviour of the primary button on the incomplete address error alert, so that it now opens the `adminUrl` received from the API. 

[Like Android](https://github.com/woocommerce/woocommerce-ios/issues/5088#issuecomment-943220808), this will open the admin pages within an authenticated in-app web view if it's a Wordpress.com store, and send the user to Safari if it's a self-hosted site.
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Questions
1. Getting the site info. I'm not sure where the best place to do this is, I've opted for one class up from the view model for now but there's no particular logic to that decision. Where do you think would be best to make that service locator call? 
2. Is there a better way of finding out whether it's a WP.com site?
3. Have you come across the runtime error `Accessing State's value outside of being installed on a View. This will result in a constant Binding of the initial value and will not update.`? This happens if I try to use the `isPresented` property of `AuthenticatedWebview` outside SwiftUI, and I think it's unavoidable in this situation. If you know otherwise, it might be nicer to be able to use that to manage presentation rather than calling `viewController.dismiss()` in the closure.
4. Handling the return from Safari for the self-hosted sites isn't attempted yet, so any comments on the options in the TODO there would be appreciated.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Wordpress.com/Atomic stores
1. With a WP.com or Atomic store set up for In-Person Payments, go to `WP-Admin > WooCommerce > Settings` and delete the contents of `Address line 1`
2. In the app, go to `⚙️ > In-Person Payments > Manage Card Reader`
3. Search for and connect to a reader (or simulated reader)
4. Observe that the error message is shown telling the merchant to update their address.
5. Tap `Enter Address` to open a webview at the admin pages, you should be logged in already.
6. Update the address in WP-Admin to include `Address line 1` again
7. Tap `Done`, and connect to the reader again.

#### Self hosted stores
1. With a self-hosted store set up for In-Person Payments, go to `WP-Admin > WooCommerce > Settings` and delete the contents of `Address line 1`
2. In the app, go to `⚙️ > In-Person Payments > Manage Card Reader`
3. Search for and connect to a reader (or simulated reader)
4. Observe that the error message is shown telling the merchant to update their address.
5. Tap `Enter Address` to go to Safari at the admin pages, login if necessary.
6. Update the address in WP-Admin to include `Address line 1` again
7. Return to the app, cancel on the alert, and connect to the reader again

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### Wordpress.com/Atomic store


https://user-images.githubusercontent.com/2472348/144076136-013fe75c-3a8f-4019-82f0-518faa01a0c9.mp4




#### Self hosted stores



https://user-images.githubusercontent.com/2472348/144076191-323cb1bb-566c-4335-9ed7-0527b1cb49b5.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
