### PR TITLE
Simple Payments: Add Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -377,27 +377,71 @@ extension WooAnalyticsEvent {
 extension WooAnalyticsEvent {
     // Namespace
     enum SimplePayments {
+        /// Possible Payment Methods
+        ///
+        enum PaymentMethod: String {
+            case card
+            case cash
+        }
+
+        /// Possible view sources
+        ///
+        enum Source: String {
+            case amount
+            case summary
+            case paymentMethod = "payment_method"
+        }
+
         /// Common event keys
         ///
         private enum Keys {
             static let state = "state"
             static let amount = "amount"
+            static let paymentMethod = "payment_method"
+            static let source = "source"
         }
 
         static func simplePaymentsFlowStarted() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .simplePaymentsFlowStarted, properties: [:])
         }
 
+        // TODO: Delete when prototype is replaced with the complete version
         static func simplePaymentsFlowCompleted(amount: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .simplePaymentsFlowCompleted, properties: [Keys.amount: amount])
+            WooAnalyticsEvent(statName: .simplePaymentsFlowCompleted, properties: [:])
         }
 
+        static func simplePaymentsFlowCompleted(amount: String, method: PaymentMethod) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowCompleted, properties: [Keys.amount: amount, Keys.paymentMethod: method.rawValue])
+        }
+
+        // TODO: Delete when prototype is replaced with the complete version
         static func simplePaymentsFlowCanceled() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .simplePaymentsFlowCanceled, properties: [:])
         }
 
+        static func simplePaymentsFlowCanceled(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowCanceled, properties: [Keys.source: source.rawValue])
+        }
+
+        // TODO: Delete when prototype is replaced with the complete version
         static func simplePaymentsFlowFailed() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .simplePaymentsFlowFailed, properties: [:])
+        }
+
+        static func simplePaymentsFlowFailed(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowFailed, properties: [Keys.source: source.rawValue])
+        }
+
+        static func simplePaymentsFlowNoteAdded() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowNoteAdded, properties: [:])
+        }
+
+        static func simplePaymentsFlowTaxesToggled(isOn: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowTaxesToggled, properties: [Keys.state: isOn ? "on" : "off"])
+        }
+
+        static func simplePaymentsFlowCollect(method: PaymentMethod) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .simplePaymentsFlowCollect, properties: [Keys.paymentMethod: method.rawValue])
         }
 
         static func settingsBetaFeaturesSimplePaymentsToggled(isOn: Bool) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -423,11 +423,6 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .simplePaymentsFlowCanceled, properties: [Keys.source: source.rawValue])
         }
 
-        // TODO: Delete when prototype is replaced with the complete version
-        static func simplePaymentsFlowFailed() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .simplePaymentsFlowFailed, properties: [:])
-        }
-
         static func simplePaymentsFlowFailed(source: Source) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .simplePaymentsFlowFailed, properties: [Keys.source: source.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -414,13 +414,8 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .simplePaymentsFlowCompleted, properties: [Keys.amount: amount, Keys.paymentMethod: method.rawValue])
         }
 
-        // TODO: Delete when prototype is replaced with the complete version
         static func simplePaymentsFlowCanceled() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .simplePaymentsFlowCanceled, properties: [:])
-        }
-
-        static func simplePaymentsFlowCanceled(source: Source) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .simplePaymentsFlowCanceled, properties: [Keys.source: source.rawValue])
         }
 
         static func simplePaymentsFlowFailed(source: Source) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -532,6 +532,9 @@ public enum WooAnalyticsStat: String {
     case simplePaymentsFlowCompleted = "simple_payments_flow_completed"
     case simplePaymentsFlowCanceled = "simple_payments_flow_canceled"
     case simplePaymentsFlowFailed = "simple_payments_flow_failed"
+    case simplePaymentsFlowNoteAdded = "simple_payments_flow_note_added"
+    case simplePaymentsFlowTaxesToggled = "simple_payments_flow_taxes_toggled"
+    case simplePaymentsFlowCollect = "simple_payments_flow_collect"
 
     // MARK: Jetpack-the-plugin events
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -139,7 +139,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
 
             case .failure(let error):
                 self.presentNoticeSubject.send(.error(Localization.creationError))
-                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowFailed(source: .summary))
+                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowFailed(source: .amount))
                 DDLogError("⛔️ Error creating simple payments order: \(error)")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -134,12 +134,12 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
                                                                            presentNoticeSubject: self.presentNoticeSubject)
                 } else {
                     self.onOrderCreated(order)
+                    self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowCompleted(amount: order.total))
                 }
