### PR TITLE
Simple Payments: Cancel note when dismissing it via a drag gesture

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -53,12 +53,21 @@ struct SimplePaymentsSummary: View {
         }
         .background(Color(.listBackground).ignoresSafeArea())
         .navigationTitle(Localization.title)
-        .sheet(isPresented: $showEditNote) {
-            EditCustomerNote(dismiss: {
-                showEditNote.toggle()
+        .sheet(
+            isPresented: $showEditNote,
+            onDismiss: { // Interactive drag dismiss
+                viewModel.noteViewModel.userDidCancelFlow()
                 viewModel.reloadContent()
-                }, viewModel: viewModel.noteViewModel)
-        }
+            },
+            content: {
+                EditCustomerNote(
+                    dismiss: { // Cancel button dismiss
+                        showEditNote.toggle()
+                        viewModel.reloadContent()
+                    },
+                    viewModel: viewModel.noteViewModel
+                )
+            })
         .disabled(viewModel.disableViewActions)
     }
 }


### PR DESCRIPTION
closes #5605 

# Why

Prior to this PR, when dismissing interactively the edit note screen, the edited note content was not reverted to the original note contet.

This PR fixes that by calling the `viewModel.userDidCancelFlow()` method  on the `.sheet(isDismissed:)` closure parameter.

# Demo

https://user-images.githubusercontent.com/562080/146305014-0ca54adc-9489-4b7b-89bb-e504174eb022.mov

# Testing Steps

- Start the simple payments flow
- Enter an amount & tap next
- Add a note & tap done
- Edit that note and cancel it by dismissing the screen via a drag gesture.
- See that the last note content edit was correctly reverted.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
