### PR TITLE
Add tooltip that refunding fees is currently not supported

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -134,6 +134,7 @@ private extension IssueRefundViewController {
         tableView.registerNib(for: RefundProductsTotalTableViewCell.self)
         tableView.registerNib(for: RefundShippingDetailsTableViewCell.self)
         tableView.registerNib(for: SwitchTableViewCell.self)
+        tableView.registerNib(for: ImageAndTitleAndTextTableViewCell.self)
     }
 
     func configureHeaderView() {
@@ -212,6 +213,10 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
         case let viewModel as RefundShippingDetailsViewModel:
             let cell = tableView.dequeueReusableCell(RefundShippingDetailsTableViewCell.self, for: indexPath)
             cell.configure(with: viewModel)
+            return cell
+        case let viewModel as ImageAndTitleAndTextTableViewCell.ViewModel:
+            let cell = tableView.dequeueReusableCell(ImageAndTitleAndTextTableViewCell.self, for: indexPath)
+            cell.updateUI(viewModel: viewModel)
             return cell
         default:
             return UITableViewCell()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -219,6 +219,9 @@ private extension IssueRefundViewModel {
         static let refundShippingTitle = NSLocalizedString("Refund Shipping", comment: "Title of the switch in the IssueRefund screen to refund shipping")
         static let itemSingular = NSLocalizedString("1 item selected", comment: "Title of the label indicating that there is 1 item to refund.")
         static let itemsPlural = NSLocalizedString("%d items selected", comment: "Title of the label indicating that there are multiple items to refund.")
+        static let unsupportedFeesRefund = NSLocalizedString(
+            "You can refund fees in your store admin",
+            comment: "Shown in Refunds screen. Refunding fees are currently not supported.")
     }
 }
 
@@ -264,7 +267,7 @@ extension IssueRefundViewModel {
         let refundItems = state.refundQuantityStore.refundableItems()
         let summaryRow = RefundProductsTotalViewModel(refundItems: refundItems, currency: state.order.currency, currencySettings: state.currencySettings)
 
-        return Section(rows: itemsRows + [summaryRow])
+        return Section(rows: itemsRows + [summaryRow] + [createUnsupportedFeesRefundTooltipRow()])
     }
 
     /// Returns a `Section` with the shipping switch row and the shipping details row.
@@ -291,6 +294,17 @@ extension IssueRefundViewModel {
 
         let detailsRow = RefundShippingDetailsViewModel(shippingLine: shippingLine, currency: state.order.currency, currencySettings: state.currencySettings)
         return Section(rows: [switchRow, detailsRow])
+    }
+
+    private func createUnsupportedFeesRefundTooltipRow() -> ImageAndTitleAndTextTableViewCell.ViewModel {
+        ImageAndTitleAndTextTableViewCell.ViewModel(title: Localization.unsupportedFeesRefund,
+                                                    titleFontStyle: .footnote,
+                                                    text: nil,
+                                                    image: .infoOutlineFootnoteImage,
+                                                    imageTintColor: .systemColor(.secondaryLabel),
+                                                    numberOfLinesForTitle: 0,
+                                                    isActionable: false,
+                                                    showsSeparator: false)
     }
 
     /// Returns a string of the refund total formatted with the proper currency settings and store currency.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -135,7 +135,7 @@ extension IssueRefundViewModel {
         return refundable.quantity
     }
 
-    /// Returns the current quantlty set for refund for the provided item index.
+    /// Returns the current quantity set for refund for the provided item index.
     /// Returns `nil` if the index is out of bounds.
     ///
     func currentQuantityForItemAtIndex(_ itemIndex: Int) -> Int? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -214,7 +214,7 @@ private extension IssueRefundViewModel {
 }
 
 // MARK: Constants
