### PR TITLE
Fix ghost tableview cells not be selectable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -78,11 +78,15 @@ private extension PluginListViewController {
         let options = GhostOptions(reuseIdentifier: HeadlineLabelTableViewCell.reuseIdentifier, rowsPerSection: [10])
         ghostTableView.displayGhostContent(options: options, style: .wooDefaultGhostStyle)
         ghostTableView.startGhostAnimation()
+        // Disable the selection of the cells when display placeholders
+        ghostTableView.allowsSelection = false
         ghostTableView.isHidden = false
     }
 
     func stopGhostAnimation() {
         ghostTableView.isHidden = true
+        // Allow selection of cells after the tableview's ghosting has ended
+        ghostTableView.allowsSelection = true
         ghostTableView.stopGhostAnimation()
         ghostTableView.removeGhostContent()
     }

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -384,7 +384,8 @@ private extension PaginatedListSelectorViewController {
         let options = GhostOptions(reuseIdentifier: Cell.reuseIdentifier, rowsPerSection: placeholderRowsPerSection)
         tableView.displayGhostContent(options: options,
                                       style: .wooDefaultGhostStyle)
-
+        // Disable the selection of the cells when display placeholders
+        tableView.allowsSelection = false
         resultsController.stopForwardingEvents()
     }
 
@@ -392,6 +393,8 @@ private extension PaginatedListSelectorViewController {
     ///
     func removePlaceholderProducts() {
         tableView.removeGhostContent()
+        // Allow selection of cells after the tableview's ghosting has ended
+        tableView.allowsSelection = true
         resultsController.startForwardingEvents(to: tableView)
         tableView.reloadData()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -419,12 +419,16 @@ private extension OrderListViewController {
                                                style: .wooDefaultGhostStyle)
         ghostableTableView.startGhostAnimation()
         ghostableTableView.isHidden = false
+        // Disable the selection of the cells when display placeholders
+        ghostableTableView.allowsSelection = false
     }
 
     /// Removes the Placeholder Orders (and restores the ResultsController <> UITableView link).
     ///
     func removePlaceholderOrders() {
         ghostableTableView.isHidden = true
+        // Allow selection of cells after the tableview's ghosting has ended
+        ghostableTableView.allowsSelection = true
         ghostableTableView.stopGhostAnimation()
         ghostableTableView.removeGhostContent()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -721,6 +721,8 @@ private extension ProductsViewController {
         let options = GhostOptions(reuseIdentifier: ProductsTabProductTableViewCell.reuseIdentifier, rowsPerSection: Constants.placeholderRowsPerSection)
         tableView.displayGhostContent(options: options,
         style: .wooDefaultGhostStyle)
+        // Disable the selection of the cells when display placeholders
+        tableView.allowsSelection = false
         resultsController.stopForwardingEvents()
     }
 
@@ -728,6 +730,8 @@ private extension ProductsViewController {
     ///
     func removePlaceholderProducts() {
         tableView.removeGhostContent()
+        // Allow selection of cells after the tableview's ghosting has ended
+        tableView.allowsSelection = true
         // Assign again the original closure
         setClosuresToResultController(resultsController, onReload: { [weak self] in
             self?.reloadTableAndView()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -76,6 +76,7 @@ private extension AddAttributeViewController {
     func configureGhostTableView() {
         view.addSubview(ghostTableView)
         ghostTableView.isHidden = true
+        tableView.allowsSelection = false
         ghostTableView.translatesAutoresizingMaskIntoConstraints = false
         ghostTableView.pinSubviewToAllEdges(view)
         ghostTableView.backgroundColor = .listBackground

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -548,7 +548,8 @@ private extension ProductVariationsViewController {
     func displayPlaceholderProducts() {
         let options = GhostOptions(reuseIdentifier: ProductsTabProductTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
         tableView.displayGhostContent(options: options, style: .wooDefaultGhostStyle)
-
+        // Disable the selection of the cells when display placeholders
+        tableView.allowsSelection = false
         resultsController.stopForwardingEvents()
     }
 
@@ -556,6 +557,8 @@ private extension ProductVariationsViewController {
     ///
     func removePlaceholderProducts() {
         tableView.removeGhostContent()
+        // Allow selection of cells after the tableview's ghosting has ended
+        tableView.allowsSelection = true
         resultsController.startForwardingEvents(to: tableView)
         configureResultsControllerEventHandling(resultsController)
         tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -44,7 +44,8 @@ final class ReviewsViewModel {
         let options = GhostOptions(reuseIdentifier: ProductReviewTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
         tableView.displayGhostContent(options: options,
                                       style: .wooDefaultGhostStyle)
-
+        // Disable the selection of the cells when display placeholders
+        tableView.allowsSelection = false
         data.stopForwardingEvents()
     }
 
@@ -52,6 +53,8 @@ final class ReviewsViewModel {
     ///
     func removePlaceholderReviews(tableView: UITableView) {
         tableView.removeGhostContent()
+        // Allow selection of cells after the tableview's ghosting has ended
+        tableView.allowsSelection = true
         data.startForwardingEvents(to: tableView)
         tableView.reloadData()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #2513 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When you start the app, it loads data for orders, reviews, e.t.c. While loading the data, it shows placeholder cells (ghost table view cells), and you can tap on these cells and see that they're changing color because **selectable** is enabled. 
This PR fixes the ghost tableview cells not being selectable in every screen that uses them.

### Testing instructions
• Start the app and add your email and pass and login into your store
• Go to Orders or Products or Reviews screens
• While you see the placeholder cells tap on them. They're selectable

### Screenshots
Here's an example for the **Reviews** screen

**Before:**
<img src="https://user-images.githubusercontent.com/11445928/145007981-fb12f722-5214-456c-82b7-00cf9ad931ec.png" width="350" width="100%">



**After:**
<img src="https://user-images.githubusercontent.com/11445928/145008003-f9a73243-b0e8-40b0-8cb8-e6969c92d17a.png" width="350" width="100%">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
