### PR TITLE
System Status Report: Update Networking to separate SystemPluginMapper from SystemStatusMapper

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -553,6 +553,7 @@
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
 		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
 		DEC51A9B274E3206009F3DF4 /* plugin-inactive.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */; };
+		DEC51AE7276848A9009F3DF4 /* SystemStatus+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1147,6 +1148,7 @@
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
 		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
 		DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "plugin-inactive.json"; sourceTree = "<group>"; };
+		DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+Environment.swift"; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1602,6 +1604,7 @@
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
 				077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */,
 				3148976F27232982007A86BD /* SystemStatus.swift */,
+				DEC51AE527684717009F3DF4 /* SystemStatusDetails */,
 				450106842399A7CB00E24722 /* TaxClass.swift */,
 				3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */,
 				31799AF7270508C600D78179 /* WCPayReaderLocation.swift */,
@@ -2035,6 +2038,14 @@
 				458C6DE325AC72A1009B300D /* StoredProductSettings.swift */,
 			);
 			path = Product;
+			sourceTree = "<group>";
+		};
+		DEC51AE527684717009F3DF4 /* SystemStatusDetails */ = {
+			isa = PBXGroup;
+			children = (
+				DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */,
+			);
+			path = SystemStatusDetails;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2550,6 +2561,7 @@
 				026CF620237D69D6009563D4 /* ProductVariationsRemote.swift in Sources */,
 				077F39D626A58E4500ABEADC /* SystemStatusRemote.swift in Sources */,
 				4599FC5E24A62AA70056157A /* ProductTagsRemote.swift in Sources */,
+				DEC51AE7276848A9009F3DF4 /* SystemStatus+Environment.swift in Sources */,
 				FE28F6E226840DED004465C7 /* User.swift in Sources */,
 				7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */,
 				D87F6151226591E10031A13B /* NullNetwork.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -555,6 +555,7 @@
 		DEC51A9B274E3206009F3DF4 /* plugin-inactive.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */; };
 		DEC51AE7276848A9009F3DF4 /* SystemStatus+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */; };
 		DEC51AE927687AAF009F3DF4 /* SystemPluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AE827687AAF009F3DF4 /* SystemPluginMapper.swift */; };
+		DEC51AED2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51AEC2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1151,6 +1152,7 @@
 		DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "plugin-inactive.json"; sourceTree = "<group>"; };
 		DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+Environment.swift"; sourceTree = "<group>"; };
 		DEC51AE827687AAF009F3DF4 /* SystemPluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPluginMapper.swift; sourceTree = "<group>"; };
+		DEC51AEC2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = systemStatusWithPluginsOnly.json; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1800,6 +1802,7 @@
 				31799AFB2705189200D78179 /* wcpay-location.json */,
 				31799AFD270518AD00D78179 /* wcpay-location-error.json */,
 				02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */,
+				DEC51AEC2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json */,
 				077F39D726A58EB600ABEADC /* systemStatus.json */,
 			);
 			path = Responses;
@@ -2265,6 +2268,7 @@
 				7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */,
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,
+				DEC51AED2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json in Resources */,
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -81,7 +81,7 @@
 		077F39D626A58E4500ABEADC /* SystemStatusRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39D526A58E4500ABEADC /* SystemStatusRemote.swift */; };
 		077F39D826A58EB600ABEADC /* systemStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = 077F39D726A58EB600ABEADC /* systemStatus.json */; };
 		077F39DA26A58ED700ABEADC /* SystemStatusRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39D926A58ED700ABEADC /* SystemStatusRemoteTests.swift */; };
-		077F39E626A5D15800ABEADC /* SystemStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DB26A58F4800ABEADC /* SystemStatusMapperTests.swift */; };
+		077F39E626A5D15800ABEADC /* SystemPluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DB26A58F4800ABEADC /* SystemPluginMapperTests.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -554,6 +554,7 @@
 		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
 		DEC51A9B274E3206009F3DF4 /* plugin-inactive.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */; };
 		DEC51AE7276848A9009F3DF4 /* SystemStatus+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */; };
+		DEC51AE927687AAF009F3DF4 /* SystemPluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AE827687AAF009F3DF4 /* SystemPluginMapper.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -672,7 +673,7 @@
 		077F39D526A58E4500ABEADC /* SystemStatusRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusRemote.swift; sourceTree = "<group>"; };
 		077F39D726A58EB600ABEADC /* systemStatus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = systemStatus.json; sourceTree = "<group>"; };
 		077F39D926A58ED700ABEADC /* SystemStatusRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusRemoteTests.swift; sourceTree = "<group>"; };
-		077F39DB26A58F4800ABEADC /* SystemStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapperTests.swift; sourceTree = "<group>"; };
+		077F39DB26A58F4800ABEADC /* SystemPluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPluginMapperTests.swift; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1149,6 +1150,7 @@
 		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
 		DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "plugin-inactive.json"; sourceTree = "<group>"; };
 		DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+Environment.swift"; sourceTree = "<group>"; };
+		DEC51AE827687AAF009F3DF4 /* SystemPluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPluginMapper.swift; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1876,6 +1878,7 @@
 				CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
 				077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */,
+				DEC51AE827687AAF009F3DF4 /* SystemPluginMapper.swift */,
 				02C11275274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift */,
 				02BE0A7A274B695F001176D2 /* WordPressMediaMapper.swift */,
 				02C112772742862600F4F0B4 /* WordPressSiteSettingsMapper.swift */,
