### PR TITLE
[Mobile Payments] Pass a fresh print info to each receipt print job to avoid a crash on the 2nd job

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
@@ -3,24 +3,19 @@ import UIKit
 /// Barebones Implementation of the ReceiptPrinterService that integrates with AirPrint
 /// Will be iterated in https://github.com/woocommerce/woocommerce-ios/issues/3982
 public final class AirPrintReceiptPrinterService: PrinterService {
-    private let printInfo: UIPrintInfo = {
+    public init() { }
+
+    public func printReceipt(content: ReceiptContent, completion: @escaping (PrintingResult) -> Void) {
         let info = UIPrintInfo(dictionary: nil)
         // Will be localized in #3982
         info.jobName = "Order Receipt"
         info.orientation = .portrait
         info.duplex = .longEdge
 
-        return info
-    }()
-
-    public init() { }
-
-    public func printReceipt(content: ReceiptContent, completion: @escaping (PrintingResult) -> Void) {
-        let printController = UIPrintInteractionController.shared
-
-        printController.printInfo = printInfo
-
         let renderer = ReceiptRenderer(content: content)
+
+        let printController = UIPrintInteractionController.shared
+        printController.printInfo = info
         printController.printPageRenderer = renderer
 
         printController.present(animated: true) { (controller, completed, error) in

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 8.2
 -----
 - [*] Shipping Labels: Fixes a crash when saving a new shipping label after opening the order from a push notification. [https://github.com/woocommerce/woocommerce-ios/pull/5549]
+- [*] In-Person Payments: Fixes a crash when printing more than one receipt. [https://github.com/woocommerce/woocommerce-ios/pull/5575]
 
 8.1
 -----


### PR DESCRIPTION
Closes: #5574

@ctarda @joshheald @jaclync - just one review is needed, but all y'all are welcome

### Description
- While debugging, I noticed that the UIPrintInfo we were passing to the UIPrintInteractionController was mutating with things like the last printer printed to.
- Creating a fresh UIPrintInfo before presenting the interaction controller avoids an unrecognized selector being sent to PKPrinter.
- Apple's documentation implies (but isn't explicit) that we should be passing in a fresh UIPrintInfo for each print job https://developer.apple.com/documentation/uikit/uiprintinteractioncontroller/1618171-printinfo

### Testing instructions
- Print a receipt
- Attempt to print again for the same order
- Ensure the app does not crash

### Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
