### PR TITLE
Hide visitor stats in the Today tab only when an interval bar is selected

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] In-Person Payments: Now you can collect Simple Payments on the go. [https://github.com/woocommerce/woocommerce-ios/pull/5635]
 - [*] Products: After generating a new variation for a variable product, you are now taken directly to edit the new variation. [https://github.com/woocommerce/woocommerce-ios/pull/5649]
+- [*] Dashboard: the visitor count in the Today tab is now shown when Jetpack site stats are enabled.
 
 8.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -419,12 +419,6 @@ private extension StoreStatsV4PeriodViewController {
 //
 private extension StoreStatsV4PeriodViewController {
     func updateSiteVisitStats(mode: SiteVisitStatsMode) {
-        // Hides site visit stats for "today"
-        guard timeRange != .today else {
-            visitorsStackView.isHidden = true
-            return
-        }
-
         visitorsStackView.isHidden = mode == .hidden
         reloadSiteFields()
     }
@@ -485,7 +479,16 @@ private extension StoreStatsV4PeriodViewController {
     ///
     /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
     func updateSiteVisitStats(selectedIndex: Int?) {
-        updateSiteVisitStats(mode: siteVisitStatsMode)
+        let mode: SiteVisitStatsMode
+
+        // Hides site visit stats for "today" when an interval bar is selected.
+        if timeRange == .today, selectedIndex != nil {
+            mode = .hidden
+        } else {
+            mode = siteVisitStatsMode
+        }
+
+        updateSiteVisitStats(mode: mode)
 
         switch siteVisitStatsMode {
         case .hidden, .redactedDueToJetpack:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5667 
<!-- Id number of the GitHub issue this PR addresses. -->

- [x] ⚠️ Update release notes based on time of review ⚠️ 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When we implemented the stats 2 years ago, we intentionally hide the visitor stats for today but only when an interval bar is selected. The reason is that the visitor stats endpoint does not support hourly stats, so we hide the visitor count when a specific "hour" is selected for today. 

When we worked on the JCP project that shows Jetpack empty visitor stats view in [these changes](https://github.com/woocommerce/woocommerce-ios/pull/5451/files), a piece of logic that hides the visitor stats for the Today tab was moved while one condition was missed (you can search for // Hides site visit stats for "today" in these changes). The logic that hides the visitor count was applied to all cases, whereas it used to be only when a bar is selected. I didn't catch this during code review, and the original comment that I wrote 2 years ago also didn't mention this condition 😅 

This PR fixes the issue by moving and updating the logic that hides the visitor stats for the Today tab so that it's only called when an interval bar is selected.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Jetpack site

Prerequisite: the account is connected to a Jetpack and JCP site

- In WC Admin website (`wp-admin/admin.php?page=wc-admin`), make sure you can see the visitor stats
- In the app, log in to a Jetpack site if needed
- Go to the My store tab --> the visitor data should be shown in the Today tab
- Select an hour interval in Today's stats --> the visitor data should be hidden because hourly stats are not available
- Tap on other time range tabs like This Week, This Month, and This Year --> the visitor data should be shown like before
- In wp-admin website, turn off site stats in Jetpack modules following the [official guide](https://jetpack.com/support/control-jetpack-features-on-one-page/) by going to `wp-admin/admin.php?page=jetpack_modules`
- In the app, pull down to refresh the dashboard stats --> the visitor data should be hidden now for all time range tabs, and when selecting an interval bar

#### JCP site

- In WC Admin website (`wp-admin/admin.php?page=wc-admin`), make sure you can see the visitor stats
- In the app, log in to a JCP site
- Go to the My store tab --> the Jetpack empty stats UI should be shown on the visitor stats for all time range tabs, and when selecting an interval bar

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Jetpack site | Jetpack site - selecting an interval bar | JCP site
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2021-12-13 at 13 35 51](https://user-images.githubusercontent.com/1945542/145761627-ba2bbaac-0c3b-4ba3-87a7-33c27316790a.png) | ![Simulator Screen Shot - iPhone 11 - 2021-12-13 at 13 36 11](https://user-images.githubusercontent.com/1945542/145761703-3109fa1c-5151-4d7c-8f0b-ebdda178edf0.png) | ![Simulator Screen Shot - iPhone 11 - 2021-12-13 at 14 15 53](https://user-images.githubusercontent.com/1945542/145761811-05feb467-9933-41cc-9785-b8628d20acc5.png)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
