### PR TITLE
[Mobile Payments] PR changes from card reader connection address/postcode errors

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
+++ b/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
@@ -3,16 +3,16 @@
 /// It is meant to abstract an implementation of the [adapter pattern](https://en.wikipedia.org/wiki/Adapter_pattern)
 
 public protocol ReaderTokenProvider {
-    func fetchToken(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void)
 }
 
 public protocol ReaderLocationProvider {
-    func fetchDefaultLocationID(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void)
 }
 
 public protocol CardReaderConfigProvider: ReaderLocationProvider, ReaderTokenProvider {
-    func fetchToken(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
-    func fetchDefaultLocationID(completion: @escaping(Result<String, CardReaderConfigError>) -> Void)
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void)
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void)
 }
 
 /// An error that occurs while configuring a reader

--- a/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
+++ b/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
@@ -19,10 +19,9 @@ public protocol CardReaderConfigProvider: ReaderLocationProvider, ReaderTokenPro
 ///
 /// - incompleteStoreAddress: The location could not be created because the Store address configured for the site failed validation.
 ///     May include URL for wp-admin page to update address.
-/// - unknown: other error cases.
+/// - invalidPostalCode: The location could not be created because the Store postal code configured for the site failed validation.
 ///
 public enum CardReaderConfigError: Error, LocalizedError {
     case incompleteStoreAddress(adminUrl: URL?)
     case invalidPostalCode
-    case unknown(error: Error)
 }

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -161,8 +161,6 @@ extension UnderlyingError {
             self = .incompleteStoreAddress(adminUrl: adminUrl)
         case .invalidPostalCode:
             self = .invalidPostalCode
-        default:
-            return nil
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -99,7 +99,7 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
 private extension CardPresentModalConnectingFailedUpdateAddress {
     enum Localization {
         static let title = NSLocalizedString(
-            "Please update your store address to proceed.",
+            "Please correct your store address to proceed",
             comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
             "due to address problems"
         )

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -595,7 +595,7 @@ private extension CardReaderConnectionController {
                 UIApplication.shared.open(adminUrl)
                 self?.showIncompleteAddressErrorWithRefreshButton()
             }
-            alerts.connectingFailedMissingAddress(from: from,
+            alerts.connectingFailedIncompleteAddress(from: from,
                                                   adminUrl: adminUrl,
                                                   site: ServiceLocator.stores.sessionManager.defaultSite,
                                                   openUrlInSafari: openUrlInSafari,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -25,7 +25,7 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         setViewModelAndPresent(from: from, viewModel: connectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch))
     }
 
-    func connectingFailedMissingAddress(from: UIViewController,
+    func connectingFailedIncompleteAddress(from: UIViewController,
                                         adminUrl: URL?,
                                         site: Site?,
                                         openUrlInSafari: @escaping (URL) -> Void,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -49,7 +49,7 @@ protocol CardReaderSettingsAlertsProvider {
     /// Defines an alert indicating connecting failed because their address needs updating.
     /// The user may try again or cancel
     ///
-    func connectingFailedMissingAddress(from: UIViewController,
+    func connectingFailedIncompleteAddress(from: UIViewController,
                                         adminUrl: URL?,
                                         site: Site?,
                                         openUrlInSafari: @escaping (URL) -> Void,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -440,7 +440,7 @@ private extension ShippingLabelAddressFormViewController {
         case .name:
             errorMessage = Localization.missingName
         case .address:
-            errorMessage = viewModel.addressValidationError?.addressError ?? Localization.missingAddress
+            errorMessage = viewModel.addressValidationError?.addressError ?? Localization.incompleteAddress
         case .city:
             errorMessage = Localization.missingCity
         case .postcode:
@@ -607,8 +607,8 @@ private extension ShippingLabelAddressFormViewController {
                                                           comment: "Action to use the address in Shipping Label Validation screen as entered")
         static let missingName = NSLocalizedString("Name missing",
                                                    comment: "Error showed in Shipping Label Address Validation for the name field")
-        static let missingAddress = NSLocalizedString("Address missing",
-                                                      comment: "Error showed in Shipping Label Address Validation for the address field")
+        static let incompleteAddress = NSLocalizedString("Address incomplete",
+                                                         comment: "Error showed in Shipping Label Address Validation for the address field")
         static let missingCity = NSLocalizedString("City missing",
                                                    comment: "Error showed in Shipping Label Address Validation for the city field")
         static let missingPostcode = NSLocalizedString("Postcode missing",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -440,7 +440,7 @@ private extension ShippingLabelAddressFormViewController {
         case .name:
             errorMessage = Localization.missingName
         case .address:
-            errorMessage = viewModel.addressValidationError?.addressError ?? Localization.incompleteAddress
+            errorMessage = viewModel.addressValidationError?.addressError ?? Localization.missingAddress
         case .city:
             errorMessage = Localization.missingCity
         case .postcode:
@@ -607,8 +607,8 @@ private extension ShippingLabelAddressFormViewController {
                                                           comment: "Action to use the address in Shipping Label Validation screen as entered")
         static let missingName = NSLocalizedString("Name missing",
                                                    comment: "Error showed in Shipping Label Address Validation for the name field")
-        static let incompleteAddress = NSLocalizedString("Address incomplete",
-                                                         comment: "Error showed in Shipping Label Address Validation for the address field")
+        static let missingAddress = NSLocalizedString("Address missing",
+                                                      comment: "Error showed in Shipping Label Address Validation for the address field")
         static let missingCity = NSLocalizedString("City missing",
                                                    comment: "Error showed in Shipping Label Address Validation for the city field")
         static let missingPostcode = NSLocalizedString("Postcode missing",

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -84,7 +84,7 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         }
     }
 
-    func connectingFailedMissingAddress(from: UIViewController,
+    func connectingFailedIncompleteAddress(from: UIViewController,
                                         adminUrl: URL?,
                                         site: Site?,
                                         openUrlInSafari: @escaping (URL) -> Void,

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -112,11 +112,11 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
 
 private final class MockTokenProvider: CardReaderConfigProvider {
-    func fetchToken(completion: @escaping(Result<String, CardReaderConfigError>) -> Void) {
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void) {
         completion(.success("a token"))
     }
 
-    func fetchDefaultLocationID(completion: @escaping(Result<String, CardReaderConfigError>) -> Void) {
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void) {
         completion(.success("a location ID"))
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -248,7 +248,11 @@ private final class WCPayTokenProvider: CardReaderConfigProvider {
             case .success(let token):
                 completion(.success(token.token))
             case .failure(let error):
-                completion(.failure(CardReaderConfigError(error: error)))
+                if let configError = CardReaderConfigError(error: error) {
+                    completion(.failure(configError))
+                } else {
+                    completion(.failure(error))
+                }
             }
         }
     }
@@ -260,17 +264,20 @@ private final class WCPayTokenProvider: CardReaderConfigProvider {
                 let readerLocation = wcpayReaderLocation.toReaderLocation(siteID: self.siteID)
                 completion(.success(readerLocation.id))
             case .failure(let error):
-                completion(.failure(CardReaderConfigError(error: error)))
+                if let configError = CardReaderConfigError(error: error) {
+                    completion(.failure(configError))
+                } else {
+                    completion(.failure(error))
+                }
             }
         }
     }
 }
 
 private extension CardReaderConfigError {
-    init(error: Error) {
+    init?(error: Error) {
         guard let dotcomError = error as? DotcomError else {
-            self = .unknown(error: error)
-            return
+            return nil
         }
         switch dotcomError {
         case .unknown("store_address_is_incomplete", let message):
@@ -280,7 +287,7 @@ private extension CardReaderConfigError {
             self = .invalidPostalCode
             return
         default:
-            self = .unknown(error: dotcomError.toAnyError)
+            return nil
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -242,7 +242,7 @@ private final class WCPayTokenProvider: CardReaderConfigProvider {
         self.remote = remote
     }
 
-    func fetchToken(completion: @escaping(Result<String, CardReaderConfigError>) -> Void) {
+    func fetchToken(completion: @escaping(Result<String, Error>) -> Void) {
         remote.loadConnectionToken(for: siteID) { result in
             switch result {
             case .success(let token):
@@ -253,7 +253,7 @@ private final class WCPayTokenProvider: CardReaderConfigProvider {
         }
     }
 
-    func fetchDefaultLocationID(completion: @escaping(Result<String, CardReaderConfigError>) -> Void) {
+    func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void) {
         remote.loadDefaultReaderLocation(for: siteID) { result in
             switch result {
             case .success(let wcpayReaderLocation):


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5567 
Addresses comments from #5515 

### Description
Renames/rewords the address error to use `incomplete` as the key word.
Changes user facing error message for clarification.
Returns unchanged error when fetching a location or token and the error is not recognised (i.e. not a postcode or address error)

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. With a store set up for In-Person Payments, go to `WP-Admin > WooCommerce > Settings` and delete the contents of `Address line 1`
2. In the app, go to `⚙️ > In-Person Payments > Manage Card Reader`
3. Search for and connect to a reader (or simulated reader)
4. Observe that the error message is shown telling the merchant to **correct** their address.
5. Update the address in WP-Admin to include `Address line 1` again
6. Tap retry, and connect to the reader again.

Repeat above but entering an invalid postal code (e.g. UK Postcode on a US address)

Run unit tests
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
