### PR TITLE
Jetpack CP: fix Jetpack empty visitor stats UI not shown for JCP sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -147,7 +147,11 @@ private extension StoreStatsAndTopPerformersViewController {
             vc.currentDate = currentDate
             let latestDateToInclude = vc.timeRange.latestDate(currentDate: currentDate, siteTimezone: timezoneForSync)
 
+            // For tasks dispatched for each time period.
+            let periodGroup = DispatchGroup()
+
             group.enter()
+            periodGroup.enter()
             self.syncStats(for: siteID,
                            siteTimezone: timezoneForSync,
                            timeRange: vc.timeRange,
@@ -160,9 +164,11 @@ private extension StoreStatsAndTopPerformersViewController {
                     periodSyncError = error
                 }
                 group.leave()
+                periodGroup.leave()
             }
 
             group.enter()
+            periodGroup.enter()
             self.syncSiteVisitStats(for: siteID,
                                     siteTimezone: timezoneForSync,
                                     timeRange: vc.timeRange,
@@ -172,9 +178,11 @@ private extension StoreStatsAndTopPerformersViewController {
                     periodSyncError = error
                 }
                 group.leave()
+                periodGroup.leave()
             }
 
             group.enter()
+            periodGroup.enter()
             self.syncTopEarnersStats(for: siteID,
                                      siteTimezone: timezoneForSync,
                                      timeRange: vc.timeRange,
@@ -184,13 +192,16 @@ private extension StoreStatsAndTopPerformersViewController {
                     periodSyncError = error
                 }
                 group.leave()
+                periodGroup.leave()
             }
 
-            // Update last successful data sync timestamp
-            if periodSyncError == nil {
-                vc.lastFullSyncTimestamp = Date()
-            } else {
-                syncError = periodSyncError
+            periodGroup.notify(queue: .main) {
+                // Update last successful data sync timestamp
+                if periodSyncError == nil {
+                    vc.lastFullSyncTimestamp = Date()
+                } else {
+                    syncError = periodSyncError
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5577 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Recently, the Jetpack empty visitor stats UI stopped showing for JCP sites where it used to work. After some debugging, it was from the changes in this commit https://github.com/woocommerce/woocommerce-ios/commit/bea9175baeb754f0f6e6820e75c400f878bf684e#diff-83092453a66f9df2ae4a5617bd44ed4d85688a02ef5d1a3f03ff30547c563391 where updates after syncing for a time range tab aren't executed after the async tasks:

https://github.com/woocommerce/woocommerce-ios/blob/0202de608dfc86f6944f919c4210dcfbf5722e9c/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersViewController.swift#L189-L194

This is where we set any error from an async task to `syncError`, which is used to determine the visitor stats state:

https://github.com/woocommerce/woocommerce-ios/blob/0202de608dfc86f6944f919c4210dcfbf5722e9c/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersViewController.swift#L114-L121

But because the updates including `syncError` are executed right after dispatching async tasks for a period, `syncError` is always `nil` and thus the default visitor stats UI is always shown.

This PR executes the updates after all async tasks finish with a `DispatchGroup` for each period.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23) and a Jetpack site.

- Launch the app and log in to a JCP site if needed
- In the My store tab, tap another stats time range tab (e.g. "This Week") --> the empty Jetpack UI should be shown on the visitor stats
- Go to Settings > Switch Store and switch to a Jetpack site
- In the My store tab, tap another stats time range tab (e.g. "This Week") --> the empty Jetpack UI should not be shown on the visitor stats

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1945542/144527122-5d80e914-4cfa-4cb0-9a45-ff08913938b8.png" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
