### PR TITLE
Jetpack CP: log JCP properties in `site_picker_continue_tapped` event

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1318,6 +1318,7 @@ extension Site {
             isJetpackConnected: .fake(),
             isWooCommerceActive: .fake(),
             isWordPressStore: .fake(),
+            jetpackConnectionActivePlugins: .fake(),
             timezone: .fake(),
             gmtOffset: .fake()
         )

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1155,6 +1155,7 @@ extension Site {
         isJetpackConnected: CopiableProp<Bool> = .copy,
         isWooCommerceActive: CopiableProp<Bool> = .copy,
         isWordPressStore: CopiableProp<Bool> = .copy,
+        jetpackConnectionActivePlugins: CopiableProp<[String]> = .copy,
         timezone: CopiableProp<String> = .copy,
         gmtOffset: CopiableProp<Double> = .copy
     ) -> Site {
@@ -1167,6 +1168,7 @@ extension Site {
         let isJetpackConnected = isJetpackConnected ?? self.isJetpackConnected
         let isWooCommerceActive = isWooCommerceActive ?? self.isWooCommerceActive
         let isWordPressStore = isWordPressStore ?? self.isWordPressStore
+        let jetpackConnectionActivePlugins = jetpackConnectionActivePlugins ?? self.jetpackConnectionActivePlugins
         let timezone = timezone ?? self.timezone
         let gmtOffset = gmtOffset ?? self.gmtOffset
 
@@ -1180,6 +1182,7 @@ extension Site {
             isJetpackConnected: isJetpackConnected,
             isWooCommerceActive: isWooCommerceActive,
             isWordPressStore: isWordPressStore,
+            jetpackConnectionActivePlugins: jetpackConnectionActivePlugins,
             timezone: timezone,
             gmtOffset: gmtOffset
         )

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -41,6 +41,9 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     ///
     public let isWordPressStore: Bool
 
+    /// For Jetpack CP sites (connected to Jetpack with Jetpack Connection Package instead of Jetpack-the-plugin), this property contains a list of active plugins with Jetpack Connection Package
+    /// (e.g. WooCommerce Payments, Jetpack Backup).
+    ///
     public let jetpackConnectionActivePlugins: [String]
 
     /// Time zone identifier of the site (TZ database name).

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -41,8 +41,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     ///
     public let isWordPressStore: Bool
 
-    /// For Jetpack CP sites (connected to Jetpack with Jetpack Connection Package instead of Jetpack-the-plugin), this property contains a list of active plugins with Jetpack Connection Package
-    /// (e.g. WooCommerce Payments, Jetpack Backup).
+    /// For Jetpack CP sites (connected to Jetpack with Jetpack Connection Package instead of Jetpack-the-plugin), this property contains
+    /// a list of active plugins with Jetpack Connection Package (e.g. WooCommerce Payments, Jetpack Backup).
     ///
     public let jetpackConnectionActivePlugins: [String]
 

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -41,6 +41,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     ///
     public let isWordPressStore: Bool
 
+    public let jetpackConnectionActivePlugins: [String]
+
     /// Time zone identifier of the site (TZ database name).
     ///
     public let timezone: String
@@ -64,6 +66,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         let optionsContainer = try siteContainer.nestedContainer(keyedBy: OptionKeys.self, forKey: .options)
         let isWordPressStore = try optionsContainer.decode(Bool.self, forKey: .isWordPressStore)
         let isWooCommerceActive = try optionsContainer.decode(Bool.self, forKey: .isWooCommerceActive)
+        let jetpackConnectionActivePlugins = try optionsContainer.decodeIfPresent([String].self, forKey: .jetpackConnectionActivePlugins) ?? []
         let timezone = try optionsContainer.decode(String.self, forKey: .timezone)
         let gmtOffset = try optionsContainer.decode(Double.self, forKey: .gmtOffset)
 
@@ -76,6 +79,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                   isJetpackConnected: isJetpackConnected,
                   isWooCommerceActive: isWooCommerceActive,
                   isWordPressStore: isWordPressStore,
+                  jetpackConnectionActivePlugins: jetpackConnectionActivePlugins,
                   timezone: timezone,
                   gmtOffset: gmtOffset)
     }
@@ -91,6 +95,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                 isJetpackConnected: Bool,
                 isWooCommerceActive: Bool,
                 isWordPressStore: Bool,