-                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowCompleted(amount: order.total))
 
             case .failure(let error):
                 self.presentNoticeSubject.send(.error(Localization.creationError))
-                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowFailed())
+                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowFailed(source: .summary))
                 DDLogError("⛔️ Error creating simple payments order: \(error)")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -33,6 +33,7 @@ struct SimplePaymentsMethod: View {
             Group {
                 MethodRow(icon: .priceImage, title: Localization.cash) {
                     showingCashAlert = true
+                    viewModel.trackCollectByCash()
                 }
 
                 Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -120,11 +120,14 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
             self.trackFlowCompleted(method: .cash)
         }
         stores.dispatch(action)
+        trackCollectIntention(method: .cash)
     }
 
     /// Starts the collect payment flow in the provided `rootViewController`
     ///
     func collectPayment(on rootViewController: UIViewController?, onSuccess: @escaping () -> ()) {
+        trackCollectIntention(method: .card)
+
         guard let rootViewController = rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
             return presentNoticeSubject.send(.error(Localization.genericCollectError))
@@ -170,13 +173,19 @@ private extension SimplePaymentsMethodsViewModel {
     /// Tracks the `simplePaymentsFlowCompleted` event.
     ///
     func trackFlowCompleted(method: WooAnalyticsEvent.SimplePayments.PaymentMethod) {
-        analytics.track(event: .SimplePayments.simplePaymentsFlowCompleted(amount: formattedTotal, method: method))
+        analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowCompleted(amount: formattedTotal, method: method))
     }
 
     /// Tracks the `simplePaymentsFlowFailed` event.
     ///
     func trackFlowFailed() {
         analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowFailed(source: .paymentMethod))
+    }
+
+    /// Tracks `simplePaymentsFlowCollect` event.
+    ///
+    func trackCollectIntention(method: WooAnalyticsEvent.SimplePayments.PaymentMethod) {
+        analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowCollect(method: method))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -120,7 +120,6 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
             self.trackFlowCompleted(method: .cash)
         }
         stores.dispatch(action)
-        trackCollectIntention(method: .cash)
     }
 
     /// Starts the collect payment flow in the provided `rootViewController`
@@ -165,6 +164,12 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
             // Tracks completion
             self?.trackFlowCompleted(method: .card)
         })
