### PR TITLE
Simple Payments: Present notice after completing flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -18,7 +18,14 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
         return presenter
     }()
 
-    init(viewModel: SimplePaymentsAmountViewModel, presentNoticePublisher: AnyPublisher<SimplePaymentsNotice, Never>) {
+    /// Presents notices at the system level, currently uses the main tab-bar as source view controller.
+    ///
+    private let systemNoticePresenter: NoticePresenter
+
+    init(viewModel: SimplePaymentsAmountViewModel,
+         presentNoticePublisher: AnyPublisher<SimplePaymentsNotice, Never>,
+         systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
+        self.systemNoticePresenter = systemNoticePresenter
         super.init(rootView: SimplePaymentsAmount(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
@@ -32,6 +39,8 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
             .sink { [weak self] notice in
 
                 switch notice {
+                case .completed:
+                    self?.systemNoticePresenter.enqueue(notice: .init(title: SimplePaymentsAmount.Localization.completed, feedbackType: .success))
                 case .error(let description):
                     self?.modalNoticePresenter.enqueue(notice: .init(title: description, feedbackType: .error))
                 }
@@ -154,6 +163,7 @@ private extension SimplePaymentsAmount {
         static let title = NSLocalizedString("Take Payment", comment: "Title for the simple payments screen")
         static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the simple payments screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the simple payments screen")
+        static let completed = NSLocalizedString("🎉 Order completed", comment: "Title for the button to cancel the simple payments screen")
 
         static func buttonTitle() -> String {
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplePaymentsPrototype) {
@@ -175,5 +185,6 @@ private extension SimplePaymentsAmount {
 /// Representation of possible notices that can be displayed
 ///
 enum SimplePaymentsNotice: Equatable {
+    case completed
     case error(String)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -105,6 +105,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
 
             if error == nil {
                 onSuccess()
+                self.presentNoticeSubject.send(.completed)
             } else {
                 self.presentNoticeSubject.send(.error(Localization.markAsPaidError))
             }
@@ -137,12 +138,13 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                                                             paymentGatewayAccount: paymentGateway,
                                                             rootViewController: rootViewController)
         collectPaymentsUseCase?.collectPayment(onCollect: { _ in
-            print("On collect does nothing for now...")
+            /* No op. */
         }, onCompleted: { [weak self] in
-            // TODO: Show success notice
-
             // Inform success to consumer
             onSuccess()
+
+            // Sent notice request
+            self?.presentNoticeSubject.send(.completed)
 
             // Make sure we free all the resources
             self?.collectPaymentsUseCase = nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -300,6 +300,8 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
                 switch intent {
                 case .error:
                     promise(true)
+                case .completed:
+                    promise(false)
                 }
             }
             .store(in: &self.subscriptions)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -133,6 +133,8 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
                 switch intent {
                 case .error:
                     promise(true)
+                case .completed:
+                    promise(false)
                 }
             }
             .store(in: &self.subscriptions)


### PR DESCRIPTION
Closes: #5351 

# Why

After taking payments by card is merged in #5581, this PR takes care of showing a "Complete" notice after the simple payments flow is dismissed.

# How

- Adds a new `completed` case to `SimplePaymentsNotice` enum.

- Sends the `.competed` intention when either the order is marked as paid or when the collect payment flow has finished.

- Update `SimplePaymentsAmountHostingController` to show the `completed`noticed in the system-wide notice presenter.

# Demo

https://user-images.githubusercontent.com/562080/144498645-39deb9c0-1353-4de7-a561-0fff72ee95a2.mov

https://user-images.githubusercontent.com/562080/144498665-91c9172f-c246-4174-bc09-b08e39199628.mov

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store
- Make sure you have a store with taxes set for your store location

## Steps
- Start the simple payments flow
- Enter an amount & tap next
- Tap next on the summary screen
- Collect payment either by tapping the cash or card row.
- See that when the flow is finished and dismissed a "completed" notice is presented. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

