### PR TITLE
Product SKU scanner: handle camera permission with a coordinator

### DIFF
--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Observables
 
 
 /// UIAlertController Helpers
@@ -74,24 +73,24 @@ extension UIAlertController {
                                                    title: String? = nil,
                                                    message: String? = nil,
                                                    onCancel: (() -> Void)? = nil) {
-        let actionSheet = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        actionSheet.view.tintColor = .text
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.view.tintColor = .text
 
-        actionSheet.addDefaultActionWithTitle(AlertWithLinkToOpenSettings.Localization.openSettings) { _ in
+        alert.addDefaultActionWithTitle(AlertWithLinkToOpenSettings.Localization.openSettings) { _ in
             AlertWithLinkToOpenSettings.openSettings()
         }
 
-        actionSheet.addCancelActionWithTitle(AlertWithLinkToOpenSettings.Localization.cancel) { _ in
+        alert.addCancelActionWithTitle(AlertWithLinkToOpenSettings.Localization.cancel) { _ in
             onCancel?()
         }
 
-        if let popoverController = actionSheet.popoverPresentationController {
+        if let popoverController = alert.popoverPresentationController {
             popoverController.sourceView = viewController.view
             popoverController.sourceRect = viewController.view.bounds
             popoverController.permittedArrowDirections = []
         }
 
-        viewController.present(actionSheet, animated: true)
+        viewController.present(alert, animated: true)
     }
 
     open override func viewWillLayoutSubviews() {

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -59,7 +59,8 @@ extension UIAlertController {
         viewController.present(actionSheet, animated: true)
     }
 
-    /// Present an alert when the app does not have permission to use camera for barcode scanner. The alert has an action that links to device settings and a cancel action.
+    /// Present an alert when the app does not have permission to use camera for barcode scanner.
+    /// The alert has an action that links to device settings and a cancel action.
     static func presentBarcodeScannerNoCameraPermissionAlert(viewController: UIViewController,
                                                              onCancel: (() -> Void)? = nil) {
         presentAlertWithLinkToOpenSettings(viewController: viewController,
@@ -80,7 +81,7 @@ extension UIAlertController {
             AlertWithLinkToOpenSettings.openSettings()
         }
 
-        actionSheet.addDestructiveActionWithTitle(AlertWithLinkToOpenSettings.Localization.cancel) { _ in
+        actionSheet.addCancelActionWithTitle(AlertWithLinkToOpenSettings.Localization.cancel) { _ in
             onCancel?()
         }
 

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Observables
 
 
 /// UIAlertController Helpers
@@ -58,6 +59,40 @@ extension UIAlertController {
         viewController.present(actionSheet, animated: true)
     }
 
+    /// Present an alert when the app does not have permission to use camera for barcode scanner. The alert has an action that links to device settings and a cancel action.
+    static func presentBarcodeScannerNoCameraPermissionAlert(viewController: UIViewController,
+                                                             onCancel: (() -> Void)? = nil) {
+        presentAlertWithLinkToOpenSettings(viewController: viewController,
+                                           title: BarcodeScannerNoCameraPermissionAlert.Localization.title,
+                                           message: BarcodeScannerNoCameraPermissionAlert.Localization.message,
+                                           onCancel: onCancel)
+    }
+
+    /// Present an alert with an action that links to device settings and cancel action.
+    static func presentAlertWithLinkToOpenSettings(viewController: UIViewController,
+                                                   title: String? = nil,
+                                                   message: String? = nil,
+                                                   onCancel: (() -> Void)? = nil) {
+        let actionSheet = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        actionSheet.view.tintColor = .text
+
+        actionSheet.addDefaultActionWithTitle(AlertWithLinkToOpenSettings.Localization.openSettings) { _ in
+            AlertWithLinkToOpenSettings.openSettings()
+        }
+
+        actionSheet.addDestructiveActionWithTitle(AlertWithLinkToOpenSettings.Localization.cancel) { _ in
+            onCancel?()
+        }
+
+        if let popoverController = actionSheet.popoverPresentationController {
+            popoverController.sourceView = viewController.view
+            popoverController.sourceRect = viewController.view.bounds
+            popoverController.permittedArrowDirections = []
+        }
+
+        viewController.present(actionSheet, animated: true)
+    }
+
     open override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         if let window = UIApplication.shared.currentKeyWindow {
@@ -75,4 +110,31 @@ private enum ActionSheetStrings {
                                           comment: "Button title Discard Changes in Discard Changes Action Sheet")
     static let cancel = NSLocalizedString("Cancel",
                                           comment: "Button title Cancel in Discard Changes Action Sheet")
+}
+
+private enum AlertWithLinkToOpenSettings {
+    enum Localization {
+        static let openSettings = NSLocalizedString("Open Settings",
+                                                    comment: "Button title to open device settings in an alert")
+        static let cancel = NSLocalizedString("Cancel",
+                                              comment: "Button title to cancel opening device settings in an alert")
+    }
+
+    static let openSettings: () -> Void = {
+        guard let targetURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        UIApplication.shared.open(targetURL)
+    }
+}
+
+private enum BarcodeScannerNoCameraPermissionAlert {
+    enum Localization {
+        static let title =
+        NSLocalizedString("Allow camera access",
+                          comment: "Title of alert that links to settings for camera access.")
+        static let message =
+        NSLocalizedString("Please change your camera permissions in device settings.",
+                          comment: "Message of alert that links to settings for camera access.")
+    }
 }

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -86,12 +86,6 @@ extension UIAlertController {
             onCancel?()
         }
 
-        if let popoverController = alert.popoverPresentationController {
-            popoverController.sourceView = viewController.view
-            popoverController.sourceRect = viewController.view.bounds
-            popoverController.permittedArrowDirections = []
-        }
-
         viewController.present(alert, animated: true)
     }
 

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -76,9 +76,11 @@ extension UIAlertController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.view.tintColor = .text
 
-        alert.addDefaultActionWithTitle(AlertWithLinkToOpenSettings.Localization.openSettings) { _ in
+        let openSettingsAction = UIAlertAction(title: AlertWithLinkToOpenSettings.Localization.openSettings, style: .default) { _ in
             AlertWithLinkToOpenSettings.openSettings()
         }
+        alert.addAction(openSettingsAction)
+        alert.preferredAction = openSettingsAction
 
         alert.addCancelActionWithTitle(AlertWithLinkToOpenSettings.Localization.cancel) { _ in
             onCancel?()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -27,6 +27,8 @@ final class ProductInventorySettingsViewController: UIViewController {
     typealias Completion = (_ data: ProductInventoryEditableData) -> Void
     private let onCompletion: Completion
 
+    private var skuBarcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
+
     private var cancellable: ObservationToken?
 
     init(product: ProductFormDataModel, formType: FormType = .inventory, completion: @escaping Completion) {
@@ -336,11 +338,14 @@ private extension ProductInventorySettingsViewController {
 //
 private extension ProductInventorySettingsViewController {
     @objc func scanSKUButtonTapped() {
-        let scannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] barcode in
+        guard let navigationController = navigationController else {
+            return
+        }
+        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController) { [weak self] barcode in
             self?.onSKUBarcodeScanned(barcode: barcode)
-            self?.navigationController?.popViewController(animated: true)
-        })
-        show(scannerViewController, sender: self)
+        }
+        skuBarcodeScannerCoordinator = coordinator
+        coordinator.start()
     }
 
     func onSKUBarcodeScanned(barcode: String) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -344,6 +344,7 @@ private extension ProductInventorySettingsViewController {
         let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController) { [weak self] barcode in
             self?.onSKUBarcodeScanned(barcode: barcode)
         }
+        view.endEditing(true)
         skuBarcodeScannerCoordinator = coordinator
         coordinator.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CaptureDevicePermissionChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CaptureDevicePermissionChecker.swift
@@ -5,11 +5,27 @@ protocol CaptureDevicePermissionChecker {
     /// Returns a constant indicating whether the app has permission for recording a specified media type.
     /// - Returns: A constant indicating authorization status.
     func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus
+
+    /// Requests the user’s permission, if needed, for recording a specified media type.
+    /// - Parameters:
+    ///   - mediaType: A media type constant, either video or audio.
+    ///   - handler: A block to be called once permission is granted or denied, always on the main thread.
+    func requestAccess(for mediaType: AVMediaType,
+                       completionHandler handler: @escaping (_ isGranted: Bool) -> Void)
 }
 
 /// An implementation of `CaptureDevicePermissionChecker` protocol using `AVFoundation`.
 struct AVCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
     func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
         AVCaptureDevice.authorizationStatus(for: mediaType)
+    }
+
+    func requestAccess(for mediaType: AVMediaType,
+                       completionHandler handler: @escaping (_ isGranted: Bool) -> Void) {
+        AVCaptureDevice.requestAccess(for: mediaType) { granted in
+            DispatchQueue.main.async {
+                handler(granted)
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CaptureDevicePermissionChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CaptureDevicePermissionChecker.swift
@@ -1,0 +1,15 @@
+import AVFoundation
+
+/// A protocol that checks device permission to capture media.
+protocol CaptureDevicePermissionChecker {
+    /// Returns a constant indicating whether the app has permission for recording a specified media type.
+    /// - Returns: A constant indicating authorization status.
+    func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus
+}
+
+/// An implementation of `CaptureDevicePermissionChecker` protocol using `AVFoundation`.
+struct AVCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
+    func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
+        AVCaptureDevice.authorizationStatus(for: mediaType)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
@@ -22,12 +22,24 @@ final class ProductSKUBarcodeScannerCoordinator: Coordinator {
             UIAlertController.presentBarcodeScannerNoCameraPermissionAlert(viewController: navigationController) { [weak self] in
                 self?.navigationController.dismiss(animated: true, completion: nil)
             }
+        case .notDetermined:
+            permissionChecker.requestAccess(for: .video) { [weak self] granted in
+                if granted {
+                    self?.showSKUScanner()
+                }
+            }
         default:
-            let scannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] barcode in
-                self?.onSKUBarcodeScanned(barcode)
-                self?.navigationController.popViewController(animated: true)
-            })
-            navigationController.show(scannerViewController, sender: self)
+            showSKUScanner()
         }
+    }
+}
+
+private extension ProductSKUBarcodeScannerCoordinator {
+    func showSKUScanner() {
+        let scannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] barcode in
+            self?.onSKUBarcodeScanned(barcode)
+            self?.navigationController.popViewController(animated: true)
+        })
+        navigationController.show(scannerViewController, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
@@ -1,20 +1,24 @@
-import AVFoundation
 import Experiments
 import UIKit
 
+/// Coordinates navigation for product SKU barcode scanner based on camera permission.
 final class ProductSKUBarcodeScannerCoordinator: Coordinator {
     var navigationController: UINavigationController
+    private let permissionChecker: CaptureDevicePermissionChecker
     private let onSKUBarcodeScanned: (_ barcode: String) -> Void
 
-    init(sourceNavigationController: UINavigationController, onSKUBarcodeScanned: @escaping (_ barcode: String) -> Void) {
+    init(sourceNavigationController: UINavigationController,
+         permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
+         onSKUBarcodeScanned: @escaping (_ barcode: String) -> Void) {
         self.navigationController = sourceNavigationController
+        self.permissionChecker = permissionChecker
         self.onSKUBarcodeScanned = onSKUBarcodeScanned
     }
 
     func start() {
-        let cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        let cameraAuthorizationStatus = permissionChecker.authorizationStatus(for: .video)
         switch cameraAuthorizationStatus {
-        case .denied:
+        case .denied, .restricted:
             UIAlertController.presentBarcodeScannerNoCameraPermissionAlert(viewController: navigationController) { [weak self] in
                 self?.navigationController.dismiss(animated: true, completion: nil)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
@@ -1,0 +1,29 @@
+import AVFoundation
+import Experiments
+import UIKit
+
+final class ProductSKUBarcodeScannerCoordinator: Coordinator {
+    var navigationController: UINavigationController
+    private let onSKUBarcodeScanned: (_ barcode: String) -> Void
+
+    init(sourceNavigationController: UINavigationController, onSKUBarcodeScanned: @escaping (_ barcode: String) -> Void) {
+        self.navigationController = sourceNavigationController
+        self.onSKUBarcodeScanned = onSKUBarcodeScanned
+    }
+
+    func start() {
+        let cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        switch cameraAuthorizationStatus {
+        case .denied:
+            UIAlertController.presentBarcodeScannerNoCameraPermissionAlert(viewController: navigationController) { [weak self] in
+                self?.navigationController.dismiss(animated: true, completion: nil)
+            }
+        default:
+            let scannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] barcode in
+                self?.onSKUBarcodeScanned(barcode)
+                self?.navigationController.popViewController(animated: true)
+            })
+            navigationController.show(scannerViewController, sender: self)
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -329,6 +329,9 @@
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
 		02CE43022768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */; };
+		02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */; };
+		02CE4307276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */; };
+		02CE43092769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE43082769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift */; };
 		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
 		02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */; };
 		02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */; };
@@ -1861,6 +1864,9 @@
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSKUBarcodeScannerCoordinator.swift; sourceTree = "<group>"; };
+		02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureDevicePermissionChecker.swift; sourceTree = "<group>"; };
+		02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSKUBarcodeScannerCoordinatorTests.swift; sourceTree = "<group>"; };
+		02CE43082769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCaptureDevicePermissionChecker.swift; sourceTree = "<group>"; };
 		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
 		02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormDataModel.swift; sourceTree = "<group>"; };
 		02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingTests.swift"; sourceTree = "<group>"; };