+    }
+
+    /// Tracks the collect by cash intention.
+    ///
+    func trackCollectByCash() {
+        trackCollectIntention(method: .cash)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsNoteViewModel.swift
@@ -26,6 +26,8 @@ final class SimplePaymentsNoteViewModel: EditCustomerNoteViewModelProtocol {
     func updateNote(onFinish: @escaping (Bool) -> Void) {
         originalNote = newNote
         onFinish(true)
+
+        analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowNoteAdded())
     }
 
     /// Revert to original content.
@@ -39,9 +41,14 @@ final class SimplePaymentsNoteViewModel: EditCustomerNoteViewModelProtocol {
     ///
     private var originalNote: String
 
-    init(originalNote: String = "") {
+    /// Analytics engine.
+    ///
+    private let analytics: Analytics
+
+    init(originalNote: String = "", analytics: Analytics = ServiceLocator.analytics) {
         self.originalNote = originalNote
         self.newNote = originalNote
+        self.analytics = analytics
         bindNoteChanges()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -84,7 +84,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
 
     /// ViewModel for the edit order note view.
     ///
-    lazy private(set) var noteViewModel = SimplePaymentsNoteViewModel()
+    lazy private(set) var noteViewModel = { SimplePaymentsNoteViewModel(analytics: analytics) }()
 
     init(providedAmount: String,
          totalWithTaxes: String,
@@ -148,11 +148,6 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     func reloadContent() {
         objectWillChange.send()
-
-        // Tracks if the merchant has added a note.
-        if noteContent.isNotEmpty {
-            analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowNoteAdded())
-        }
     }
 
     /// Updates the order remotely with the information entered by the merchant.

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -24,7 +24,11 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
 
     /// Determines if taxes should be added to the provided amount.
     ///
-    @Published var enableTaxes: Bool = false
+    @Published var enableTaxes: Bool = false {
+        didSet {
+            analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowTaxesToggled(isOn: enableTaxes))
+        }
+    }
 
     /// Defines when to navigate to the payments method screen.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -173,11 +173,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
             switch result {
             case .success:
                 self.navigateToPaymentMethods = true
-                // TODO: Analytics
-                break
-            case .failure:
+            case .failure(let error):
                 self.presentNoticeSubject.send(.error(Localization.updateError))
-                // TODO: Analytics
+                self.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowFailed(source: .summary))
+                DDLogError("⛔️ Error updating simple payments order: \(error)")
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -74,6 +74,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
+    /// Tracks analytics events.
+    ///
+    private let analytics: Analytics
+
     /// ViewModel for the edit order note view.
     ///
     lazy private(set) var noteViewModel = SimplePaymentsNoteViewModel()
@@ -87,13 +91,15 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
          feeID: Int64 = 0,
          presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.orderID = orderID
         self.feeID = feeID
         self.presentNoticeSubject = presentNoticeSubject
         self.currencyFormatter = currencyFormatter
         self.stores = stores
+        self.analytics = analytics
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
         self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? totalWithTaxes
         self.taxAmount = currencyFormatter.formatAmount(taxAmount) ?? taxAmount
@@ -138,6 +144,11 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     func reloadContent() {
         objectWillChange.send()
+
+        // Tracks if the merchant has added a note.
+        if noteContent.isNotEmpty {
+            analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowNoteAdded())
+        }
     }
 
     /// Updates the order remotely with the information entered by the merchant.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -280,7 +280,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.summaryViewModel)
     }
 
-    func test_view_model_attempts_error_notice_presentation_when_failing_to_crete_order() {
+    func test_view_model_attempts_error_notice_presentation_when_failing_to_create_order() {
         // Given
         let testingStore = MockStoresManager(sessionManager: .testingInstance)
         let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
@@ -310,6 +310,29 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(receivedError)
+    }
+
+    func test_failure_is_tracked_when_failing_to_create_order() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .createSimplePaymentsOrder(_, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        let analytics = MockAnalyticsProvider()
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.createSimplePaymentsOrder()
+
+        // Then
+        assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowFailed.rawValue])
+        assertEqual(analytics.receivedProperties.first?["source"] as? String, "amount")
     }
 
     func test_view_model_disable_cancel_button_while_creating_payment_order() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -198,4 +198,32 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowFailed.rawValue])
         assertEqual(analytics.receivedProperties.first?["source"] as? String, "payment_method")
     }
+
+    func test_collect_event_is_tracked_when_marking_order_as_paid() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.markOrderAsPaid(onSuccess: {})
+
+        // Then
+        assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowCollect.rawValue])
+        assertEqual(analytics.receivedProperties.first?["payment_method"] as? String, "cash")
+    }
+
+    func test_collect_event_is_tracked_when_collecting_payment() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.collectPayment(on: UIViewController(), onSuccess: {})
+
+        // Then
+        assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowCollect.rawValue])
+        assertEqual(analytics.receivedProperties.first?["payment_method"] as? String, "card")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -199,14 +199,14 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         assertEqual(analytics.receivedProperties.first?["source"] as? String, "payment_method")
     }
 
-    func test_collect_event_is_tracked_when_marking_order_as_paid() {
+    func test_collect_event_is_tracked_when_required() {
         // Given
         let analytics = MockAnalyticsProvider()
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores, analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
-        viewModel.markOrderAsPaid(onSuccess: {})
+        viewModel.trackCollectByCash()
 
         // Then
         assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowCollect.rawValue])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -171,7 +171,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         viewModel.markOrderAsPaid(onSuccess: {})
 
         // Then
