### PR TITLE
Simple Payments: Enable Simple Payments Feature to all merchants

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 8.3
 -----
-
+- [***] All mercants can create Simple Payments orders. [https://github.com/woocommerce/woocommerce-ios/pull/5684]
 
 8.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -115,8 +115,6 @@ private extension BetaFeaturesViewController {
         case let cell as BasicTableViewCell where row == .orderAddOnsDescription:
             configureOrderAddOnsDescription(cell: cell)
         // Orders
-        case let cell as BasicTableViewCell where row == .simplePaymentsDescription:
-            configureSimplePaymentsDescription(cell: cell)
         case let cell as SwitchTableViewCell where row == .orderCreation:
             configureOrderCreationSwitch(cell: cell)
         case let cell as BasicTableViewCell where row == .orderCreationDescription:
@@ -159,11 +157,6 @@ private extension BetaFeaturesViewController {
     func configureOrderAddOnsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
         cell.textLabel?.text = Localization.orderAddOnsDescription
-    }
-
-    func configureSimplePaymentsDescription(cell: BasicTableViewCell) {
-        configureCommonStylesForDescriptionCell(cell)
-        cell.textLabel?.text = Localization.simplePaymentsDescription
     }
 
     func configureOrderCreationSwitch(cell: SwitchTableViewCell) {
@@ -261,16 +254,14 @@ private enum Row: CaseIterable {
     case orderAddOnsDescription
 
     // Orders.
-    case simplePayments
-    case simplePaymentsDescription
     case orderCreation
     case orderCreationDescription
 
     var type: UITableViewCell.Type {
         switch self {
-        case .orderAddOns, .simplePayments, .orderCreation:
+        case .orderAddOns, .orderCreation:
             return SwitchTableViewCell.self
-        case .orderAddOnsDescription, .simplePaymentsDescription, .orderCreationDescription:
+        case .orderAddOnsDescription, .orderCreationDescription:
             return BasicTableViewCell.self
         }
     }
@@ -286,10 +277,6 @@ private extension BetaFeaturesViewController {
         static let orderAddOnsDescription = NSLocalizedString("Test out viewing Order Add-Ons as we get ready to launch",
                                                               comment: "Cell description on the beta features screen to enable the order add-ons feature")
 
-        static let simplePaymentsTitle = NSLocalizedString("Simple Payments",
-                                                           comment: "Cell title on the beta features screen to enable the Simple Payments feature")
-        static let simplePaymentsDescription = NSLocalizedString("Test out creating orders with minimal information as we get ready to launch",
-                                                              comment: "Cell description on the beta features screen to enable the Simple Payments feature")
         static let orderCreationTitle = NSLocalizedString("Order Creation", comment: "Cell title on the beta features screen to enable creating new orders")
         static let orderCreationDescription = NSLocalizedString("Test out creating new manual orders as we get ready to launch",
                                                                 comment: "Cell description on the beta features screen to enable creating new orders")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -17,10 +17,6 @@ class BetaFeaturesViewController: UIViewController {
     ///
     private var sections = [Section]()
 
-    /// Use case to tell us if the store is enrolled in the in-person payments program.
-    ///
-    private let paymentsStoreUseCase = CardPresentPaymentsOnboardingUseCase()
-
     init() {
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/AddOrderCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/AddOrderCoordinator.swift
@@ -7,7 +7,6 @@ final class AddOrderCoordinator: Coordinator {
 
     private let siteID: Int64
     private let isOrderCreationEnabled: Bool
-    private let shouldShowSimplePaymentsButton: Bool
     private let sourceBarButtonItem: UIBarButtonItem?
     private let sourceView: UIView?
 
@@ -17,12 +16,10 @@ final class AddOrderCoordinator: Coordinator {
 
     init(siteID: Int64,
          isOrderCreationEnabled: Bool,
-         shouldShowSimplePaymentsButton: Bool,
          sourceBarButtonItem: UIBarButtonItem,
          sourceNavigationController: UINavigationController) {
         self.siteID = siteID
         self.isOrderCreationEnabled = isOrderCreationEnabled
-        self.shouldShowSimplePaymentsButton = shouldShowSimplePaymentsButton
         self.sourceBarButtonItem = sourceBarButtonItem
         self.sourceView = nil
         self.navigationController = sourceNavigationController
@@ -33,15 +30,10 @@ final class AddOrderCoordinator: Coordinator {
     }
 
     func start() {
-        switch (isOrderCreationEnabled, shouldShowSimplePaymentsButton) {
-        case (true, true):
+        if isOrderCreationEnabled {
             presentOrderTypeBottomSheet()
-        case (false, true):
+        } else {
             presentOrderCreationFlow(bottomSheetOrderType: .simple)
-        case (true, false):
-            presentOrderCreationFlow(bottomSheetOrderType: .full)
-        case (false, false):
-            return
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -215,7 +215,7 @@ private extension OrderListViewController {
                     self.hideTopBannerView()
                 case .error:
                     self.setErrorTopBanner()
-                case .simplePaymentsEnabled:
+                case .simplePayments:
                     self.setSimplePaymentsEnabledTopBanner()
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -276,7 +276,7 @@ extension OrderListViewModel {
                     return .none
                 }
 
-                return .simplePaymentsEnabled
+                return .simplePayments
             }
             .assign(to: &$topBanner)
     }
@@ -318,7 +318,7 @@ extension OrderListViewModel {
     ///
     enum TopBanner {
         case error
-        case simplePaymentsEnabled
+        case simplePayments
         case none
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -275,7 +275,7 @@ extension OrderListViewModel {
                 guard !hasDismissedBanners else {
                     return .none
                 }
-                
+
                 return .simplePaymentsEnabled
             }
             .assign(to: &$topBanner)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -29,10 +29,6 @@ final class OrdersRootViewController: UIViewController {
 
     private let analytics = ServiceLocator.analytics
 
-    /// Lets us know if the store is ready to receive in person payments
-    ///
-    private let inPersonPaymentsUseCase = CardPresentPaymentsOnboardingUseCase()
-
     /// Stores any active observation.
     ///
     private var subscriptions = Set<AnyCancellable>()
@@ -59,10 +55,6 @@ final class OrdersRootViewController: UIViewController {
     ///
     private var isOrderCreationEnabled: Bool = false
 
-    /// Stores status for Simple Payments availability.
-    ///
-    private var shouldShowSimplePaymentsButton: Bool = false
-
     // MARK: View Lifecycle
 
     init(siteID: Int64) {
@@ -83,7 +75,6 @@ final class OrdersRootViewController: UIViewController {
         configureView()
         configureFiltersBar()
         configureChildViewController()
-        observeInPersonPaymentsStoreState()
 
         /// We sync the local order settings for configuring local statuses and date range filters.
         /// If there are some info stored when this screen is loaded, the data will be updated using the stored filters.
@@ -162,15 +153,14 @@ private extension OrdersRootViewController {
 
     /// Sets navigation buttons.
     /// Search: Is always present.
-    /// Simple Payments: Depends  on the store inPersonPayments state.
+    /// Add: Always present.
     ///
     func configureNavigationButtons(isOrderCreationExperimentalToggleEnabled: Bool) {
-        let shouldShowSimplePaymentsButton = inPersonPaymentsUseCase.state == .completed
-        let buttons: [UIBarButtonItem?] = [
+        let buttons: [UIBarButtonItem] = [
             createSearchBarButtonItem(),
-            createAddOrderItem(isOrderCreationEnabled: isOrderCreationExperimentalToggleEnabled, shouldShowSimplePaymentsButton: shouldShowSimplePaymentsButton)
+            createAddOrderItem(isOrderCreationEnabled: isOrderCreationExperimentalToggleEnabled)
         ]
-        navigationItem.rightBarButtonItems = buttons.compactMap { $0 }
+        navigationItem.rightBarButtonItems = buttons
     }
 
     func configureFiltersBar() {
@@ -202,18 +192,6 @@ private extension OrdersRootViewController {
         addChild(ordersViewController)
         stackView.addArrangedSubview(contentView)
         ordersViewController.didMove(toParent: self)
-    }
-
-    /// Observes the store `InPersonPayments` state and reconfigure navigation buttons appropriately.
-    ///
-    func observeInPersonPaymentsStoreState() {
-        inPersonPaymentsUseCase.$state
-            .removeDuplicates()
-            .sink { [weak self] _ in
-                self?.fetchExperimentalTogglesAndConfigureNavigationButtons()
-            }
-            .store(in: &subscriptions)
-        inPersonPaymentsUseCase.refresh()
     }
 
     /// Fetches the latest values of order-related experimental feature toggles and re configures navigation buttons.
@@ -300,9 +278,8 @@ private extension OrdersRootViewController {
 
     /// Create a `UIBarButtonItem` to be used as a way to create a new order.
     ///
-    func createAddOrderItem(isOrderCreationEnabled: Bool, shouldShowSimplePaymentsButton: Bool) -> UIBarButtonItem? {
+    func createAddOrderItem(isOrderCreationEnabled: Bool) -> UIBarButtonItem {
         self.isOrderCreationEnabled = isOrderCreationEnabled
-        self.shouldShowSimplePaymentsButton = shouldShowSimplePaymentsButton
 
         let button = UIBarButtonItem(image: .plusBarButtonItemImage,
                                      style: .plain,
@@ -310,16 +287,10 @@ private extension OrdersRootViewController {
                                      action: #selector(presentOrderCreationFlow(sender:)))
         button.accessibilityTraits = .button
 
-        switch (isOrderCreationEnabled, shouldShowSimplePaymentsButton) {
-        case (false, false):
-            return nil
-        case (true, true):
+        if isOrderCreationEnabled {
             button.accessibilityLabel = NSLocalizedString("Choose new order type", comment: "Opens action sheet to choose a type of a new order")
             button.accessibilityIdentifier = "new-order-type-sheet-button"
-        case (true, false):
-            button.accessibilityLabel = NSLocalizedString("Add a new order", comment: "Navigates to a screen to create a full manual order")
-            button.accessibilityIdentifier = "full-order-add-button"
-        case (false, true):
+        } else {
             button.accessibilityLabel = NSLocalizedString("Add simple payments order", comment: "Navigates to a screen to create a simple payments order")
             button.accessibilityIdentifier = "simple-payments-add-button"
         }
@@ -335,7 +306,6 @@ private extension OrdersRootViewController {
 
         let coordinatingController = AddOrderCoordinator(siteID: siteID,
                                                          isOrderCreationEnabled: isOrderCreationEnabled,
-                                                         shouldShowSimplePaymentsButton: shouldShowSimplePaymentsButton,
                                                          sourceBarButtonItem: sender,
                                                          sourceNavigationController: navigationController)
         coordinatingController.onOrderCreated = { [weak self] order in

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -36,10 +36,12 @@ struct SimplePaymentsMethod: View {
                     viewModel.trackCollectByCash()
                 }
 
-                Divider()
-
-                MethodRow(icon: .creditCardImage, title: Localization.card) {
-                    viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
+                if viewModel.showPayWithCardRow {
+                    Divider()
+                    
+                    MethodRow(icon: .creditCardImage, title: Localization.card) {
+                        viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
+                    }
                 }
             }
             .padding(.horizontal)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -38,7 +38,7 @@ struct SimplePaymentsMethod: View {
 
                 if viewModel.showPayWithCardRow {
                     Divider()
-                    
+
                     MethodRow(icon: .creditCardImage, title: Localization.card) {
                         viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
                     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddOrderCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddOrderCoordinatorTests.swift
@@ -32,8 +32,7 @@ final class AddOrderCoordinatorTests: XCTestCase {
 
     func test_it_presents_bottom_sheet_when_all_types_are_available() throws {
         // Given
-        let coordinator = makeAddProductCoordinator(isOrderCreationEnabled: true,
-                                                    shouldShowSimplePaymentsButton: true)
+        let coordinator = makeAddProductCoordinator(isOrderCreationEnabled: true)
 
         // When
         coordinator.start()
@@ -45,22 +44,9 @@ final class AddOrderCoordinatorTests: XCTestCase {
         assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
     }
 
-    func test_it_does_nothing_when_all_types_are_unavailable() throws {
-        // Given
-        let coordinator = makeAddProductCoordinator(isOrderCreationEnabled: false,
-                                                    shouldShowSimplePaymentsButton: false)
-
-        // When
-        coordinator.start()
-
-        // Then
-        XCTAssertNil(coordinator.navigationController.presentedViewController)
-    }
-
     func test_it_opens_simple_payments_when_its_only_available_type() throws {
         // Given
-        let coordinator = makeAddProductCoordinator(isOrderCreationEnabled: false,
-                                                    shouldShowSimplePaymentsButton: true)
+        let coordinator = makeAddProductCoordinator(isOrderCreationEnabled: false)
 
         // When
         coordinator.start()
@@ -70,26 +56,13 @@ final class AddOrderCoordinatorTests: XCTestCase {
         assertThat(presentedNC, isAnInstanceOf: WooNavigationController.self)
         assertThat(presentedNC?.topViewController, isAnInstanceOf: SimplePaymentsAmountHostingController.self)
     }
-
-    func test_it_opens_order_creation_when_its_only_available_type() throws {
-        // Given
-        let coordinator = makeAddProductCoordinator(isOrderCreationEnabled: true,
-                                                    shouldShowSimplePaymentsButton: false)
-
-        // When
-        coordinator.start()
-
-        // Then
-        assertThat(coordinator.navigationController.topViewController, isAnInstanceOf: NewOrderHostingController.self)
-    }
 }
 
 private extension AddOrderCoordinatorTests {
-    func makeAddProductCoordinator(isOrderCreationEnabled: Bool, shouldShowSimplePaymentsButton: Bool) -> AddOrderCoordinator {
+    func makeAddProductCoordinator(isOrderCreationEnabled: Bool) -> AddOrderCoordinator {
         let sourceBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
         return AddOrderCoordinator(siteID: 100,
                                    isOrderCreationEnabled: isOrderCreationEnabled,
-                                   shouldShowSimplePaymentsButton: shouldShowSimplePaymentsButton,
                                    sourceBarButtonItem: sourceBarButtonItem,
                                    sourceNavigationController: navigationController)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -231,17 +231,16 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertFalse(resynchronizeRequested)
     }
 
-    func test_having_no_error_and_no_simple_payments_does_not_show_banner() {
+    func test_when_having_no_error_shows_simple_payments_banner() {
         // Given
-        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .wcpayNotInstalled)
-        let viewModel = OrderListViewModel(siteID: siteID, filters: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
+        let viewModel = OrderListViewModel(siteID: siteID, filters: nil)
 
         // When
         viewModel.activate()
 
         // Then
         waitUntil {
-            viewModel.topBanner == .none
+            viewModel.topBanner == .simplePaymentsEnabled
         }
     }
 
@@ -259,57 +258,10 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_storing_error_shows_error_banner_with_precedence_over_other_state() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
-
-        // When
-        viewModel.activate()
-        viewModel.hasErrorLoadingData = true
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .error
-        }
-    }
-
-    func test_having_store_onboarded_and_simple_payments_enabled_shows_enabled_top_banner() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
-
-        // When
-        viewModel.activate()
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .simplePaymentsEnabled
-        }
-    }
-
-    func test_having_store_not_onboarded_and_simple_payments_enabled_shows_no_banner() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .wcpayNotInstalled)
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
-
-        // When
-        viewModel.activate()
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .none
-        }
-    }
-
     func test_dismissing_simple_payments_banners_does_not_show_banners() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
 
         // When
         viewModel.activate()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -240,7 +240,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.topBanner == .simplePaymentsEnabled
+            viewModel.topBanner == .simplePayments
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -236,7 +236,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.showPayWithCardRow)
     }
 
-    func test_card_row_is_note_shown_for_non_cpp_store() {
+    func test_card_row_is_not_shown_for_non_cpp_store() {
         // Given
         let cppStateObserver = MockCardPresentPaymentsOnboardingUseCase(initial: .wcpayNotInstalled)
         let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", cppStoreStateObserver: cppStateObserver)
@@ -245,7 +245,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showPayWithCardRow)
     }
 
-    func test_card_row_sate_changes_when_store_state_changes() {
+    func test_card_row_state_changes_when_store_state_changes() {
         // Given
         let subject = PassthroughSubject<CardPresentPaymentOnboardingState, Never>()
         let cppStateObserver = MockCardPresentPaymentsOnboardingUseCase(initial: .wcpayNotInstalled, publisher: subject.eraseToAnyPublisher())


### PR DESCRIPTION
closes #5658

# Why

It was proposed to enable the Simple Payments feature for all merchants since we can mark orders as "paid by cash". 
The "Pay  By Card" row will be hidden for stores that are not CPP ready.

# How

- Remove all the code that conditionally shows the simple payments button in the order list, now it's always visible.

- Move the store CPP status check to `SimplePaymentsMethodViewModel` and render its view accordingly.

# Screenshots

Regular Store | CPP Store
---- | ----
<img width="436" alt="Regular Store" src="https://user-images.githubusercontent.com/562080/146263378-9d4e0517-b2e7-45b3-b7c2-f6a1e136e1ee.png"> |  <img width="438" alt="IPP Store" src="https://user-images.githubusercontent.com/562080/146263393-113b2a03-c2ec-4aa2-9a46-c730b79f4688.png">

# Testing Steps

### In a CPP-Ready store

- Start the simple payments flow
- Go all the way until the payment methods section
- See `Cash` and `Card` rows available.

### In a Non-CPP store

- Start the simple payments flow
- Go all the way until the payment methods section
- See only the `Cash` row available.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