@@ -3506,6 +3512,7 @@
 				025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */,
 				025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */,
 				02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */,
+				02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */,
 			);
 			path = "SKU Scanner";
 			sourceTree = "<group>";
@@ -3572,6 +3579,7 @@
 				CCD2E68725DD528000BD975D /* Variations */,
 				020B2F9723BDF2D000BD79AD /* Edit Product */,
 				45FBDF29238BF87800127F77 /* Collection View Cells */,
+				02CE43052769946A0006EAEF /* SKU Scanner */,
 				0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */,
 				02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */,
 				022A45ED237BADA6001417F0 /* Product+ProductFormTests.swift */,
@@ -3905,6 +3913,14 @@
 				02C887702450285100E4470F /* BottomButtonContainerView.swift */,
 			);
 			path = BottomButtonContainer;
+			sourceTree = "<group>";
+		};
+		02CE43052769946A0006EAEF /* SKU Scanner */ = {
+			isa = PBXGroup;
+			children = (
+				02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */,
+			);
+			path = "SKU Scanner";
 			sourceTree = "<group>";
 		};
 		02D4564A231D059E008CF0A9 /* Beta features */ = {
@@ -5098,6 +5114,7 @@
 				DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */,
 				FE3E427626A8545B00C596CE /* MockRoleEligibilityUseCase.swift */,
 				02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */,
+				02CE43082769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8311,6 +8328,7 @@
 				02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
 				DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */,
+				02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */,
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,
 				934CB123224EAB150005CCB9 /* main.swift in Sources */,
 				456396AE25C81D81001F1A26 /* ShippingLabelFormViewModel.swift in Sources */,
@@ -8640,6 +8658,7 @@
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,
+				02CE43092769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift in Sources */,
 				7E6A01A32726C5D3001668D5 /* MockProductCategoryStoresManager.swift in Sources */,
 				45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */,
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
@@ -8693,6 +8712,7 @@
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
 				DEC51AA0274F9922009F3DF4 /* JetpackInstallStepsViewModelTests.swift in Sources */,
 				26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */,
+				02CE4307276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift in Sources */,
 				3190D61D26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */; };
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
+		02CE43022768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */; };
 		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
 		02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */; };
 		02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */; };
