### PR TITLE
Order Creation: Add product to order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -99,16 +99,10 @@ private struct ProductsSection: View {
                 Text(NewOrder.Localization.products)
                     .headlineStyle()
 
-                // TODO: Add a product row for each product added to the order
-                let productRowViewModel = ProductRowViewModel(id: 1,
-                                                    name: "Love Ficus",
-                                                    sku: "123456",
-                                                    price: "20",
-                                                    stockStatusKey: "instock",
-                                                    stockQuantity: 7,
-                                                    manageStock: true,
-                                                    canChangeQuantity: true) // Temporary view model with fake data
-                ProductRow(viewModel: productRowViewModel)
+                ForEach(viewModel.productRows) { productRowViewModel in
+                    ProductRow(viewModel: productRowViewModel)
+                    Divider()
+                }
 
                 Button(NewOrder.Localization.addProduct) {
                     showAddProduct.toggle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -74,7 +74,10 @@ final class NewOrderViewModel: ObservableObject {
     /// View model for the product list
     ///
     lazy var addProductViewModel = {
-        AddProductToOrderViewModel(siteID: siteID, storageManager: storageManager)
+        AddProductToOrderViewModel(siteID: siteID, storageManager: storageManager, stores: stores) { [weak self] product in
+            guard let self = self else { return }
+            self.addProductToOrder(product)
+        }
     }()
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, storageManager: StorageManagerType = ServiceLocator.storageManager) {
@@ -207,5 +210,25 @@ private extension NewOrderViewModel {
                 return StatusBadgeViewModel(orderStatus: siteOrderStatus)
             }
             .assign(to: &$statusBadgeViewModel)
+    }
+
+    /// Adds a selected product (from the product list) to the order
+    ///
+    func addProductToOrder(_ product: Product) {
+        let newOrderItem = OrderItem(itemID: 0,
+                                     name: product.name,
+                                     productID: product.productID,
+                                     variationID: 0,
+                                     quantity: 1,
+                                     price: NSDecimalNumber(string: product.price),
+                                     sku: product.sku,
+                                     subtotal: product.price,
+                                     subtotalTax: "0",
+                                     taxClass: product.taxClass ?? "",
+                                     taxes: [],
+                                     total: product.price,
+                                     totalTax: "",
+                                     attributes: [])
+        orderDetails.products.append(newOrderItem)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -224,30 +224,7 @@ private extension NewOrderViewModel {
         productRows.append(productRowViewModel)
 
         // Add product to the order details
-        let orderItem = convertToOrderItem(product: product, quantity: 1)
+        let orderItem = product.toOrderItem(quantity: 1)
         orderDetails.items.append(orderItem)
-    }
-
-    /// Converts product to order item, so it can be added to the order
-    ///
-    func convertToOrderItem(product: Product, quantity: Decimal) -> OrderItem {
-        let price = NSDecimalNumber(string: product.price)
-        let total = quantity * price.decimalValue
-
-        return OrderItem(itemID: 0,
-                         name: product.name,
-                         productID: product.productID,
-                         variationID: 0,
-                         quantity: quantity,
-                         price: price,
-                         sku: nil,
-                         subtotal: "\(total)",
-                         subtotalTax: "",
-                         taxClass: "",
-                         taxes: [],
-                         total: "\(total)",
-                         totalTax: "0",
-                         attributes: []
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -19,6 +19,10 @@ struct AddProductToOrder: View {
                     List {
                         ForEach(viewModel.productRows) { rowViewModel in
                             ProductRow(viewModel: rowViewModel)
+                                .onTapGesture {
+                                    viewModel.selectProduct(rowViewModel.id)
+                                    isPresented.toggle()
+                                }
                                 .onAppear {
                                     if rowViewModel == viewModel.productRows.last {
                                         viewModel.syncNextPage()
@@ -78,7 +82,7 @@ private extension AddProductToOrder {
 
 struct AddProduct_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = AddProductToOrderViewModel(siteID: 123)
+        let viewModel = AddProductToOrderViewModel(siteID: 123, onProductSelected: { _ in })
 
         AddProductToOrder(isPresented: .constant(true), viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -82,7 +82,7 @@ private extension AddProductToOrder {
 
 struct AddProduct_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = AddProductToOrderViewModel(siteID: 123, onProductSelected: { _ in })
+        let viewModel = AddProductToOrderViewModel(siteID: 123)
 
         AddProductToOrder(isPresented: .constant(true), viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -40,6 +40,10 @@ final class AddProductToOrderViewModel: ObservableObject {
         products.map { .init(product: $0, canChangeQuantity: false) }
     }
 
+    /// Closure to be invoked when a product is selected
+    ///
+    let onProductSelected: (Product) -> Void
+
     // MARK: Sync & Storage properties
 
     /// Current sync status; used to determine what list view to display.
@@ -71,13 +75,26 @@ final class AddProductToOrderViewModel: ObservableObject {
         return resultsController
     }()
 
-    init(siteID: Int64, storageManager: StorageManagerType = ServiceLocator.storageManager, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores,
+         onProductSelected: @escaping (Product) -> Void) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
+        self.onProductSelected = onProductSelected
 
         configureSyncingCoordinator()
         configureProductsResultsController()
+    }
+
+    /// Select a product to add to the order
+    ///
+    func selectProduct(_ productID: Int64) {
+        guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
+            return
+        }
+        onProductSelected(selectedProduct)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -42,7 +42,7 @@ final class AddProductToOrderViewModel: ObservableObject {
 
     /// Closure to be invoked when a product is selected
     ///
-    let onProductSelected: (Product) -> Void
+    let onProductSelected: ((Product) -> Void)?
 
     // MARK: Sync & Storage properties
 
@@ -78,7 +78,7 @@ final class AddProductToOrderViewModel: ObservableObject {
     init(siteID: Int64,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         onProductSelected: @escaping (Product) -> Void) {
+         onProductSelected: ((Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
@@ -94,7 +94,7 @@ final class AddProductToOrderViewModel: ObservableObject {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }
-        onProductSelected(selectedProduct)
+        onProductSelected?(selectedProduct)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -14,7 +14,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable, Equatable {
     // MARK: Product properties
 
     /// Product ID
-    /// Required by SwiftUI as a unique identifier
     ///
     let id: Int64
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -5,13 +5,19 @@ import Yosemite
 class NewOrderViewModelTests: XCTestCase {
 
     let sampleSiteID: Int64 = 123
+    let sampleProductID: Int64 = 5
 
-    func test_view_model_starts_with_create_button_hidden() {
+    func test_view_model_inits_with_expected_values() {
         // Given
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+
+        // When
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
 
         // Then
         XCTAssertEqual(viewModel.navigationTrailingItem, .none)
+        XCTAssertEqual(viewModel.statusBadgeViewModel.title, "pending")
+        XCTAssertEqual(viewModel.productRows.count, 0)
     }
 
     func test_create_button_is_enabled_when_order_detail_changes_from_default_value() {
@@ -101,17 +107,6 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "Pending payment")
     }
 
-    func test_view_model_inits_order_status_as_pending_when_there_are_no_synced_statuses() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-
-        // When
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
-
-        // Then
-        XCTAssertEqual(viewModel.statusBadgeViewModel.title, "pending")
-    }
-
     func test_view_model_is_updated_when_order_status_updated() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -130,6 +125,23 @@ class NewOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "Processing")
+    }
+
+    func test_view_model_is_updated_when_product_is_added_to_order() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish")
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // When
+        viewModel.addProductViewModel.selectProduct(product.productID)
+
+        // Then
+        let expectedProductRow = ProductRowViewModel(product: product, canChangeQuantity: true)
+        let expectedOrderItem = product.toOrderItem(quantity: 1)
+        XCTAssertTrue(viewModel.productRows.contains(expectedProductRow), "Product rows do not contain expected product")
+        XCTAssertTrue(viewModel.orderDetails.items.contains(expectedOrderItem), "Order details do not contain expected order item")
     }
 }
 

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		B5F2AE9720EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F2AE9620EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift */; };
 		CC2C036C262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */; };
 		CC2C0372262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */; };
+		CC7D89F62767A9FB00046E8D /* Product+OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7D89F52767A9FB00046E8D /* Product+OrderItem.swift */; };
 		CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */; };
 		CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */; };
 		CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */; };
@@ -681,6 +682,7 @@
 		C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAccountSettings+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelPaymentMethod+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
+		CC7D89F52767A9FB00046E8D /* Product+OrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+OrderItem.swift"; sourceTree = "<group>"; };
 		CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+ReadOnlyType.swift"; sourceTree = "<group>"; };
 		CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderRefundCondensed+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatus+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -795,6 +797,7 @@
 			children = (
 				0212AC61242C68B600C51F6C /* ResultsController+SortProducts.swift */,
 				0248B3642459018100A271A4 /* ResultsController+FilterProducts.swift */,
+				CC7D89F52767A9FB00046E8D /* Product+OrderItem.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -1963,6 +1966,7 @@
 				022F00C224726090008CD97F /* SiteNotificationCountFileContents.swift in Sources */,
 				247CE7BC2582DC1E00F9D9D1 /* MockCustomer.swift in Sources */,
 				D87F614C22657B150031A13B /* AppSettingsStore.swift in Sources */,
+				CC7D89F62767A9FB00046E8D /* Product+OrderItem.swift in Sources */,
 				247CE850258325AC00F9D9D1 /* MockOrderNoteActionHandler.swift in Sources */,
 				4591A6B4274BB29000F51DCD /* StoredOrderSettings.swift in Sources */,
 				D8C11A5422DFAE9500D4A88D /* OrderStatsV4+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		CC2C036C262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */; };
 		CC2C0372262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */; };
 		CC7D89F62767A9FB00046E8D /* Product+OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7D89F52767A9FB00046E8D /* Product+OrderItem.swift */; };
+		CCC284152768FD8100F6CC8B /* Product+OrderItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC284142768FD8100F6CC8B /* Product+OrderItemTests.swift */; };
 		CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */; };
 		CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */; };
 		CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */; };
@@ -683,6 +684,7 @@
 		CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAccountSettings+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelPaymentMethod+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		CC7D89F52767A9FB00046E8D /* Product+OrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+OrderItem.swift"; sourceTree = "<group>"; };
+		CCC284142768FD8100F6CC8B /* Product+OrderItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+OrderItemTests.swift"; sourceTree = "<group>"; };
 		CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+ReadOnlyType.swift"; sourceTree = "<group>"; };
 		CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderRefundCondensed+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatus+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -807,6 +809,7 @@
 			children = (
 				0212AC66242C799B00C51F6C /* ResultsController+StorageProductTests.swift */,
 				0248B3662459020500A271A4 /* ResultsController+FilterProductTests.swift */,
+				CCC284142768FD8100F6CC8B /* Product+OrderItemTests.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -2083,6 +2086,7 @@
 				B5BC736820D1AA8F00B5B6FA /* AccountStoreTests.swift in Sources */,
 				0212AC67242C799B00C51F6C /* ResultsController+StorageProductTests.swift in Sources */,
 				D4CBAE6026D440FA00BBE6D1 /* MockAnnouncementsRemote.swift in Sources */,
+				CCC284152768FD8100F6CC8B /* Product+OrderItemTests.swift in Sources */,
 				578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */,
 				D87F615E2265B1BC0031A13B /* AppSettingsStoreTests.swift in Sources */,
 				02E7FFD52562226B00C53030 /* ShippingLabelStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Tools/Products/Product+OrderItem.swift
+++ b/Yosemite/Yosemite/Tools/Products/Product+OrderItem.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+extension Product {
+    /// Converts a `Product` to an `OrderItem`
+    ///
+    public func toOrderItem(quantity: Decimal) -> OrderItem {
+        let price = NSDecimalNumber(string: price)
+        let total = quantity * price.decimalValue
+
+        return OrderItem(itemID: 0,
+                         name: name,
+                         productID: productID,
+                         variationID: 0,
+                         quantity: quantity,
+                         price: price,
+                         sku: nil,
+                         subtotal: "\(total)",
+                         subtotalTax: "",
+                         taxClass: "",
+                         taxes: [],
+                         total: "\(total)",
+                         totalTax: "0",
+                         attributes: []
+        )
+    }
+}

--- a/Yosemite/YosemiteTests/Tools/Products/Product+OrderItemTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Products/Product+OrderItemTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Yosemite
+
+final class Product_OrderItemTests: XCTestCase {
+
+    func test_product_to_order_item() {
+        // Given
+        let productID: Int64 = 5
+        let name = "Test Product"
+        let quantity: Decimal = 2
+        let price: Decimal = 2.50
+        let total = (quantity * price).description
+        let product = Product.fake().copy(productID: productID, name: name, price: price.description)
+        let expectedOrderItem = OrderItem(itemID: 0,
+                                          name: name,
+                                          productID: productID,
+                                          variationID: 0,
+                                          quantity: quantity,
+                                          price: NSDecimalNumber(decimal: price),
+                                          sku: nil,
+                                          subtotal: total,
+                                          subtotalTax: "",
+                                          taxClass: "",
+                                          taxes: [],
+                                          total: total,
+                                          totalTax: "0",
+                                          attributes: [])
+
+        // Then
+        XCTAssertEqual(product.toOrderItem(quantity: quantity), expectedOrderItem)
+    }
+}


### PR DESCRIPTION
Part of: #5408
⚠️ Based on #5669 ⚠️ 

## Description

In the order creation flow, this adds the ability to select a product and add it to the order.

Selecting a product adds it to the order, and you can repeat the steps to add multiple products to the order. As in Core/wp-admin, you can select/add the same product more than once. (The ability to change the product quantity or remove a product is coming in a future PR.)

## Changes

* Selecting a product from the Add Product screen:
   * In the `AddProductToOrder` view, when a product row is tapped, the product is selected and the view is closed.
   * `AddProductToOrderViewModel` now takes a closure `onProductSelected` and calls it when a product is selected from the list.
* Selected product in the product list on the New Order screen:
   * The product list in `NewOrder` is now populated by the view model.
   * `NewOrderViewModel` adds the selected product to the order by converting it to an `OrderItem` and adding it to `orderDetails.items`. It also saves the product in an array that is used to generate the product row view models for display in the list of products in the order. (Saving the added products this way avoids having to keep a full synced list of products from the store while also maintaining `orderDetails.items` as the source of truth for what items are in the order.)
* Adds the extension `Product+OrderItem` in the Yosemite layer to convert a product into an order item.
* Updates unit tests.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, confirm you see the Products section with no products listed yet.
5. Tap the "Add product" button.
6. On the Add Product screen, tap to select a product.
7. Confirm the Add Product screen closes and your selected product is now shown in the Products section of the new order.
8. Repeat steps 5-6 to add more products to the order.

## Screenshots

https://user-images.githubusercontent.com/8658164/145995348-dfd21a63-069a-486b-94ef-ba7be8a58dcc.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
