### PR TITLE
[Mobile Payments] Move logic to open WP-Settings from the address error viewmodel to its caller

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -59,17 +59,12 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-extension CardPresentModalConnectingFailedUpdateAddress {
+private extension CardPresentModalConnectingFailedUpdateAddress {
     enum Localization {
         static let title = NSLocalizedString(
             "Please correct your store address to proceed",
             comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
             "due to address problems"
-        )
-
-        static let adminWebviewTitle = NSLocalizedString(
-            "WooCommerce Settings",
-            comment: "Navigation title of the webview which used by the merchant to update their store address"
         )
 
         static let openAdmin = NSLocalizedString(
@@ -88,12 +83,6 @@ extension CardPresentModalConnectingFailedUpdateAddress {
             "Cancel",
             comment: "Button to dismiss the alert presented when connecting to a specific reader fails due to address " +
             "problems. This also cancels searching."
-        )
-
-        static let doneButtonUpdateAddress = NSLocalizedString(
-            "Done",
-            comment: "The button title to indicate that the user has finished updating their store's address and is" +
-            "ready to close the webview. This also tries to connect to the reader again."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -628,7 +628,7 @@ private extension CardReaderConnectionController {
                                  url: adminUrl,
                                  urlToTriggerExit: nil,
                                  exitTrigger: nil)
-                                 .navigationTitle(CardPresentModalConnectingFailedUpdateAddress.Localization.adminWebviewTitle)
+                                 .navigationTitle(Localization.adminWebviewTitle)
                                  .navigationBarTitleDisplayMode(.inline)
                                  .toolbar {
                                      ToolbarItem(placement: .confirmationAction) {
@@ -637,7 +637,7 @@ private extension CardReaderConnectionController {
                                                  retrySearch()
                                              }
                                          }, label: {
-                                             Text(CardPresentModalConnectingFailedUpdateAddress.Localization.doneButtonUpdateAddress)
+                                             Text(Localization.doneButtonUpdateAddress)
                                          })
                                      }
                                  }
@@ -678,5 +678,20 @@ private extension CardReaderConnectionController {
         self.alerts.dismiss()
         self.onCompletion?(.failure(error))
         self.state = .idle
+    }
+}
+
+private extension CardReaderConnectionController {
+    enum Localization {
+        static let adminWebviewTitle = NSLocalizedString(
+            "WooCommerce Settings",
+            comment: "Navigation title of the webview which used by the merchant to update their store address"
+        )
+
+        static let doneButtonUpdateAddress = NSLocalizedString(
+            "Done",
+            comment: "The button title to indicate that the user has finished updating their store's address and is" +
+            "ready to close the webview. This also tries to connect to the reader again."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import UIKit
+import SwiftUI
 import Yosemite
 
 /// Facilitates connecting to a card reader
@@ -588,24 +589,62 @@ private extension CardReaderConnectionController {
 
         switch underlyingError {
         case .incompleteStoreAddress(let adminUrl):
-            let openUrlInSafari = { [weak self] (url: URL?) -> Void in
-                guard let adminUrl = url else {
-                    return
-                }
-                UIApplication.shared.open(adminUrl)
-                self?.showIncompleteAddressErrorWithRefreshButton()
-            }
             alerts.connectingFailedIncompleteAddress(from: from,
-                                                  adminUrl: adminUrl,
-                                                  site: ServiceLocator.stores.sessionManager.defaultSite,
-                                                  openUrlInSafari: openUrlInSafari,
-                                                  retrySearch: retrySearch,
-                                                  cancelSearch: cancelSearch)
+                                                     openWCSettings: openWCSettingsAction(adminUrl: adminUrl,
+                                                                                          from: from,
+                                                                                          retrySearch: retrySearch),
+                                                     retrySearch: retrySearch,
+                                                     cancelSearch: cancelSearch)
         case .invalidPostalCode:
             alerts.connectingFailedInvalidPostalCode(from: from, retrySearch: retrySearch, cancelSearch: cancelSearch)
         default:
             alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }
+    }
+
+    private func openWCSettingsAction(adminUrl: URL?,
+                                      from viewController: UIViewController,
+                                      retrySearch: @escaping () -> Void) -> ((UIViewController) -> Void)? {
+        if let adminUrl = adminUrl {
+            if let site = ServiceLocator.stores.sessionManager.defaultSite,
+               site.isWordPressStore {
+                return { [weak self] viewController in
+                    self?.openWCSettingsInWebview(url: adminUrl, from: viewController, retrySearch: retrySearch)
+                }
+            } else {
+                return { [weak self] _ in
+                    UIApplication.shared.open(adminUrl)
+                    self?.showIncompleteAddressErrorWithRefreshButton()
+                }
+            }
+        }
+        return nil
+    }
+    private func openWCSettingsInWebview(url adminUrl: URL,
+                                         from viewController: UIViewController,
+                                         retrySearch: @escaping () -> Void) {
+        let nav = NavigationView {
+            AuthenticatedWebView(isPresented: .constant(true),
+                                 url: adminUrl,
+                                 urlToTriggerExit: nil,
+                                 exitTrigger: nil)
+                                 .navigationTitle(CardPresentModalConnectingFailedUpdateAddress.Localization.adminWebviewTitle)
+                                 .navigationBarTitleDisplayMode(.inline)
+                                 .toolbar {
+                                     ToolbarItem(placement: .confirmationAction) {
+                                         Button(action: {
+                                             viewController.dismiss(animated: true) {
+                                                 retrySearch()
+                                             }
+                                         }, label: {
+                                             Text(CardPresentModalConnectingFailedUpdateAddress.Localization.doneButtonUpdateAddress)
+                                         })
+                                     }
+                                 }
+        }
+        .wooNavigationBarStyle()
+        let hostingController = UIHostingController(rootView: nav)
+        viewController.present(hostingController, animated: true, completion: nil)
     }
 
     private func showIncompleteAddressErrorWithRefreshButton() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -26,15 +26,11 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedIncompleteAddress(from: UIViewController,
-                                        adminUrl: URL?,
-                                        site: Site?,
-                                        openUrlInSafari: @escaping (URL) -> Void,
+                                        openWCSettings: ((UIViewController) -> Void)?,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
         setViewModelAndPresent(from: from,
-                               viewModel: connectingFailedUpdateAddress(adminUrl: adminUrl,
-                                                                        site: site,
-                                                                        openUrlInSafari: openUrlInSafari,
+                               viewModel: connectingFailedUpdateAddress(openWCSettings: openWCSettings,
                                                                         retrySearch: retrySearch,
                                                                         cancelSearch: cancelSearch))
     }
@@ -178,14 +174,10 @@ private extension CardReaderSettingsAlerts {
         CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
-    func connectingFailedUpdateAddress(adminUrl: URL?,
-                                       site: Site?,
-                                       openUrlInSafari: @escaping (URL) -> Void,
+    func connectingFailedUpdateAddress(openWCSettings: ((UIViewController) -> Void)?,
                                        retrySearch: @escaping () -> Void,
                                        cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        return CardPresentModalConnectingFailedUpdateAddress(adminUrl: adminUrl,
-                                                             site: site,
-                                                             openUrlInSafari: openUrlInSafari,
+        return CardPresentModalConnectingFailedUpdateAddress(openWCSettings: openWCSettings,
                                                              retrySearch: retrySearch,
                                                              cancelSearch: cancelSearch)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -50,11 +50,9 @@ protocol CardReaderSettingsAlertsProvider {
     /// The user may try again or cancel
     ///
     func connectingFailedIncompleteAddress(from: UIViewController,
-                                        adminUrl: URL?,
-                                        site: Site?,
-                                        openUrlInSafari: @escaping (URL) -> Void,
-                                        retrySearch: @escaping () -> Void,
-                                        cancelSearch: @escaping () -> Void)
+                                           openWCSettings: ((UIViewController) -> Void)?,
+                                           retrySearch: @escaping () -> Void,
+                                           cancelSearch: @escaping () -> Void)
 
     /// Defines an alert indicating connecting failed because their postal code needs updating.
     /// The user may try again or cancel

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -85,11 +85,9 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedIncompleteAddress(from: UIViewController,
-                                        adminUrl: URL?,
-                                        site: Site?,
-                                        openUrlInSafari: @escaping (URL) -> Void,
-                                        retrySearch: @escaping () -> Void,
-                                        cancelSearch: @escaping () -> Void) {
+                                           openWCSettings: ((UIViewController) -> Void)?,
+                                           retrySearch: @escaping () -> Void,
+                                           cancelSearch: @escaping () -> Void) {
         if mode == .continueSearchingAfterConnectionFailure {
             retrySearch()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5590
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
@allendav [noted in a previous code review](https://github.com/woocommerce/woocommerce-ios/pull/5552#discussion_r760386780) that the `CardPresentModalConnectingFailedUpdateAddress` view model had too much logic around _how_ to open the WooCommerce settings so the merchant could update their address, relying on the `siteInfo` and knowledge of `AuthenticatedWebview`. 

This change provides an optional `openWCSettingsAction` to the view model. If set, the view model presents an open settings button, and uses the action as the tap action. If not set, it defaults to a refresh behaviour as previously.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Wordpress.com/Atomic stores
1. With a WP.com or Atomic store set up for In-Person Payments, go to `WP-Admin > WooCommerce > Settings` and delete the contents of `Address line 1`
2. In the app, go to `⚙️ > In-Person Payments > Manage Card Reader`
3. Search for and connect to a reader (or simulated reader)
4. Observe that the error message is shown telling the merchant to update their address.
5. Tap `Enter Address` to open a webview at the admin pages, you should be logged in already.
6. Update the address in WP-Admin to include `Address line 1` again
7. Tap `Done`, and connect to the reader again.

#### Self hosted stores
1. With a self-hosted store set up for In-Person Payments, go to `WP-Admin > WooCommerce > Settings` and delete the contents of `Address line 1`
2. In the app, go to `⚙️ > In-Person Payments > Manage Card Reader`
3. Search for and connect to a reader (or simulated reader)
4. Observe that the error message is shown telling the merchant to update their address.
5. Tap `Enter Address` to go to Safari at the admin pages, login if necessary.
6. Update the address in WP-Admin to include `Address line 1` again
7. Return to the app, cancel on the alert, and connect to the reader again

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### Wordpress.com/Atomic stores

https://user-images.githubusercontent.com/2472348/144587990-b2e655cf-d9aa-4654-9eee-181cfcfa2b96.mp4

#### Self hosted stores

https://user-images.githubusercontent.com/2472348/144587960-ff166308-5729-46ac-bce2-336fb9ac1b49.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
