### PR TITLE
Order Creation: Navigate to order details after creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/AddOrderCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/AddOrderCoordinator.swift
@@ -86,6 +86,8 @@ private extension AddOrderCoordinator {
     ///
     func presentNewOrderController() {
         let viewModel = NewOrderViewModel(siteID: siteID)
+        viewModel.onOrderCreated = onOrderCreated
+
         let viewController = NewOrderHostingController(viewModel: viewModel)
         viewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -41,6 +41,10 @@ final class NewOrderViewModel: ObservableObject {
     ///
     @Published var shouldShowOrderStatusList: Bool = false
 
+    /// Assign this closure to be notified when a new order is created
+    ///
+    var onOrderCreated: (Order) -> Void = { _ in }
+
     /// Status Results Controller.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
@@ -83,9 +87,10 @@ final class NewOrderViewModel: ObservableObject {
             self.performingNetworkRequest = false
 
             switch result {
-            case .success:
+            case .success(let newOrder):
                 // TODO: Handle newly created order / remove success logging
                 DDLogInfo("New order created successfully!")
+                self.onOrderCreated(newOrder)
             case .failure(let error):
                 self.presentNotice = .error
                 DDLogError("⛔️ Error creating new order: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -366,7 +366,14 @@ private extension OrdersRootViewController {
     private func navigateToOrderDetail(_ order: Order) {
         guard let orderViewController = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else { return }
         orderViewController.viewModel = OrderDetailsViewModel(order: order)
-        show(orderViewController, sender: self)
+
+        // Cleanup navigation (remove new order flow views) before navigating to order details
+        if let navigationController = navigationController, let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) {
+            let viewControllersIncludingSelf = navigationController.viewControllers[0...indexOfSelf]
+            navigationController.setViewControllers(viewControllersIncludingSelf + [orderViewController], animated: true)
+        } else {
+            show(orderViewController, sender: self)
+        }
 
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID, "status": order.status.rawValue])
     }


### PR DESCRIPTION
## Description

This PR connects navigation from new order flow to created order details.

## Changes

- Adds `onOrderCreated` callback closure to `NewOrderViewModel`.
- Adds navigation stack manipulation in `OrdersRootViewController` to remove new order flow before pushing details VC.

### Considerations

Empty order is created now, sending of selected status/products data is not yet implemented.

## Testing

1. Disable `simplePaymentsPrototype` feature flag in `DefaultFeatureFlagService` (to test navigation on Simple Payments).
2. Build and run the app in debug mode (to ensure the feature flag is enabled).
3. Make sure Order Creation and Simple Payments are enabled under Settings > Experimental Features.

Check new navigation for Order creation:
1. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
2. Tap "Edit" button to display status picker.
3. Select different status and tap "Apply".
4. Tap "Create" button appeared in navbar.
5. Confirm Order Details opens.
6. Go back in navigation from Order Details to Orders List and confirm there is no leftovers of Order Creation flow.

Confirm Simple Payments navigation still works:
1. Go to the Orders tab and tap the + button. Tap "Simple Payments" in the bottom sheet.
2. Enter some amount and tap "Done".
3. Confirm Order Details opens.
4. Go back in navigation from Order Details to Orders List.

## Screenshots

https://user-images.githubusercontent.com/3132438/144893386-afbfacd2-e98a-4927-bc79-7adf49c1c1f5.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
