### PR TITLE
Order Creation: Add Product UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -81,6 +81,7 @@ struct NewOrder: View {
 ///
 private struct ProductsSection: View {
     let geometry: GeometryProxy
+    @State private var showAddProduct: Bool = false
 
     var body: some View {
         Group {
@@ -94,9 +95,12 @@ private struct ProductsSection: View {
                 ProductRow()
 
                 Button(NewOrder.Localization.addProduct) {
-                    // TODO: Open Add Product modal view
+                    showAddProduct.toggle()
                 }
                 .buttonStyle(PlusButtonStyle())
+                .sheet(isPresented: $showAddProduct) {
+                    AddProduct(isPresented: $showAddProduct)
+                }
             }
             .padding(.horizontal, insets: geometry.safeAreaInsets)
             .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -105,96 +105,6 @@ private struct ProductsSection: View {
             Divider()
         }
     }
-
-    /// Represent a single product row in the Product section
-    ///
-    struct ProductRow: View {
-
-        // Tracks the scale of the view due to accessibility changes
-        @ScaledMetric private var scale: CGFloat = 1
-
-        var body: some View {
-            AdaptiveStack(horizontalAlignment: .leading) {
-                HStack(alignment: .top) {
-                    // Product image
-                    // TODO: Display actual product image when available
-                    Image(uiImage: .productPlaceholderImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: NewOrder.Layout.productImageSize * scale, height: NewOrder.Layout.productImageSize * scale)
-                        .foregroundColor(Color(UIColor.listSmallIcon))
-                        .accessibilityHidden(true)
-
-                    // Product details
-                    VStack(alignment: .leading) {
-                        Text("Love Ficus") // Fake data - product name
-                        Text("7 in stock • $20.00") // Fake data - stock / price
-                            .subheadlineStyle()
-                        Text("SKU: 123456") // Fake data - SKU
-                            .subheadlineStyle()
-                    }
-                    .accessibilityElement(children: .combine)
-                }
-
-                Spacer()
-
-                ProductStepper()
-            }
-
-            Divider()
-        }
-    }
-
-    /// Represents a custom stepper.
-    /// Used to change the product quantity in the order.
-    ///
-    struct ProductStepper: View {
-
-        // Tracks the scale of the view due to accessibility changes
-        @ScaledMetric private var scale: CGFloat = 1
-
-        var body: some View {
-            HStack(spacing: NewOrder.Layout.stepperSpacing * scale) {
-                Button {
-                    // TODO: Decrement the product quantity
-                } label: {
-                    Image(uiImage: .minusSmallImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(height: NewOrder.Layout.stepperButtonSize * scale)
-                }
-
-                Text("1") // Fake data - quantity
-
-                Button {
-                    // TODO: Increment the product quantity
-                } label: {
-                    Image(uiImage: .plusSmallImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(height: NewOrder.Layout.stepperButtonSize * scale)
-                }
-            }
-            .padding(NewOrder.Layout.stepperSpacing/2 * scale)
-            .overlay(
-                RoundedRectangle(cornerRadius: NewOrder.Layout.stepperBorderRadius)
-                    .stroke(Color(UIColor.separator), lineWidth: NewOrder.Layout.stepperBorderWidth)
-            )
-            .accessibilityElement(children: .ignore)
-            .accessibility(label: Text("Quantity"))
-            .accessibility(value: Text("1")) // Fake static data - quantity
-            .accessibilityAdjustableAction { direction in
-                switch direction {
-                case .decrement:
-                    break // TODO: Decrement the product quantity
-                case .increment:
-                    break // TODO: Increment the product quantity
-                @unknown default:
-                    break
-                }
-            }
-        }
-    }
 }
 
 // MARK: Constants
@@ -203,11 +113,6 @@ private extension NewOrder {
         static let sectionSpacing: CGFloat = 16.0
         static let verticalSpacing: CGFloat = 22.0
         static let noSpacing: CGFloat = 0.0
-        static let productImageSize: CGFloat = 44.0
-        static let stepperBorderWidth: CGFloat = 1.0
-        static let stepperBorderRadius: CGFloat = 4.0
-        static let stepperButtonSize: CGFloat = 22.0
-        static let stepperSpacing: CGFloat = 22.0
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -92,7 +92,7 @@ private struct ProductsSection: View {
                     .headlineStyle()
 
                 // TODO: Add a product row for each product added to the order
-                ProductRow()
+                ProductRow(canChangeQuantity: true)
 
                 Button(NewOrder.Localization.addProduct) {
                     showAddProduct.toggle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -81,6 +81,9 @@ struct NewOrder: View {
 ///
 private struct ProductsSection: View {
     let geometry: GeometryProxy
+
+    /// Defines whether `AddProduct` modal is presented.
+    ///
     @State private var showAddProduct: Bool = false
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct AddProduct: View {
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                // TODO: Make the product list searchable
+                LazyVStack {
+                    // TODO: Add a product row for each non-variable product in the store
+                    ProductRow()
+                }
+                .padding()
+            }
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.close) {
+                        isPresented.toggle()
+                    }
+                }
+            }
+        }
+        .wooNavigationBarStyle()
+    }
+}
+
+private extension AddProduct {
+    enum Localization {
+        static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
+        static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
+    }
+}
+
+struct AddProduct_Previews: PreviewProvider {
+    static var previews: some View {
+        AddProduct(isPresented: .constant(true))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
+/// View showing a list of products to add to an order.
+///
 struct AddProduct: View {
+    /// Defines whether the view is presented.
+    ///
     @Binding var isPresented: Bool
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
@@ -9,7 +9,7 @@ struct AddProduct: View {
                 // TODO: Make the product list searchable
                 LazyVStack {
                     // TODO: Add a product row for each non-variable product in the store
-                    ProductRow()
+                    ProductRow(canChangeQuantity: false)
                 }
                 .padding()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -77,7 +77,7 @@ private struct ProductStepper: View {
                 .stroke(Color(UIColor.separator), lineWidth: Layout.stepperBorderWidth)
         )
         .accessibilityElement(children: .ignore)
-        .accessibility(label: Text("Quantity"))
+        .accessibility(label: Text(Localization.quantityLabel))
         .accessibility(value: Text("1")) // Fake static data - quantity
         .accessibilityAdjustableAction { direction in
             switch direction {
@@ -98,6 +98,10 @@ private enum Layout {
     static let stepperBorderRadius: CGFloat = 4.0
     static let stepperButtonSize: CGFloat = 22.0
     static let stepperSpacing: CGFloat = 22.0
+}
+
+private enum Localization {
+    static let quantityLabel = NSLocalizedString("Quantity", comment: "Accessibility label for product quantity field")
 }
 
 struct ProductRow_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -3,6 +3,9 @@ import SwiftUI
 /// Represent a single product row in the Product section of a New Order
 ///
 struct ProductRow: View {
+    /// Whether the product quantity can be changed.
+    /// Controls whether the stepper is rendered.
+    ///
     let canChangeQuantity: Bool
 
     // Tracks the scale of the view due to accessibility changes

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+/// Represent a single product row in the Product section of a New Order
+///
+struct ProductRow: View {
+
+    // Tracks the scale of the view due to accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1
+
+    var body: some View {
+        VStack {
+            AdaptiveStack(horizontalAlignment: .leading) {
+                HStack(alignment: .top) {
+                    // Product image
+                    // TODO: Display actual product image when available
+                    Image(uiImage: .productPlaceholderImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: Layout.productImageSize * scale, height: Layout.productImageSize * scale)
+                        .foregroundColor(Color(UIColor.listSmallIcon))
+                        .accessibilityHidden(true)
+
+                    // Product details
+                    VStack(alignment: .leading) {
+                        Text("Love Ficus") // Fake data - product name
+                        Text("7 in stock • $20.00") // Fake data - stock / price
+                            .subheadlineStyle()
+                        Text("SKU: 123456") // Fake data - SKU
+                            .subheadlineStyle()
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+
+                Spacer()
+
+                ProductStepper()
+            }
+
+            Divider()
+        }
+    }
+}
+
+/// Represents a custom stepper.
+/// Used to change the quantity of the product in a `ProductRow`.
+///
+private struct ProductStepper: View {
+
+    // Tracks the scale of the view due to accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1
+
+    var body: some View {
+        HStack(spacing: Layout.stepperSpacing * scale) {
+            Button {
+                // TODO: Decrement the product quantity
+            } label: {
+                Image(uiImage: .minusSmallImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: Layout.stepperButtonSize * scale)
+            }
+
+            Text("1") // Fake data - quantity
+
+            Button {
+                // TODO: Increment the product quantity
+            } label: {
+                Image(uiImage: .plusSmallImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: Layout.stepperButtonSize * scale)
+            }
+        }
+        .padding(Layout.stepperSpacing/2 * scale)
+        .overlay(
+            RoundedRectangle(cornerRadius: Layout.stepperBorderRadius)
+                .stroke(Color(UIColor.separator), lineWidth: Layout.stepperBorderWidth)
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibility(label: Text("Quantity"))
+        .accessibility(value: Text("1")) // Fake static data - quantity
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .decrement:
+                break // TODO: Decrement the product quantity
+            case .increment:
+                break // TODO: Increment the product quantity
+            @unknown default:
+                break
+            }
+        }
+    }
+}
+
+private enum Layout {
+    static let productImageSize: CGFloat = 44.0
+    static let stepperBorderWidth: CGFloat = 1.0
+    static let stepperBorderRadius: CGFloat = 4.0
+    static let stepperButtonSize: CGFloat = 22.0
+    static let stepperSpacing: CGFloat = 22.0
+}
+
+struct ProductRow_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductRow()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Represent a single product row in the Product section of a New Order
 ///
 struct ProductRow: View {
+    let canChangeQuantity: Bool
 
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1
@@ -34,6 +35,7 @@ struct ProductRow: View {
                 Spacer()
 
                 ProductStepper()
+                    .renderedIf(canChangeQuantity)
             }
 
             Divider()
@@ -106,7 +108,12 @@ private enum Localization {
 
 struct ProductRow_Previews: PreviewProvider {
     static var previews: some View {
-        ProductRow()
+        ProductRow(canChangeQuantity: true)
+            .previewDisplayName("ProductRow with stepper")
+            .previewLayout(.sizeThatFits)
+
+        ProductRow(canChangeQuantity: false)
+            .previewDisplayName("ProductRow without stepper")
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1052,6 +1052,7 @@
 		CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */; };
 		CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */; };
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
+		CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3427551A6E00C4CA4F /* ProductRow.swift */; };
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
@@ -2534,6 +2535,7 @@
 		CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndToggleRow.swift; sourceTree = "<group>"; };
 		CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModel.swift; sourceTree = "<group>"; };
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
+		CC53FB3427551A6E00C4CA4F /* ProductRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRow.swift; sourceTree = "<group>"; };
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
@@ -5727,6 +5729,14 @@
 			path = "Payment Methods";
 			sourceTree = "<group>";
 		};
+		CC53FB3627551A8700C4CA4F /* ProductsSection */ = {
+			isa = PBXGroup;
+			children = (
+				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
+			);
+			path = ProductsSection;
+			sourceTree = "<group>";
+		};
 		CCB366AD274518CD007D437A /* Order Creation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5941,6 +5951,7 @@
 			children = (
 				CCFC50542743BC0D001E505F /* NewOrder.swift */,
 				CCFC50582743E021001E505F /* NewOrderViewModel.swift */,
+				CC53FB3627551A8700C4CA4F /* ProductsSection */,
 				AEA622B327466B78002A9B57 /* BottomSheetOrderType.swift */,
 				AEA622B1274669D3002A9B57 /* AddOrderCoordinator.swift */,
 			);
@@ -8178,6 +8189,7 @@
 				DE279BA626E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,
+				CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */,
 				2662D90A26E16B3600E25611 /* FilterListSelector.swift in Sources */,
 				314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1053,6 +1053,7 @@
 		CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */; };
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
 		CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3427551A6E00C4CA4F /* ProductRow.swift */; };
+		CC53FB382755213900C4CA4F /* AddProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB372755213900C4CA4F /* AddProduct.swift */; };
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
@@ -2536,6 +2537,7 @@
 		CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModel.swift; sourceTree = "<group>"; };
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		CC53FB3427551A6E00C4CA4F /* ProductRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRow.swift; sourceTree = "<group>"; };
+		CC53FB372755213900C4CA4F /* AddProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProduct.swift; sourceTree = "<group>"; };
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
@@ -5732,6 +5734,7 @@
 		CC53FB3627551A8700C4CA4F /* ProductsSection */ = {
 			isa = PBXGroup;
 			children = (
+				CC53FB372755213900C4CA4F /* AddProduct.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
 			);
 			path = ProductsSection;
@@ -7998,6 +8001,7 @@
 				57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */,
 				B5A8532220BDBFAF00FAAB4D /* CircularImageView.swift in Sources */,
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,
+				CC53FB382755213900C4CA4F /* AddProduct.swift in Sources */,
 				0235595324496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift in Sources */,
 				452FE6522565849B00EB54A0 /* LinkedProductsViewModel.swift in Sources */,
 				45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */,


### PR DESCRIPTION
Part of: #5408

## Description

This adds the Add Product UI in the order creation flow. Tapping the "Add product" button on the New Order screen opens a modal Add Product view. For now, the UI is a static product row with temporary, fake data; it will eventually be populated with a list of products on the store.

Future PRs will add real data and interactions, as well as a search bar on the Add Product screen.

## Changes

* Moves `ProductRow` out of the `NewOrder` view, so it can be reused in the `AddProduct` view.
* Adds the option to show/hide the stepper in `ProductRow` (shown on the New Order screen and hidden on the Add Product screen).
* Adds the `AddProduct` view, which for now displays a navigation bar and single product row with static data.
* Adds navigation from `NewOrder` to `AddProduct` when you tap on the "Add product" button.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, tap the "Add product" button.
5. Confirm the Add Product modal appears with a product row, and you can tap the Close button or swipe to dismiss it.

## Screenshots


https://user-images.githubusercontent.com/8658164/144036120-9cb70da7-a696-46ae-aac6-3c60b5627eeb.mp4

iPhone|iPad
-|-
![AddProductUI-iPhone](https://user-images.githubusercontent.com/8658164/144036137-0339bdb8-1761-4777-97c9-de94ae667517.png)|![AddProductUI-iPad](https://user-images.githubusercontent.com/8658164/144036143-a1a06dfc-40f0-4072-b54a-4b3e917eae1a.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