@@ -1943,7 +1946,7 @@
 			children = (
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
-				077F39DB26A58F4800ABEADC /* SystemStatusMapperTests.swift */,
+				077F39DB26A58F4800ABEADC /* SystemPluginMapperTests.swift */,
 				2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
 				45150A9F26837357006922EA /* CountryListMapperTests.swift */,
@@ -2650,6 +2653,7 @@
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
 				CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */,
+				DEC51AE927687AAF009F3DF4 /* SystemPluginMapper.swift in Sources */,
 				B557DA0B20975D7E005962F4 /* WooAPIVersion.swift in Sources */,
 				45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
@@ -2749,7 +2753,7 @@
 				020C907F24C7D359001E2BEB /* ProductVariationMapperTests.swift in Sources */,
 				74ABA1D5213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift in Sources */,
 				74AB5B5121AF426D00859C12 /* SiteAPIRemoteTests.swift in Sources */,
-				077F39E626A5D15800ABEADC /* SystemStatusMapperTests.swift in Sources */,
+				077F39E626A5D15800ABEADC /* SystemPluginMapperTests.swift in Sources */,
 				4599FC6624A633A10056157A /* ProductTagsRemoteTests.swift in Sources */,
 				B567AF2F20A0FB8F00AB6C62 /* AuthenticatedRequestTests.swift in Sources */,
 				B5C6FCCD20A34B8300A4F8E4 /* OrderListMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/SystemPluginMapper.swift
+++ b/Networking/Networking/Mapper/SystemPluginMapper.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Mapper: System Plugins
+///
+struct SystemPluginMapper: Mapper {
+
+    /// Site Identifier associated to the system plugins that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID in the system plugin endpoint.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into [SystemPlugin].
+    ///
+    func map(response: Data) throws -> [SystemPlugin] {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        let systemStatus = try decoder.decode(SystemStatusEnvelope.self, from: response).systemStatus
+
+        /// Active and in-active plugins share identical structure, but are stored in separate parts of the remote response
+        /// (and without an active attribute in the response). So... we use the same decoder for active and in-active plugins
+        /// and here we apply the correct value for active (or not)
+        ///
+        let activePlugins = systemStatus.activePlugins.map {
+            $0.copy(active: true)
+        }
+
+        let inactivePlugins = systemStatus.inactivePlugins.map {
+            $0.copy(active: false)
+        }
+
+        return activePlugins + inactivePlugins
+    }
+}

--- a/Networking/Networking/Mapper/SystemStatusMapper.swift
+++ b/Networking/Networking/Mapper/SystemStatusMapper.swift
@@ -4,41 +4,28 @@ import Foundation
 ///
 struct SystemStatusMapper: Mapper {
 
-    /// Site Identifier associated to the system plugins that will be parsed.
+    /// Site Identifier associated to the system status that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID in the system plugin endpoint.
     ///
     let siteID: Int64
 
-    /// (Attempts) to convert a dictionary into [SystemPlugin].
+    /// (Attempts) to convert a dictionary into SystemStatus
     ///
-    func map(response: Data) throws -> [SystemPlugin] {
+    func map(response: Data) throws -> SystemStatus {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID
         ]
 
         let systemStatus = try decoder.decode(SystemStatusEnvelope.self, from: response).systemStatus
-
-        /// Active and in-active plugins share identical structure, but are stored in separate parts of the remote response
-        /// (and without an active attribute in the response). So... we use the same decoder for active and in-active plugins
-        /// and here we apply the correct value for active (or not)
-        ///
-        let activePlugins = systemStatus.activePlugins.map {
-            $0.copy(active: true)
-        }
-
-        let inactivePlugins = systemStatus.inactivePlugins.map {
-            $0.copy(active: false)
-        }
-
-        return activePlugins + inactivePlugins
+        return systemStatus
     }
 }
 
 /// System Status endpoint returns the requested account in the `data` key. This entity
 /// allows us to parse it with JSONDecoder.
 ///
-private struct SystemStatusEnvelope: Decodable {
+struct SystemStatusEnvelope: Decodable {
     let systemStatus: SystemStatus
 
     private enum CodingKeys: String, CodingKey {

--- a/Networking/Networking/Model/SystemStatus.swift
+++ b/Networking/Networking/Model/SystemStatus.swift
@@ -3,13 +3,16 @@
 public struct SystemStatus: Decodable {
     let activePlugins: [SystemPlugin]
     let inactivePlugins: [SystemPlugin]
+    let environment: Environment
 
     public init(
         activePlugins: [SystemPlugin],
-        inactivePlugins: [SystemPlugin]
+        inactivePlugins: [SystemPlugin],
+        environment: Environment
     ) {
         self.activePlugins = activePlugins
         self.inactivePlugins = inactivePlugins
+        self.environment = environment
     }
 
     /// The public initializer for System Status.
@@ -18,10 +21,12 @@ public struct SystemStatus: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let activePlugins = try container.decode([SystemPlugin].self, forKey: .activePlugins)
         let inactivePlugins = try container.decode([SystemPlugin].self, forKey: .inactivePlugins)
+        let environment = try container.decode(Environment.self, forKey: .environment)
 
         self.init(
             activePlugins: activePlugins,
-            inactivePlugins: inactivePlugins
+            inactivePlugins: inactivePlugins,
+            environment: environment
         )
     }
 }

--- a/Networking/Networking/Model/SystemStatus.swift
+++ b/Networking/Networking/Model/SystemStatus.swift
@@ -3,12 +3,12 @@
 public struct SystemStatus: Decodable {
     let activePlugins: [SystemPlugin]
     let inactivePlugins: [SystemPlugin]
-    let environment: Environment
+    let environment: Environment?
 
     public init(
         activePlugins: [SystemPlugin],
         inactivePlugins: [SystemPlugin],
-        environment: Environment
+        environment: Environment?
     ) {
         self.activePlugins = activePlugins
         self.inactivePlugins = inactivePlugins
@@ -21,7 +21,7 @@ public struct SystemStatus: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let activePlugins = try container.decode([SystemPlugin].self, forKey: .activePlugins)
         let inactivePlugins = try container.decode([SystemPlugin].self, forKey: .inactivePlugins)
-        let environment = try container.decode(Environment.self, forKey: .environment)
+        let environment = try container.decodeIfPresent(Environment.self, forKey: .environment)
 
         self.init(
             activePlugins: activePlugins,

--- a/Networking/Networking/Model/SystemStatus.swift
+++ b/Networking/Networking/Model/SystemStatus.swift
@@ -1,5 +1,4 @@
 /// Represent a System Status.
-/// Note: We are only decoding the active and inactive plugins portions at the moment.
 ///
 public struct SystemStatus: Decodable {
     let activePlugins: [SystemPlugin]
@@ -31,5 +30,12 @@ private extension SystemStatus {
     enum CodingKeys: String, CodingKey {
         case activePlugins = "active_plugins"
         case inactivePlugins = "inactive_plugins"
+        case dropinMustUsePlugins = "dropins_mu_plugins"
+        case environment
+        case database
+        case theme
+        case settings
+        case pages
+        case postTypeCounts = "post_type_counts"
     }
 }

--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
@@ -3,8 +3,160 @@ import Foundation
 public extension SystemStatus {
     /// Subtype for details about environment in system status.
     ///
-    struct Environment {
-        
+    struct Environment: Decodable {
+        let homeURL: String
+        let siteURL: String
+        let version: String
+        let logDirectoryWritable: Bool
+        let wpVersion: String
+        let wpMultisite: Bool
+        let wpMemoryLimit: Int64
+        let wpDebugMode: Bool
+        let wpCron: Bool
+        let language: String
+        let externalObjectCache: Bool
+        let serverInfo: String
+        let phpVersion: String
+        let phpPostMaxSize: Int64
+        let phpMaxExecutionTime: Int64
+        let phpMaxInputVars: Int64
+        let curlVersion: String
+        let suhosinInstalled: Bool
+        let maxUploadSize: Int64
+        let mysqlVersion: String
+        let defaultTimezone: String
+        let fsockopenOrCurlEnabled: Bool
+        let soapClientEnabled: Bool
+        let domDocumentEnabled: Bool
+        let gzipEnabled: Bool
+        let mbstringEnabled: Bool
+        let remotePostSuccessful: Bool
+        let remoteGetSuccessful: Bool
+
+        public init(
+            homeURL: String,
+            siteURL: String,
+            version: String,
+            logDirectoryWritable: Bool,
+            wpVersion: String,
+            wpMultisite: Bool,
+            wpMemoryLimit: Int64,
+            wpDebugMode: Bool,
+            wpCron: Bool,
+            language: String,
+            externalObjectCache: Bool,
+            serverInfo: String,
+            phpVersion: String,
+            phpPostMaxSize: Int64,
+            phpMaxExecutionTime: Int64,
+            phpMaxInputVars: Int64,
+            curlVersion: String,
+            suhosinInstalled: Bool,
+            maxUploadSize: Int64,
+            mysqlVersion: String,
+            defaultTimezone: String,
+            fsockopenOrCurlEnabled: Bool,
+            soapClientEnabled: Bool,
+            domDocumentEnabled: Bool,
+            gzipEnabled: Bool,
+            mbstringEnabled: Bool,
+            remotePostSuccessful: Bool,
+            remoteGetSuccessful: Bool
+        ) {
+            self.homeURL = homeURL
+            self.siteURL = siteURL
+            self.version = version
+            self.logDirectoryWritable = logDirectoryWritable
+            self.wpVersion = wpVersion
+            self.wpMultisite = wpMultisite
+            self.wpMemoryLimit = wpMemoryLimit
+            self.wpDebugMode = wpDebugMode
+            self.wpCron = wpCron
+            self.language = language
+            self.externalObjectCache = externalObjectCache
+            self.serverInfo = serverInfo
+            self.phpVersion = phpVersion
+            self.phpPostMaxSize = phpPostMaxSize
+            self.phpMaxExecutionTime = phpMaxExecutionTime
+            self.phpMaxInputVars = phpMaxInputVars
+            self.curlVersion = curlVersion
+            self.suhosinInstalled = suhosinInstalled
+            self.maxUploadSize = maxUploadSize
+            self.mysqlVersion = mysqlVersion
+            self.defaultTimezone = defaultTimezone
+            self.fsockopenOrCurlEnabled = fsockopenOrCurlEnabled
+            self.soapClientEnabled = soapClientEnabled
+            self.domDocumentEnabled = domDocumentEnabled
+            self.gzipEnabled = gzipEnabled
+            self.mbstringEnabled = mbstringEnabled
+            self.remotePostSuccessful = remotePostSuccessful
+            self.remoteGetSuccessful = remoteGetSuccessful
+        }
+
+        /// The public initializer for Environment.
+        ///
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let homeURL = try container.decode(String.self, forKey: .homeURL)
+            let siteURL = try container.decode(String.self, forKey: .siteURL)
+            let version = try container.decode(String.self, forKey: .version)
+            let logDirectoryWritable = try container.decode(Bool.self, forKey: .logDirectoryWritable)
+            let wpVersion = try container.decode(String.self, forKey: .wpVersion)
+            let wpMultisite = try container.decode(Bool.self, forKey: .wpMultisite)
+            let wpMemoryLimit = try container.decode(Int64.self, forKey: .wpMemoryLimit)
+            let wpDebugMode = try container.decode(Bool.self, forKey: .wpDebugMode)
+            let wpCron = try container.decode(Bool.self, forKey: .wpCron)
+            let language = try container.decode(String.self, forKey: .language)
+            let externalObjectCache = try container.decode(Bool.self, forKey: .externalObjectCache)
+            let serverInfo = try container.decode(String.self, forKey: .serverInfo)
+            let phpVersion = try container.decode(String.self, forKey: .phpVersion)
+            let phpPostMaxSize = try container.decode(Int64.self, forKey: .phpPostMaxSize)
+            let phpMaxExecutionTime = try container.decode(Int64.self, forKey: .phpMaxExecutionTime)
+            let phpMaxInputVars = try container.decode(Int64.self, forKey: .phpMaxInputVars)
+            let curlVersion = try container.decode(String.self, forKey: .curlVersion)
+            let suhosinInstalled = try container.decode(Bool.self, forKey: .suhosinInstalled)
+            let maxUploadSize = try container.decode(Int64.self, forKey: .maxUploadSize)
+            let mysqlVersion = try container.decode(String.self, forKey: .mysqlVersion)
+            let defaultTimezone = try container.decode(String.self, forKey: .defaultTimezone)
+            let fsockopenOrCurlEnabled = try container.decode(Bool.self, forKey: .fsockopenOrCurlEnabled)
+            let soapClientEnabled = try container.decode(Bool.self, forKey: .soapClientEnabled)
+            let domDocumentEnabled = try container.decode(Bool.self, forKey: .domDocumentEnabled)
+            let gzipEnabled = try container.decode(Bool.self, forKey: .gzipEnabled)
+            let mbstringEnabled = try container.decode(Bool.self, forKey: .mbstringEnabled)
+            let remotePostSuccessful = try container.decode(Bool.self, forKey: .remotePostSuccessful)
+            let remoteGetSuccessful = try container.decode(Bool.self, forKey: .remoteGetSuccessful)
+
+            self.init(
+                homeURL: homeURL,
+                siteURL: siteURL,
+                version: version,
+                logDirectoryWritable: logDirectoryWritable,
+                wpVersion: wpVersion,
+                wpMultisite: wpMultisite,
+                wpMemoryLimit: wpMemoryLimit,
+                wpDebugMode: wpDebugMode,
+                wpCron: wpCron,
+                language: language,
+                externalObjectCache: externalObjectCache,
+                serverInfo: serverInfo,
+                phpVersion: phpVersion,
+                phpPostMaxSize: phpPostMaxSize,
+                phpMaxExecutionTime: phpMaxExecutionTime,
+                phpMaxInputVars: phpMaxInputVars,
+                curlVersion: curlVersion,
+                suhosinInstalled: suhosinInstalled,
+                maxUploadSize: maxUploadSize,
+                mysqlVersion: mysqlVersion,
+                defaultTimezone: defaultTimezone,
+                fsockopenOrCurlEnabled: fsockopenOrCurlEnabled,
+                soapClientEnabled: soapClientEnabled,
+                domDocumentEnabled: domDocumentEnabled,
+                gzipEnabled: gzipEnabled,
+                mbstringEnabled: mbstringEnabled,
+                remotePostSuccessful: remotePostSuccessful,
+                remoteGetSuccessful: remoteGetSuccessful
+            )
+        }
     }
 }
 
@@ -13,7 +165,30 @@ private extension SystemStatus.Environment {
         case homeURL = "home_url"
         case siteURL = "site_url"
         case version
-//        case 
+        case logDirectoryWritable = "log_directory_writable"
+        case wpVersion = "wp_version"
+        case wpMultisite = "wp_multisite"
+        case wpMemoryLimit = "wp_memory_limit"
+        case wpDebugMode = "wp_debug_mode"
+        case wpCron = "wp_cron"
+        case language
+        case externalObjectCache = "external_object_cache"
+        case serverInfo = "server_info"
+        case phpVersion = "php_version"
+        case phpPostMaxSize = "php_post_max_size"
+        case phpMaxExecutionTime = "php_max_execution_time"
+        case phpMaxInputVars = "php_max_input_vars"
+        case curlVersion = "curl_version"
+        case suhosinInstalled = "suhosin_installed"
+        case maxUploadSize = "max_upload_size"
+        case mysqlVersion = "mysql_version_string"
+        case defaultTimezone = "default_timezone"
+        case fsockopenOrCurlEnabled = "fsockopen_or_curl_enabled"
+        case soapClientEnabled = "soapclient_enabled"
+        case domDocumentEnabled = "domdocument_enabled"
+        case gzipEnabled = "gzip_enabled"
+        case mbstringEnabled = "mbstring_enabled"
+        case remotePostSuccessful = "remote_post_successful"
+        case remoteGetSuccessful = "remote_get_successful"
     }
-    
 }

--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public extension SystemStatus {
+    /// Subtype for details about environment in system status.
+    ///
+    struct Environment {
+        
+    }
+}
+
+private extension SystemStatus.Environment {
+    enum CodingKeys: String, CodingKey {
+        case homeURL = "home_url"
+        case siteURL = "site_url"
+        case version
+//        case 
+    }
+    
+}

--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
@@ -14,7 +14,7 @@ public extension SystemStatus {
         let wpDebugMode: Bool
         let wpCron: Bool
         let language: String
-        let externalObjectCache: Bool
+        let externalObjectCache: Bool? // this can return null so keeping it optional
         let serverInfo: String
         let phpVersion: String
         let phpPostMaxSize: Int64
@@ -32,131 +32,6 @@ public extension SystemStatus {
         let mbstringEnabled: Bool
         let remotePostSuccessful: Bool
         let remoteGetSuccessful: Bool
-
-        public init(
-            homeURL: String,
-            siteURL: String,
-            version: String,
-            logDirectoryWritable: Bool,
-            wpVersion: String,
-            wpMultisite: Bool,
-            wpMemoryLimit: Int64,
-            wpDebugMode: Bool,
-            wpCron: Bool,
-            language: String,
-            externalObjectCache: Bool,
-            serverInfo: String,
-            phpVersion: String,
-            phpPostMaxSize: Int64,
-            phpMaxExecutionTime: Int64,
-            phpMaxInputVars: Int64,
-            curlVersion: String,
-            suhosinInstalled: Bool,
-            maxUploadSize: Int64,
-            mysqlVersion: String,
-            defaultTimezone: String,
-            fsockopenOrCurlEnabled: Bool,
-            soapClientEnabled: Bool,
-            domDocumentEnabled: Bool,
-            gzipEnabled: Bool,
-            mbstringEnabled: Bool,
-            remotePostSuccessful: Bool,
-            remoteGetSuccessful: Bool
-        ) {
-            self.homeURL = homeURL
-            self.siteURL = siteURL
-            self.version = version
-            self.logDirectoryWritable = logDirectoryWritable
-            self.wpVersion = wpVersion
-            self.wpMultisite = wpMultisite
-            self.wpMemoryLimit = wpMemoryLimit
-            self.wpDebugMode = wpDebugMode
-            self.wpCron = wpCron
-            self.language = language
-            self.externalObjectCache = externalObjectCache
-            self.serverInfo = serverInfo
-            self.phpVersion = phpVersion
-            self.phpPostMaxSize = phpPostMaxSize
-            self.phpMaxExecutionTime = phpMaxExecutionTime
-            self.phpMaxInputVars = phpMaxInputVars
-            self.curlVersion = curlVersion
-            self.suhosinInstalled = suhosinInstalled
-            self.maxUploadSize = maxUploadSize
-            self.mysqlVersion = mysqlVersion
-            self.defaultTimezone = defaultTimezone
-            self.fsockopenOrCurlEnabled = fsockopenOrCurlEnabled
-            self.soapClientEnabled = soapClientEnabled
-            self.domDocumentEnabled = domDocumentEnabled
-            self.gzipEnabled = gzipEnabled
-            self.mbstringEnabled = mbstringEnabled
-            self.remotePostSuccessful = remotePostSuccessful
-            self.remoteGetSuccessful = remoteGetSuccessful
-        }
-
-        /// The public initializer for Environment.
-        ///
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            let homeURL = try container.decode(String.self, forKey: .homeURL)
-            let siteURL = try container.decode(String.self, forKey: .siteURL)
-            let version = try container.decode(String.self, forKey: .version)
-            let logDirectoryWritable = try container.decode(Bool.self, forKey: .logDirectoryWritable)
-            let wpVersion = try container.decode(String.self, forKey: .wpVersion)
-            let wpMultisite = try container.decode(Bool.self, forKey: .wpMultisite)
-            let wpMemoryLimit = try container.decode(Int64.self, forKey: .wpMemoryLimit)
-            let wpDebugMode = try container.decode(Bool.self, forKey: .wpDebugMode)
-            let wpCron = try container.decode(Bool.self, forKey: .wpCron)
-            let language = try container.decode(String.self, forKey: .language)
-            let externalObjectCache = (try? container.decode(Bool.self, forKey: .externalObjectCache)) ?? false
-            let serverInfo = try container.decode(String.self, forKey: .serverInfo)
-            let phpVersion = try container.decode(String.self, forKey: .phpVersion)
-            let phpPostMaxSize = try container.decode(Int64.self, forKey: .phpPostMaxSize)
-            let phpMaxExecutionTime = try container.decode(Int64.self, forKey: .phpMaxExecutionTime)
-            let phpMaxInputVars = try container.decode(Int64.self, forKey: .phpMaxInputVars)
-            let curlVersion = try container.decode(String.self, forKey: .curlVersion)
-            let suhosinInstalled = try container.decode(Bool.self, forKey: .suhosinInstalled)
-            let maxUploadSize = try container.decode(Int64.self, forKey: .maxUploadSize)
-            let mysqlVersion = try container.decode(String.self, forKey: .mysqlVersion)
-            let defaultTimezone = try container.decode(String.self, forKey: .defaultTimezone)
-            let fsockopenOrCurlEnabled = try container.decode(Bool.self, forKey: .fsockopenOrCurlEnabled)
-            let soapClientEnabled = try container.decode(Bool.self, forKey: .soapClientEnabled)
-            let domDocumentEnabled = try container.decode(Bool.self, forKey: .domDocumentEnabled)
-            let gzipEnabled = try container.decode(Bool.self, forKey: .gzipEnabled)
-            let mbstringEnabled = try container.decode(Bool.self, forKey: .mbstringEnabled)
-            let remotePostSuccessful = try container.decode(Bool.self, forKey: .remotePostSuccessful)
-            let remoteGetSuccessful = try container.decode(Bool.self, forKey: .remoteGetSuccessful)
-
-            self.init(
-                homeURL: homeURL,
-                siteURL: siteURL,
-                version: version,
-                logDirectoryWritable: logDirectoryWritable,
-                wpVersion: wpVersion,
-                wpMultisite: wpMultisite,
-                wpMemoryLimit: wpMemoryLimit,
-                wpDebugMode: wpDebugMode,
-                wpCron: wpCron,
-                language: language,
-                externalObjectCache: externalObjectCache,
-                serverInfo: serverInfo,
-                phpVersion: phpVersion,
-                phpPostMaxSize: phpPostMaxSize,
-                phpMaxExecutionTime: phpMaxExecutionTime,
-                phpMaxInputVars: phpMaxInputVars,
-                curlVersion: curlVersion,
-                suhosinInstalled: suhosinInstalled,
-                maxUploadSize: maxUploadSize,
-                mysqlVersion: mysqlVersion,
-                defaultTimezone: defaultTimezone,
-                fsockopenOrCurlEnabled: fsockopenOrCurlEnabled,
-                soapClientEnabled: soapClientEnabled,
-                domDocumentEnabled: domDocumentEnabled,
-                gzipEnabled: gzipEnabled,
-                mbstringEnabled: mbstringEnabled,
-                remotePostSuccessful: remotePostSuccessful,
-                remoteGetSuccessful: remoteGetSuccessful
-            )
-        }
     }
 }
 

--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
@@ -107,7 +107,7 @@ public extension SystemStatus {
             let wpDebugMode = try container.decode(Bool.self, forKey: .wpDebugMode)
             let wpCron = try container.decode(Bool.self, forKey: .wpCron)
             let language = try container.decode(String.self, forKey: .language)
-            let externalObjectCache = try container.decode(Bool.self, forKey: .externalObjectCache)
+            let externalObjectCache = (try? container.decode(Bool.self, forKey: .externalObjectCache)) ?? false
             let serverInfo = try container.decode(String.self, forKey: .serverInfo)
             let phpVersion = try container.decode(String.self, forKey: .phpVersion)
             let phpPostMaxSize = try container.decode(Int64.self, forKey: .phpPostMaxSize)

--- a/Networking/Networking/Remote/SystemStatusRemote.swift
+++ b/Networking/Networking/Remote/SystemStatusRemote.swift
@@ -17,7 +17,7 @@ public class SystemStatusRemote: Remote {
             ParameterKeys.fields: [ParameterValues.activePlugins, ParameterValues.inactivePlugins]
         ]
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
-        let mapper = SystemStatusMapper(siteID: siteID)
+        let mapper = SystemPluginMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
@@ -97,6 +97,6 @@ private extension SystemPluginMapperTests {
     /// Returns the SystemStatusMapper output upon receiving `systemPlugins`
     ///
     func mapLoadSystemStatusResponse() throws -> [SystemPlugin] {
-        return try mapPlugins(from: "systemStatus")
+        return try mapPlugins(from: "systemStatusWithPluginsOnly")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
@@ -1,9 +1,9 @@
 import XCTest
 @testable import Networking
 
-/// SystemStatusMapperTests Unit Tests
+/// SystemPluginMapper Unit Tests
 ///
-class SystemStatusMapperTests: XCTestCase {
+final class SystemPluginMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
@@ -82,7 +82,7 @@ class SystemStatusMapperTests: XCTestCase {
 
 /// Private Methods.
 ///
-private extension SystemStatusMapperTests {
+private extension SystemPluginMapperTests {
 
     /// Returns the SystemStatusMapper output upon receiving `filename` (Data Encoded)
     ///
@@ -91,7 +91,7 @@ private extension SystemStatusMapperTests {
             return []
         }
 
-        return try SystemStatusMapper(siteID: dummySiteID).map(response: response)
+        return try SystemPluginMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the SystemStatusMapper output upon receiving `systemPlugins`

--- a/Networking/NetworkingTests/Responses/systemStatus.json
+++ b/Networking/NetworkingTests/Responses/systemStatus.json
@@ -1,5 +1,269 @@
 {
-    "data":{
+    "data": {
+        "environment": {
+            "home_url": "https://additional-beetle.jurassic.ninja",
+            "site_url": "https://additional-beetle.jurassic.ninja",
+            "version": "5.9.0",
+            "log_directory": "/srv/users/user9fe179e8/apps/user9fe179e8/public/wp-content/uploads/wc-logs/",
+            "log_directory_writable": true,
+            "wp_version": "5.8.2",
+            "wp_multisite": false,
+            "wp_memory_limit": 268435456,
+            "wp_debug_mode": true,
+            "wp_cron": true,
+            "language": "en_US",
+            "external_object_cache": null,
+            "server_info": "Apache/2.4.51 (Unix) OpenSSL/1.0.2g",
+            "php_version": "7.4.26",
+            "php_post_max_size": 1073741824,
+            "php_max_execution_time": 30,
+            "php_max_input_vars": 5000,
+            "curl_version": "7.47.0, OpenSSL/1.0.2g",
+            "suhosin_installed": false,
+            "max_upload_size": 536870912,
+            "mysql_version": "5.7.33",
+            "mysql_version_string": "5.7.33-0ubuntu0.16.04.1-log",
+            "default_timezone": "UTC",
+            "fsockopen_or_curl_enabled": true,
+            "soapclient_enabled": true,
+            "domdocument_enabled": true,
+            "gzip_enabled": true,
+            "mbstring_enabled": true,
+            "remote_post_successful": true,
+            "remote_post_response": 200,
+            "remote_get_successful": true,
+            "remote_get_response": 200
+        },
+        "database": {
+            "wc_database_version": "5.9.0",
+            "database_prefix": "wp_",
+            "maxmind_geoip_database": "",
+            "database_tables": {
+                "woocommerce": {
+                    "wp_woocommerce_sessions": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_api_keys": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_attribute_taxonomies": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_downloadable_product_permissions": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_order_items": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_order_itemmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_tax_rates": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_tax_rate_locations": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_shipping_zones": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_shipping_zone_locations": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_shipping_zone_methods": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_payment_tokens": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_payment_tokenmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_log": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    }
+                },
+                "other": {
+                    "wp_actionscheduler_actions": {
+                        "data": "0.02",
+                        "index": "0.13",
+                        "engine": "InnoDB"
+                    },
+                    "wp_actionscheduler_claims": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_actionscheduler_groups": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_actionscheduler_logs": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_commentmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_comments": {
+                        "data": "0.02",
+                        "index": "0.09",
+                        "engine": "InnoDB"
+                    },
+                    "wp_links": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_options": {
+                        "data": "3.48",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_postmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_posts": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_termmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_terms": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_term_relationships": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_term_taxonomy": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_usermeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_users": {
+                        "data": "0.02",
+                        "index": "0.05",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_admin_notes": {
+                        "data": "0.05",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_admin_note_actions": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_category_lookup": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_customer_lookup": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_download_log": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_coupon_lookup": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_product_lookup": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_stats": {
+                        "data": "0.02",
+                        "index": "0.05",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_tax_lookup": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_product_meta_lookup": {
+                        "data": "0.02",
+                        "index": "0.09",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_reserved_stock": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_tax_rate_classes": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_webhooks": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    }
+                }
+            },
+            "database_size": {
+                "data": 4.3499999999999925,
+                "index": 1.4300000000000006
+            }
+        },
         "active_plugins":[
             {
                 "plugin":"woocommerce\/woocommerce.php",
@@ -63,7 +327,141 @@
                 "author_url":"http:\/\/ma.tt\/",
                 "network_activated":false
             }
+        ],
+        "dropins_mu_plugins": {
+            "dropins": [],
+            "mu_plugins": []
+        },
+        "theme": {
+            "name": "Twenty Twenty-One",
+            "version": "1.4",
+            "version_latest": "1.4",
+            "author_url": "https://wordpress.org/",
+            "is_child_theme": false,
+            "has_woocommerce_support": true,
+            "has_woocommerce_file": false,
+            "has_outdated_templates": false,
+            "overrides": [],
+            "parent_name": "",
+            "parent_version": "",
+            "parent_version_latest": "",
+            "parent_author_url": ""
+        },
+        "settings": {
+            "api_enabled": false,
+            "force_ssl": false,
+            "currency": "USD",
+            "currency_symbol": "&#36;",
+            "currency_position": "left",
+            "thousand_separator": ",",
+            "decimal_separator": ".",
+            "number_of_decimals": 2,
+            "geolocation_enabled": false,
+            "taxonomies": {
+                "external": "external",
+                "grouped": "grouped",
+                "simple": "simple",
+                "subscription": "subscription",
+                "variable": "variable",
+                "variable-subscription": "variable subscription"
+            },
+            "product_visibility_terms": {
+                "exclude-from-catalog": "exclude-from-catalog",
+                "exclude-from-search": "exclude-from-search",
+                "featured": "featured",
+                "outofstock": "outofstock",
+                "rated-1": "rated-1",
+                "rated-2": "rated-2",
+                "rated-3": "rated-3",
+                "rated-4": "rated-4",
+                "rated-5": "rated-5"
+            },
+            "woocommerce_com_connected": "no"
+        },
+        "security": {
+            "secure_connection": true,
+            "hide_errors": false
+        },
+        "pages": [
+            {
+                "page_name": "Shop base",
+                "page_id": "5",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "",
+                "block": "",
+                "shortcode_required": false,
+                "shortcode_present": false,
+                "block_present": false,
+                "block_required": false
+            },
+            {
+                "page_name": "Cart",
+                "page_id": "6",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "[woocommerce_cart]",
+                "block": "woocommerce/cart",
+                "shortcode_required": true,
+                "shortcode_present": true,
+                "block_present": false,
+                "block_required": true
+            },
+            {
+                "page_name": "Checkout",
+                "page_id": "7",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "[woocommerce_checkout]",
+                "block": "woocommerce/checkout",
+                "shortcode_required": true,
+                "shortcode_present": true,
+                "block_present": false,
+                "block_required": true
+            },
+            {
+                "page_name": "My account",
+                "page_id": "8",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "[woocommerce_my_account]",
+                "block": "",
+                "shortcode_required": true,
+                "shortcode_present": true,
+                "block_present": false,
+                "block_required": false
+            },
+            {
+                "page_name": "Terms and conditions",
+                "page_id": "",
+                "page_set": false,
+                "page_exists": false,
+                "page_visible": false,
+                "shortcode": "",
+                "block": "",
+                "shortcode_required": false,
+                "shortcode_present": false,
+                "block_present": false,
+                "block_required": false
+            }
+        ],
+        "post_type_counts": [
+            {
+                "type": "attachment",
+                "count": "1"
+            },
+            {
+                "type": "page",
+                "count": "7"
+            },
+            {
+                "type": "post",
+                "count": "2"
+            }
         ]
     }
 }
-

--- a/Networking/NetworkingTests/Responses/systemStatusWithPluginsOnly.json
+++ b/Networking/NetworkingTests/Responses/systemStatusWithPluginsOnly.json
@@ -1,0 +1,68 @@
+{
+    "data": {
+        "active_plugins":[
+            {
+                "plugin":"woocommerce\/woocommerce.php",
+                "name":"WooCommerce",
+                "version":"5.8.0",
+                "version_latest":"5.8.0",
+                "url":"https:\/\/woocommerce.com\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com",
+                "network_activated":false
+            },
+            {
+                "plugin":"woocommerce-payments\/woocommerce-payments.php",
+                "name":"WooCommerce Payments",
+                "version":"3.1.0",
+                "version_latest":"3.1.0",
+                "url":"https:\/\/woocommerce.com\/payments\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"woocommerce-subscriptions\/woocommerce-subscriptions",
+                "name":"WooCommerce Subscriptions",
+                "version":"3.1.6",
+                "version_latest":"3.1.6",
+                "url":"https:\/\/www.woocommerce.com\/products\/woocommerce-subscriptions\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"jetpack\/jetpack.php",
+                "name":"Jetpack",
+                "version":"10.2",
+                "version_latest":"10.2.1",
+                "url":"https:\/\/jetpack.com",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/jetpack.com",
+                "network_activated":false
+            }
+        ],
+        "inactive_plugins":[
+            {
+                "plugin":"akismet\/akismet.php",
+                "name":"Akismet Anti-Spam",
+                "version":"4.2.1",
+                "version_latest":"4.2.1",
+                "url":"https:\/\/akismet.com\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"hello.php",
+                "name":"Hello Dolly",
+                "version":"1.7.2",
+                "version_latest":"1.7.2",
+                "url":"http:\/\/wordpress.org\/plugins\/hello-dolly\/",
+                "author_name":"Matt Mullenweg",
+                "author_url":"http:\/\/ma.tt\/",
+                "network_activated":false
+            }
+        ]
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/system_status/status.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/system_status/status.json
@@ -15,130 +15,530 @@
         "status": 200,
         "jsonBody": {
             "data": {
-                "active_plugins": [{
-                    "plugin": "akismet\/akismet.php",
-                    "name": "Akismet Anti-Spam",
-                    "version": "4.2.1",
-                    "version_latest": "4.2.1",
-                    "url": "https:\/\/akismet.com\/",
-                    "author_name": "Automattic",
-                    "author_url": "https:\/\/automattic.com\/wordpress-plugins\/",
-                    "network_activated": false
-                }, {
-                    "plugin": "amp\/amp.php",
-                    "name": "AMP",
-                    "version": "2.1.4",
-                    "version_latest": "2.1.4",
-                    "url": "https:\/\/amp-wp.org",
-                    "author_name": "AMP Project Contributors",
-                    "author_url": "https:\/\/github.com\/ampproject\/amp-wp\/graphs\/contributors",
-                    "network_activated": false
-                }, {
-                    "plugin": "coblocks\/class-coblocks.php",
-                    "name": "CoBlocks",
-                    "version": "2.19.1",
-                    "version_latest": "2.19.1",
-                    "url": "",
-                    "author_name": "GoDaddy",
-                    "author_url": "https:\/\/www.godaddy.com",
-                    "network_activated": false
-                }, {
-                    "plugin": "crowdsignal-forms\/crowdsignal-forms.php",
-                    "name": "Crowdsignal Forms",
-                    "version": "1.5.12",
-                    "version_latest": "1.5.12",
-                    "url": "https:\/\/crowdsignal.com\/crowdsignal-forms\/",
-                    "author_name": "Automattic",
-                    "author_url": "https:\/\/automattic.com\/",
-                    "network_activated": false
-                }, {
-                    "plugin": "full-site-editing\/full-site-editing-plugin.php",
-                    "name": "WordPress.com Editing Toolkit",
-                    "version": "3.20657",
-                    "version_latest": "3.20657",
-                    "url": "",
-                    "author_name": "Automattic",
-                    "author_url": "https:\/\/automattic.com\/wordpress-plugins\/",
-                    "network_activated": false
-                }, {
-                    "plugin": "gutenberg\/gutenberg.php",
-                    "name": "Gutenberg",
-                    "version": "12.0.1",
-                    "version_latest": "12.0.1",
-                    "url": "https:\/\/github.com\/WordPress\/gutenberg",
-                    "author_name": "Gutenberg Team",
-                    "author_url": "",
-                    "network_activated": false
-                }, {
-                    "plugin": "jetpack\/jetpack.php",
-                    "name": "Jetpack",
-                    "version": "10.4-a.9",
-                    "version_latest": "10.4-a.9",
-                    "url": "https:\/\/jetpack.com",
-                    "author_name": "Automattic",
-                    "author_url": "https:\/\/jetpack.com",
-                    "network_activated": false
-                }, {
-                    "plugin": "layout-grid\/index.php",
-                    "name": "Layout Grid",
-                    "version": "1.7.2",
-                    "version_latest": "1.7.2",
-                    "url": "",
-                    "author_name": "Automattic",
-                    "author_url": "https:\/\/automattic.com",
-                    "network_activated": false
-                }, {
-                    "plugin": "page-optimize\/page-optimize.php",
-                    "name": "Page Optimize",
-                    "version": "0.5.1",
-                    "version_latest": "0.5.1",
-                    "url": "https:\/\/wordpress.org\/plugins\/page-optimize\/",
-                    "author_name": "Automattic",
-                    "author_url": "http:\/\/automattic.com\/",
-                    "network_activated": false
-                }, {
-                    "plugin": "polldaddy\/polldaddy.php",
-                    "name": "Crowdsignal Polls &amp; Ratings",
-                    "version": "3.0.1",
-                    "version_latest": "3.0.1",
-                    "url": "http:\/\/wordpress.org\/extend\/plugins\/polldaddy\/",
-                    "author_name": "Automattic, Inc.",
-                    "author_url": "",
-                    "network_activated": false
-                }, {
-                    "plugin": "woocommerce-payments\/woocommerce-payments.php",
-                    "name": "WooCommerce Payments",
-                    "version": "3.3.0",
-                    "version_latest": "3.3.0",
-                    "url": "https:\/\/woocommerce.com\/payments\/",
-                    "author_name": "Automattic",
-                    "author_url": "https:\/\/woocommerce.com\/",
-                    "network_activated": false
-                }, {
-                    "plugin": "woocommerce\/woocommerce.php",
-                    "name": "WooCommerce",
+                "environment": {
+                    "home_url": "https://additional-beetle.jurassic.ninja",
+                    "site_url": "https://additional-beetle.jurassic.ninja",
                     "version": "5.9.0",
-                    "version_latest": "5.9.0",
-                    "url": "https:\/\/woocommerce.com\/",
-                    "author_name": "Automattic",
-                    "author_url": "https:\/\/woocommerce.com",
-                    "network_activated": false
-                }],
-                "inactive_plugins": [{
-                    "plugin": "classic-editor\/classic-editor.php",
-                    "name": "Classic Editor",
-                    "version": "1.6.2",
-                    "version_latest": "1.6.2",
-                    "url": "https:\/\/wordpress.org\/plugins\/classic-editor\/",
-                    "author_name": "WordPress Contributors",
-                    "author_url": "https:\/\/github.com\/WordPress\/classic-editor\/",
-                    "network_activated": false
-                }]
-            }
-        },
-        "headers": {
-            "Content-Type": "application/json",
-            "Connection": "keep-alive"
+                    "log_directory": "/srv/users/user9fe179e8/apps/user9fe179e8/public/wp-content/uploads/wc-logs/",
+                    "log_directory_writable": true,
+                    "wp_version": "5.8.2",
+                    "wp_multisite": false,
+                    "wp_memory_limit": 268435456,
+                    "wp_debug_mode": true,
+                    "wp_cron": true,
+                    "language": "en_US",
+                    "external_object_cache": null,
+                    "server_info": "Apache/2.4.51 (Unix) OpenSSL/1.0.2g",
+                    "php_version": "7.4.26",
+                    "php_post_max_size": 1073741824,
+                    "php_max_execution_time": 30,
+                    "php_max_input_vars": 5000,
+                    "curl_version": "7.47.0, OpenSSL/1.0.2g",
+                    "suhosin_installed": false,
+                    "max_upload_size": 536870912,
+                    "mysql_version": "5.7.33",
+                    "mysql_version_string": "5.7.33-0ubuntu0.16.04.1-log",
+                    "default_timezone": "UTC",
+                    "fsockopen_or_curl_enabled": true,
+                    "soapclient_enabled": true,
+                    "domdocument_enabled": true,
+                    "gzip_enabled": true,
+                    "mbstring_enabled": true,
+                    "remote_post_successful": true,
+                    "remote_post_response": 200,
+                    "remote_get_successful": true,
+                    "remote_get_response": 200
+                },
+                "database": {
+                    "wc_database_version": "5.9.0",
+                    "database_prefix": "wp_",
+                    "maxmind_geoip_database": "",
+                    "database_tables": {
+                        "woocommerce": {
+                            "wp_woocommerce_sessions": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_api_keys": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_attribute_taxonomies": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_downloadable_product_permissions": {
+                                "data": "0.02",
+                                "index": "0.06",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_order_items": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_order_itemmeta": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_tax_rates": {
+                                "data": "0.02",
+                                "index": "0.06",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_tax_rate_locations": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_shipping_zones": {
+                                "data": "0.02",
+                                "index": "0.00",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_shipping_zone_locations": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_shipping_zone_methods": {
+                                "data": "0.02",
+                                "index": "0.00",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_payment_tokens": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_payment_tokenmeta": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_woocommerce_log": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            }
+                        },
+                        "other": {
+                            "wp_actionscheduler_actions": {
+                                "data": "0.02",
+                                "index": "0.13",
+                                "engine": "InnoDB"
+                            },
+                            "wp_actionscheduler_claims": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_actionscheduler_groups": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_actionscheduler_logs": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_commentmeta": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_comments": {
+                                "data": "0.02",
+                                "index": "0.09",
+                                "engine": "InnoDB"
+                            },
+                            "wp_links": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_options": {
+                                "data": "3.48",
+                                "index": "0.06",
+                                "engine": "InnoDB"
+                            },
+                            "wp_postmeta": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_posts": {
+                                "data": "0.02",
+                                "index": "0.06",
+                                "engine": "InnoDB"
+                            },
+                            "wp_termmeta": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_terms": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_term_relationships": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_term_taxonomy": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_usermeta": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_users": {
+                                "data": "0.02",
+                                "index": "0.05",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_admin_notes": {
+                                "data": "0.05",
+                                "index": "0.00",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_admin_note_actions": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_category_lookup": {
+                                "data": "0.02",
+                                "index": "0.00",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_customer_lookup": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_download_log": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_order_coupon_lookup": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_order_product_lookup": {
+                                "data": "0.02",
+                                "index": "0.06",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_order_stats": {
+                                "data": "0.02",
+                                "index": "0.05",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_order_tax_lookup": {
+                                "data": "0.02",
+                                "index": "0.03",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_product_meta_lookup": {
+                                "data": "0.02",
+                                "index": "0.09",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_reserved_stock": {
+                                "data": "0.02",
+                                "index": "0.00",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_tax_rate_classes": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            },
+                            "wp_wc_webhooks": {
+                                "data": "0.02",
+                                "index": "0.02",
+                                "engine": "InnoDB"
+                            }
+                        }
+                    },
+                    "database_size": {
+                        "data": 4.3499999999999925,
+                        "index": 1.4300000000000006
+                    }
+                },
+                "dropins_mu_plugins": {
+                    "dropins": [],
+                    "mu_plugins": []
+                },
+                "theme": {
+                    "name": "Twenty Twenty-One",
+                    "version": "1.4",
+                    "version_latest": "1.4",
+                    "author_url": "https://wordpress.org/",
+                    "is_child_theme": false,
+                    "has_woocommerce_support": true,
+                    "has_woocommerce_file": false,
+                    "has_outdated_templates": false,
+                    "overrides": [],
+                    "parent_name": "",
+                    "parent_version": "",
+                    "parent_version_latest": "",
+                    "parent_author_url": ""
+                },
+                "settings": {
+                    "api_enabled": false,
+                    "force_ssl": false,
+                    "currency": "USD",
+                    "currency_symbol": "&#36;",
+                    "currency_position": "left",
+                    "thousand_separator": ",",
+                    "decimal_separator": ".",
+                    "number_of_decimals": 2,
+                    "geolocation_enabled": false,
+                    "taxonomies": {
+                        "external": "external",
+                        "grouped": "grouped",
+                        "simple": "simple",
+                        "subscription": "subscription",
+                        "variable": "variable",
+                        "variable-subscription": "variable subscription"
+                    },
+                    "product_visibility_terms": {
+                        "exclude-from-catalog": "exclude-from-catalog",
+                        "exclude-from-search": "exclude-from-search",
+                        "featured": "featured",
+                        "outofstock": "outofstock",
+                        "rated-1": "rated-1",
+                        "rated-2": "rated-2",
+                        "rated-3": "rated-3",
+                        "rated-4": "rated-4",
+                        "rated-5": "rated-5"
+                    },
+                    "woocommerce_com_connected": "no"
+                },
+                "security": {
+                    "secure_connection": true,
+                    "hide_errors": false
+                },
+                "pages": [
+                    {
+                        "page_name": "Shop base",
+                        "page_id": "5",
+                        "page_set": true,
+                        "page_exists": true,
+                        "page_visible": true,
+                        "shortcode": "",
+                        "block": "",
+                        "shortcode_required": false,
+                        "shortcode_present": false,
+                        "block_present": false,
+                        "block_required": false
+                    },
+                    {
+                        "page_name": "Cart",
+                        "page_id": "6",
+                        "page_set": true,
+                        "page_exists": true,
+                        "page_visible": true,
+                        "shortcode": "[woocommerce_cart]",
+                        "block": "woocommerce/cart",
+                        "shortcode_required": true,
+                        "shortcode_present": true,
+                        "block_present": false,
+                        "block_required": true
+                    },
+                    {
+                        "page_name": "Checkout",
+                        "page_id": "7",
+                        "page_set": true,
+                        "page_exists": true,
+                        "page_visible": true,
+                        "shortcode": "[woocommerce_checkout]",
+                        "block": "woocommerce/checkout",
+                        "shortcode_required": true,
+                        "shortcode_present": true,
+                        "block_present": false,
+                        "block_required": true
+                    },
+                    {
+                        "page_name": "My account",
+                        "page_id": "8",
+                        "page_set": true,
+                        "page_exists": true,
+                        "page_visible": true,
+                        "shortcode": "[woocommerce_my_account]",
+                        "block": "",
+                        "shortcode_required": true,
+                        "shortcode_present": true,
+                        "block_present": false,
+                        "block_required": false
+                    },
+                    {
+                        "page_name": "Terms and conditions",
+                        "page_id": "",
+                        "page_set": false,
+                        "page_exists": false,
+                        "page_visible": false,
+                        "shortcode": "",
+                        "block": "",
+                        "shortcode_required": false,
+                        "shortcode_present": false,
+                        "block_present": false,
+                        "block_required": false
+                    }
+                ],
+                "post_type_counts": [
+                    {
+                        "type": "attachment",
+                        "count": "1"
+                    },
+                    {
+                        "type": "page",
+                        "count": "7"
+                    },
+                    {
+                        "type": "post",
+                        "count": "2"
+                    }
+                ]
+            },
+            "active_plugins": [{
+                "plugin": "akismet\/akismet.php",
+                "name": "Akismet Anti-Spam",
+                "version": "4.2.1",
+                "version_latest": "4.2.1",
+                "url": "https:\/\/akismet.com\/",
+                "author_name": "Automattic",
+                "author_url": "https:\/\/automattic.com\/wordpress-plugins\/",
+                "network_activated": false
+            }, {
+                "plugin": "amp\/amp.php",
+                "name": "AMP",
+                "version": "2.1.4",
+                "version_latest": "2.1.4",
+                "url": "https:\/\/amp-wp.org",
+                "author_name": "AMP Project Contributors",
+                "author_url": "https:\/\/github.com\/ampproject\/amp-wp\/graphs\/contributors",
+                "network_activated": false
+            }, {
+                "plugin": "coblocks\/class-coblocks.php",
+                "name": "CoBlocks",
+                "version": "2.19.1",
+                "version_latest": "2.19.1",
+                "url": "",
+                "author_name": "GoDaddy",
+                "author_url": "https:\/\/www.godaddy.com",
+                "network_activated": false
+            }, {
+                "plugin": "crowdsignal-forms\/crowdsignal-forms.php",
+                "name": "Crowdsignal Forms",
+                "version": "1.5.12",
+                "version_latest": "1.5.12",
+                "url": "https:\/\/crowdsignal.com\/crowdsignal-forms\/",
+                "author_name": "Automattic",
+                "author_url": "https:\/\/automattic.com\/",
+                "network_activated": false
+            }, {
+                "plugin": "full-site-editing\/full-site-editing-plugin.php",
+                "name": "WordPress.com Editing Toolkit",
+                "version": "3.20657",
+                "version_latest": "3.20657",
+                "url": "",
+                "author_name": "Automattic",
+                "author_url": "https:\/\/automattic.com\/wordpress-plugins\/",
+                "network_activated": false
+            }, {
+                "plugin": "gutenberg\/gutenberg.php",
+                "name": "Gutenberg",
+                "version": "12.0.1",
+                "version_latest": "12.0.1",
+                "url": "https:\/\/github.com\/WordPress\/gutenberg",
+                "author_name": "Gutenberg Team",
+                "author_url": "",
+                "network_activated": false
+            }, {
+                "plugin": "jetpack\/jetpack.php",
+                "name": "Jetpack",
+                "version": "10.4-a.9",
+                "version_latest": "10.4-a.9",
+                "url": "https:\/\/jetpack.com",
+                "author_name": "Automattic",
+                "author_url": "https:\/\/jetpack.com",
+                "network_activated": false
+            }, {
+                "plugin": "layout-grid\/index.php",
+                "name": "Layout Grid",
+                "version": "1.7.2",
+                "version_latest": "1.7.2",
+                "url": "",
+                "author_name": "Automattic",
+                "author_url": "https:\/\/automattic.com",
+                "network_activated": false
+            }, {
+                "plugin": "page-optimize\/page-optimize.php",
+                "name": "Page Optimize",
+                "version": "0.5.1",
+                "version_latest": "0.5.1",
+                "url": "https:\/\/wordpress.org\/plugins\/page-optimize\/",
+                "author_name": "Automattic",
+                "author_url": "http:\/\/automattic.com\/",
+                "network_activated": false
+            }, {
+                "plugin": "polldaddy\/polldaddy.php",
+                "name": "Crowdsignal Polls &amp; Ratings",
+                "version": "3.0.1",
+                "version_latest": "3.0.1",
+                "url": "http:\/\/wordpress.org\/extend\/plugins\/polldaddy\/",
+                "author_name": "Automattic, Inc.",
+                "author_url": "",
+                "network_activated": false
+            }, {
+                "plugin": "woocommerce-payments\/woocommerce-payments.php",
+                "name": "WooCommerce Payments",
+                "version": "3.3.0",
+                "version_latest": "3.3.0",
+                "url": "https:\/\/woocommerce.com\/payments\/",
+                "author_name": "Automattic",
+                "author_url": "https:\/\/woocommerce.com\/",
+                "network_activated": false
+            }, {
+                "plugin": "woocommerce\/woocommerce.php",
+                "name": "WooCommerce",
+                "version": "5.9.0",
+                "version_latest": "5.9.0",
+                "url": "https:\/\/woocommerce.com\/",
+                "author_name": "Automattic",
+                "author_url": "https:\/\/woocommerce.com",
+                "network_activated": false
+            }],
+            "inactive_plugins": [{
+                "plugin": "classic-editor\/classic-editor.php",
+                "name": "Classic Editor",
+                "version": "1.6.2",
+                "version_latest": "1.6.2",
+                "url": "https:\/\/wordpress.org\/plugins\/classic-editor\/",
+                "author_name": "WordPress Contributors",
+                "author_url": "https:\/\/github.com\/WordPress\/classic-editor\/",
+                "network_activated": false
+            }]
         }
+    },
+    "headers": {
+        "Content-Type": "application/json",
+        "Connection": "keep-alive"
     }
+}
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5071 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently `SystemStatusMapper` is decoding response from `GET /wp-json/wc/v3/system_status` and returns a plugin list from there since previous usage includes only information about plugins.

For #5071 we want to get all information about system status, so this PR separates the old mapper into 2 different ones: one for plugins only and one for all information.

This PR also adds new type `Environment` for system status and updates unit tests and JSON file, hence the large number of file changes. Other changes will be added in another PR to avoid bloating this PR even more!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that CI (all unit tests) pass
- If possible, please follow the testing steps in #5341 to make sure that system plugins are still loaded correctly.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
