### PR TITLE
Simple Payments: Prevent invalid amounts 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -75,7 +75,7 @@ extension SimplePaymentsAmountHostingController: UIAdaptivePresentationControlle
     }
 
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        !rootView.viewModel.disableCancel
+        !rootView.viewModel.disableViewActions
     }
 }
 
@@ -139,9 +139,10 @@ struct SimplePaymentsAmount: View {
                     dismiss()
                     viewModel.userDidCancelFlow()
                 })
-                    .disabled(viewModel.disableCancel)
+                    .disabled(viewModel.disableViewActions)
             }
         }
+        .disabled(viewModel.disableViewActions)
         .wooNavigationBarStyle()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -139,7 +139,6 @@ struct SimplePaymentsAmount: View {
                     dismiss()
                     viewModel.userDidCancelFlow()
                 })
-                    .disabled(viewModel.disableViewActions)
             }
         }
         .disabled(viewModel.disableViewActions)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -42,10 +42,10 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
         amount.count < 2
     }
 
-    /// Use this to disables interactive dismissal and
-    /// Disables cancel button while performing the create order operation
+    /// Defines if the view actions should be disabled.
+    /// Currently true while a network operation is happening.
     ///
-    var disableCancel: Bool {
+    var disableViewActions: Bool {
         loading
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -35,11 +35,11 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     var onOrderCreated: (Order) -> Void = { _ in }
 
-    /// Returns true when amount has less than two characters.
-    /// Less than two, because `$` should be the first character.
+    /// Returns true when amount is a valid number bigger than .zero.
     ///
     var shouldDisableDoneButton: Bool {
-        amount.count < 2
+        let decimalAmount = (currencyFormatter.convertToDecimal(from: amount) ?? .zero) as Decimal
+        return decimalAmount <= .zero
     }
 
     /// Defines if the view actions should be disabled.
@@ -85,6 +85,10 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     private let storeCurrencySettings: CurrencySettings
 
+    /// Currency formatter for the provided amount
+    ///
+    private let currencyFormatter: CurrencyFormatter
+
     /// Current store currency symbol
     ///
     private let storeCurrencySymbol: String
@@ -110,6 +114,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
         self.presentNoticeSubject = presentNoticeSubject
         self.storeCurrencySettings = storeCurrencySettings
         self.storeCurrencySymbol = storeCurrencySettings.symbol(from: storeCurrencySettings.currencyCode)
+        self.currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
         self.analytics = analytics
         self.isDevelopmentPrototype = isDevelopmentPrototype
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -35,7 +35,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     var onOrderCreated: (Order) -> Void = { _ in }
 
-    /// Returns true when amount is a valid number bigger than .zero.
+    /// Returns true when the amount is not a positive number.
     ///
     var shouldDisableDoneButton: Bool {
         let decimalAmount = (currencyFormatter.convertToDecimal(from: amount) ?? .zero) as Decimal

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -59,6 +59,7 @@ struct SimplePaymentsSummary: View {
                 viewModel.reloadContent()
                 }, viewModel: viewModel.noteViewModel)
         }
+        .disabled(viewModel.disableViewActions)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -46,6 +46,12 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         noteViewModel.newNote
     }
 
+    /// Disable view actions while a network request is being performed
+    ///
+    var disableViewActions: Bool {
+        return showLoadingIndicator
+    }
+
     /// Total to charge with taxes.
     ///
     private let totalWithTaxes: String

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -320,7 +320,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.loading)
 
         // Before creating simple payment order
-        XCTAssertFalse(viewModel.disableCancel)
+        XCTAssertFalse(viewModel.disableViewActions)
 
         // When
         let _: Bool = waitFor { promise in
@@ -336,7 +336,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(viewModel.disableCancel)
+        XCTAssertTrue(viewModel.disableViewActions)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -91,6 +91,17 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
     }
 
+    func test_view_model_disables_next_button_when_amount_is_not_greater_than_zero() {
+        // Given
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, storeCurrencySettings: usStoreSettings)
+
+        // When
+        viewModel.amount = "$0"
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+    }
+
     func test_view_model_enables_next_button_when_amount_has_more_than_one_character() {
         // Given
         let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, storeCurrencySettings: usStoreSettings)


### PR DESCRIPTION
Closes: #5598 #5599 

# Why

It was reported that in the summary screen the merchant could
- Enter a zero amount
- Keep modifying the amount after the next button has been pressed.

This PR fixes that by:

- Disabling view actions while networks requests are being performed (in Amount & in Summary views)
- Checking that the amount has to be greater than zero in order to enable the "Next" button

# Demo

https://user-images.githubusercontent.com/562080/144919813-a9850e55-3c9c-4f3e-8375-56d2cdd8e79a.mov

# Testing

- Start the Simple Payments Flow
- Enter 0 as the amount and see that the "Next" button continues to be disabled.
- Enter a possitive amount and tap next.
- See that you can't edit the amount anymore while the simple payments order is being created.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
