### PR TITLE
Order Creation: Add view model to display product data in ProductRow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -95,7 +95,8 @@ private struct ProductsSection: View {
                     .headlineStyle()
 
                 // TODO: Add a product row for each product added to the order
-                ProductRow(canChangeQuantity: true)
+                let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: false) // Temporary view model
+                ProductRow(viewModel: viewModel)
 
                 Button(NewOrder.Localization.addProduct) {
                     showAddProduct.toggle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -95,7 +95,14 @@ private struct ProductsSection: View {
                     .headlineStyle()
 
                 // TODO: Add a product row for each product added to the order
-                let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: true) // Temporary view model
+                let viewModel = ProductRowViewModel(id: 1,
+                                                    name: "Love Ficus",
+                                                    sku: "123456",
+                                                    price: "20",
+                                                    stockStatusKey: "instock",
+                                                    stockQuantity: 7,
+                                                    manageStock: true,
+                                                    canChangeQuantity: true) // Temporary view model with fake data
                 ProductRow(viewModel: viewModel)
 
                 Button(NewOrder.Localization.addProduct) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -95,7 +95,7 @@ private struct ProductsSection: View {
                     .headlineStyle()
 
                 // TODO: Add a product row for each product added to the order
-                let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: false) // Temporary view model
+                let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: true) // Temporary view model
                 ProductRow(viewModel: viewModel)
 
                 Button(NewOrder.Localization.addProduct) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
@@ -13,7 +13,14 @@ struct AddProduct: View {
                 // TODO: Make the product list searchable
                 LazyVStack {
                     // TODO: Add a product row for each non-variable product in the store
-                    let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: false) // Temporary view model
+                    let viewModel = ProductRowViewModel(id: 1,
+                                                        name: "Love Ficus",
+                                                        sku: "123456",
+                                                        price: "20",
+                                                        stockStatusKey: "instock",
+                                                        stockQuantity: 7,
+                                                        manageStock: true,
+                                                        canChangeQuantity: false) // Temporary view model with fake data
                     ProductRow(viewModel: viewModel)
                 }
                 .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 /// View showing a list of products to add to an order.
 ///
@@ -13,7 +14,8 @@ struct AddProduct: View {
                 // TODO: Make the product list searchable
                 LazyVStack {
                     // TODO: Add a product row for each non-variable product in the store
-                    ProductRow(canChangeQuantity: false)
+                    let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: false) // Temporary view model
+                    ProductRow(viewModel: viewModel)
                 }
                 .padding()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProduct.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Yosemite
 
 /// View showing a list of products to add to an order.
 ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -1,12 +1,12 @@
 import SwiftUI