+                jetpackConnectionActivePlugins: [String],
                 timezone: String,
                 gmtOffset: Double) {
         self.siteID = siteID
@@ -102,6 +107,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         self.isJetpackConnected = isJetpackConnected
         self.isWordPressStore = isWordPressStore
         self.isWooCommerceActive = isWooCommerceActive
+        self.jetpackConnectionActivePlugins = jetpackConnectionActivePlugins
         self.timezone = timezone
         self.gmtOffset = gmtOffset
     }
@@ -135,6 +141,7 @@ private extension Site {
         case isWooCommerceActive = "woocommerce_is_active"
         case timezone = "timezone"
         case gmtOffset = "gmt_offset"
+        case jetpackConnectionActivePlugins = "jetpack_connection_active_plugins"
     }
 
     enum PlanKeys: String, CodingKey {

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -69,7 +69,7 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
         let path = "me/sites"
         let parameters = [
             "fields": "ID,name,description,URL,options,jetpack,jetpack_connection",
-            "options": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset"
+            "options": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset,jetpack_connection_active_plugins"
         ]
 
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)

--- a/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// AccountMapper Unit Tests
 ///
-class AccountMapperTests: XCTestCase {
+final class AccountMapperTests: XCTestCase {
 
     /// Verifies that all of the Account fields are properly parsed.
     ///
@@ -27,25 +27,35 @@ class AccountMapperTests: XCTestCase {
         let sites = mapLoadSitesResponse()
         XCTAssert(sites?.count == 2)
 
+        // The first site is a Jetpack site.
         let first = sites!.first!
         XCTAssertEqual(first.siteID, 1112233334444555)
         XCTAssertEqual(first.name, "Testing Blog")
         XCTAssertEqual(first.description, "Testing Tagline")
         XCTAssertEqual(first.url, "https://some-testing-url.testing.blog")
+        XCTAssertFalse(first.isJetpackCPConnected)
+        XCTAssertTrue(first.isJetpackConnected)
+        XCTAssertTrue(first.isJetpackThePluginInstalled)
         XCTAssertEqual(first.isWooCommerceActive, true)
         XCTAssertEqual(first.isWordPressStore, true)
         XCTAssertEqual(first.gmtOffset, 3.5)
         XCTAssertEqual(first.siteTimezone, TimeZone(secondsFromGMT: 12600))
+        XCTAssertEqual(first.jetpackConnectionActivePlugins, [])
 
+        // The second site is a Jetpack CP site (connected to Jetpack without Jetpack-the-plugin).
         let second = sites!.last!
         XCTAssertEqual(second.siteID, 11122333344446666)
         XCTAssertEqual(second.name, "Thoughts")
         XCTAssertEqual(second.description, "Your Favorite Blog")
         XCTAssertEqual(second.url, "https://thoughts.testing.blog")
+        XCTAssertTrue(second.isJetpackCPConnected)
+        XCTAssertTrue(second.isJetpackConnected)
+        XCTAssertFalse(second.isJetpackThePluginInstalled)
         XCTAssertEqual(second.isWooCommerceActive, false)
         XCTAssertEqual(second.isWordPressStore, false)
         XCTAssertEqual(second.gmtOffset, -4)
         XCTAssertEqual(second.siteTimezone, TimeZone(secondsFromGMT: -14400))
+        XCTAssertEqual(second.jetpackConnectionActivePlugins, ["jetpack", "woocommerce-payments"])
     }
 
     /// Verifies that the Plan field for Site is properly parsed.

--- a/Networking/NetworkingTests/Responses/sites.json
+++ b/Networking/NetworkingTests/Responses/sites.json
@@ -216,7 +216,11 @@
         "is_wpcom_store": false,
         "woocommerce_is_active": false,
         "design_type": null,
-        "site_goals": null
+        "site_goals": null,
+        "jetpack_connection_active_plugins": [
+            "jetpack",
+            "woocommerce-payments"
+        ]
       }
     }
     ]

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -89,11 +89,13 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         // We need to call refreshUserData() here because the user selected
         // their default store and tracks should to know about it.
         ServiceLocator.analytics.refreshUserData()
