### PR TITLE
Fix typo in Enter Store Address screen

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -27,7 +27,7 @@ struct AuthenticationConstants {
     /// Login with site URL instructions.
     ///
     static let siteInstructions = NSLocalizedString(
-        "Enter the address of your WooCommerce store you'd like to connect.",
+        "Enter the address of the WooCommerce store you'd like to connect.",
         comment: "Sign in instructions for logging in with a URL."
     )
 


### PR DESCRIPTION
Fixes #3551.
Changes the phrase "Enter the address of _your_ WooCommerce store you'd like to connect" to "Enter the address of _the_ WooCommerce store you'd like to connect.

### Testing instructions
Logout if logged in.
Begin login via Store Address.
On the Log In screen, where you are prompted to enter your store address, check that the phrase is correct, using "the WooCommerce store" instead of "your WooCommerce store".


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