+import Yosemite
 
 /// Represent a single product row in the Product section of a New Order
 ///
 struct ProductRow: View {
-    /// Whether the product quantity can be changed.
-    /// Controls whether the stepper is rendered.
+    /// View model to drive the view.
     ///
-    let canChangeQuantity: Bool
+    @ObservedObject var viewModel: ProductRowViewModel
 
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1
@@ -26,10 +26,10 @@ struct ProductRow: View {
 
                     // Product details
                     VStack(alignment: .leading) {
-                        Text("Love Ficus") // Fake data - product name
-                        Text("7 in stock • $20.00") // Fake data - stock / price
+                        Text(viewModel.nameLabel)
+                        Text(viewModel.stockAndPriceLabel)
                             .subheadlineStyle()
-                        Text("SKU: 123456") // Fake data - SKU
+                        Text(viewModel.skuLabel)
                             .subheadlineStyle()
                     }
                     .accessibilityElement(children: .combine)
@@ -37,8 +37,8 @@ struct ProductRow: View {
 
                 Spacer()
 
-                ProductStepper()
-                    .renderedIf(canChangeQuantity)
+                ProductStepper(viewModel: viewModel)
+                    .renderedIf(viewModel.canChangeQuantity)
             }
 
             Divider()
@@ -50,6 +50,10 @@ struct ProductRow: View {
 /// Used to change the quantity of the product in a `ProductRow`.
 ///
 private struct ProductStepper: View {
+
+    /// View model to drive the view.
+    ///
+    @ObservedObject var viewModel: ProductRowViewModel
 
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1
@@ -83,7 +87,7 @@ private struct ProductStepper: View {
         )
         .accessibilityElement(children: .ignore)
         .accessibility(label: Text(Localization.quantityLabel))
-        .accessibility(value: Text("1")) // Fake static data - quantity
+        .accessibility(value: Text("\(viewModel.quantity)"))
         .accessibilityAdjustableAction { direction in
             switch direction {
             case .decrement:
@@ -111,11 +115,15 @@ private enum Localization {
 
 struct ProductRow_Previews: PreviewProvider {
     static var previews: some View {
-        ProductRow(canChangeQuantity: true)
+        let sampleProduct = Product().copy(productID: 2, name: "Love Ficus", sku: "123456", price: "20", stockQuantity: 7, stockStatusKey: "instock")
+        let viewModel = ProductRowViewModel(product: sampleProduct, canChangeQuantity: true)
+        let viewModel2 = ProductRowViewModel(product: sampleProduct, canChangeQuantity: false)
+
+        ProductRow(viewModel: viewModel)
             .previewDisplayName("ProductRow with stepper")
             .previewLayout(.sizeThatFits)
 
-        ProductRow(canChangeQuantity: false)
+        ProductRow(viewModel: viewModel2)
             .previewDisplayName("ProductRow without stepper")
             .previewLayout(.sizeThatFits)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Yosemite
 
 /// Represent a single product row in the Product section of a New Order
 ///
@@ -115,9 +114,8 @@ private enum Localization {
 
 struct ProductRow_Previews: PreviewProvider {
     static var previews: some View {
-        let sampleProduct = Product().copy(productID: 2, name: "Love Ficus", sku: "123456", price: "20", stockQuantity: 7, stockStatusKey: "instock")
-        let viewModel = ProductRowViewModel(product: sampleProduct, canChangeQuantity: true)
-        let viewModel2 = ProductRowViewModel(product: sampleProduct, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: true)
+        let viewModel2 = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: false)
 
         ProductRow(viewModel: viewModel)
             .previewDisplayName("ProductRow with stepper")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -68,7 +68,7 @@ private struct ProductStepper: View {
                     .frame(height: Layout.stepperButtonSize * scale)
             }
 
-            Text("1") // Fake data - quantity
+            Text("\(viewModel.quantity)")
 
             Button {
                 // TODO: Increment the product quantity

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -25,7 +25,7 @@ struct ProductRow: View {
 
                     // Product details
                     VStack(alignment: .leading) {
-                        Text(viewModel.nameLabel)
+                        Text(viewModel.name)
                         Text(viewModel.stockAndPriceLabel)
                             .subheadlineStyle()
                         Text(viewModel.skuLabel)
@@ -114,14 +114,28 @@ private enum Localization {
 
 struct ProductRow_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: true)
-        let viewModel2 = ProductRowViewModel(product: ProductRowViewModel.sampleProduct, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(id: 1,
+                                            name: "Love Ficus",
+                                            sku: "123456",
+                                            price: "20",
+                                            stockStatusKey: "instock",
+                                            stockQuantity: 7,
+                                            manageStock: true,
+                                            canChangeQuantity: true)
+        let viewModelWithoutStepper = ProductRowViewModel(id: 1,
+                                                          name: "Love Ficus",
+                                                          sku: "123456",
+                                                          price: "20",
+                                                          stockStatusKey: "instock",
+                                                          stockQuantity: 7,
+                                                          manageStock: true,
+                                                          canChangeQuantity: false)
 
         ProductRow(viewModel: viewModel)
             .previewDisplayName("ProductRow with stepper")
             .previewLayout(.sizeThatFits)
 
-        ProductRow(viewModel: viewModel2)
+        ProductRow(viewModel: viewModelWithoutStepper)
             .previewDisplayName("ProductRow without stepper")
             .previewLayout(.sizeThatFits)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -4,11 +4,6 @@ import Yosemite
 /// View model for `ProductRow`.
 ///
 final class ProductRowViewModel: ObservableObject, Identifiable {
-    /// Product ID
-    /// Required by SwiftUI as a unique identifier
-    ///
-    let id: Int64
-
     private let currencyFormatter: CurrencyFormatter
 
     /// Whether the product quantity can be changed.
@@ -16,13 +11,36 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     let canChangeQuantity: Bool
 
-    /// Product to display
-    ///
-    private let product: Product
+    // MARK: Product properties
 
-    /// Label showing product name
+    /// Product ID
+    /// Required by SwiftUI as a unique identifier
     ///
-    let nameLabel: String
+    let id: Int64
+
+    /// Product name
+    ///
+    let name: String
+
+    /// Product SKU
+    ///
+    private let sku: String?
+
+    /// Product price
+    ///
+    private let price: String
+
+    /// Product stock status
+    ///
+    private let stockStatus: ProductStockStatus
+
+    /// Product stock quantity
+    ///
+    private let stockQuantity: Decimal?
+
+    /// Whether the product's stock quantity is managed
+    ///
+    private let manageStock: Bool
 
     /// Label showing product stock status and price.
     ///
@@ -38,7 +56,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Label showing product SKU
     ///
     lazy var skuLabel: String = {
-        guard let sku = product.sku, sku.isNotEmpty else {
+        guard let sku = sku, sku.isNotEmpty else {
             return ""
         }
         return String.localizedStringWithFormat(Localization.skuFormat, sku)
@@ -48,36 +66,60 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     @Published var quantity: Int64 = 1
 
-    init(product: Product,
+    init(id: Int64,
+         name: String,
+         sku: String?,
+         price: String,
+         stockStatusKey: String,
+         stockQuantity: Decimal?,
+         manageStock: Bool,
          canChangeQuantity: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
-        self.id = product.productID
-        self.product = product
-        self.nameLabel = product.name
+        self.id = id
+        self.name = name
+        self.sku = sku
+        self.price = price
+        self.stockStatus = .init(rawValue: stockStatusKey)
+        self.stockQuantity = stockQuantity
+        self.manageStock = manageStock
         self.canChangeQuantity = canChangeQuantity
         self.currencyFormatter = currencyFormatter
+    }
+
+    convenience init(product: Product,
+                     canChangeQuantity: Bool,
+                     currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        self.init(id: product.productID,
+                  name: product.name,
+                  sku: product.sku,
+                  price: product.price,
+                  stockStatusKey: product.stockStatusKey,
+                  stockQuantity: product.stockQuantity,
+                  manageStock: product.manageStock,
+                  canChangeQuantity: canChangeQuantity,
+                  currencyFormatter: currencyFormatter)
     }
 
     /// Create the stock text based on a product's stock status/quantity.
     ///
     private func createStockText() -> String {
-        switch product.productStockStatus {
+        switch stockStatus {
         case .inStock:
-            if let stockQuantity = product.stockQuantity, product.manageStock {
+            if let stockQuantity = stockQuantity, manageStock {
                 let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
                 return String.localizedStringWithFormat(Localization.stockFormat, localizedStockQuantity)
             } else {
-                return product.productStockStatus.description
+                return stockStatus.description
             }
         default:
-            return product.productStockStatus.description
+            return stockStatus.description
         }
     }
 
     /// Create the price text based on a product's price.
     ///
     private func createPriceText() -> String? {
-        let unformattedPrice = product.price.isNotEmpty ? product.price : "0"
+        let unformattedPrice = price.isNotEmpty ? price : "0"
         return currencyFormatter.formatAmount(unformattedPrice)
     }
 }
@@ -87,9 +129,4 @@ private extension ProductRowViewModel {
         static let stockFormat = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown during order creation")
         static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
     }
-}
-
-// MARK: SwiftUI Preview Helpers
-extension ProductRowViewModel {
-    static let sampleProduct = Product().copy(productID: 2, name: "Love Ficus", sku: "123456", price: "20", stockQuantity: 7, stockStatusKey: "instock")
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Yosemite
+
+/// View model for `ProductRow`.
+///
+final class ProductRowViewModel: ObservableObject {
+    private let currencyFormatter: CurrencyFormatter
+
+    /// Whether the product quantity can be changed.
+    /// Controls whether the stepper is rendered.
+    ///
+    let canChangeQuantity: Bool
+
+    /// Product to display
+    ///
+    let product: Product
+
+    /// Label showing product name
+    ///
+    var nameLabel: String {
+        product.name
+    }
+
+    /// Label showing product stock status and price.
+    ///
+    var stockAndPriceLabel: String {
+        let stockLabel = createStockText()
+        let priceLabel = createPriceText()
+
+        return [stockLabel, priceLabel]
+            .compactMap({ $0 })
+            .joined(separator: " • ")
+    }
+
+    /// Label showing product SKU
+    ///
+    var skuLabel: String {
+        guard let sku = product.sku, sku.isNotEmpty else {
+            return ""
+        }
+        return String.localizedStringWithFormat(Localization.skuFormat, sku)
+    }
+
+    /// Quantity of product in the order
+    ///
+    var quantity: Int64 = 1
+
+    init(product: Product,
+         canChangeQuantity: Bool,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        self.product = product
+        self.canChangeQuantity = canChangeQuantity
+        self.currencyFormatter = currencyFormatter
+    }
+
+    /// Create the stock text based on a product's stock status/quantity.
+    ///
+    private func createStockText() -> String {
+        switch product.productStockStatus {
+        case .inStock:
+            if let stockQuantity = product.stockQuantity, product.manageStock {
+                let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
+                return String.localizedStringWithFormat(Localization.stockFormat, localizedStockQuantity)
+            } else {
+                return product.productStockStatus.description
+            }
+        default:
+            return product.productStockStatus.description
+        }
+    }
+
+    /// Create the price text based on a product's price.
+    ///
+    private func createPriceText() -> String? {
+        let unformattedPrice = product.price.isNotEmpty ? product.price : "0"
+        return currencyFormatter.formatAmount(unformattedPrice)
+    }
+}
+
+private extension ProductRowViewModel {
+    enum Localization {
+        static let stockFormat = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown during order creation")
+        static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -18,43 +18,42 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Product to display
     ///
-    let product: Product
+    private let product: Product
 
     /// Label showing product name
     ///
-    var nameLabel: String {
-        product.name
-    }
+    let nameLabel: String
 
     /// Label showing product stock status and price.
     ///
-    var stockAndPriceLabel: String {
+    lazy var stockAndPriceLabel: String = {
         let stockLabel = createStockText()
         let priceLabel = createPriceText()
 
         return [stockLabel, priceLabel]
             .compactMap({ $0 })
             .joined(separator: " • ")
-    }
+    }()
 
     /// Label showing product SKU
     ///
-    var skuLabel: String {
+    lazy var skuLabel: String = {
         guard let sku = product.sku, sku.isNotEmpty else {
             return ""
         }
         return String.localizedStringWithFormat(Localization.skuFormat, sku)
-    }
+    }()
 
     /// Quantity of product in the order
     ///
-    var quantity: Int64 = 1
+    @Published var quantity: Int64 = 1
 
     init(product: Product,
          canChangeQuantity: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.id = product.productID
         self.product = product
+        self.nameLabel = product.name
         self.canChangeQuantity = canChangeQuantity
         self.currencyFormatter = currencyFormatter
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -89,3 +89,8 @@ private extension ProductRowViewModel {
         static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
     }
 }
+
+// MARK: SwiftUI Preview Helpers
+extension ProductRowViewModel {
+    static let sampleProduct = Product().copy(productID: 2, name: "Love Ficus", sku: "123456", price: "20", stockQuantity: 7, stockStatusKey: "instock")
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -3,7 +3,12 @@ import Yosemite
 
 /// View model for `ProductRow`.
 ///
-final class ProductRowViewModel: ObservableObject {
+final class ProductRowViewModel: ObservableObject, Identifiable {
+    /// Product ID
+    /// Required by SwiftUI as a unique identifier
+    ///
+    let id: Int64
+
     private let currencyFormatter: CurrencyFormatter
 
     /// Whether the product quantity can be changed.
@@ -48,6 +53,7 @@ final class ProductRowViewModel: ObservableObject {
     init(product: Product,
          canChangeQuantity: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        self.id = product.productID
         self.product = product
         self.canChangeQuantity = canChangeQuantity
         self.currencyFormatter = currencyFormatter

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1065,6 +1065,7 @@
 		CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3427551A6E00C4CA4F /* ProductRow.swift */; };
 		CC53FB382755213900C4CA4F /* AddProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB372755213900C4CA4F /* AddProduct.swift */; };
 		CC53FB3A275697B000C4CA4F /* ProductRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */; };
+		CC53FB3E2758E2D500C4CA4F /* ProductRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */; };
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
@@ -2561,6 +2562,7 @@
 		CC53FB3427551A6E00C4CA4F /* ProductRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRow.swift; sourceTree = "<group>"; };
 		CC53FB372755213900C4CA4F /* AddProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProduct.swift; sourceTree = "<group>"; };
 		CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowViewModel.swift; sourceTree = "<group>"; };
+		CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
@@ -5801,6 +5803,7 @@
 			children = (
 				CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */,
 				AEA622B627468790002A9B57 /* AddOrderCoordinatorTests.swift */,
+				CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -8571,6 +8574,7 @@
 				26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */,
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,
 				027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */,
+				CC53FB3E2758E2D500C4CA4F /* ProductRowViewModelTests.swift in Sources */,
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
 				FEEB2F61268A215E0075A6E0 /* StorageEligibilityErrorInfoWooTests.swift in Sources */,
 				31F21B02263C8E150035B50A /* CardReaderSettingsSearchingViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1064,6 +1064,7 @@
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
 		CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3427551A6E00C4CA4F /* ProductRow.swift */; };
 		CC53FB382755213900C4CA4F /* AddProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB372755213900C4CA4F /* AddProduct.swift */; };
+		CC53FB3A275697B000C4CA4F /* ProductRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */; };
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
@@ -2559,6 +2560,7 @@
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		CC53FB3427551A6E00C4CA4F /* ProductRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRow.swift; sourceTree = "<group>"; };
 		CC53FB372755213900C4CA4F /* AddProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProduct.swift; sourceTree = "<group>"; };
+		CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowViewModel.swift; sourceTree = "<group>"; };
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
@@ -5789,6 +5791,7 @@
 			children = (
 				CC53FB372755213900C4CA4F /* AddProduct.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
+				CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */,
 			);
 			path = ProductsSection;
 			sourceTree = "<group>";
@@ -8163,6 +8166,7 @@
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				D85A3C5626C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,
+				CC53FB3A275697B000C4CA4F /* ProductRowViewModel.swift in Sources */,
 				AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */,
 				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -12,10 +12,10 @@ class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
 
         // Then
-        XCTAssertEqual(viewModel.product, product)
+        XCTAssertEqual(viewModel.id, product.productID)
+        XCTAssertEqual(viewModel.name, product.name)
         XCTAssertFalse(viewModel.canChangeQuantity)
         XCTAssertEqual(viewModel.quantity, 1)
-        XCTAssertEqual(viewModel.nameLabel, product.name)
     }
 
     func test_view_model_creates_expected_label_for_product_with_managed_stock() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+class ProductRowViewModelTests: XCTestCase {
+
+    func test_viewModel_is_created_with_correct_initial_values() {
+        // Given
+        let product = Product.fake().copy(productID: 12, name: "Test Product")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        XCTAssertEqual(viewModel.product, product)
+        XCTAssertFalse(viewModel.canChangeQuantity)
+        XCTAssertEqual(viewModel.quantity, 1)
+        XCTAssertEqual(viewModel.nameLabel, product.name)
+    }
+
+    func test_view_model_creates_expected_label_for_product_with_managed_stock() {
+        // Given
+        let stockQuantity: Decimal = 7
+        let product = Product.fake().copy(manageStock: true, stockQuantity: stockQuantity, stockStatusKey: "instock")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
+        let format = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown during order creation")
+        let expectedStockLabel = String.localizedStringWithFormat(format, localizedStockQuantity)
+        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedStockLabel),
+                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+    }
+
+    func test_view_model_creates_expected_label_for_product_with_unmanaged_stock() {
+        // Given
+        let product = Product.fake().copy(stockStatusKey: "instock")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let expectedStockLabel = NSLocalizedString("In stock", comment: "Display label for the product's inventory stock status")
+        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedStockLabel),
+                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+    }
+
+    func test_view_model_creates_expected_label_for_out_of_stock_product() {
+        // Given
+        let product = Product.fake().copy(stockStatusKey: "outofstock")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let expectedStockLabel = NSLocalizedString("Out of stock", comment: "Display label for the product's inventory stock status")
+        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedStockLabel),
+                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+    }
+
+    func test_view_model_creates_expected_label_for_product_with_price() {
+        // Given
+        let price = "2.50"
+        let product = Product.fake().copy(price: price)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+
+        // Then
+        let expectedPriceLabel = "2.50"
+        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedPriceLabel),
+                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+    }
+
+    func test_view_model_creates_expected_label_for_product_with_no_price() {
+        // Given
+        let price = ""
+        let product = Product.fake().copy(price: price)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+
+        // Then
+        let expectedPriceLabel = "$0.00"
+        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedPriceLabel),
+                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+    }
+
+    func test_sku_label_is_formatted_correctly_for_product_with_sku() {
+        // Given
+        let sku = "123456"
+        let product = Product.fake().copy(sku: sku)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let format = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
+        let expectedSKULabel = String.localizedStringWithFormat(format, sku)
+        XCTAssertEqual(viewModel.skuLabel, expectedSKULabel)
+    }
+
+    func test_sku_label_is_empty_for_product_without_sku() {
+        // Given
+        let sku = ""
+        let product = Product.fake().copy(sku: sku)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let expectedSKULabel = ""
+        XCTAssertEqual(viewModel.skuLabel, expectedSKULabel)
+    }
+}


### PR DESCRIPTION
Part of: #5408

## Description

This adds a view model to display actual product data in `ProductRow`, the row that displays product information during order creation. There are a couple things that aren't yet fully implemented:

* The actual product image is not yet displayed (only the placeholder image).
* Product quantity (in the stepper) can't be changed.

Everything else in `ProductRow` should be driven by the view model, including:

* Product name
* Product stock quantity/status
* Product price
* Product SKU
* Product quantity in order (static quantity set to 1)

The order creation screens that display `ProductRow` (New Order and Add Product) are still showing fake data, but it's now powered by the new view model. Future PRs will implement the final pieces of `ProductRow` and add real data from the store.

## Changes

* Adds `ProductRowViewModel` to drive the data displayed in `ProductRow`.
* Updates `ProductRow` to remove fake, static data and use the view model instead.
* Updates `NewOrder` and `AddProduct` views to displays a product row using a sample product (temporary until we implement real data in these views).
* Adds unit tests for `ProductRowViewModel`.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, confirm a product row appears showing the expected (sample) product data and stepper.
5. Tap the "Add product" button. Confirm the Add Product modal appears with a product row showing the expected (sample) product data and no stepper.

## Screenshots

New Order|Add Product
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-12-02 at 13 05 46](https://user-images.githubusercontent.com/8658164/144428899-b872eec6-6ba2-4bb4-9add-3d5ce2db332d.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-12-02 at 13 05 49](https://user-images.githubusercontent.com/8658164/144428893-740b8ff0-9cc3-4cb2-9636-a365be675a80.png)



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
