### PR TITLE
Jetpack CP: log how long it takes to fetch JCP sites

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -537,6 +537,7 @@ public enum WooAnalyticsStat: String {
     //
     case jetpackBenefitsBanner = "feature_jetpack_benefits_banner"
     case jetpackInstallButtonTapped = "jetpack_install_button_tapped"
+    case jetpackCPSitesFetched = "jetpack_cp_sites_fetched"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -284,10 +284,12 @@ private extension DefaultStoresManager {
     /// Synchronizes the WordPress.com Sites, associated with the current credentials.
     ///
     func synchronizeSites(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let isJetpackConnectionPackageSupported = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport)
         let action = AccountAction
             .synchronizeSites(selectedSiteID: sessionManager.defaultStoreID,
-                              isJetpackConnectionPackageSupported: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport),
-                              onCompletion: onCompletion)
+                              isJetpackConnectionPackageSupported: isJetpackConnectionPackageSupported) { result in
+                onCompletion(result.map { _ in () })
+            }
         dispatch(action)
     }
 

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -10,7 +10,8 @@ public enum AccountAction: Action {
     case loadAndSynchronizeSite(siteID: Int64, forcedUpdate: Bool, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Site, Error>) -> Void)
     case synchronizeAccount(onCompletion: (Result<Account, Error>) -> Void)
     case synchronizeAccountSettings(userID: Int64, onCompletion: (Result<AccountSettings, Error>) -> Void)
-    case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Void, Error>) -> Void)
+    /// The boolean in the completion block indicates whether the sites contain any JCP sites (connected to Jetpack without Jetpack-the-plugin).
+    case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Bool, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -117,7 +117,7 @@ private extension AccountStore {
 
     /// Synchronizes the WordPress.com sites associated with the Network's Auth Token.
     ///
-    func synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         remote.loadSites()
             .flatMap { result -> AnyPublisher<Result<[Site], Error>, Never> in
                 switch result {
@@ -159,8 +159,9 @@ private extension AccountStore {
             .sink { [weak self] result in
                 switch result {
                 case .success(let sites):
+                    let containsJCPSites = sites.contains(where: { $0.isJetpackCPConnected })
                     self?.upsertStoredSitesInBackground(readOnlySites: sites, selectedSiteID: selectedSiteID) {
-                        onCompletion(.success(()))
+                        onCompletion(.success(containsJCPSites))
                     }
                 case .failure(let error):
                     onCompletion(.failure(error))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5402 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To understand how the user experience is when loading sites with JCP sites which requires a workaround to make extra API requests, we are logging `jetpack_cp_sites_fetched` in the site picker to record the total time. Since the merchant might have no JCP sites, I implemented this by returning a boolean flag that indicates whether JCP sites are present in `AccountAction.synchronizeSites`. Then in the site picker, `jetpack_cp_sites_fetched` is only logged when this boolean flag is `true`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite:
Having two accounts:
* Account 1 is connected to all Jetpack sites
* Account 2 is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23)

---

- Launch the app, log in to account 1 in the prerequisite if needed
- Go to Settings > Switch Store --> there should be no event in the console named `jetpack_cp_sites_fetched`
- Log out and in to account 2 in the prerequisite --> when reaching the site picker, there should be an event in the console like `🔵 Tracked jetpack_cp_sites_fetched, properties: [AnyHashable("duration"): 2592.0]` where the duration is in milliseconds
- Select any site and continue
- Go to Settings > Switch Store --> there should be an event in the console like `🔵 Tracked jetpack_cp_sites_fetched, properties: [AnyHashable("duration"): 2592.0]` where the duration is in milliseconds

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
