### PR TITLE
5320 Show card reader connection postal code error

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
+++ b/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
@@ -23,5 +23,6 @@ public protocol CardReaderConfigProvider: ReaderLocationProvider, ReaderTokenPro
 ///
 public enum CardReaderConfigError: Error, LocalizedError {
     case incompleteStoreAddress(adminUrl: URL?)
+    case invalidPostalCode
     case unknown(error: Error)
 }

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -131,6 +131,9 @@ public enum UnderlyingError: Error, Equatable {
     /// The store setup is incomplete, and the action can't be performed until the user provides a full store address in the site admin.
     /// May include the URL for the appropriate admin page
     case incompleteStoreAddress(adminUrl: URL?)
+
+    /// The store setup is incomplete, and the action can't be performed until the user provides a valid postal code in the site admin.
+    case invalidPostalCode
 }
 
 extension UnderlyingError {
@@ -156,6 +159,8 @@ extension UnderlyingError {
         switch configError {
         case .incompleteStoreAddress(let adminUrl):
             self = .incompleteStoreAddress(adminUrl: adminUrl)
+        case .invalidPostalCode:
+            self = .invalidPostalCode
         default:
             return nil
         }
@@ -302,6 +307,10 @@ updating the application or using a different reader
         case .incompleteStoreAddress(_):
             return NSLocalizedString("The store address is incomplete or missing, please update it before continuing.",
                                      comment: "Error message when there is an issue with the store address preventing " +
+                                     "an action (e.g. reader connection.)")
+        case .invalidPostalCode:
+            return NSLocalizedString("The store postal code is invalid or missing, please update it before continuing.",
+                                     comment: "Error message when there is an issue with the store postal code preventing " +
                                      "an action (e.g. reader connection.)")
         }
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedUpdatePostalCode.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedUpdatePostalCode.swift
@@ -22,7 +22,7 @@ final class CardPresentModalConnectingFailedUpdatePostalCode: CardPresentPayment
 
     let auxiliaryButtonTitle: String? = nil
 
-    var bottomTitle: String? = nil
+    var bottomTitle: String? = Localization.subtitle
 
     let bottomSubtitle: String? = nil
 
@@ -45,8 +45,14 @@ final class CardPresentModalConnectingFailedUpdatePostalCode: CardPresentPayment
 private extension CardPresentModalConnectingFailedUpdatePostalCode {
     enum Localization {
         static let title = NSLocalizedString(
-            "Please update your store's postal code to proceed - this can be done in your site's admin pages.",
+            "Please update your postal code",
             comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to postal code problems"
+        )
+
+        static let subtitle = NSLocalizedString(
+            "You can set it in your site's admin pages on the web",
+            comment: "Subtitle of the alert presented when the user tries to connect to a specific card reader and it fails " +
             "due to postal code problems"
         )
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedUpdatePostalCode.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedUpdatePostalCode.swift
@@ -45,13 +45,13 @@ final class CardPresentModalConnectingFailedUpdatePostalCode: CardPresentPayment
 private extension CardPresentModalConnectingFailedUpdatePostalCode {
     enum Localization {
         static let title = NSLocalizedString(
-            "Please update your postal code",
+            "Please correct your store's postcode/ZIP",
             comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
             "due to postal code problems"
         )
 
         static let subtitle = NSLocalizedString(
-            "You can set it in your site's admin pages on the web",
+            "You can set your store's postcode/ZIP in wp-admin > WooCommerce > Settings (General)",
             comment: "Subtitle of the alert presented when the user tries to connect to a specific card reader and it fails " +
             "due to postal code problems"
         )

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedUpdatePostalCode.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedUpdatePostalCode.swift
@@ -1,0 +1,65 @@
+import UIKit
+import Yosemite
+
+/// Modal presented when an error occurs while connecting to a reader
+///
+final class CardPresentModalConnectingFailedUpdatePostalCode: CardPresentPaymentsModalViewModel {
+    private let retrySearchAction: () -> Void
+    private let cancelSearchAction: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedTopInfo
+    let actionsMode: PaymentsModalActionsMode = .twoAction
+
+    let topTitle: String = Localization.title
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage = .paymentErrorImage
+
+    let primaryButtonTitle: String? = Localization.retry
+
+    let secondaryButtonTitle: String? = Localization.cancel
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? = nil
+
+    let bottomSubtitle: String? = nil
+
+    init(retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        self.retrySearchAction = retrySearch
+        self.cancelSearchAction = cancelSearch
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        retrySearchAction()
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        cancelSearchAction()
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalConnectingFailedUpdatePostalCode {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Please update your store's postal code to proceed - this can be done in your site's admin pages.",
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to postal code problems"
+        )
+
+        static let retry = NSLocalizedString(
+            "Retry After Updating",
+            comment: "Button to try again after connecting to a specific reader fails due to postal code problems. " +
+            "Intended for use after the merchant corrects the postal code in the store admin pages."
+        )
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails due to postal code " +
+            "problems. This also cancels searching."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -106,7 +106,8 @@ private extension CardPresentModalConnectingFailedUpdateAddress {
 
         static let adminWebviewTitle = NSLocalizedString(
             "WooCommerce Settings",
-            comment: "Navigation title of the webview which used by the merchant to update their store address")
+            comment: "Navigation title of the webview which used by the merchant to update their store address"
+        )
 
         static let openAdmin = NSLocalizedString(
             "Enter Address",

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -570,8 +570,12 @@ private extension CardReaderConnectionController {
             return
         }
 
-        let continueSearch = {
+        let retrySearch = {
             self.state = .retry
+        }
+
+        let continueSearch = {
+            self.state = .searching
         }
 
         let cancelSearch = {
@@ -595,8 +599,10 @@ private extension CardReaderConnectionController {
                                                   adminUrl: adminUrl,
                                                   site: ServiceLocator.stores.sessionManager.defaultSite,
                                                   openUrlInSafari: openUrlInSafari,
-                                                  retrySearch: continueSearch,
+                                                  retrySearch: retrySearch,
                                                   cancelSearch: cancelSearch)
+        case .invalidPostalCode:
+            alerts.connectingFailedInvalidPostalCode(from: from, retrySearch: retrySearch, cancelSearch: cancelSearch)
         default:
             alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -39,6 +39,10 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
                                                                         cancelSearch: cancelSearch))
     }
 
+    func connectingFailedInvalidPostalCode(from: UIViewController, retrySearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        setViewModelAndPresent(from: from, viewModel: connectingFailedUpdatePostalCode(retrySearch: retrySearch, cancelSearch: cancelSearch))
+    }
+
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) {
         setViewModelAndPresent(from: from, viewModel: updatingFailedLowBattery(from: from, batteryLevel: batteryLevel, close: close))
     }
@@ -184,6 +188,11 @@ private extension CardReaderSettingsAlerts {
                                                              openUrlInSafari: openUrlInSafari,
                                                              retrySearch: retrySearch,
                                                              cancelSearch: cancelSearch)
+    }
+
+    func connectingFailedUpdatePostalCode(retrySearch: @escaping () -> Void,
+                                          cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        return CardPresentModalConnectingFailedUpdatePostalCode(retrySearch: retrySearch, cancelSearch: cancelSearch)
     }
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -56,6 +56,13 @@ protocol CardReaderSettingsAlertsProvider {
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void)
 
+    /// Defines an alert indicating connecting failed because their postal code needs updating.
+    /// The user may try again or cancel
+    ///
+    func connectingFailedInvalidPostalCode(from: UIViewController,
+                                           retrySearch: @escaping () -> Void,
+                                           cancelSearch: @escaping () -> Void)
+
     /// Defines an alert indicating an update couldn't be installed because the reader is low on battery.
     ///
     func updatingFailedLowBattery(from: UIViewController,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
+		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -1866,6 +1867,7 @@
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectionFailedUpdateAddress.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
+		035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingFailedUpdatePostalCode.swift; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
@@ -6606,6 +6608,7 @@
 				E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */,
 				31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */,
 				31AD0B1026E9575F000B6391 /* CardPresentModalConnectingFailed.swift */,
+				035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */,
 				031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */,
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 				D8752EF6265E60F4008ACC80 /* PaymentCaptureCelebration.swift */,
@@ -7754,6 +7757,7 @@
 				02307924258731B2008EADEE /* PrintShippingLabelViewModel.swift in Sources */,
 				D843D5D92248EE91001BFA55 /* ManualTrackingViewModel.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
+				035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */,
 				457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */,
 				D8815B0D263861A400EDAD62 /* CardPresentModalSuccess.swift in Sources */,
 				0235595524496B6D004BE2B8 /* BottomSheetListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -99,6 +99,18 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         }
     }
 
+    func connectingFailedInvalidPostalCode(from: UIViewController,
+                                           retrySearch: @escaping () -> Void,
+                                           cancelSearch: @escaping () -> Void) {
+        if mode == .continueSearchingAfterConnectionFailure {
+            retrySearch()
+        }
+
+        if mode == .cancelSearchingAfterConnectionFailure {
+            cancelSearch()
+        }
+    }
+
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) {
         close()
     }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -272,12 +272,15 @@ private extension CardReaderConfigError {
             self = .unknown(error: error)
             return
         }
-
-        if case .unknown("store_address_is_incomplete", let message) = dotcomError {
+        switch dotcomError {
+        case .unknown("store_address_is_incomplete", let message):
             self = .incompleteStoreAddress(adminUrl: URL(string: message ?? ""))
             return
+        case .unknown("postal_code_invalid", _):
+            self = .invalidPostalCode
+            return
+        default:
+            self = .unknown(error: dotcomError.toAnyError)
         }
-
-        self = .unknown(error: dotcomError.toAnyError)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5320 
<!-- Id number of the GitHub issue this PR addresses. -->
Merge #5552 before this

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a specific error state for when the Postal Code is rejected by Stripe. Unfortunately, we don't get an adminUrl back in this case, so there's no straightforward signposting to the user with a button to go directly to the WP-Admin page.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. With a store set up for In-Person Payments, go to `WP-Admin > WooCommerce > Settings` and change the contents of `Postcode/ZIP` to a non-US format, or delete.
2. In the app, go to `⚙️ > In-Person Payments > Manage Card Reader`
3. Search for and connect to a reader (or simulated reader)
4. Observe that the error message is shown telling the merchant to update their address.
5. Update the address in WP-Admin to include the correct `Postcode/ZIP` again
6. Tap retry, and connect to the reader again.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/144096589-ac5add73-cd71-48b8-b1e2-a477720f908a.mp4


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
