### PR TITLE
Inline single usage of `OrdersScreen` visibility introspection

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -21,11 +21,6 @@ public final class OrdersScreen: ScreenObject {
 
     private var searchButton: XCUIElement { searchButtonGetter(app) }
 
-    // TODO: There's only one usage of this and it can be replaced with a screen instantiation
-    static var isVisible: Bool {
-        (try? OrdersScreen().isLoaded) ?? false
-    }
-
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [

--- a/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
@@ -48,11 +48,12 @@ public final class TabNavComponent: ScreenObject {
     @discardableResult
     public func gotoOrdersScreen() throws -> OrdersScreen {
         // Avoid transitioning if it is already on screen
-        if !OrdersScreen.isVisible {
+        guard let orderScreen = try? OrdersScreen(), orderScreen.isLoaded else {
             ordersTabButton.tap()
+            return try OrdersScreen()
         }
 
-        return try OrdersScreen()
+        return orderScreen
     }
 
     @discardableResult


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Making good on my promise from https://github.com/woocommerce/woocommerce-ios/pull/5091/files#r721033084.

### Description
_What it says in the title, if the diff is not self-explanatory, then I didn't do a neat enough work and you should let me know._

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
If CI is green, we're good to merge.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
