### PR TITLE
Simple Payments: Fix "Done" button when committing note

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsNoteViewModel.swift
@@ -37,9 +37,8 @@ final class SimplePaymentsNoteViewModel: EditCustomerNoteViewModelProtocol {
     }
 
     /// Stores the original note content.
-    /// Temporarily empty.
     ///
-    private var originalNote: String
+    @Published private var originalNote: String
 
     /// Analytics engine.
     ///
@@ -55,9 +54,9 @@ final class SimplePaymentsNoteViewModel: EditCustomerNoteViewModelProtocol {
     /// Assigns the correct navigation trailing item as the new note content changes.
     ///
     private func bindNoteChanges() {
-        $newNote
-            .map { editedContent -> EditCustomerNoteNavigationItem in
-                .done(enabled: editedContent != self.originalNote)
+        Publishers.CombineLatest($newNote, $originalNote)
+            .map { editedContent, originalNote -> EditCustomerNoteNavigationItem in
+                .done(enabled: editedContent != originalNote)
             }
             .assign(to: &$navigationTrailingItem)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsNoteViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsNoteViewModelTests.swift
@@ -42,4 +42,17 @@ final class SimplePaymentsNoteViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.newNote, "")
     }
+
+    func test_viewModel_done_button_gets_disabled_after_commiting_note() {
+        // Given
+        let viewModel = SimplePaymentsNoteViewModel(originalNote: "")
+        viewModel.newNote = "Content"
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: true))
+
+        // When
+        viewModel.updateNote(onFinish: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+    }
 }


### PR DESCRIPTION
closes #5604 

# Why

Prior to this PR, after the merchant entered a note, the done button in the order note screen remains enabled after the merchant navigates to the order note screen again.

This PR fixes that scenario by recalculating the done button state after the note is committed.

# Demo

https://user-images.githubusercontent.com/562080/146301843-9bd738fd-7fbf-4df4-8c11-2f591975a22d.mov

# Testing Steps

- Start the simple payments flow
- Enter an amount & tap next
- Add a note & tap done
- Tap the edit note button and see that the done button is disabled.
- Modify the note and see the done button getting enabled.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
