### PR TITLE
Products: Navigate to the variation detail after generating a new variation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 8.2
 -----
 - [***] In-Person Payments: Now you can collect Simple Payments on the go. [https://github.com/woocommerce/woocommerce-ios/pull/5635]
+- [*] Products: After generating a new variation for a variable product, you are now taken directly to edit the new variation. [https://github.com/woocommerce/woocommerce-ios/pull/5649]
 
 8.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -16,7 +16,7 @@ final class EditAttributesViewController: UIViewController {
 
     /// Assign this closure to be notified after a variation is created.
     ///
-    var onVariationCreation: ((Product) -> Void)?
+    var onVariationCreation: ((Product, ProductVariation) -> Void)?
 
     /// Assign this closure to be notified after an attribute  is created or updated.
     ///
@@ -126,11 +126,11 @@ extension EditAttributesViewController {
         viewModel.generateVariation { [onVariationCreation, noticePresenter] result in
             progressViewController.dismiss(animated: true)
 
-            guard let variation = try? result.get() else {
+            guard let (product, variation) = try? result.get() else {
                 return noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
             }
 
-            onVariationCreation?(variation)
+            onVariationCreation?(product, variation)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -48,7 +48,7 @@ extension EditAttributesViewModel {
 
     /// Generates a variation in the host site using the product attributes
     ///
-    func generateVariation(onCompletion: @escaping (Result<Product, Error>) -> Void) {
+    func generateVariation(onCompletion: @escaping (Result<(Product, ProductVariation), Error>) -> Void) {
         let useCase = GenerateVariationUseCase(product: product, stores: stores)
         useCase.generateVariation(onCompletion: onCompletion)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
@@ -25,7 +25,7 @@ final class GenerateVariationUseCase {
 
     /// Generates a variation in the host site using the product attributes
     ///
-    func generateVariation(onCompletion: @escaping (Result<Product, Error>) -> Void) {
+    func generateVariation(onCompletion: @escaping (Result<(Product, ProductVariation), Error>) -> Void) {
 
         let startDate = Date()
         analytics.track(event: WooAnalyticsEvent.Variations.createVariation(productID: product.productID))
@@ -34,12 +34,13 @@ final class GenerateVariationUseCase {
                                                                    productID: product.productID,
                                                                    newVariation: createVariationParameter()) { [product, analytics] result in
 
-            // Convert the variationResult into a productResult by appending the variationID to the variations array
-            let productResult = result.map { variation in
-                product.copy(variations: product.variations + [variation.productVariationID])
+            // Create a result with both the new variation and the updated product (by appending the new variationID to the product variations array)
+            let combinedResult = result.map { variation -> (Product, ProductVariation) in
+                let product = product.copy(variations: product.variations + [variation.productVariationID])
+                return (product, variation)
             }
 
-            onCompletion(productResult)
+            onCompletion(combinedResult)
 
             // Track generation result
             let timeElapsed = Date().timeIntervalSince(startDate)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -20,7 +20,7 @@ final class ProductVariationsViewModel {
 
     /// Generates a variation in the host site using the product attributes
     ///
-    func generateVariation(for product: Product, onCompletion: @escaping (Result<Product, Error>) -> Void) {
+    func generateVariation(for product: Product, onCompletion: @escaping (Result<(Product, ProductVariation), Error>) -> Void) {
         let useCase = GenerateVariationUseCase(product: product, stores: stores)
         useCase.generateVariation(onCompletion: onCompletion)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
@@ -36,7 +36,7 @@ final class GenerateVariationUseCaseTests: XCTestCase {
         XCTAssertEqual(expectedVariation, variationSubmitted)
     }
 
-    func test_create_variations_updates_the_product_variations_array() throws {
+    func test_create_variations_returns_variation_and_updated_product_variations_array() throws {
         // Given
         let attribute = sampleAttribute(attributeID: 0, name: "attr", options: ["Option 1", "Option 2"])
         let attribute2 = sampleAttribute(attributeID: 1, name: "attr-2", options: ["Option 3", "Option 4"])
@@ -54,16 +54,17 @@ final class GenerateVariationUseCaseTests: XCTestCase {
         let useCase = GenerateVariationUseCase(product: product, stores: mockStores)
 
         // When
-        let result: Result<Product, Error> = waitFor { promise in
+        let result: Result<(Product, ProductVariation), Error> = waitFor { promise in
             useCase.generateVariation { result in
                 promise(result)
             }
         }
 
         // Then
-        let updatedProduct = try XCTUnwrap(result.get())
-        let expectedVariations = [MockProductVariation().productVariation().productVariationID]
-        XCTAssertEqual(updatedProduct.variations, expectedVariations)
+        let (updatedProduct, newVariation) = try XCTUnwrap(result.get())
+        let expectedVariationID = MockProductVariation().productVariation().productVariationID
+        XCTAssertEqual(updatedProduct.variations, [expectedVariationID])
+        XCTAssertEqual(newVariation.productVariationID, expectedVariationID)
     }
 }
 


### PR DESCRIPTION
Closes: #5314

## Description

This updates the navigation when creating new variations for a variable product, to match the Android behavior. The expected behavior:

* After creating the **first** variation for a variable product you are taken back to the product detail screen. (No change from previous behavior)
* After creating an **additional** variation (after the first) you are taken directly to the variation detail screen to edit it. (Previously you were taken to the variation list.)

## Changes

* In `GenerateVariationUseCase`, generating a variation now returns a `(Product, ProductVariation)` tuple containing the updated product and the new variation, instead of just the updated product.
* In `ProductVariationsViewController`, the work to navigate to the variation detail is extracted to `navigateToVariationDetail(for:)`. That method is now also used in `createVariation()` to navigate to the variation detail after a new variation (after the first) is generated.
* Unit tests are updated.

## Testing

1. Build and run the app.
2. Go to the Products tab.
3. Tap + and choose to create a new variable product.
4. Tap "Add variations"
5. Tap "Add attributes" and follow the prompts to add at least one attribute and option.
6. Tap "Generate Variation" and confirm you are directed back to the main product detail screen.
7. Tap the Variations row to open the variation list.
8. Tap "Generate New Variation" and confirm you are directed to the variation detail screen for the new variation.

## Video


https://user-images.githubusercontent.com/8658164/145478968-8139b09d-7454-4051-9fbc-9f6ca824fbc6.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
