### PR TITLE
Remove use of accidentally called 3rd-party SDK helpers and types

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/DeclineReason+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/DeclineReason+Stripe.swift
@@ -3,7 +3,6 @@
 ///
 
 import Foundation
-import StripeTerminal
 
 extension DeclineReason {
     init(with stripeDeclineCode: String) {

--- a/WooCommerce/Classes/Extensions/UIView+SafeAreaConstraints.swift
+++ b/WooCommerce/Classes/Extensions/UIView+SafeAreaConstraints.swift
@@ -1,0 +1,58 @@
+import UIKit
+
+extension UIView {
+    var safeLeadingAnchor: NSLayoutAnchor<NSLayoutXAxisAnchor> {
+        get {
+            if #available(iOS 11.0, *) {
+                return self.safeAreaLayoutGuide.leadingAnchor
+            } else {
+                return self.leadingAnchor
+            }
+        }
+    }
+    var safeTrailingAnchor: NSLayoutAnchor<NSLayoutXAxisAnchor> {
+        get {
+            if #available(iOS 11.0, *) {
+                return self.safeAreaLayoutGuide.trailingAnchor
+            } else {
+                return self.trailingAnchor
+            }
+        }
+    }
+    var safeLeftAnchor: NSLayoutAnchor<NSLayoutXAxisAnchor> {
+        get {
+            if #available(iOS 11.0, *) {
+                return self.safeAreaLayoutGuide.leftAnchor
+            } else {
+                return self.leftAnchor
+            }
+        }
+    }
+    var safeRightAnchor: NSLayoutAnchor<NSLayoutXAxisAnchor> {
+        get {
+            if #available(iOS 11.0, *) {
+                return self.safeAreaLayoutGuide.rightAnchor
+            } else {
+                return self.rightAnchor
+            }
+        }
+    }
+    var safeTopAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor> {
+        get {
+            if #available(iOS 11.0, *) {
+                return self.safeAreaLayoutGuide.topAnchor
+            } else {
+                return self.topAnchor
+            }
+        }
+    }
+    var safeBottomAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor> {
+        get {
+            if #available(iOS 11.0, *) {
+                return self.safeAreaLayoutGuide.bottomAnchor
+            } else {
+                return self.bottomAnchor
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/Extensions/UIView+SubviewsAxis.swift
+++ b/WooCommerce/Classes/Extensions/UIView+SubviewsAxis.swift
@@ -5,7 +5,7 @@ extension UIView {
     /// This is based on the assumption that there are two subviews.
     /// Otherwise, nil is returned.
     ///
-    func axisOfTwoSubviews() -> UIView.Axis? {
+    func axisOfTwoSubviews() -> NSLayoutConstraint.Axis? {
         guard subviews.count == 2 else {
             return nil
         }

--- a/WooCommerce/Classes/Extensions/UIView+SuperviewConstraints.swift
+++ b/WooCommerce/Classes/Extensions/UIView+SuperviewConstraints.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+extension UIView {
+    @discardableResult
+    public func constrainToSuperview(attribute: NSLayoutConstraint.Attribute,
+                                     relatedBy relation: UIKit.NSLayoutConstraint.Relation = .equal,
+                                     constant: CoreGraphics.CGFloat = 0) -> UIKit.NSLayoutConstraint {
+        NSLayoutConstraint(item: self,
+                           attribute: attribute,
+                           relatedBy: relation,
+                           toItem: superview,
+                           attribute: attribute,
+                           multiplier: 1,
+                           constant: constant)
+    }
+}

--- a/WooCommerce/Classes/Tools/SiteAddress.swift
+++ b/WooCommerce/Classes/Tools/SiteAddress.swift
@@ -52,7 +52,7 @@ final class SiteAddress {
 
     private func getValueFromSiteSettings(_ settingID: String) -> String? {
         return siteSettings.first { (setting) -> Bool in
-            return setting.settingID.isEqual(to: settingID)
+            return setting.settingID == settingID
         }?.value
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -378,6 +378,8 @@
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
+		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
+		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -1909,6 +1911,8 @@
 		031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectionFailedUpdateAddress.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingFailedUpdatePostalCode.swift; sourceTree = "<group>"; };
+		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
+		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
@@ -6257,6 +6261,8 @@
 				02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */,
 				020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */,
 				021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */,
+				039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */,
+				039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */,
 				D88CA757237D1C27005D2F44 /* Ghost+Woo.swift */,
 				02784A02238B8BC800BDD6A8 /* UIView+Border.swift */,
 				02396250239948470096F34C /* UIImage+TintColor.swift */,
@@ -7862,6 +7868,7 @@
 				26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,
 				E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */,
+				039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */,
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
@@ -8116,6 +8123,7 @@
 				D82BB3AA26454F3300A82741 /* CardPresentModalProcessing.swift in Sources */,
 				0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
+				039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */,
 				7E7C5F792719A8F900315B61 /* EditProductCategoryListViewModel.swift in Sources */,
 				DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5652
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
These are issues which showed up when building the app for Catalyst, when I excluded the Zendesk `SupportSDK` framework from the build. This PR doesn't turn Catalyst support on, or have any other relation to building the app for the Mac, but the changes are here are tidying up things that we shouldn't do in the iOS app anyway.

`SupportSDK` includes a dependency, `ZendeskCommonUI`, and calls `@_exported import ZendeskCommonUI`, meaning that our app can call the dependency's functions without specifically importing it.

`axisOfTwoSubviews()` appears to be unused, but was a trivial fix.

The `.isEqual()` call in `SiteAddress` was not very swifty, and again a trivial fix to use the `==` operator.

#### Layout constraint helpers
These helpers were accessible from iOS only, not Mac Catalyst. Xcode wasn't able to determine _where_ they were implemented, but my web searches show that they're in the Zendesk SDKs, so I've added new implementations here.

See https://github.com/zendesk/zendesk_sdk_ios/blob/cdad693720ca9b8b794b514f2c48189c2812ff3a/ZendeskSDK/5.1/CommonUISDK.framework/Modules/CommonUISDK.swiftmodule/arm64-apple-ios.swiftinterface#L627 and https://github.com/zendesk/zendesk_sdk_ios/blob/cdad693720ca9b8b794b514f2c48189c2812ff3a/ZendeskSDK/5.1/CommonUISDK.framework/Modules/CommonUISDK.swiftmodule/arm64-apple-ios.swiftinterface#L666 for declarations.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
General smoke testing of ProductsViewController, empty states, offline banner, and ShippingLabels when dealing with addresses. There's no visual difference in either place, but the layout helpers were used in all these places.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