@@ -1859,6 +1860,7 @@
 		02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
+		02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSKUBarcodeScannerCoordinator.swift; sourceTree = "<group>"; };
 		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
 		02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormDataModel.swift; sourceTree = "<group>"; };
 		02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingTests.swift"; sourceTree = "<group>"; };
@@ -3503,6 +3505,7 @@
 				025C00652550DE4700FAC222 /* BarcodeScannerViewController.xib */,
 				025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */,
 				025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */,
+				02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */,
 			);
 			path = "SKU Scanner";
 			sourceTree = "<group>";
@@ -7953,6 +7956,7 @@
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				262AF387271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift in Sources */,
+				02CE43022768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
 				AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */,
 				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
@@ -1,0 +1,15 @@
+import AVFoundation
+@testable import WooCommerce
+
+/// An implementation of `CaptureDevicePermissionChecker` protocol using `AVFoundation`.
+struct MockCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
+    private let authorizationStatus: AVAuthorizationStatus
+
+    init(authorizationStatus: AVAuthorizationStatus) {
+        self.authorizationStatus = authorizationStatus
+    }
+
+    func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
+        authorizationStatus
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
@@ -2,14 +2,25 @@ import AVFoundation
 @testable import WooCommerce
 
 /// A mock implementation of `CaptureDevicePermissionChecker` protocol.
