### PR TITLE
Fix flaky tests in `develop` to reduce CI time

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -48,13 +48,15 @@ final class MainTabBarControllerTests: XCTestCase {
     }
 
     func test_tab_view_controllers_returns_expected_values_with_hub_menu_enabled() {
-        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
-            return
-        }
+        // Arrange
+        // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
         let isHubMenuFeatureFlagOn = true
         ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn))
 
-        // Arrange
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
+            return
+        }
+
         // Trigger `viewDidLoad`
         XCTAssertNotNil(tabBarController.view)
 
@@ -150,11 +152,13 @@ final class MainTabBarControllerTests: XCTestCase {
 
     func test_when_receiving_a_review_notification_from_a_different_site_navigates_to_reviews_tab_and_presents_review_details() throws {
         // Arrange
+        // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
+        let isHubMenuFeatureFlagOn = false
+        ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn))
+
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
             return
         }
-        let isHubMenuFeatureFlagOn = false
-        ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn))
 
         let pushNotificationsManager = MockPushNotificationsManager()
         ServiceLocator.setPushNotesManager(pushNotificationsManager)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddOrderCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddOrderCoordinatorTests.swift
@@ -7,6 +7,7 @@ import WordPressUI
 
 final class AddOrderCoordinatorTests: XCTestCase {
     private var navigationController: UINavigationController!
+    private var window: UIWindow?
 
     override func setUp() {
         super.setUp()
@@ -16,10 +17,16 @@ final class AddOrderCoordinatorTests: XCTestCase {
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
         window.rootViewController = navigationController
+        self.window = window
     }
 
     override func tearDown() {
         navigationController = nil
+
+        // Resets `UIWindow` and its view hierarchy so that it can be deallocated cleanly.
+        window?.resignKey()
+        window?.rootViewController = nil
+
         super.tearDown()
     }
 
@@ -38,7 +45,7 @@ final class AddOrderCoordinatorTests: XCTestCase {
         assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
     }
 
-    func test_it_does_nothing_when_all_types_are_unaviable() throws {
+    func test_it_does_nothing_when_all_types_are_unavailable() throws {
         // Given
         let coordinator = makeAddProductCoordinator(isOrderCreationEnabled: false,
                                                     shouldShowSimplePaymentsButton: false)
@@ -57,9 +64,6 @@ final class AddOrderCoordinatorTests: XCTestCase {
 
         // When
         coordinator.start()
-        waitUntil {
-            coordinator.navigationController.presentedViewController != nil
-        }
 
         // Then
         let presentedNC = coordinator.navigationController.presentedViewController as? UINavigationController


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes `MainTabBarControllerTests` and `AddOrderCoordinatorTests` in `develop`
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I noticed that unit tests were taking a long time to run (~30 minutes), with some flaky tests in CI:

<img width="1128" alt="Screen Shot 2021-12-01 at 2 32 27 PM" src="https://user-images.githubusercontent.com/1945542/144184623-2522b788-28c0-4717-9992-cef2efdab83e.png">

#### `MainTabBarControllerTests`

It looks like unit tests time increased after the HUB menu was introduced (from [~20 minutes before the PR](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/15808/workflows/15fde2f0-e513-4d59-ab8f-4650bfc5dca1/jobs/30077) to [~28 minutes after the PR](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/15811/workflows/cee9d46c-e2b0-4415-93bf-a78419133473/jobs/30086)).

Then I ran `MainTabBarControllerTests` locally, and `test_tab_view_controllers_returns_expected_values_with_hub_menu_enabled` passed when it was run by itself but failed consistently when it was run with other test cases. The issue is from the mock feature flag not being set before `MainTabBarController` is initialized from the Storyboard in the test case. Thus, the feature flag value is from the previous value of `ServiceLocator.featureFlagService` singleton which is `false` when running with other tests:

https://github.com/woocommerce/woocommerce-ios/blob/ba540a717b975a67c60d384d15f3928fea8dfaac/WooCommerce/Classes/ViewRelated/MainTabBarController.swift#L108

In https://github.com/woocommerce/woocommerce-ios/commit/e6bc27d4c0a41de91f0c69301319226450f664e5, the feature flag service mock is now set before `MainTabBarController` is initialized. Ideally, the feature flag service or value can be DI'ed to `MainTabBarController` in its initializer but this isn't feasible with Storyboard setup.

#### `AddOrderCoordinatorTests`

After `MainTabBarControllerTests` was fixed, the [CI time was down to ~22 minutes](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/15847/workflows/8a28fa21-b532-495c-b9e3-a9bb6b994071/jobs/30165/tests). However, in CI TESTS tab, it still showed `AddOrderCoordinatorTests.test_it_opens_simple_payments_when_its_only_available_type` as flaky. This one was more tricky to debug. I ran `AddOrderCoordinatorTests` a few times, and almost every time tests crashed after `test_it_opens_simple_payments_when_its_only_available_type` was started. In the console, it showed an error message before crashing:

```
Cannot form weak reference to instance (0x7f8f4c126260) of class UIWindow. It is possible that this object was over-released, or is in the process of deallocation.
```

My guess is that it's from `UIWindow` not being torn down properly between test cases. After resetting `UIWindow` more in https://github.com/woocommerce/woocommerce-ios/commit/aaabc2f355caa1561fa75799d55d2fa140ebd88e, the test case now passed consistently locally and on CI. The [CI time was now down to 15 minutes](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/15849/workflows/e8c1bcdd-00cc-4887-ae15-8881c9d3c0d2/jobs/30169/steps) without any retries! 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to run `WooCommerceTests` locally to verify! Before this PR, tests failed on `MainTabBarControllerTests` and did not finish from `AddOrderCoordinatorTests`.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
