### PR TITLE
Fix retain cycles in OrderStatusListViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -966,12 +966,12 @@ private extension OrderDetailsViewController {
         let statusList = OrderStatusListViewController(siteID: viewModel.order.siteID,
                                                        status: viewModel.order.status)
 
-        statusList.didSelectCancel = {
-            statusList.dismiss(animated: true, completion: nil)
+        statusList.didSelectCancel = { [weak statusList] in
+            statusList?.dismiss(animated: true, completion: nil)
         }
 
-        statusList.didSelectApply = { (selectedStatus) in
-            statusList.dismiss(animated: true) {
+        statusList.didSelectApply = { [weak statusList] (selectedStatus) in
+            statusList?.dismiss(animated: true) {
                 self.setOrderStatus(to: selectedStatus)
             }
         }


### PR DESCRIPTION
## Description

`OrderStatusListViewController` referenses itself in own callback closures without weak links - so it never deallocates.
The fix is to use weak capturing of listVC inside its own closure properties.

## Testing

1. Run app, open any existing order.
2. Tap on pencil icon in order status section to open Status List.
3. Close it with button or swipe.
4. Repeat multiple times and keep it open.
5. Open Memory Graph.
6. Filter for OrderStatusList and confirm there is only one instance of VC.

## Screenshots

<img width="540" src="https://user-images.githubusercontent.com/3132438/144464355-6820870c-d4d1-4be2-a865-6a55edb01e6a.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
