### PR TITLE
Product images: fix crash when tapping on an image while another image is pending upload

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,6 @@
 
 8.3
 -----
-
 - [*] Add/Edit Product Images: tapping on the last `n` images while `n` images are pending upload does not crash the app anymore. [https://github.com/woocommerce/woocommerce-ios/pull/5672]
 
 8.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 8.3
 -----
 
+- [*] Add/Edit Product Images: tapping on the last `n` images while `n` images are pending upload does not crash the app anymore. [https://github.com/woocommerce/woocommerce-ios/pull/5672]
 
 8.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,13 +2,14 @@
 
 8.3
 -----
-- [*] Add/Edit Product Images: tapping on the last `n` images while `n` images are pending upload does not crash the app anymore. [https://github.com/woocommerce/woocommerce-ios/pull/5672]
+
 
 8.2
 -----
 - [***] In-Person Payments: Now you can collect Simple Payments on the go. [https://github.com/woocommerce/woocommerce-ios/pull/5635]
 - [*] Products: After generating a new variation for a variable product, you are now taken directly to edit the new variation. [https://github.com/woocommerce/woocommerce-ios/pull/5649]
 - [*] Dashboard: the visitor count in the Today tab is now shown when Jetpack site stats are enabled.
+- [*] Add/Edit Product Images: tapping on the last `n` images while `n` images are pending upload does not crash the app anymore. [https://github.com/woocommerce/woocommerce-ios/pull/5672]
 
 8.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -123,8 +123,14 @@ extension ProductImagesCollectionViewController {
             return
         }
 
+        let selectedImageIndex: Int = {
+            // In case of any pending images, deduct the number of pending images from the index.
+            let imageStatusIndex = indexPath.row
+            let numberOfPendingImages = productImageStatuses.count - productImageStatuses.images.count
+            return imageStatusIndex - numberOfPendingImages
+        }()
         let productImagesGalleryViewController = ProductImagesGalleryViewController(images: productImageStatuses.images,
-                                                                                    selectedIndex: indexPath.row,
+                                                                                    selectedIndex: selectedImageIndex,
                                                                                     isDeletionEnabled: isDeletionEnabled,
                                                                                     productUIImageLoader: productUIImageLoader) { [weak self] (productImage) in
                                                                                         self?.onDeletion(productImage)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5569 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In product images grid view, tapping on an uploaded image navigates to a gallery view (`ProductImagesGalleryViewController`). The gallery view shows the tapped image first, implemented by a collection view  scrolling to the index of the tapped image.

product images grid view | uploading an image | tapping on the last image to a gallery view
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2021-12-14 at 13 56 30](https://user-images.githubusercontent.com/1945542/145941701-07116055-3498-461f-9896-591a9da957af.png) | ![Simulator Screen Shot - iPhone 11 - 2021-12-14 at 13 56 52](https://user-images.githubusercontent.com/1945542/145941709-aba48fa0-c3c8-4f82-b558-8623a86bab96.png) | ![Simulator Screen Shot - iPhone 11 - 2021-12-14 at 13 57 20](https://user-images.githubusercontent.com/1945542/145941716-9146a20c-5fe5-4f00-b765-45723a810043.png)

When there is any image pending upload, the index of the tapped image in the product images view is now different from the index in the gallery view because the gallery view only contains uploaded images. This causes a crash when the gallery view tries scrolling to an index that exceeds the number of uploaded images in the gallery view (e.g. the last `n` images when `n` other images are being uploaded).

This PR fixes the crash by deducting the number of pending images from the selected index in the gallery view.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

It's the easiest to reproduce with a product that already has at least an image.

- Go to the Products tab
- Tap on a product with at least an image
- Tap the images header view to edit product images
- Tap "Add Photos"
- Select "Take a photo" or "Choose from device"
- Take/select a photo to add it to the product
- While the second photo is still uploading, quickly tap the images header view to edit product images again and then tap the last photo in the grid view (make sure the image you added is still pending upload like in the second screenshot) --> it used to crash consistently before this PR, and now it should navigate to the gallery view with the PR branch

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
