### PR TITLE
Fix `me/sites` expected request parameters for UI test failures in `develop`

### DIFF
--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -7,7 +7,7 @@
             "equalTo": "ID,name,description,URL,options,jetpack,jetpack_connection"
           },
           "options": {
-            "equalTo": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset"
+            "equalTo": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset,jetpack_connection_active_plugins"
           }
         }
     },


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes UI test failures in `develop`
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In UI tests `LoginTests`, we use network response mocks that match requests with the expected parameters. For site picker in the login flow, `me/sites` request is made but couldn't find a response mock. It's because https://github.com/woocommerce/woocommerce-ios/pull/5556 added a new option `jetpack_connection_active_plugins` in `me/sites` params, and I forgot to update the request for the mock (we only run UI tests in `develop`).

This PR updates the `me/sites` request to include `jetpack_connection_active_plugins` option for the response mock in UI tests.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I manually triggered [UI tests](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/15841/workflows/aa48ca99-faaa-42c4-b5d0-db79f693f28b) for this PR, just make sure they pass!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
