### PR TITLE
Fall back to presenting Zendesk view modally when the source view controller doesn't belong to any navigation stack

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -531,10 +531,7 @@ private extension ZendeskManager {
 
         // If the controller is a UIViewController, set the modal display for iPad.
         if !controller.isKind(of: UINavigationController.self) && UIDevice.current.userInterfaceIdiom == .pad {
-            let navController = WooNavigationController(rootViewController: zendeskView)
-            navController.modalPresentationStyle = .fullScreen
-            navController.modalTransitionStyle = .crossDissolve
-            controller.present(navController, animated: true)
+            presentZendeskViewModally(zendeskView, from: controller)
             return
         }
 
@@ -550,9 +547,21 @@ private extension ZendeskManager {
 
         if let navController = presentInController as? UINavigationController {
             navController.pushViewController(zendeskView, animated: true)
+            return
         }
+
+        presentZendeskViewModally(zendeskView, from: controller)
     }
 
+    private func presentZendeskViewModally(_ zendeskView: UIViewController, from controller: UIViewController) {
+        let navController = WooNavigationController(rootViewController: zendeskView)
+        // Keeping the modal fullscreen on iPad like previous implementation.
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            navController.modalPresentationStyle = .fullScreen
+            navController.modalTransitionStyle = .crossDissolve
+        }
+        controller.present(navController, animated: true)
+    }
 
     // MARK: - User Defaults
     //


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
While working on #5568, I found that we're not handling the case to display Zendesk view when the source view controller doesn't belong to any navigation stack and the device is iPhone. We're currently presenting the view modally on iPad, so this PR updates the behavior to also present the view as a modal on iPhone when needed.

On iPad, the modal is currently presented full-screen with cross-dissolved animation - and this is kept as-is. However on iPhone, I'm presenting the modal with default properties, because it looks more intuitive that way.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Double check that Zendesk view can still be pushed as before:
- Navigation to My Store tab
- Select Settings icon > Help & Support > Contact Support.
- Notice that Zendesk view is pushed successfully.

I cannot find where in the app we're presenting the view modally, so the modal case can be tested as part of #5568.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
