### PR TITLE
 Fix wrapping title of the extra info button in the error screens

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -86,6 +86,8 @@ private extension ULErrorViewController {
         extraInfoButton.applyLinkButtonStyle()
         extraInfoButton.contentEdgeInsets = Constants.extraInfoCustomInsets
         extraInfoButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
+        extraInfoButton.titleLabel?.numberOfLines = 2
+        extraInfoButton.titleLabel?.textAlignment = .center
         extraInfoButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapAuxiliaryButton()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3361
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes the wrapping of the title of the extra info button in the error screen when the user uses an email that is not associated with a wordpress.com account and has a small screen device.

### Testing instructions
• Log out of the app. Use a device with a smaller screen size, and/or go to the device accessibility settings and choose larger text size.
• Select "Continue with WordPress.com."
• Enter an email address not linked to a WordPress.com account.
• On the error screen, the help link is cut off

### Screenshots
**Before:**
<img src="https://user-images.githubusercontent.com/11445928/144854784-8d0ef2c4-7f84-4fae-8027-592853a1f6dd.png" width="350" height="100%">
**After:**
<img src="https://user-images.githubusercontent.com/11445928/144853400-fcdd86f9-7ce1-4fcd-bbad-4b4bc87c26ad.png" width="350" height="100%">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->