-private extension IssueRefundViewModel {
+extension IssueRefundViewModel {
     enum Localization {
         static let refundShippingTitle = NSLocalizedString("Refund Shipping", comment: "Title of the switch in the IssueRefund screen to refund shipping")
         static let itemSingular = NSLocalizedString("1 item selected", comment: "Title of the label indicating that there is 1 item to refund.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -297,6 +297,12 @@ extension IssueRefundViewModel {
         return Section(rows: [switchRow, detailsRow])
     }
 
+    /// If the order has fees, this returns a row with a message that refunding fees is currently
+    /// not supported.
+    ///
+    /// We will implement refunding fees within a few weeks. This is just temporary and is primarily
+    /// for setting expectations for Simple Payments users.
+    ///
     private func createUnsupportedFeesRefundTooltipRow() -> ImageAndTitleAndTextTableViewCell.ViewModel? {
         state.order.fees.isEmpty ? nil : ImageAndTitleAndTextTableViewCell.ViewModel(
             title: Localization.unsupportedFeesRefund,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -266,8 +266,9 @@ extension IssueRefundViewModel {
 
         let refundItems = state.refundQuantityStore.refundableItems()
         let summaryRow = RefundProductsTotalViewModel(refundItems: refundItems, currency: state.order.currency, currencySettings: state.currencySettings)
+        let unsupportedFeesTooltipRows = [createUnsupportedFeesRefundTooltipRow()].compactMap { $0 }
 
-        return Section(rows: itemsRows + [summaryRow] + [createUnsupportedFeesRefundTooltipRow()])
+        return Section(rows: itemsRows + [summaryRow] + unsupportedFeesTooltipRows)
     }
 
     /// Returns a `Section` with the shipping switch row and the shipping details row.
@@ -296,15 +297,16 @@ extension IssueRefundViewModel {
         return Section(rows: [switchRow, detailsRow])
     }
 
-    private func createUnsupportedFeesRefundTooltipRow() -> ImageAndTitleAndTextTableViewCell.ViewModel {
-        ImageAndTitleAndTextTableViewCell.ViewModel(title: Localization.unsupportedFeesRefund,
-                                                    titleFontStyle: .footnote,
-                                                    text: nil,
-                                                    image: .infoOutlineFootnoteImage,
-                                                    imageTintColor: .systemColor(.secondaryLabel),
-                                                    numberOfLinesForTitle: 0,
-                                                    isActionable: false,
-                                                    showsSeparator: false)
+    private func createUnsupportedFeesRefundTooltipRow() -> ImageAndTitleAndTextTableViewCell.ViewModel? {
+        state.order.fees.isEmpty ? nil : ImageAndTitleAndTextTableViewCell.ViewModel(
+            title: Localization.unsupportedFeesRefund,
+            titleFontStyle: .footnote,
+            text: nil,
+            image: .infoOutlineFootnoteImage,
+            imageTintColor: .systemColor(.secondaryLabel),
+            numberOfLinesForTitle: 0,
+            isActionable: false,
+            showsSeparator: false)
     }
 
     /// Returns a string of the refund total formatted with the proper currency settings and store currency.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -399,6 +399,8 @@ extension RefundProductsTotalViewModel: IssueRefundRow {}
 
 extension RefundShippingDetailsViewModel: IssueRefundRow {}
 
+extension ImageAndTitleAndTextTableViewCell.ViewModel: IssueRefundRow {}
+
 // MARK: Refund Quantity Store
 private extension IssueRefundViewModel {
     /// Structure that holds and provides the quantity of items to refund

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -141,6 +141,40 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.quantityAvailableForRefundForItemAtIndex(3), nil)
     }
 
+    func test_viewModel_does_not_have_unsupported_fees_tooltip_row_if_the_order_has_no_fees() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = Order.fake()
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        let rows = viewModel.sections.flatMap { $0.rows }
+        XCTAssertFalse(rows.isEmpty)
+
+        let unsupportedFeesTooltipRow = rows.compactMap { $0 as? ImageAndTitleAndTextTableViewCell.ViewModel }
+            .first { $0.title == IssueRefundViewModel.Localization.unsupportedFeesRefund }
+        XCTAssertNil(unsupportedFeesTooltipRow)
+    }
+
+    func test_viewModel_has_unsupported_fees_tooltip_row_if_the_order_has_fees() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = Order.fake().copy(fees: [OrderFeeLine.fake()])
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        let rows = viewModel.sections.flatMap { $0.rows }
+        XCTAssertFalse(rows.isEmpty)
+
+        let unsupportedFeesTooltipRow = rows.compactMap { $0 as? ImageAndTitleAndTextTableViewCell.ViewModel }
+            .first { $0.title == IssueRefundViewModel.Localization.unsupportedFeesRefund }
+        XCTAssertNotNil(unsupportedFeesTooltipRow)
+    }
+
     func test_viewModel_returns_0_current_refund_quantity_for_a_clean_order() {
         // Given
         let currencySettings = CurrencySettings()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -475,7 +475,7 @@ final class IssueRefundViewModelTests: XCTestCase {
 
     // MARK: Analytics
     //
-    func test_viewModel_tracks_shipping_switch_action_correcly() {
+    func test_viewModel_tracks_shipping_switch_action_correctly() {
         // Given
         let currencySettings = CurrencySettings()
         let order = MockOrders().makeOrder()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -309,7 +309,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedItemsTitle, selectedItemsTitle)
     }
 
-    func test_viewModel_correctly_calculates_multitple_selected_item_title() {
+    func test_viewModel_correctly_calculates_multiple_selected_item_title() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [


### PR DESCRIPTION
Part of #5624 

As discussed in p91TBi-6Px-p2#comment-7686, we will temporarily add a tooltip to inform merchants that refunding fees is currently not supported. We will soon implement support for this but we're currently nearing the end of the sprint and we want to be more cautious when implementing refunds. 

This tooltip change is mainly for setting expectations with Simple Payments users. Most of the code in here will be removed once we've implemented refunding for fees. 

## Design

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/144904360-1e05e30d-0089-4b0f-ae7d-06715a0dc494.png" width="300">        |       <img src="https://user-images.githubusercontent.com/198826/144904387-3d649c95-7ecb-4b31-9ac1-ce4b1853d8e4.png" width="300">



## Rationales

I considered adding the tooltip inside [`RefundProductsTotalTableViewCell.xib`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Issue%20Refunds/Cells/RefundProductsTotalTableViewCell.xib) to match Android's UI. But considering that this is temporary, I opted to just place the tooltip below everything else to keep it simple.

I also tried implementing linking to wp-admin. But that required decoding the `options.admin_url` property for [`Site`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Model/Site.swift) and also adding a new Core Data version. It seemed like a lot of work. The time may be better spent on implementing refunds itself. 

I also considered adding the Fees line on the screen but figured I'll do that as a separate PR later when we work on the actual refunds support. 

## Testing

1. Open an order that has Fees. (maybe created using Simple Payments)
2. Tap Issue Refund. 
3. Confirm the "You can refund fees in your store admin" tooltip is visible. 
4. Open an order that has no Fees. 
5. Tap Issue Refund. 
6. Confirm the message is not visible. 

## Reviewing

Only 1 reviewer is needed but anyone can review.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

---

cc @malinajirka 