### PR TITLE
System Status Report: Update Yosemite layer with action to fetch system status

### DIFF
--- a/Yosemite/Yosemite/Actions/SystemStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/SystemStatusAction.swift
@@ -11,4 +11,8 @@ public enum SystemStatusAction: Action {
     /// Fetch an specific systemPlugin by siteID and name
     ///
     case fetchSystemPlugin(siteID: Int64, systemPluginName: String, onCompletion: (SystemPlugin?) -> Void)
+
+    /// Fetch system status report for a site given its ID
+    ///
+    case fetchSystemStatusReport(siteID: Int64, onCompletion: (Result<SystemStatus, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/SystemStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/SystemStatusStore.swift
@@ -31,6 +31,8 @@ public final class SystemStatusStore: Store {
             synchronizeSystemPlugins(siteID: siteID, completionHandler: onCompletion)
         case .fetchSystemPlugin(let siteID, let systemPluginName, let onCompletion):
             fetchSystemPlugin(siteID: siteID, systemPluginName: systemPluginName, completionHandler: onCompletion)
+        case .fetchSystemStatusReport(let siteID, let onCompletion):
+            fetchSystemStatusReport(siteID: siteID, completionHandler: onCompletion)
         }
     }
 }
@@ -48,6 +50,10 @@ private extension SystemStatusStore {
                 completionHandler(.failure(error))
             }
         }
+    }
+
+    func fetchSystemStatusReport(siteID: Int64, completionHandler: @escaping (Result<SystemStatus, Error>) -> Void) {
+        remote.fetchSystemStatusReport(for: siteID, completion: completionHandler)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -5,7 +5,7 @@ import Fakes
 @testable import Networking
 @testable import Storage
 
-class SystemStatusStoreTests: XCTestCase {
+final class SystemStatusStoreTests: XCTestCase {
     /// Mock Dispatcher
     ///
     private var dispatcher: Dispatcher!
@@ -101,5 +101,23 @@ class SystemStatusStoreTests: XCTestCase {
 
         // Then
         XCTAssertEqual(systemPluginResult?.name, "Plugin 3") // number of systemPlugins in storage
+    }
+
+    func test_fetchSystemStatusReport_returns_systemStatus_correctly() {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "system_status", filename: "systemStatus")
+        let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<SystemStatus, Error> = waitFor { promise in
+            let action = SystemStatusAction.fetchSystemStatusReport(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual((try? result.get())?.environment?.siteURL, "https://additional-beetle.jurassic.ninja") // site URL of the site in the json file
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5071 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new case in `SystemStatusAction` to fetch system status report for a site given its ID. `SystemStatusStore` has also been updated to handle the new action.

System status report should always be up-to-date, so the fetched report is not persisted.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The new action hasn't been used anywhere, so just unit tests passing is fine.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
