### PR TITLE
Localize the quotation marks

### DIFF
--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -68,4 +68,20 @@ extension String {
     var isNotEmpty: Bool {
         return !isEmpty
     }
+
+    /// Get quotation marks from Locale
+    static var quotes: (String, String) {
+        guard
+            let bQuote = Locale.current.quotationBeginDelimiter,
+            let eQuote = Locale.current.quotationEndDelimiter
+        else { return ("\"", "\"") }
+
+        return (bQuote, eQuote)
+    }
+
+    /// Puts quotation marks at the beginning and the end of the string
+    var quoted: String {
+        let (bQuote, eQuote) = String.quotes
+        return bQuote + self + eQuote
+    }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -377,7 +377,6 @@ private extension OrderDetailsDataSource {
     private func configureCustomerNote(cell: CustomerNoteTableViewCell) {
         cell.headline = Title.customerNote
         cell.selectionStyle = .none
-        
         if customerNote.isNotEmpty {
             cell.body = customerNote.quoted
             cell.onEditTapped = { [weak self] in

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -376,14 +376,10 @@ private extension OrderDetailsDataSource {
 
     private func configureCustomerNote(cell: CustomerNoteTableViewCell) {
         cell.headline = Title.customerNote
-        let localizedBody = String.localizedStringWithFormat(
-            NSLocalizedString("“%@”",
-                              comment: "Customer note, wrapped in quotes"),
-            customerNote)
         cell.selectionStyle = .none
-
+        
         if customerNote.isNotEmpty {
-            cell.body = localizedBody
+            cell.body = customerNote.quoted
             cell.onEditTapped = { [weak self] in
                 self?.onCellAction?(.editCustomerNote, nil)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -295,11 +295,7 @@ private extension ReviewOrderViewController {
         }
 
         cell.headline = Localization.customerNoteTitle
-        let localizedBody = String.localizedStringWithFormat(
-            NSLocalizedString("“%@”",
-                              comment: "Customer note, wrapped in quotes"),
-            note)
-        cell.body = localizedBody
+        cell.body = note.quoted
         cell.selectionStyle = .none
     }
 


### PR DESCRIPTION
### Description
This is a PR draft.
As issue #1739 describes, some languages have different quotation marks.
We're using hardcoded quotes that wrap the customer note in the Order Details & Reviews Order screen.

The translation of the quotation marks can be handled by iOS using [Locale](https://developer.apple.com/documentation/foundation/locale)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
