### PR TITLE
[Mobile Payments] Make software version label multiline

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
@@ -13,10 +13,21 @@ final class ConnectedReaderTableViewCell: UITableViewCell {
 
     private var viewModel: ViewModel?
 
+    override func awakeFromNib() {
+        styleSoftwareVersionLabel()
+    }
+
     func configure(viewModel: ViewModel) {
         self.viewModel = viewModel
         nameLabel.text = viewModel.name
         batteryLevelLabel.text = viewModel.batteryLevel
         softwareVersionLabel.text = viewModel.softwareVersion
+    }
+}
+
+private extension ConnectedReaderTableViewCell {
+    func styleSoftwareVersionLabel() {
+        softwareVersionLabel.lineBreakMode = .byCharWrapping
+        softwareVersionLabel.numberOfLines = 0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,7 +13,7 @@
         <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="109" id="U1w-T7-U6Q" customClass="ConnectedReaderTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="84"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="U1w-T7-U6Q" id="JJm-pT-xv2">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="U1w-T7-U6Q" id="JJm-pT-xv2">
                 <rect key="frame" x="0.0" y="0.0" width="414" height="84"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
@@ -34,11 +35,8 @@
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version: 1.00.03.34-SZZZ_Generic_v45-300001" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h7d-re-rAr">
-                        <rect key="frame" x="20" y="54" width="374" height="15"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="15" id="oaP-vs-GdN"/>
-                        </constraints>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version: 1.00.03.34-SZZZ_Generic_v45-300001" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h7d-re-rAr">
+                        <rect key="frame" x="20" y="54" width="374" height="25"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <nil key="highlightedColor"/>


### PR DESCRIPTION
Closes: #5571

### Description
Make the label presenting the reader firmware version multiline

### Testing instructions
* Checkout the branch, build and run
* Connect to a reader
* If the reader is up to date, the version number would probably span two lines, depending on the device


### Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/562080/144285548-5d1fc2c5-8691-47a2-984f-79d8575f00ba.jpeg" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/144314921-69eb6f51-d6b8-469a-bf4e-64fa11c61bc1.PNG" width="350"/> |

Setting the lineBreakMode to .byWordWrapping looking slightly less pleasant, so I went with `.byCharWrapping`:
<img src="https://user-images.githubusercontent.com/2722505/144315047-49b75f60-c08e-45ed-aee2-e6c1a2ad8054.PNG" width="350"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