-struct MockCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
+final class MockCaptureDevicePermissionChecker {
     private let authorizationStatus: AVAuthorizationStatus
+    private var isAccessGranted: Bool = false
 
     init(authorizationStatus: AVAuthorizationStatus) {
         self.authorizationStatus = authorizationStatus
     }
 
+    func whenRequestingAccess(thenReturn isGranted: Bool) {
+        isAccessGranted = isGranted
+    }
+}
+
+extension MockCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
     func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
         authorizationStatus
+    }
+
+    func requestAccess(for mediaType: AVMediaType, completionHandler handler: @escaping (_ isGranted: Bool) -> Void) {
+        handler(isAccessGranted)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 @testable import WooCommerce
 
-/// An implementation of `CaptureDevicePermissionChecker` protocol using `AVFoundation`.
+/// A mock implementation of `CaptureDevicePermissionChecker` protocol.
 struct MockCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
     private let authorizationStatus: AVAuthorizationStatus
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
@@ -1,0 +1,83 @@
+import TestKit
+import XCTest
+@testable import WooCommerce
+
+final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
+    private var navigationController: UINavigationController!
+    private var window: UIWindow?
+
+    override func setUp() {
+        super.setUp()
+        navigationController = UINavigationController()
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        window.rootViewController = navigationController
+        self.window = window
+    }
+
+    override func tearDown() {
+        navigationController = nil
+
+        // Resets `UIWindow` and its view hierarchy so that it can be deallocated cleanly.
+        window?.resignKey()
+        window?.rootViewController = nil
+
+        super.tearDown()
+    }
+
+    func test_coordinator_shows_sku_scanner_when_permission_is_not_determined() {
+        // Given
+        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                              permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined),
+                                                              onSKUBarcodeScanned: { _ in })
+
+        // When
+        coordinator.start()
+
+        // Then
+        assertThat(navigationController.topViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
+    }
+
+    func test_coordinator_shows_sku_scanner_when_permission_is_authorized() {
+        // Given
+        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                              permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .authorized),
+                                                              onSKUBarcodeScanned: { _ in })
+
+        // When
+        coordinator.start()
+
+        // Then
+        assertThat(navigationController.topViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
+    }
+
+    func test_coordinator_shows_alert_when_permission_is_denied() {
+        // Given
+        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                              permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .denied),
+                                                              onSKUBarcodeScanned: { _ in })
+
+        // When
+        coordinator.start()
+
+        // Then
+        assertThat(navigationController.presentedViewController, isAnInstanceOf: UIAlertController.self)
+        XCTAssertNil(navigationController.topViewController)
+    }
+
+    func test_coordinator_shows_alert_when_permission_is_restricted() {
+        // Given
+        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                              permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .restricted),
+                                                              onSKUBarcodeScanned: { _ in })
+
+        // When
+        coordinator.start()
+
+        // Then
+        assertThat(navigationController.presentedViewController, isAnInstanceOf: UIAlertController.self)
+        XCTAssertNil(navigationController.topViewController)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
@@ -11,7 +11,6 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         navigationController = UINavigationController()
 
         let window = UIWindow(frame: UIScreen.main.bounds)
