### PR TITLE
Simple Payments: Rename "Order Note" to "Customer Provided Note"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -123,7 +123,7 @@ struct EditCustomerNote<ViewModel: EditCustomerNoteViewModelProtocol>: View {
 
 // MARK: Constants
 private enum Localization {
-    static let title = NSLocalizedString("Edit Note", comment: "Title for the edit customer provided note screen")
+    static let title = NSLocalizedString("Customer Provided Note", comment: "Title for the edit customer provided note screen")
     static let done = NSLocalizedString("Done", comment: "Text for the done button in the edit customer provided note screen")
     static let cancel = NSLocalizedString("Cancel", comment: "Text for the cancel button in the edit customer provided note screen")
     static let success = NSLocalizedString("Successfully updated", comment: "Notice text after updating the order successfully")

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -282,7 +282,7 @@ private extension SimplePaymentsSummary {
                                                comment: "Title text of the row that has a switch when creating a simple payment")
         static let total = NSLocalizedString("Order Total",
                                                comment: "Title text of the row that shows the total to charge when creating a simple payment")
-        static let orderNote = NSLocalizedString("Order Note",
+        static let orderNote = NSLocalizedString("Customer Provided Note",
                                                comment: "Title text of the row that holds the order note when creating a simple payment")
         static let addNote = NSLocalizedString("Add Note",
                                                comment: "Title text of the button that adds a note when creating a simple payment")


### PR DESCRIPTION
closes #5602 

# Why

As discussed in https://github.com/woocommerce/woocommerce-ios/pull/5516#issuecomment-981227555, this PR updates the "Order Note" titles to  "Customer Provided Note" titles, in order to be consistent with what the real field the merchant is editing.

# Screenshots

Summary | Edit Customer Provided Note
---- | ---- 
<img width="431" alt="edit-1" src="https://user-images.githubusercontent.com/562080/145465423-ee123040-160d-43ec-af20-4fc4f92913d0.png"> | <img width="425" alt="edit-2" src="https://user-images.githubusercontent.com/562080/145465428-928cf57c-9ae7-416b-9563-373bd49b2b5f.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.