### PR TITLE
Simple Payments: Update "Back To Order" button title

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -26,7 +26,7 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     let secondaryButtonTitle: String? = Localization.emailReceipt
 
-    let auxiliaryButtonTitle: String? = Localization.noThanks
+    let auxiliaryButtonTitle: String?
 
     let bottomTitle: String? = nil
 
@@ -36,10 +36,14 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
         return topTitle
     }
 
-    init(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
+    init(printReceipt: @escaping () -> Void,
+         emailReceipt: @escaping () -> Void,
+         noReceiptTitle: String,
+         noReceiptAction: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
         self.emailReceiptAction = emailReceipt
         self.noReceiptAction = noReceiptAction
+        self.auxiliaryButtonTitle = noReceiptTitle
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -76,11 +80,6 @@ private extension CardPresentModalSuccess {
         static let emailReceipt = NSLocalizedString(
             "Email receipt",
             comment: "Button to email receipts. Presented to users after a payment has been successfully collected"
-        )
-
-        static let noThanks = NSLocalizedString(
-            "Back to Order",
-            comment: "Button to dismiss modal overlay. Presented to users after a payment has been successfully collected"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -20,7 +20,7 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
 
     let primaryButtonTitle: String? = Localization.printReceipt
 
-    let secondaryButtonTitle: String? = Localization.noThanks
+    let secondaryButtonTitle: String?
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -32,9 +32,12 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
         return Localization.paymentSuccessful
     }
 
-    init(printReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
+    init(printReceipt: @escaping () -> Void,
+         noReceiptTitle: String,
+         noReceiptAction: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
         self.noReceiptAction = noReceiptAction
+        self.secondaryButtonTitle = noReceiptTitle
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -62,11 +65,6 @@ private extension CardPresentModalSuccessWithoutEmail {
         static let printReceipt = NSLocalizedString(
             "Print receipt",
             comment: "Button to print receipts. Presented to users after a payment has been successfully collected"
-        )
-
-        static let noThanks = NSLocalizedString(
-            "Back to Order",
-            comment: "Button to dismiss modal overlay. Presented to users after a payment has been successfully collected"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -63,8 +63,11 @@ final class OrderDetailsPaymentAlerts {
         presentViewModel(viewModel: viewModel)
     }
 
-    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
-        let viewModel = successViewModel(printReceipt: printReceipt, emailReceipt: emailReceipt, noReceiptAction: noReceiptAction)
+    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptTitle: String, noReceiptAction: @escaping () -> Void) {
+        let viewModel = successViewModel(printReceipt: printReceipt,
+                                         emailReceipt: emailReceipt,
+                                         noReceiptTitle: noReceiptTitle,
+                                         noReceiptAction: noReceiptAction)
         presentViewModel(viewModel: viewModel)
     }
 
@@ -103,11 +106,15 @@ private extension OrderDetailsPaymentAlerts {
 
     func successViewModel(printReceipt: @escaping () -> Void,
                           emailReceipt: @escaping () -> Void,
+                          noReceiptTitle: String,
                           noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         if MFMailComposeViewController.canSendMail() {
-            return CardPresentModalSuccess(printReceipt: printReceipt, emailReceipt: emailReceipt, noReceiptAction: noReceiptAction)
+            return CardPresentModalSuccess(printReceipt: printReceipt,
+                                           emailReceipt: emailReceipt,
+                                           noReceiptTitle: noReceiptTitle,
+                                           noReceiptAction: noReceiptAction)
         } else {
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptTitle: noReceiptTitle, noReceiptAction: noReceiptAction)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -243,8 +243,8 @@ private extension CollectOrderPaymentUseCase {
                 self?.onCompleted = onCompleted // Saved to be able to reference from the `MailComposer` delegate.
                 self?.presentEmailForm(content: emailContent)
             }
-            
-        }, noReceiptTitle: backButtonTitle, noReceiptAction: {
+        }, noReceiptTitle: backButtonTitle,
+           noReceiptAction: {
             // Inform about flow completion.
             onCompleted()
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -84,10 +84,10 @@ final class CollectOrderPaymentUseCase: NSObject {
     /// 4. If failure: Allows retry
     ///
     ///
+    /// - Parameter backButtonTitle: Title for the back button after a payment is sucessfull.
     /// - Parameter onCollect: Closure Invoked after the collect process has finished.
     /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed, Currently after merchant has handled the receipt.
-    // TODO: Remember to check why the amount is provided in order details view model
-    func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
+    func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
         connectReader { [weak self] in
             self?.attemptPayment(onCompletion: { [weak self] result in
                 // Inform about the collect payment state
@@ -97,7 +97,7 @@ final class CollectOrderPaymentUseCase: NSObject {
                 guard let receiptParameters = try? result.get() else {
                     return
                 }
-                self?.presentReceiptAlert(receiptParameters: receiptParameters, onCompleted: onCompleted)
+                self?.presentReceiptAlert(receiptParameters: receiptParameters, backButtonTitle: backButtonTitle, onCompleted: onCompleted)
             })
         }
     }
@@ -225,7 +225,7 @@ private extension CollectOrderPaymentUseCase {
 
     /// Allow merchants to print or email the payment receipt.
     ///
-    func presentReceiptAlert(receiptParameters: CardPresentReceiptParameters, onCompleted: @escaping () -> ()) {
+    func presentReceiptAlert(receiptParameters: CardPresentReceiptParameters, backButtonTitle: String, onCompleted: @escaping () -> ()) {
         // Present receipt alert
         alerts.success(printReceipt: { [order] in
             // Inform about flow completion.
@@ -243,8 +243,8 @@ private extension CollectOrderPaymentUseCase {
                 self?.onCompleted = onCompleted // Saved to be able to reference from the `MailComposer` delegate.
                 self?.presentEmailForm(content: emailContent)
             }
-
-        }, noReceiptAction: {
+            
+        }, noReceiptTitle: backButtonTitle, noReceiptAction: {
             // Inform about flow completion.
             onCompleted()
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -772,7 +772,8 @@ private extension OrderDetailsViewController {
                         self.viewModel.emailReceipt(params: receiptParameters, onContent: { emailContent in
                             self.emailReceipt(emailContent)
                         })
-                    }, noReceiptTitle: Localization.Payments.backToOrder, noReceiptAction: {})
+                    }, noReceiptTitle: Localization.Payments.backToOrder,
+                       noReceiptAction: {})
                 }
             }
         )
@@ -1092,7 +1093,7 @@ private extension OrderDetailsViewController {
                 NSLocalizedString("Track shipment",
                                   comment: "Track shipment of a shipping label from the shipping label tracking more menu action sheet")
         }
-        
+
         enum Payments {
             static let backToOrder = NSLocalizedString("Back to Order",
                                                        comment: "Button to dismiss modal overlay and go back to the order after a sucessful payment")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -772,7 +772,7 @@ private extension OrderDetailsViewController {
                         self.viewModel.emailReceipt(params: receiptParameters, onContent: { emailContent in
                             self.emailReceipt(emailContent)
                         })
-                    }, noReceiptAction: {})
+                    }, noReceiptTitle: Localization.Payments.backToOrder, noReceiptAction: {})
                 }
             }
         )
@@ -1091,6 +1091,11 @@ private extension OrderDetailsViewController {
             static let trackShipmentAction =
                 NSLocalizedString("Track shipment",
                                   comment: "Track shipment of a shipping label from the shipping label tracking more menu action sheet")
+        }
+        
+        enum Payments {
+            static let backToOrder = NSLocalizedString("Back to Order",
+                                                       comment: "Button to dismiss modal overlay and go back to the order after a sucessful payment")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -147,7 +147,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                                                             formattedAmount: formattedTotal,
                                                             paymentGatewayAccount: paymentGateway,
                                                             rootViewController: rootViewController)
-        collectPaymentsUseCase?.collectPayment(onCollect: { [weak self] result in
+        collectPaymentsUseCase?.collectPayment(backButtonTitle: Localization.continueToOrders, onCollect: { [weak self] result in
             if result.isFailure {
                 self?.trackFlowFailed()
             }
@@ -200,6 +200,8 @@ private extension SimplePaymentsMethodsViewModel {
                                                        comment: "Text when there is an error while marking the order as paid for simple payments.")
         static let genericCollectError = NSLocalizedString("There was an error while trying to collect the payment.",
                                                        comment: "Text when there is an unknown error while trying to collect payments")
+        static let continueToOrders = NSLocalizedString("Continue To Orders",
+                                                        comment: "Button to dismiss modal overlay and go back to the orders list after a sucessful payment")
 
         static func title(total: String) -> String {
             NSLocalizedString("Take Payment (\(total))", comment: "Navigation bar title for the Simple Payments Methods screens")

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -10,6 +10,7 @@ final class CardPresentModalSuccessTests: XCTestCase {
         closures = Closures()
         viewModel = CardPresentModalSuccess(printReceipt: closures.printReceipt(),
                                             emailReceipt: closures.emailReceipt(),
+                                            noReceiptTitle: "Back",
                                             noReceiptAction: closures.noReceiptAction())
     }
 
@@ -41,6 +42,7 @@ final class CardPresentModalSuccessTests: XCTestCase {
 
     func test_auxiliary_button_title_is_not_nil() {
         XCTAssertNotNil(viewModel.auxiliaryButtonTitle)
+        XCTAssertEqual(viewModel.auxiliaryButtonTitle, "Back")
     }
 
     func test_bottom_title_is_nil() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
@@ -8,7 +8,9 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt(), noReceiptAction: closures.noReceiptAction())
+        viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt(),
+                                                        noReceiptTitle: "Back",
+                                                        noReceiptAction: closures.noReceiptAction())
     }
 
     override func tearDown() {
@@ -35,6 +37,7 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
 
     func test_secondary_button_title_is_not_nil() {
         XCTAssertNotNil(viewModel.secondaryButtonTitle)
+        XCTAssertEqual(viewModel.secondaryButtonTitle, "Back")
     }
 
     func test_auxiliary_button_title_is_nil() {


### PR DESCRIPTION
closes #5660 

# Why

It was reported that after making a successful payment the "Back" button said "Back To Order" which is not accurate for the Simple Payments Flow.

This PR makes the necessary changes to customize that button which now reads "Continue to Orders"

# How

Extract the hardcoded text in `CardPresentModalSuccessWithoutEmail` and in `CardPresentModalSuccess.swift` and provide the back button title at the call sites. `OrderDetailsViewController` and `SimplePaymentMethodViewModel`. 

# Screnshots

Simple Payments | Regular order 
---- | ----
![simple-payments](https://user-images.githubusercontent.com/562080/146203670-bb1e4810-f64a-44fe-9e11-6b5356695307.PNG) | ![regular-order](https://user-images.githubusercontent.com/562080/146203678-b2cfe253-a9d8-4de2-b995-23a87b666edd.PNG)

# Testing Steps

- Create a simple Payments Order
- Goo all the way until a successful card payment
- See the "Continue to Orders" button


- Collect payment on a regular order
- Goo all the way until a successful card payment
- See the "Bac to order" button

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
