### PR TITLE
5325 Refresh version info after reader update

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -491,6 +491,7 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
             }
         } else {
             softwareUpdateSubject.send(.completed)
+            connectedReadersSubject.send([CardReader(reader: reader)])
             softwareUpdateSubject.send(.none)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5325 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, the version number of the card reader would not change after the update was completed. This passes the updated card reader details back to be displayed in the connected card reader view, so the user can see the correct software version number.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Set up the simulated card reader with an available optional software update
2. Connect to the reader in the `⚙️ > In-Person Payments > Manage Card Reader` screen
3. Screenshot the connected page with the version number
4. Start the software update
5. Screenshot the connected page after the update with the version number
6. Compare version numbers and check that the post-update one has increased.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/144486612-6204d744-cace-4709-b1b7-1f91bc865dc1.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
