### PR TITLE
System Status Report: Add new item in Help screen for System Status Report

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -29,6 +29,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .hubMenu:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .systemStatusReport:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -57,4 +57,8 @@ public enum FeatureFlag: Int {
     /// Display the new tab "Menu" in the tab bar.
     ///
     case hubMenu
+
+    /// Displays the System Status Report on Settings/Help screen
+    ///
+    case systemStatusReport
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -147,7 +147,8 @@ private extension HelpAndSupportViewController {
                     .contactSupport,
                     .myTickets,
                     .contactEmail,
-                    .applicationLog]
+                    .applicationLog,
+                    .systemStatusReport]
         }
 
         return [.helpCenter,
@@ -155,7 +156,8 @@ private extension HelpAndSupportViewController {
                 .contactWCPaySupport,
                 .myTickets,
                 .contactEmail,
-                .applicationLog]
+                .applicationLog,
+                .systemStatusReport]
     }
 
     /// Register table cells.
@@ -199,6 +201,8 @@ private extension HelpAndSupportViewController {
             configureMyContactEmail(cell: cell)
         case let cell as ValueOneTableViewCell where row == .applicationLog:
             configureApplicationLog(cell: cell)
+        case let cell as ValueOneTableViewCell where row == .systemStatusReport:
+            configureSystemStatusReport(cell: cell)
         default:
             fatalError()
         }
@@ -264,6 +268,18 @@ private extension HelpAndSupportViewController {
         cell.detailTextLabel?.text = NSLocalizedString(
             "Advanced tool to review the app status",
             comment: "Cell subtitle explaining why you might want to navigate to view the application log."
+        )
+    }
+
+    /// System Status Report cell
+    ///
+    func configureSystemStatusReport(cell: ValueOneTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("System Status Report", comment: "View system status report cell title on Help screen")
+        cell.detailTextLabel?.text = NSLocalizedString(
+            "Various system information about your site",
+            comment: "Description of the system status report on Help screen"
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -142,22 +142,18 @@ private extension HelpAndSupportViewController {
     }
 
     private func calculateRows() -> [Row] {
-        guard isPaymentsAvailable else {
-            return [.helpCenter,
-                    .contactSupport,
-                    .myTickets,
-                    .contactEmail,
-                    .applicationLog,
-                    .systemStatusReport]
+        var rows: [Row] = [.helpCenter, .contactSupport]
+        if isPaymentsAvailable {
+            rows.append(.contactWCPaySupport)
         }
 
-        return [.helpCenter,
-                .contactSupport,
-                .contactWCPaySupport,
-                .myTickets,
-                .contactEmail,
-                .applicationLog,
-                .systemStatusReport]
+        rows.append(contentsOf: [.myTickets,
+                                 .contactEmail,
+                                 .applicationLog])
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.systemStatusReport) {
+            rows.append(.systemStatusReport)
+        }
+        return rows
     }
 
     /// Register table cells.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -377,7 +377,7 @@ private extension HelpAndSupportViewController {
     /// System status report action
     ///
     func systemStatusReportWasPressed() {
-        // TODO: Show safari web view
+        // TODO: Show system status view
     }
 
     @objc func dismissWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -358,6 +358,12 @@ private extension HelpAndSupportViewController {
         navigationController?.pushViewController(applicationLogVC, animated: true)
     }
 
+    /// System status report action
+    ///
+    func systemStatusReportWasPressed() {
+        // TODO: Show safari web view
+    }
+
     @objc func dismissWasPressed() {
         dismiss(animated: true, completion: nil)
     }
@@ -412,6 +418,8 @@ extension HelpAndSupportViewController: UITableViewDelegate {
             contactEmailWasPressed()
         case .applicationLog:
             applicationLogWasPressed()
+        case .systemStatusReport:
+            systemStatusReportWasPressed()
         }
     }
 }
@@ -436,6 +444,7 @@ private enum Row: CaseIterable {
     case myTickets
     case contactEmail
     case applicationLog
+    case systemStatusReport
 
     var type: UITableViewCell.Type {
         switch self {
@@ -450,6 +459,8 @@ private enum Row: CaseIterable {
         case .contactEmail:
             return ValueOneTableViewCell.self
         case .applicationLog:
+            return ValueOneTableViewCell.self
+        case .systemStatusReport:
             return ValueOneTableViewCell.self
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5071 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new item on Help screen to navigate to System Status Report screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a valid account
- On My Store tab, navigate to Settings screen
- Tap Help & Support
- On Help screen, notice that there's a new row "System Status Report". Tapping on this is not navigating to any screen - which will be implemented in another PR. This should be done within this week so I figure there's no need for a feature flag - let me know if you think otherwise. Release note will be updated later too.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Shot - iPhone 13 Pro - 2021-12-16 at 08 29 22](https://user-images.githubusercontent.com/5533851/146291739-c8cf4feb-32fb-4a0a-9c44-13c0a98dd9b3.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
