### PR TITLE
Fixes autofocus iOS 14 crash

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
@@ -27,6 +27,8 @@ extension View {
     /// Autofocus in `TextField` and `TextEditor` is available only for iOS15+
     ///
     func focused() -> some View {
+        // Conditional check has to be done inside the Group function builder,
+        // otherwise the iOS 15 modifier will be loaded into memory and the app will crash.
         Group {
             if #available(iOS 15.0, *) {
                 self.modifier(AutofocusTextModifier())

--- a/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
@@ -2,25 +2,20 @@ import SwiftUI
 
 /// Autofocus for `TextField` and `TextEditor` in iOS 15 and later
 ///
+@available(iOS 15.0, *)
 struct AutofocusTextModifier: ViewModifier {
 
-    @available(iOS 15.0, *)
     @FocusState private var textFieldIsFocused: Bool
 
     func body(content: Content) -> some View {
-        if #available(iOS 15.0, *) {
-            content
-                .focused($textFieldIsFocused)
-                .onAppear {
-                    // Without delay '.focused' will not work. This might fix in later releases.
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                        textFieldIsFocused = true
-                    }
+        content
+            .focused($textFieldIsFocused)
+            .onAppear {
+                // Without delay '.focused' will not work. This might fix in later releases.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    textFieldIsFocused = true
                 }
-        }
-        else {
-            content
-        }
+            }
     }
 }
 
@@ -32,6 +27,12 @@ extension View {
     /// Autofocus in `TextField` and `TextEditor` is available only for iOS15+
     ///
     func focused() -> some View {
-        self.modifier(AutofocusTextModifier())
+        Group {
+            if #available(iOS 15.0, *) {
+                self.modifier(AutofocusTextModifier())
+            } else {
+                self
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description

# Why

@shiki discovered a crash while testing **Simple Payments** while using an iOS 14 device.

After inspection, the crash seems to happen because we are accessing some iOS 15 `SwiftUI` code as a view modifier, Specifically a modifier for allowing a text field to gain focus automatically.

While the modifier has the necessary checks to avoid the code from being invoked in iOS14, it appears that the `SwiftUI` runtime still loads the modifier on memory instants before being used. I supposed for performance reasons.

# How

To fix this I have moved the conditional iOS 15 checks out of the modifier and into the view extension that creates it. The view returned is a `Group` whose internal function builder does the conditional check.

# Demo

https://user-images.githubusercontent.com/562080/144155581-ba0e54e9-5452-4ad2-bf7e-186e7dbdec03.mov

https://user-images.githubusercontent.com/562080/144155582-d1b480a3-8085-4f44-8987-8a243423cffa.mov

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location


## Steps
- Run the app on an iOS 14 device or simulator
- Start the simple payments flow
- See that the app does not crash 😅 (the amount text field should not autofocus)

- Run the app on an iOS 15 device or simulator
- Start the simple payments flow
- See that the app does not crash 😅 (the amount text field should autofocus)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