+
+        let jetpackCPActivePlugins = (stores.sessionManager.defaultSite?.jetpackConnectionActivePlugins ?? []).joined(separator: ",")
         ServiceLocator.analytics.track(.sitePickerContinueTapped,
                                   withProperties: [
                                     "selected_store_id": stores.sessionManager.defaultStoreID ?? String(),
                                     "is_jetpack_cp_connected": stores.sessionManager.defaultSite?.isJetpackCPConnected == true,
-                                    "jetpack_cp_active_plugins": stores.sessionManager.defaultSite?.jetpackConnectionActivePlugins ?? []
+                                    "jetpack_cp_active_plugins": jetpackCPActivePlugins
                                   ])
 
         AppDelegate.shared.authenticatorWasDismissed()

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -90,7 +90,11 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         // their default store and tracks should to know about it.
         ServiceLocator.analytics.refreshUserData()
         ServiceLocator.analytics.track(.sitePickerContinueTapped,
-                                  withProperties: ["selected_store_id": stores.sessionManager.defaultStoreID ?? String()])
+                                  withProperties: [
+                                    "selected_store_id": stores.sessionManager.defaultStoreID ?? String(),
+                                    "is_jetpack_cp_connected": stores.sessionManager.defaultSite?.isJetpackCPConnected == true,
+                                    "jetpack_cp_active_plugins": stores.sessionManager.defaultSite?.jetpackConnectionActivePlugins ?? []
+                                  ])
 
         AppDelegate.shared.authenticatorWasDismissed()
     }

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -40,6 +40,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         isJetpackConnected: true,
         isWooCommerceActive: true,
         isWordPressStore: true,
+        jetpackConnectionActivePlugins: [],
         timezone: "UTC",
         gmtOffset: 0
     )

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -18,6 +18,7 @@ extension Storage.Site: ReadOnlyConvertible {
         isJetpackConnected = site.isJetpackConnected
         isWooCommerceActive = NSNumber(booleanLiteral: site.isWooCommerceActive)
         isWordPressStore = NSNumber(booleanLiteral: site.isWordPressStore)
+        jetpackConnectionActivePlugins = site.jetpackConnectionActivePlugins
         timezone = site.timezone
         gmtOffset = site.gmtOffset
     }
@@ -34,6 +35,7 @@ extension Storage.Site: ReadOnlyConvertible {
                     isJetpackConnected: isJetpackConnected,
                     isWooCommerceActive: isWooCommerceActive?.boolValue ?? false,
                     isWordPressStore: isWordPressStore?.boolValue ?? false,
+                    jetpackConnectionActivePlugins: jetpackConnectionActivePlugins ?? [],
                     timezone: timezone ?? "",
                     gmtOffset: gmtOffset)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5402 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR only adds properties to the `site_picker_continue_tapped` event, the other events will be implemented in separate PR(s).

In the site picker, we log `site_picker_continue_tapped` when the user selects a site and continues with the site. To understand more about JCP sites, we are adding two properties to this event:

- `is_jetpack_cp_connected: Bool`: whether the site is JCP (connected to Jetpack without Jetpack-the-plugin)
- `jetpack_cp_active_plugins: String`: a comma-separated list of active plugins that contain Jetpack Connection Package, this is populated in JCP and Jetpack sites

In order to log `jetpack_cp_active_plugins`, we add an option field to `me/sites` API request and parse `jetpack_cp_active_plugins` in the options. We persist `jetpack_cp_active_plugins` in storage, and pass it to `Networking.Site`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23) and a Jetpack site (with Jetpack-the-plugin)

- Launch the app
- Log out from the app
- Log in with the account in the prerequisite to reach the site picker
- Select a JCP site and tap "Continue" --> the console should show `🔵 Tracked site_picker_continue_tapped` with properties including `"is_jetpack_cp_connected": true` and `"jetpack_cp_active_plugins": "jetpack-backup"` for example (please note that if the JCP site has WCPay, `jetpack_cp_active_plugins` is empty while `is_jetpack_cp_connected` is `true` due to a bug as mentioned in p91TBi-6r6-p2)
- Go to Settings > Switch Store
- Select a Jetpack site and tap "Continue" --> the console should show `🔵 Tracked site_picker_continue_tapped` with properties including `"is_jetpack_cp_connected": false` and `"jetpack_cp_active_plugins": "jetpack"`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->