-        assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowCompleted.rawValue])
+        assertEqual(analytics.receivedEvents.first, WooAnalyticsStat.simplePaymentsFlowCompleted.rawValue)
         assertEqual(analytics.receivedProperties.first?["payment_method"] as? String, "cash")
         assertEqual(analytics.receivedProperties.first?["amount"] as? String, "$12.00")
     }
@@ -195,7 +195,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         viewModel.markOrderAsPaid(onSuccess: {})
 
         // Then
-        assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowFailed.rawValue])
+        assertEqual(analytics.receivedEvents.first, WooAnalyticsStat.simplePaymentsFlowFailed.rawValue)
         assertEqual(analytics.receivedProperties.first?["source"] as? String, "payment_method")
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -204,4 +204,26 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         // Then
         assertEqual(mockAnalytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowNoteAdded.rawValue])
     }
+
+    func test_taxesToggled_event_is_tracked_after_switching_taxes_toggle() {
+        // Given
+        let mockAnalytics = MockAnalyticsProvider()
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       analytics: WooAnalytics(analyticsProvider: mockAnalytics))
+
+        // When
+        viewModel.enableTaxes = true
+        viewModel.enableTaxes = false
+
+        // Then
+        assertEqual(mockAnalytics.receivedEvents, [
+            WooAnalyticsStat.simplePaymentsFlowTaxesToggled.rawValue,  // Taxes enabled
+            WooAnalyticsStat.simplePaymentsFlowTaxesToggled.rawValue   // Taxes disabled
+        ])
+
+        assertEqual(mockAnalytics.receivedProperties[0]["state"] as? String, "on")  // Taxes enabled
+        assertEqual(mockAnalytics.receivedProperties[1]["state"] as? String, "off") // Taxes disabled
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -188,4 +188,20 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         // Then
         XCTAssertNil(emailSent)
     }
+
+    func test_noteAdded_event_is_tracked_after_editing_note() {
+        // Given
+        let mockAnalytics = MockAnalyticsProvider()
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       analytics: WooAnalytics(analyticsProvider: mockAnalytics))
+
+        // When
+        viewModel.noteViewModel.newNote = "content"
+        viewModel.reloadContent()
+
+        // Then
+        assertEqual(mockAnalytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowNoteAdded.rawValue])
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -199,7 +199,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
         // When
         viewModel.noteViewModel.newNote = "content"
-        viewModel.reloadContent()
+        viewModel.noteViewModel.updateNote(onFinish: { _ in })
 
         // Then
         assertEqual(mockAnalytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowNoteAdded.rawValue])


### PR DESCRIPTION
closes #5606 
closes #5603 

# Why

Now that the Simple Payments feature is functional this PR takes care of adding the defined analytics and some missing logs.

# How

- Update the `completed` event to add a `payment_method` property and log it when the flow actually completes.
- Update the `failed` event to add a `source` property to know where failures are happening.
- Added a new `note_added` event. https://github.com/Automattic/tracks-events-registration/pull/668
- Added a new `taxes_toggled` event. https://github.com/Automattic/tracks-events-registration/pull/669
- Added a new `collect` event.  https://github.com/Automattic/tracks-events-registration/pull/670
- Add unit tests to those events.

# Testing Steps

- Start the simple payments flow, enter the amount & tap next
-  On the summary screen, toggle the taxes switch 
- 🟦  See the `taxes_toggle` event being tracked
-  On the summary screen, add a note
- 🟦  See the `note_added` event being tracked
-  On the summary screen, add an invalid email * tap next
- 🟦  See the `failure` event being tracked.
- On the summary screen, delete the email and tap next
- On the Payment method screen, tap any payment row
- 🟦  See the `collect` event being tracked
- On the Payment method screen, finish collecting the payment
- 🟦  See the `completed` event being tracked

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
