### PR TITLE
[Mobile Payments ] Fix layout of card reader settings when running on macOS

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 import SwiftUI
-import WordPressUI
 
 final class CardReaderSettingsPresentingViewController: UIViewController {
 
@@ -56,9 +55,6 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
         self.addChild(childViewController)
         self.view.addSubview(childViewController.view)
         childViewController.didMove(toParent: self)
-
-        childViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        self.view.pinSubviewToAllEdges(childViewController.view)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import SwiftUI
+import WordPressUI
 
 final class CardReaderSettingsPresentingViewController: UIViewController {
 
@@ -52,9 +53,12 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
         }
         presenter.configure(viewModel: viewModelAndView.viewModel)
 
-        self.view.addSubview(childViewController.view)
         self.addChild(childViewController)
+        self.view.addSubview(childViewController.view)
         childViewController.didMove(toParent: self)
+
+        childViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        self.view.pinSubviewToAllEdges(childViewController.view)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5641 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When running the app on an Apple Silicon Mac (choosing as device My Mac (Designed for iPad), the layout of the screens in the card reader settings does not match the application window.

<img width="550" alt="Screen Shot 2021-12-08 at 7 43 48 AM" src="https://user-images.githubusercontent.com/2722505/145210662-0726d33b-883d-47d9-8302-945f15cacebc.png" />
<img width="550" alt="Screen Shot 2021-12-08 at 7 44 29 AM" src="https://user-images.githubusercontent.com/2722505/145210678-7bcb9676-b65c-4bbb-b584-d061cef4a42c.png"/>

This PR changes the order in which the calls to addChildView and addSubview are done.

In bb3da97 I also forced the child view to be pinned to its container. Apparently, it is not necessary to do so.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The only way to reproduce the bug I have found is by running the app on `My Mac (Designed for iPad)
1. Run the app on a Mac, by selecting as device My Mac (Designed for iPad)
2. Attempt to connect to a card reader: Settings > In Person Payments > Manage Card Reader
3. Notice the layout of screen with the CTA "Connect to card reader"
4. Notice the layout of the screen after the connection is successful
5. As extra bonus, a smoke test iPad and on an iPhone would be nice.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/145218972-c7178f8b-6a1d-439a-9792-19cbd0bd4cb8.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/145219015-1e80470c-4135-40ef-bd81-52215d78dbce.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/145219065-d81992fe-fac4-4b4d-b040-cbd5bd1e307e.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/145219115-57bb1d85-a24d-401a-bee0-7fd786da5800.png" width="350"/> |


Other screenshots after the fix:




![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-12-08 at 07 36 30](https://user-images.githubusercontent.com/2722505/145219206-0fe6bafb-a8c7-4ecc-9724-0d87ba5cdaac.png)
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-12-08 at 07 36 17](https://user-images.githubusercontent.com/2722505/145219209-87686bd4-a3ae-4cee-bf8c-cca41728d726.png)
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-12-08 at 07 36 23](https://user-images.githubusercontent.com/2722505/145219210-84906a40-ad27-4f65-9bad-dce6e75fbac4.png)

<img src="https://user-images.githubusercontent.com/2722505/145219518-b69a276f-c926-4379-902e-d2f9a49df390.png" width="350"/>

<img src="https://user-images.githubusercontent.com/2722505/145219609-79ecb7e4-4c3d-47f5-912d-47a631cd59a6.png" width="350"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