-        window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
         window.rootViewController = navigationController
         self.window = window

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
@@ -27,10 +27,13 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_coordinator_shows_sku_scanner_when_permission_is_not_determined() {
+    func test_coordinator_shows_sku_scanner_after_granting_camera_access() {
         // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        // Grants access.
+        permissionChecker.whenRequestingAccess(thenReturn: true)
         let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
-                                                              permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined),
+                                                              permissionChecker: permissionChecker,
                                                               onSKUBarcodeScanned: { _ in })
 
         // When
@@ -38,6 +41,23 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
 
         // Then
         assertThat(navigationController.topViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
+    }
+
+    func test_coordinator_does_nothing_after_denying_camera_access() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        // Denies access.
+        permissionChecker.whenRequestingAccess(thenReturn: false)
+        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                              permissionChecker: permissionChecker,
+                                                              onSKUBarcodeScanned: { _ in })
+
+        // When
+        coordinator.start()
+
+        // Then
+        XCTAssertNil(navigationController.topViewController)
+        XCTAssertNil(navigationController.presentedViewController)
     }
 
     func test_coordinator_shows_sku_scanner_when_permission_is_authorized() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #2407
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For barcode scanner in product inventory > SKU, if the app does not have camera permission then we want to show an alert that links to device settings. There are several states of camera permission:

