### PR TITLE
Add admin_url to `me/sites` response mock for UI tests

### DIFF
--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -7,7 +7,7 @@
             "equalTo": "ID,name,description,URL,options,jetpack,jetpack_connection"
           },
           "options": {
-            "equalTo": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset,jetpack_connection_active_plugins"
+            "equalTo": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset,jetpack_connection_active_plugins,admin_url"
           }
         }
     },
@@ -25,6 +25,7 @@
                       "options": {
                         "timezone": "",
                         "gmt_offset": 0,
+                        "admin_url": "http:\/\/yourwoosite.com/wp-admin/",
                         "is_wpcom_store": true,
                         "woocommerce_is_active": true,
                         "jetpack_version": "8.1.1",


### PR DESCRIPTION
## Description

https://github.com/woocommerce/woocommerce-ios/pull/5611 added non-optional `adminURL` property to `Site` mapped from `me/sites` and UI tests started failing because `me/sites` mock didn't have this property.
This PR updates `me/sites` mock to include `adminURL` in request options and response.

## Testing

Check CI status for UI tests for this PR ([optional workflow](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/16010/workflows/a122bb9a-f719-4fbd-9b62-9cc5f1c36ba5) triggered).

Or run locally:
1. Run `rake mocks` in project directory.
2. Run UI tests in Xcode.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
