### PR TITLE
Add "Analytics" in the hub

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -31,6 +31,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .hubMenu:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .analytics:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -61,4 +61,8 @@ public enum FeatureFlag: Int {
     /// Display the new tab "Menu" in the tab bar.
     ///
     case hubMenu
+
+    /// Display the button "Analytics" in the hub
+    ///
+    case analytics
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct HubMenu: View {
     @ObservedObject private var viewModel: HubMenuViewModel
     @State private var showViewStore = false
+    @State private var showAnalytics = false
     @State private var showReviews = false
 
     init(siteID: Int64) {
@@ -28,6 +29,8 @@ struct HubMenu: View {
                                 switch menu {
                                 case .viewStore:
                                     showViewStore = true
+                                case .analytics:
+                                    showAnalytics = true
                                 case .reviews:
                                     showReviews = true
                                 default:
@@ -44,6 +47,15 @@ struct HubMenu: View {
                 .background(Color(.listBackground))
             }
             .safariSheet(isPresented: $showViewStore, url: viewModel.storeURL)
+
+            // Go to the Analytics screen
+            NavigationLink(destination:
+                            EmptyView(),
+                           isActive: $showAnalytics) {
+                EmptyView()
+            }.hidden()
+
+            // Go to the Reviews screen
             NavigationLink(destination:
                             ReviewsView(siteID: viewModel.siteID),
                            isActive: $showReviews) {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -7,18 +7,21 @@ struct HubMenuElement: View {
     let text: String
 
     var body: some View {
-        VStack {
-            ZStack {
-                Color(.listBackground)
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: Constants.iconSize, height: Constants.iconSize)
+        ZStack {
+            Color(.listForeground)
+            VStack {
+                ZStack {
+                    Color(.neutral(.shade0))
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: Constants.iconSize, height: Constants.iconSize)
+                }
+                .frame(width: Constants.imageSize, height: Constants.imageSize, alignment: .center)
+                .cornerRadius(Constants.imageSize/2)
+                .padding(.bottom, Constants.paddingBetweenElements)
+                Text(text)
             }
-            .frame(width: Constants.imageSize, height: Constants.imageSize, alignment: .center)
-            .cornerRadius(Constants.imageSize/2)
-            .padding(.bottom, Constants.paddingBetweenElements)
-            Text(text)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -24,6 +24,11 @@ final class HubMenuViewModel: ObservableObject {
     init(siteID: Int64) {
         self.siteID = siteID
         menuElements = [.woocommerceAdmin, .viewStore, .reviews]
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.analytics) {
+            // Add "Analytics" before the "Reviews" button
+            menuElements.insert(.analytics, at: 2)
+        }
     }
 }
 
@@ -31,6 +36,7 @@ extension HubMenuViewModel {
     enum Menu: CaseIterable {
         case woocommerceAdmin
         case viewStore
+        case analytics
         case reviews
 
         var title: String {
@@ -39,6 +45,8 @@ extension HubMenuViewModel {
                 return Localization.woocommerceAdmin
             case .viewStore:
                 return Localization.viewStore
+            case .analytics:
+                return Localization.analytics
             case .reviews:
                 return Localization.reviews
             }
@@ -50,6 +58,8 @@ extension HubMenuViewModel {
                 return .wordPressLogoImage.imageWithTintColor(.blue) ?? .wordPressLogoImage
             case .viewStore:
                 return .storeImage.imageWithTintColor(.accent) ?? .storeImage
+            case .analytics:
+                return .analyticsImage.imageWithTintColor(.accent) ?? .analyticsImage
             case .reviews:
                 return .starImage(size: 24.0).imageWithTintColor(.primary) ?? .starOutlineImage()
             }
@@ -62,6 +72,8 @@ extension HubMenuViewModel {
         static let woocommerceAdmin = NSLocalizedString("WooCommerce Admin",
                                                         comment: "Title of one of the hub menu options")
         static let viewStore = NSLocalizedString("View Store",
+                                                 comment: "Title of one of the hub menu options")
+        static let analytics = NSLocalizedString("Analytics",
                                                  comment: "Title of one of the hub menu options")
         static let reviews = NSLocalizedString("Reviews",
                                                comment: "Title of one of the hub menu options")


### PR DESCRIPTION
Merge PR #5617 before this one.

Closes: #5650

### Description
This is a PR draft for adding the "Analytics" button in the hub with a feature flag.

### Screenshots
<img src="https://user-images.githubusercontent.com/11445928/145673970-566292d0-4830-448c-9874-ecae20c5ede5.png" width="350px" height="100%">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.