### PR TITLE
Simple Payments: Fix delay when presenting IPP alerts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -116,8 +116,15 @@ private extension CollectOrderPaymentUseCase {
         let readerConnected = CardPresentPaymentAction.checkCardReaderConnected { connectPublisher in
             self.readerSubscription = connectPublisher
                 .sink(receiveCompletion: { [weak self] _ in
-                    // Reader connected
-                    onCompletion()
+                    // Dismiss the current connection alert before notifying the completion.
+                    // If no presented controller is found(because the reader was already connected), just notify the completion.
+                    if let connectionController = self?.rootViewController.presentedViewController {
+                        connectionController.dismiss(animated: true) {
+                            onCompletion()
+                        }
+                    } else {
+                        onCompletion()
+                    }
 
                     // Nil the subscription since we are done with the connection.
                     self?.readerSubscription = nil


### PR DESCRIPTION
Closes: #5601 

# Why

There was a noticeable delay between the "connecting reader" alert and the "collect payment" alert.
This PR fixes that by dismissing the connection controller alert before proceeding to show the collect payment alert.

# Testing 
## Prerequisites
- Make sure you are using an IPP eligible store

## Steps
- Start the simple payments flow
- Enter an amount & tap next (older WC stores may need to enter a valid email)
- Tap next on the summary screen
- Tap the cash row.
- See that between connecting a reading and asking for payment there is no delay in the alert presentation
### Screenshots


# Demo

https://user-images.githubusercontent.com/562080/144672616-9e98d693-5f57-4973-b925-fd173be789f1.mov

https://user-images.githubusercontent.com/562080/144672637-09e97198-8686-4403-9e3e-7221bd67d51b.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
