### PR TITLE
Simple Payments: Integrate with Payments

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -10,6 +10,9 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     /// Closure to execute when secondary button is tapped
     private let emailReceiptAction: () -> Void
 
+    /// Closure to execute when auxiliary button is tapped.
+    private let backToOrdersAction: () -> Void
+
     let textMode: PaymentsModalTextMode = .noBottomInfo
     let actionsMode: PaymentsModalActionsMode = .twoActionAndAuxiliary
 
@@ -29,9 +32,10 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     let bottomSubtitle: String? = nil
 
-    init(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) {
+    init(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, backToOrders: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
         self.emailReceiptAction = emailReceipt
+        self.backToOrdersAction = backToOrders
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -47,7 +51,9 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
-        viewController?.dismiss(animated: true)
+        viewController?.dismiss(animated: true) { [weak self] in
+            self?.backToOrdersAction()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -11,7 +11,7 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     private let emailReceiptAction: () -> Void
 
     /// Closure to execute when auxiliary button is tapped.
-    private let backToOrdersAction: () -> Void
+    private let noReceiptAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .noBottomInfo
     let actionsMode: PaymentsModalActionsMode = .twoActionAndAuxiliary
@@ -32,10 +32,10 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     let bottomSubtitle: String? = nil
 
-    init(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, backToOrders: @escaping () -> Void) {
+    init(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
         self.emailReceiptAction = emailReceipt
-        self.backToOrdersAction = backToOrders
+        self.noReceiptAction = noReceiptAction
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -52,7 +52,7 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
         viewController?.dismiss(animated: true) { [weak self] in
-            self?.backToOrdersAction()
+            self?.noReceiptAction()
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -6,6 +6,9 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
     /// Closure to execute when primary button is tapped
     private let printReceiptAction: () -> Void
 
+    /// Closure to execute when secondary button is tapped
+    private let backToOrdersAction: () -> Void
+
     let textMode: PaymentsModalTextMode = .noBottomInfo
     let actionsMode: PaymentsModalActionsMode = .twoAction
 
@@ -25,8 +28,9 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
 
     let bottomSubtitle: String? = nil
 
-    init(printReceipt: @escaping () -> Void) {
+    init(printReceipt: @escaping () -> Void, backToOrders: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
+        self.backToOrdersAction = backToOrders
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -36,7 +40,9 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        viewController?.dismiss(animated: true)
+        viewController?.dismiss(animated: true) { [weak self] in
+            self?.backToOrdersAction()
+        }
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -7,7 +7,7 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
     private let printReceiptAction: () -> Void
 
     /// Closure to execute when secondary button is tapped
-    private let backToOrdersAction: () -> Void
+    private let noReceiptAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .noBottomInfo
     let actionsMode: PaymentsModalActionsMode = .twoAction
@@ -28,9 +28,9 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
 
     let bottomSubtitle: String? = nil
 
-    init(printReceipt: @escaping () -> Void, backToOrders: @escaping () -> Void) {
+    init(printReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
-        self.backToOrdersAction = backToOrders
+        self.noReceiptAction = noReceiptAction
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -41,7 +41,7 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
         viewController?.dismiss(animated: true) { [weak self] in
-            self?.backToOrdersAction()
+            self?.noReceiptAction()
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -63,8 +63,8 @@ final class OrderDetailsPaymentAlerts {
         presentViewModel(viewModel: viewModel)
     }
 
-    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, backToOrders: @escaping () -> Void) {
-        let viewModel = successViewModel(printReceipt: printReceipt, emailReceipt: emailReceipt, backToOrders: backToOrders)
+    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
+        let viewModel = successViewModel(printReceipt: printReceipt, emailReceipt: emailReceipt, noReceiptAction: noReceiptAction)
         presentViewModel(viewModel: viewModel)
     }
 
@@ -103,11 +103,11 @@ private extension OrderDetailsPaymentAlerts {
 
     func successViewModel(printReceipt: @escaping () -> Void,
                           emailReceipt: @escaping () -> Void,
-                          backToOrders: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+                          noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         if MFMailComposeViewController.canSendMail() {
-            return CardPresentModalSuccess(printReceipt: printReceipt, emailReceipt: emailReceipt, backToOrders: backToOrders)
+            return CardPresentModalSuccess(printReceipt: printReceipt, emailReceipt: emailReceipt, noReceiptAction: noReceiptAction)
         } else {
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, backToOrders: backToOrders)
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -63,8 +63,8 @@ final class OrderDetailsPaymentAlerts {
         presentViewModel(viewModel: viewModel)
     }
 
-    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) {
-        let viewModel = successViewModel(printReceipt: printReceipt, emailReceipt: emailReceipt)
+    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, backToOrders: @escaping () -> Void) {
+        let viewModel = successViewModel(printReceipt: printReceipt, emailReceipt: emailReceipt, backToOrders: backToOrders)
         presentViewModel(viewModel: viewModel)
     }
 
@@ -101,11 +101,13 @@ private extension OrderDetailsPaymentAlerts {
         CardPresentModalProcessing(name: name, amount: amount)
     }
 
-    func successViewModel(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+    func successViewModel(printReceipt: @escaping () -> Void,
+                          emailReceipt: @escaping () -> Void,
+                          backToOrders: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         if MFMailComposeViewController.canSendMail() {
-            return CardPresentModalSuccess(printReceipt: printReceipt, emailReceipt: emailReceipt)
+            return CardPresentModalSuccess(printReceipt: printReceipt, emailReceipt: emailReceipt, backToOrders: backToOrders)
         } else {
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt)
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, backToOrders: backToOrders)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -1,12 +1,13 @@
 import Foundation
 import Combine
 import Yosemite
+import MessageUI
 import protocol Storage.StorageManagerType
 
 /// Use case to collect payments from an order.
-/// Orchestrates reader connection, payment, UI alerts and analytics.
+/// Orchestrates reader connection, payment, UI alerts, receipt handling and analytics.
 ///
-final class CollectOrderPaymentUseCase {
+final class CollectOrderPaymentUseCase: NSObject {
 
     /// Store's ID.
     ///
@@ -16,18 +17,13 @@ final class CollectOrderPaymentUseCase {
     ///
     private let order: Order
 
-    /// Payment Gateway to use..
+    /// Payment Gateway Account to use.
     ///
-    private let paymentGateway: PaymentGateway
+    private let paymentGatewayAccount: PaymentGatewayAccount
 
     /// Stores manager.
     ///
     private let stores: StoresManager
-
-    // TODO: Check if I really need this
-    /// Storage manager.
-    ///
-    private let storage: StorageManagerType
 
     /// Analytics manager,
     ///
@@ -40,6 +36,15 @@ final class CollectOrderPaymentUseCase {
     /// Stores the card reader listener subscription while trying to connect to one.
     ///
     private var readerSubscription: AnyCancellable?
+
+    /// Closure to inform when the full flow has been completed, after receipt management.
+    /// Needed to be saved as an instance variable because it needs to be referenced from the `MailComposer` delegate.
+    ///
+    private var onCompleted: (() -> ())?
+
+    /// Alert manager to inform merchants about reader & card actions.
+    ///
+    private lazy var alerts = OrderDetailsPaymentAlerts(presentingController: rootViewController)
 
     /// IPP payments collector.
     ///
@@ -54,17 +59,238 @@ final class CollectOrderPaymentUseCase {
 
     init(siteID: Int64,
          order: Order,
-         paymentGateway: PaymentGateway,
+         paymentGatewayAccount: PaymentGatewayAccount,
          rootViewController: UIViewController,
          stores: StoresManager = ServiceLocator.stores,
-         storage: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.order = order
-        self.paymentGateway = paymentGateway
+        self.paymentGatewayAccount = paymentGatewayAccount
         self.rootViewController = rootViewController
         self.stores = stores
-        self.storage = storage
         self.analytics = analytics
+    }
+
+    /// Starts the collect payment flow.
+    /// 1. Connects to a reader
+    /// 2. Collect payment from order
+    /// 3. If successful: prints or emails receipt
+    /// 4. If failure: Allows retry
+    ///
+    ///
+    /// - Parameter onCollect: Closure Invoked after the collect process has finished.
+    /// - Parameter onCompleted: Closure Invoked after the flow has been dismissed. EG: Merchant has emailed receipt.
+    // TODO: Remember to check why the amount is provided in order details view model
+    func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
+        connectReader { [weak self] in
+            self?.attemptPayment(onCompletion: { [weak self] result in
+                // Inform about the collect payment state
+                onCollect(result.map { _ in () }) // Transforms Result<CardPresentReceiptParameters, Error> to Result<Void, Error>
+
+                // Handle payment receipt
+                guard let receiptParameters = try? result.get() else {
+                    return
+                }
+
+                self?.presentReceiptAlert(receiptParameters: receiptParameters, onCompleted: onCompleted)
+            })
+        }
+    }
+}
+
+// MARK: Private functions
+private extension CollectOrderPaymentUseCase {
+
+    /// Attempts to connect to a reader.
+    /// Finishes immediately if a reader is already connected.
+    ///
+    func connectReader(onCompletion: @escaping () -> ()) {
+        // `checkCardReaderConnected` action will return a publisher that:
+        // - Sends one value if there is no reader connected.
+        // - Completes when a reader is connected.
+        let readerConnected = CardPresentPaymentAction.checkCardReaderConnected { connectPublisher in
+            self.readerSubscription = connectPublisher
+                .sink(receiveCompletion: { [weak self] _ in
+                    // Reader connected
+                    onCompletion()
+
+                    // Nil the subscription since we are don with the connection.
+                    self?.readerSubscription = nil
+
+                }, receiveValue: { [weak self] _ in
+                    guard let self = self else { return }
+
+                    // Attempt reader connection
+                    self.connectionController.searchAndConnect(from: self.rootViewController) { _ in }
+                })
+        }
+        stores.dispatch(readerConnected)
+    }
+
+    /// Attempts to collect payment for an order.
+    ///
+    func attemptPayment(onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> ()) {
+
+        // TODO: paymentAlerts.readerIsReady(title: viewModel.collectPaymentFrom, amount: value)
+        // TODO: ServiceLocator.analytics.track(.collectPaymentTapped)
+
+        paymentOrchestrator.collectPayment(
+            for: order,
+            statementDescriptor: paymentGatewayAccount.statementDescriptor,
+            onWaitingForInput: { [weak self] in
+                // Request card input
+                self?.alerts.tapOrInsertCard(onCancel: {
+                    self?.cancelPayment()
+                })
+
+            }, onProcessingMessage: { [weak self] in
+                // Waiting message
+                self?.alerts.processingPayment()
+
+            }, onDisplayMessage: { [weak self] message in
+                // Reader messages. EG: Remove Card
+                self?.alerts.displayReaderMessage(message: message)
+
+            }, onCompletion: { [weak self] result in
+                switch result {
+                case .success(let receiptParameters):
+                    self?.handleSuccessfulPayment(receipt: receiptParameters, onCompletion: onCompletion)
+                case .failure(let error):
+                    self?.handlePaymentFailureAndRetryPayment(error, onCompletion: onCompletion)
+                }
+            }
+        )
+    }
+
+    /// Tracks the successful payments
+    ///
+    func handleSuccessfulPayment(receipt: CardPresentReceiptParameters, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> ()) {
+        // Record success
+        analytics.track(.collectPaymentSuccess)
+
+        // Success Callback
+        onCompletion(.success(receipt))
+    }
+
+    /// Log the failure reason, cancel the current payment and retry it if possible.
+    ///
+    func handlePaymentFailureAndRetryPayment(_ error: Error, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> ()) {
+        // Record error
+        analytics.track(.collectPaymentFailed, withError: error)
+        DDLogError("Failed to collect payment: \(error.localizedDescription)")
+
+        // Inform about the error
+        alerts.error(error: error) { [weak self] in
+
+            // Cancel current payment
+            self?.paymentOrchestrator.cancelPayment { [weak self] result in
+                guard let self = self else { return }
+
+                switch result {
+                case .success:
+                    // Retry payment
+                    self.attemptPayment(onCompletion: onCompletion)
+
+                case .failure(let cancelError):
+                    // Inform that payment can't be retried.
+                    self.alerts.nonRetryableError(from: self.rootViewController, error: cancelError) // TODO: Update to notify when the flow is ended
+                    onCompletion(.failure(error))
+                }
+            }
+        }
+    }
+
+    /// Cancels payment and record analytics.
+    ///
+    func cancelPayment() {
+        paymentOrchestrator.cancelPayment { [analytics] _ in
+            analytics.track(.collectPaymentCanceled)
+        }
+        // TODO: Should I be sending a completion block?
+    }
+
+    /// Allow merchants to print or email the payment receipt.
+    ///
+    func presentReceiptAlert(receiptParameters: CardPresentReceiptParameters, onCompleted: @escaping () -> ()) {
+        // Present receipt alert
+        alerts.success(printReceipt: { [order] in
+            // Inform about flow completion.
+            onCompleted()
+
+            // Delegate print action
+            ReceiptActionCoordinator.printReceipt(for: order, params: receiptParameters)
+
+        }, emailReceipt: { [order, analytics, paymentOrchestrator] in
+            // Record button tapped
+            analytics.track(.receiptEmailTapped)
+
+            // Request & present email
+            paymentOrchestrator.emailReceipt(for: order, params: receiptParameters) { [weak self] emailContent in
+                self?.onCompleted = onCompleted // Saved to be able to reference from the `MailComposer` delegate.
+                self?.presentEmailForm(content: emailContent)
+            }
+        })
+    }
+
+    /// Presents the native email client with the provided content.
+    ///
+    func presentEmailForm(content: String) {
+        guard MFMailComposeViewController.canSendMail() else {
+            return DDLogError("⛔️ Failed to submit email receipt for order: \(order.orderID). Email is not configured.")
+        }
+
+        let mail = MFMailComposeViewController()
+        mail.mailComposeDelegate = self
+
+        mail.setSubject(Localization.emailSubject(storeName: stores.sessionManager.defaultSite?.name))
+        mail.setMessageBody(content, isHTML: true)
+
+        if let customerEmail = order.billingAddress?.email {
+            mail.setToRecipients([customerEmail])
+        }
+
+        rootViewController.present(mail, animated: true)
+    }
+}
+
+// MARK: MailComposer Delegate
+extension CollectOrderPaymentUseCase: MFMailComposeViewControllerDelegate {
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        switch result {
+        case .cancelled:
+            analytics.track(.receiptEmailCanceled)
+        case .sent, .saved:
+            analytics.track(.receiptEmailSuccess)
+        case .failed:
+            analytics.track(.receiptEmailFailed, withError: error ?? UnknownEmailError())
+        @unknown default:
+            assertionFailure("MFMailComposeViewController finished with an unknown result type")
+        }
+
+        // Dismiss email controller & inform flow completion.
+        controller.dismiss(animated: true) { [weak self] in
+            self?.onCompleted?()
+            self?.onCompleted = nil
+        }
+    }
+}
+
+// MARK: Definitions
+private extension CollectOrderPaymentUseCase {
+    /// Mailing a receipt failed but the SDK didn't return a more specific error
+    ///
+    struct UnknownEmailError: Error {}
+
+    enum Localization {
+        static let emailSubjectWithStoreName = NSLocalizedString("Your receipt from %1$@",
+                                                                 comment: "Subject of email sent with a card present payment receipt")
+        static let emailSubjectWithoutStoreName = NSLocalizedString("Your receipt",
+                                                                    comment: "Subject of email sent with a card present payment receipt")
+        static func emailSubject(storeName: String?) -> String {
+            guard let storeName = storeName else {
+                return emailSubjectWithoutStoreName
+            }
+            return .localizedStringWithFormat(emailSubjectWithStoreName, storeName)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -237,7 +237,7 @@ private extension CollectOrderPaymentUseCase {
                 self?.presentEmailForm(content: emailContent)
             }
 
-        }, backToOrders: {
+        }, noReceiptAction: {
             // Inform about flow completion.
             onCompleted()
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -91,7 +91,6 @@ final class CollectOrderPaymentUseCase: NSObject {
                 guard let receiptParameters = try? result.get() else {
                     return
                 }
-
                 self?.presentReceiptAlert(receiptParameters: receiptParameters, onCompleted: onCompleted)
             })
         }
@@ -206,7 +205,6 @@ private extension CollectOrderPaymentUseCase {
         paymentOrchestrator.cancelPayment { [analytics] _ in
             analytics.track(.collectPaymentCanceled)
         }
-        // TODO: Should I be sending a completion block?
     }
 
     /// Allow merchants to print or email the payment receipt.

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -1,8 +1,70 @@
 import Foundation
+import Combine
+import Yosemite
+import protocol Storage.StorageManagerType
 
 /// Use case to collect payments from an order.
 /// Orchestrates reader connection, payment, UI alerts and analytics.
 ///
 final class CollectOrderPaymentUseCase {
 
+    /// Store's ID.
+    ///
+    private let siteID: Int64
+
+    /// Order to collect.
+    ///
+    private let order: Order
+
+    /// Payment Gateway to use..
+    ///
+    private let paymentGateway: PaymentGateway
+
+    /// Stores manager.
+    ///
+    private let stores: StoresManager
+
+    // TODO: Check if I really need this
+    /// Storage manager.
+    ///
+    private let storage: StorageManagerType
+
+    /// Analytics manager,
+    ///
+    private let analytics: Analytics
+
+    /// View Controller used to present alerts.
+    ///
+    private var rootViewController: UIViewController
+
+    /// Stores the card reader listener subscription while trying to connect to one.
+    ///
+    private var readerSubscription: AnyCancellable?
+
+    /// IPP payments collector.
+    ///
+    private lazy var paymentOrchestrator = PaymentCaptureOrchestrator()
+
+    /// Controller to connect a card reader.
+    ///
+    private lazy var connectionController = {
+        CardReaderConnectionController(forSiteID: siteID,
+                                       knownReaderProvider: CardReaderSettingsKnownReaderStorage(), alertsProvider: CardReaderSettingsAlerts())
+    }()
+
+    init(siteID: Int64,
+         order: Order,
+         paymentGateway: PaymentGateway,
+         rootViewController: UIViewController,
+         stores: StoresManager = ServiceLocator.stores,
+         storage: StorageManagerType = ServiceLocator.storageManager,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.order = order
+        self.paymentGateway = paymentGateway
+        self.rootViewController = rootViewController
+        self.stores = stores
+        self.storage = storage
+        self.analytics = analytics
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -119,7 +119,7 @@ private extension CollectOrderPaymentUseCase {
                     // Reader connected
                     onCompletion()
 
-                    // Nil the subscription since we are don with the connection.
+                    // Nil the subscription since we are done with the connection.
                     self?.readerSubscription = nil
 
                 }, receiveValue: { [weak self] _ in

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -227,6 +227,10 @@ private extension CollectOrderPaymentUseCase {
                 self?.onCompleted = onCompleted // Saved to be able to reference from the `MailComposer` delegate.
                 self?.presentEmailForm(content: emailContent)
             }
+
+        }, backToOrders: {
+            // Inform about flow completion.
+            onCompleted()
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Use case to collect payments from an order.
+/// Orchestrates reader connection, payment, UI alerts and analytics.
+///
+final class CollectOrderPaymentUseCase {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -79,7 +79,7 @@ final class CollectOrderPaymentUseCase: NSObject {
     ///
     ///
     /// - Parameter onCollect: Closure Invoked after the collect process has finished.
-    /// - Parameter onCompleted: Closure Invoked after the flow has been dismissed. EG: Merchant has emailed receipt.
+    /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed, Currently after merchant has handled the receipt.
     // TODO: Remember to check why the amount is provided in order details view model
     func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
         connectReader { [weak self] in
@@ -192,7 +192,7 @@ private extension CollectOrderPaymentUseCase {
 
                 case .failure(let cancelError):
                     // Inform that payment can't be retried.
-                    self.alerts.nonRetryableError(from: self.rootViewController, error: cancelError) // TODO: Update to notify when the flow is ended
+                    self.alerts.nonRetryableError(from: self.rootViewController, error: cancelError)
                     onCompletion(.failure(error))
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -772,7 +772,7 @@ private extension OrderDetailsViewController {
                         self.viewModel.emailReceipt(params: receiptParameters, onContent: { emailContent in
                             self.emailReceipt(emailContent)
                         })
-                    }, backToOrders: {})
+                    }, noReceiptAction: {})
                 }
             }
         )

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -772,8 +772,7 @@ private extension OrderDetailsViewController {
                         self.viewModel.emailReceipt(params: receiptParameters, onContent: { emailContent in
                             self.emailReceipt(emailContent)
                         })
-                    }
-                    )
+                    }, backToOrders: {})
                 }
             }
         )

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -797,6 +797,7 @@ private extension OrderDetailsViewController {
         }
     }
 
+    // TODO: Check if this is necessary
     private func cancelObservingCardReader() {
         cardReaderAvailableSubscription?.cancel()
         cardReaderAvailableSubscription = nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -796,7 +796,6 @@ private extension OrderDetailsViewController {
         }
     }
 
-    // TODO: Check if this is necessary
     private func cancelObservingCardReader() {
         cardReaderAvailableSubscription?.cancel()
         cardReaderAvailableSubscription = nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -78,7 +78,7 @@ struct SimplePaymentsAmount: View {
     ///
     var dismiss: (() -> Void) = {}
 
-    /// Needed because IPP capture payments using a UIViewController for providing user feedback.
+    /// Needed because IPP capture payments depend on a UIViewController for providing user feedback.
     ///
     weak var rootViewController: UIViewController?
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -26,9 +26,6 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
             self?.dismiss(animated: true, completion: nil)
         }
 
-        // Needed to present IPP collect amount alerts, which are displayed in UIKit view controllers.
-        rootView.rootViewController = navigationController
-
         // Observe the present notice intent.
         presentNoticePublisher
             .compactMap { $0 }
@@ -44,6 +41,9 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Needed to present IPP collect amount alerts, which are displayed in UIKit view controllers.
+        rootView.rootViewController = navigationController
 
         // Set presentation delegate to track the user dismiss flow event
         if let navigationController = navigationController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -26,6 +26,9 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
             self?.dismiss(animated: true, completion: nil)
         }
 
+        // Needed to present IPP collect amount alerts, which are displayed in UIKit view controllers.
+        rootView.rootViewController = navigationController
+
         // Observe the present notice intent.
         presentNoticePublisher
             .compactMap { $0 }
@@ -74,6 +77,10 @@ struct SimplePaymentsAmount: View {
     /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
     ///
     var dismiss: (() -> Void) = {}
+
+    /// Needed because IPP capture payments using a UIViewController for providing user feedback.
+    ///
+    weak var rootViewController: UIViewController?
 
     /// Keeps track of the current content scale due to accessibility changes
     ///
@@ -134,7 +141,7 @@ struct SimplePaymentsAmount: View {
     private func summaryView() -> some View {
         Group {
             if let summaryViewModel = viewModel.summaryViewModel {
-                SimplePaymentsSummary(dismiss: dismiss, viewModel: summaryViewModel)
+                SimplePaymentsSummary(dismiss: dismiss, rootViewController: rootViewController, viewModel: summaryViewModel)
             }
             EmptyView()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -38,7 +38,7 @@ struct SimplePaymentsMethod: View {
                 Divider()
 
                 MethodRow(icon: .creditCardImage, title: Localization.card) {
-                    print("Tapped Card")
+                    viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
                 }
             }
             .padding(.horizontal)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -9,6 +9,10 @@ struct SimplePaymentsMethod: View {
     ///
     var dismiss: (() -> Void) = {}
 
+    /// Needed because IPP capture payments using a UIViewController for providing user feedback.
+    ///
+    weak var rootViewController: UIViewController?
+
     /// ViewModel to render the view content.
     ///
     @ObservedObject var viewModel: SimplePaymentsMethodsViewModel

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -136,9 +136,11 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                                                             paymentGatewayAccount: paymentGateway,
                                                             rootViewController: rootViewController)
         collectPaymentsUseCase?.collectPayment(onCollect: { _ in
-            print("On collect!")
+            print("On collect does nothing for now...")
         }, onCompleted: { [weak self] in
-            print("On Completed")
+            // TODO: Show success notice
+
+            // Inform success to consumer
             onSuccess()
 
             // Make sure we free all the resources

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -133,6 +133,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
 
         collectPaymentsUseCase = CollectOrderPaymentUseCase(siteID: siteID,
                                                             order: order,
+                                                            formattedAmount: formattedTotal,
                                                             paymentGatewayAccount: paymentGateway,
                                                             rootViewController: rootViewController)
         collectPaymentsUseCase?.collectPayment(onCollect: { _ in

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -126,6 +126,14 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
             DDLogError("⛔️ Payment Gateway not found, can't collect payment.")
             return presentNoticeSubject.send(.error(Localization.genericCollectError))
         }
+
+        let useCase = CollectOrderPaymentUseCase(siteID: siteID, order: order, paymentGatewayAccount: paymentGateway, rootViewController: rootViewController)
+        useCase.collectPayment(onCollect: { _ in
+            print("On collect!")
+        }, onCompleted: {
+            print("On Completed")
+            onSuccess()
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -8,6 +8,10 @@ struct SimplePaymentsSummary: View {
     ///
     var dismiss: (() -> Void) = {}
 
+    /// Needed because IPP capture payments using a UIViewController for providing user feedback.
+    ///
+    weak var rootViewController: UIViewController?
+
     /// Defines if the order note screen should be shown or not.
     ///
     @State var showEditNote = false
@@ -40,7 +44,9 @@ struct SimplePaymentsSummary: View {
             TakePaymentSection(viewModel: viewModel)
 
             // Navigation To Payment Methods
-            LazyNavigationLink(destination: SimplePaymentsMethod(dismiss: dismiss, viewModel: viewModel.createMethodsViewModel()),
+            LazyNavigationLink(destination: SimplePaymentsMethod(dismiss: dismiss,
+                                                                 rootViewController: rootViewController,
+                                                                 viewModel: viewModel.createMethodsViewModel()),
                                isActive: $viewModel.navigateToPaymentMethods) {
                 EmptyView()
             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */; };
 		268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */; };
 		268EC46426D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */; };
+		268FD44727580A81008FDF9B /* CollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268FD44627580A81008FDF9B /* CollectOrderPaymentUseCase.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -1940,6 +1941,7 @@
 		268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNote.swift; sourceTree = "<group>"; };
 		268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModel.swift; sourceTree = "<group>"; };
 		268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelTests.swift; sourceTree = "<group>"; };
+		268FD44627580A81008FDF9B /* CollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -4102,6 +4104,14 @@
 			path = "Customer Note";
 			sourceTree = "<group>";
 		};
+		268FD44827580A92008FDF9B /* Collect Payments */ = {
+			isa = PBXGroup;
+			children = (
+				268FD44627580A81008FDF9B /* CollectOrderPaymentUseCase.swift */,
+			);
+			path = "Collect Payments";
+			sourceTree = "<group>";
+		};
 		26A630F8253F62AD00CBC3B1 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
@@ -6039,6 +6049,7 @@
 			isa = PBXGroup;
 			children = (
 				CEE006022077D0F80079161F /* Cells */,
+				268FD44827580A92008FDF9B /* Collect Payments */,
 				CE35F1092343E482007B2A6B /* Order Details */,
 				2678897A270E6E3C00BD249E /* Simple Payments */,
 				CCFC50532743BBBF001E505F /* Order Creation */,
@@ -7793,6 +7804,7 @@
 				DEC51A9D274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift in Sources */,
 				455DC3A327393C7E00D4644C /* OrderDatesFilterViewController.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
+				268FD44727580A81008FDF9B /* CollectOrderPaymentUseCase.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				45F627B6253603AE00894B86 /* Product+DownloadSettingsViewModels.swift in Sources */,
 				B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -8,7 +8,9 @@ final class CardPresentModalSuccessTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalSuccess(printReceipt: closures.printReceipt(), emailReceipt: closures.emailReceipt())
+        viewModel = CardPresentModalSuccess(printReceipt: closures.printReceipt(),
+                                            emailReceipt: closures.emailReceipt(),
+                                            backToOrders: closures.backToOrders())
     }
 
     override func tearDown() {
@@ -60,6 +62,12 @@ final class CardPresentModalSuccessTests: XCTestCase {
 
         XCTAssertTrue(closures.didTapEmail)
     }
+
+    func test_auxiliary_button_action_calls_closure() {
+        viewModel.didTapAuxiliaryButton(in: UIViewController())
+
+        XCTAssertTrue(closures.didTapBackToOrders)
+    }
 }
 
 
@@ -73,6 +81,7 @@ private extension CardPresentModalSuccessTests {
 private final class Closures {
     var didTapPrint = false
     var didTapEmail = false
+    var didTapBackToOrders = false
 
     func printReceipt() -> () -> Void {
         return { [weak self] in
@@ -83,6 +92,12 @@ private final class Closures {
     func emailReceipt() -> () -> Void {
         return { [weak self] in
             self?.didTapEmail = true
+        }
+    }
+
+    func backToOrders() -> () -> Void {
+        return { [weak self] in
+            self?.didTapBackToOrders = true
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -10,7 +10,7 @@ final class CardPresentModalSuccessTests: XCTestCase {
         closures = Closures()
         viewModel = CardPresentModalSuccess(printReceipt: closures.printReceipt(),
                                             emailReceipt: closures.emailReceipt(),
-                                            backToOrders: closures.backToOrders())
+                                            noReceiptAction: closures.noReceiptAction())
     }
 
     override func tearDown() {
@@ -66,7 +66,7 @@ final class CardPresentModalSuccessTests: XCTestCase {
     func test_auxiliary_button_action_calls_closure() {
         viewModel.didTapAuxiliaryButton(in: UIViewController())
 
-        XCTAssertTrue(closures.didTapBackToOrders)
+        XCTAssertTrue(closures.didTapNoReceipt)
     }
 }
 
@@ -81,7 +81,7 @@ private extension CardPresentModalSuccessTests {
 private final class Closures {
     var didTapPrint = false
     var didTapEmail = false
-    var didTapBackToOrders = false
+    var didTapNoReceipt = false
 
     func printReceipt() -> () -> Void {
         return { [weak self] in
@@ -95,9 +95,9 @@ private final class Closures {
         }
     }
 
-    func backToOrders() -> () -> Void {
+    func noReceiptAction() -> () -> Void {
         return { [weak self] in
-            self?.didTapBackToOrders = true
+            self?.didTapNoReceipt = true
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
@@ -8,7 +8,7 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt())
+        viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt(), backToOrders: closures.backToOrders())
     }
 
     override func tearDown() {
@@ -54,6 +54,12 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
 
         XCTAssertTrue(closures.didTapPrint)
     }
+
+    func test_secondary_button_action_calls_closure() {
+        viewModel.didTapSecondaryButton(in: UIViewController())
+
+        XCTAssertTrue(closures.didTapBackToOrders)
+    }
 }
 
 
@@ -66,10 +72,17 @@ private extension CardPresentModalSuccessWithoutEmailTests {
 
 private final class Closures {
     var didTapPrint = false
+    var didTapBackToOrders = false
 
     func printReceipt() -> () -> Void {
         return { [weak self] in
             self?.didTapPrint = true
+        }
+    }
+
+    func backToOrders() -> () -> Void {
+        return { [weak self] in
+            self?.didTapBackToOrders = true
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
@@ -8,7 +8,7 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt(), backToOrders: closures.backToOrders())
+        viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt(), noReceiptAction: closures.noReceiptAction())
     }
 
     override func tearDown() {
@@ -58,7 +58,7 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
     func test_secondary_button_action_calls_closure() {
         viewModel.didTapSecondaryButton(in: UIViewController())
 
-        XCTAssertTrue(closures.didTapBackToOrders)
+        XCTAssertTrue(closures.didTapNoReceipt)
     }
 }
 
@@ -72,7 +72,7 @@ private extension CardPresentModalSuccessWithoutEmailTests {
 
 private final class Closures {
     var didTapPrint = false
-    var didTapBackToOrders = false
+    var didTapNoReceipt = false
 
     func printReceipt() -> () -> Void {
         return { [weak self] in
@@ -80,9 +80,9 @@ private final class Closures {
         }
     }
 
-    func backToOrders() -> () -> Void {
+    func noReceiptAction() -> () -> Void {
         return { [weak self] in
-            self?.didTapBackToOrders = true
+            self?.didTapNoReceipt = true
         }
     }
 }


### PR DESCRIPTION
Part of #5351 

# Why 

Now that the payment method UI is finished #5544, this PR takes care of allowing merchants to connect to readers, collect payments and manage receipts after tapping the "Pay By Card" row.

# How

This PR is **HUGE**  and I apologize for that 😢 but taking payments involves a significant amount of code. I did not ship this incrementally since the code is already in the `OrderDetail` module and the main objective of this PR was to move that code into a shared place so it can be reused by those modules(Order Detail & Simple Payments).

## `CollectOrderPaymentUseCase`

This is the gut of the PR, here I'm just grouping all the logic I found to be necessary from `OrderDetailViewModel` & `OrderDetailsViewController` to collect payments. I did my best to not add or change logic, the main intention is to group code into smaller methods so it is easier to read and reuse. 

FYI, I'm not using this use-case in the `OrderDetails` module yet, that will come in a subsequent PR so it can be tested in isolation.

Note: Here I need special attention to edge cases, the happy paths seem to work for me but I'm not so sure about the not-so-happy paths.

## `OrderDetailsPaymentAlerts`

In the alerts realm, I'm only modifying the success view models to provide a closure when the auxiliary button is tapped. I need that in order to dismiss the simple payments flow after the merchant is done interacting with the alerts.

## `Simple Payments`

The simple payments module has two main changes.

1. Pass a `rootViewController` through all the `SwiftUI` so we can present the payments alerts at the end of the flow.

2. Use of the newly introduced `CollectOrderPaymentUseCase` on `SimplePaymentsMethodsViewModel`.  Here I have also added code to fetch the `order`  and `paymentGatewayAccount` objects as they are required by the collect payment code.

# Demo

https://user-images.githubusercontent.com/562080/144354780-18619f29-4f13-4a50-9922-087789f7b8b3.MOV

https://user-images.githubusercontent.com/562080/144354812-c53cabda-6c28-445c-9bda-01ab26ff67df.MOV

https://user-images.githubusercontent.com/562080/144354792-06e3cfee-bd34-4bfb-a2e5-1178a8050c30.MOV

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- Enter an amount & tap next
- Tap next on the summary screen
- After the order is updated tap the "cash" row in the payment method screen
- Play with connecting, collecting, and managing receipts.
- See that after finishing with the payment flow, the user lands on the order list screen.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