- Not determined: this is when the user accesses a feature that uses camera for the first time. In this case, we want to request user's permission for camera, and show the barcode scanner when access is granted
- Authorized: we show the barcode scanner directly
- Denied: when the user has denied camera access and want to use a feature that uses camera, we show an alert that links to device settings for them to change the permission
- Restricted: this is one `AVAuthorizationStatus` enum case, but according to [Apple documentation](https://developer.apple.com/documentation/avfoundation/avauthorizationstatus/restricted) it is normally not returned 🤷🏻‍♀️ I handle this case the same way as "denied", but lemme know if you think it's better to just not handle it

Please note that after most of the work is done, the CTAs to the barcode scanner won't be shown if the device doesn't have a camera (e.g. simulator). The CTAs are shown in simulators right now for easier debugging during development.

### Changes

- Created `ProductSKUBarcodeScannerCoordinator` that is based on camera permission:
  - When camera permission is denied or restricted: presents an alert that links to device settings 
  - Otherwise, shows barcode scanner
- Added helpers to `UIAlertController` for a generic alert with any title/message and action that links to device settings, and a helper for barcode scanner
- Created `CaptureDevicePermissionChecker` protocol for mocking authorization status

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Camera is only available on a device, please try on a device - iPad would be super helpful since I mostly tested on iPhone!

- If you've granted camera access in the app before like for product images or Zendesk support, please reinstall the app
- Go to the products tab
- Tap on a product whose SKU is editable
- Tap on the inventory/SKU row
- Tap on the scan CTA in the accessory view of the SKU row --> an iOS alert should appear for camera access
- Tap "Don't Allow" --> it should stay on the inventory settings
- Tap on the scan CTA in the accessory view of the SKU row again --> an alert should be shown that encourages you to open device settings and change camera permission (as shown in the screenshot below)
- Tap "Open Settings" --> it should deep link to device settings
- Turn on camera access
- Go back to the app (the app relaunches whenever a system permission changes)
- Go to the products tab
- Tap on a product whose SKU is editable
- Tap on the inventory/SKU row
- Tap on the scan CTA in the accessory view of the SKU row --> the barcode scanner should be shown now with camera access
- Scan any barcode that is available to you --> after a barcode is detected, the barcode should be populated on the SKU row

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

New alert when the user has denied camera access before:

<img src="https://user-images.githubusercontent.com/1945542/146144804-c8ba166f-cb23-48ab-a1a8-16a233d25ee6.PNG" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
