### PR TITLE
Simple Payments: Don't send empty email when updating simple payment order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -144,13 +144,14 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     func updateOrder() {
         showLoadingIndicator = true
+        // Don't send empty emails as older WC stores can't handle them.
         let action = OrderAction.updateSimplePaymentsOrder(siteID: siteID,
                                                            orderID: orderID,
                                                            feeID: feeID,
                                                            amount: providedAmount,
                                                            taxable: enableTaxes,
                                                            orderNote: noteContent,
-                                                           email: email) { [weak self] result in
+                                                           email: email.isEmpty ? nil : email) { [weak self] result in
             guard let self = self else { return }
             self.showLoadingIndicator = false
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -165,4 +165,27 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.navigateToPaymentMethods)
     }
+
+    func test_empty_emails_are_send_as_nil_when_updating_orders() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        viewModel.email = ""
+
+        // When
+        let emailSent: String? = waitFor { promise in
+            mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateSimplePaymentsOrder(_, _, _, _, _, _, email, _):
+                    promise(email)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+            viewModel.updateOrder()
+        }
+
+        // Then
+        XCTAssertNil(emailSent)
+    }
 }


### PR DESCRIPTION
Closes: #5600 

# Why
It was reported that a user could not proceed with the simple payments flow without entering a valid email address.

This happens because the REST API:
- Has a remote validation where they only allow a valid email address.
- Older stores(WC v < 4.9) can't handle empty emails as they are flagged as invalid emails.

This PR solves the "empty email" situation by not encoding/sending the email if the user does not provide one.

The "valid email situation" should be resolved holistically(and in a separate PR) as the API response is trimming the concrete email error and is just returning a generic error response.

# Testing Steps
- Make sure your wc store is running a version lower than 4.9
- Launch the simple payments flow
- Proceed until the collect payment screen without entering any email value
- See no error

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

