### PR TITLE
Order Creation: Add status mapping to order creation request

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -132,6 +132,8 @@ public class OrdersRemote: Remote {
                     switch field {
                     case .feeLines:
                         params[Order.CodingKeys.feeLines.rawValue] = try order.fees.compactMap { try $0.toDictionary() }
+                    case .status:
+                        params[Order.CodingKeys.status.rawValue] = order.status.rawValue
                     }
                 }
             }()
@@ -274,5 +276,6 @@ public extension OrdersRemote {
     ///
     enum CreateOrderField {
         case feeLines
+        case status
     }
 }

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -285,4 +285,20 @@ final class OrdersRemoteTests: XCTestCase {
         let received = try XCTUnwrap(request.parameters["status"] as? String)
         assertEqual(received, status.rawValue)
     }
+
+    func test_create_order_properly_encodes_custom_status() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let expectedStatusString = "backorder"
+        let status = OrderStatusEnum.custom(expectedStatusString)
+        let order = Order.fake().copy(status: status)
+
+        // When
+        remote.createOrder(siteID: 123, order: order, fields: [.status]) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["status"] as? String)
+        assertEqual(received, expectedStatusString)
+    }
 }

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -270,4 +270,19 @@ final class OrdersRemoteTests: XCTestCase {
         ]
         assertEqual(received, expected)
     }
+
+    func test_create_order_properly_encodes_status() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let status = OrderStatusEnum.onHold
+        let order = Order.fake().copy(status: status)
+
+        // When
+        remote.createOrder(siteID: 123, order: order, fields: [.status]) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["status"] as? String)
+        assertEqual(received, status.rawValue)
+    }
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -315,7 +315,7 @@ private extension OrderStore {
     /// Creates a manual order with the provided order details.
     ///
     func createOrder(siteID: Int64, order: Order, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        remote.createOrder(siteID: siteID, order: order, fields: []) { [weak self] result in
+        remote.createOrder(siteID: siteID, order: order, fields: [.status]) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/5407.

## Description

This PR adds selected order status mapping to new order API request.

## Changes

- Adds `status` case to `CreateOrderField`.
- Adds `status` field handling on Networking layer - just getting `rawValue` of enum.
- Adds unit test for mapping new field.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "Edit" button to display status picker.
5. Select different status and tap "Apply".
6. Tap "Create" button appeared in navbar.
7. Confirm Order Details shows correct custom status.
8. Go back in navigation to Orders List and confirm there is same custom status for created order in a list.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
