### PR TITLE
System Status Report: Fix parsing for drop-in and must-use plugins

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -563,6 +563,7 @@
 		DEC51AF72769A15B009F3DF4 /* SystemStatus+Security.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AF62769A15B009F3DF4 /* SystemStatus+Security.swift */; };
 		DEC51AF92769A212009F3DF4 /* SystemStatus+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AF82769A212009F3DF4 /* SystemStatus+Settings.swift */; };
 		DEC51AFB2769C66B009F3DF4 /* SystemStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */; };
+		DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1167,6 +1168,7 @@
 		DEC51AF62769A15B009F3DF4 /* SystemStatus+Security.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+Security.swift"; sourceTree = "<group>"; };
 		DEC51AF82769A212009F3DF4 /* SystemStatus+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+Settings.swift"; sourceTree = "<group>"; };
 		DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapperTests.swift; sourceTree = "<group>"; };
+		DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+DropinMustUsePlugin.swift"; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -2071,6 +2073,7 @@
 				DEC51AE6276848A9009F3DF4 /* SystemStatus+Environment.swift */,
 				DEC51AF427699F3A009F3DF4 /* SystemStatus+Theme.swift */,
 				DEC51AF62769A15B009F3DF4 /* SystemStatus+Security.swift */,
+				DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */,
 			);
 			path = SystemStatusDetails;
 			sourceTree = "<group>";
@@ -2570,6 +2573,7 @@
 				B53EF53C21814900003E146F /* SuccessResultMapper.swift in Sources */,
 				D8EDFE2625EE8A60003D2213 /* WCPayConnectionTokenMapper.swift in Sources */,
 				CC6A1FF5270E042200F6AF4A /* OrderMetaData.swift in Sources */,
+				DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */,
 				02C254A4256371B200A04423 /* ShippingLabelSettings.swift in Sources */,
 				B554FA912180BCFC00C54DFF /* NoteHash.swift in Sources */,
 				CE0A0F19223987DF0075ED8D /* ProductListMapper.swift in Sources */,

--- a/Networking/Networking/Model/SystemStatus.swift
+++ b/Networking/Networking/Model/SystemStatus.swift
@@ -5,8 +5,8 @@ public struct SystemStatus: Decodable {
     let inactivePlugins: [SystemPlugin]
     let environment: Environment?
     let database: Database?
-    let dropinPlugins: [SystemPlugin]
-    let mustUsePlugins: [SystemPlugin]
+    let dropinPlugins: [DropinMustUsePlugin]
+    let mustUsePlugins: [DropinMustUsePlugin]
     let theme: Theme?
     let settings: Settings?
     let pages: [Page]
@@ -18,8 +18,8 @@ public struct SystemStatus: Decodable {
         inactivePlugins: [SystemPlugin],
         environment: Environment?,
         database: Database?,
-        dropinPlugins: [SystemPlugin],
-        mustUsePlugins: [SystemPlugin],
+        dropinPlugins: [DropinMustUsePlugin],
+        mustUsePlugins: [DropinMustUsePlugin],
         theme: Theme?,
         settings: Settings?,
         pages: [Page],
@@ -49,8 +49,8 @@ public struct SystemStatus: Decodable {
         let database = try container.decodeIfPresent(Database.self, forKey: .database)
 
         let dropinMustUsePlugins = try? container.nestedContainer(keyedBy: DropinMustUserPluginsCodingKeys.self, forKey: .dropinMustUsePlugins)
-        let dropinPlugins = try dropinMustUsePlugins?.decodeIfPresent([SystemPlugin].self, forKey: .dropins) ?? []
-        let mustUsePlugins = try dropinMustUsePlugins?.decodeIfPresent([SystemPlugin].self, forKey: .mustUsePlugins) ?? []
+        let dropinPlugins = try dropinMustUsePlugins?.decodeIfPresent([DropinMustUsePlugin].self, forKey: .dropins) ?? []
+        let mustUsePlugins = try dropinMustUsePlugins?.decodeIfPresent([DropinMustUsePlugin].self, forKey: .mustUsePlugins) ?? []
 
         let theme = try container.decodeIfPresent(Theme.self, forKey: .theme)
         let settings = try container.decodeIfPresent(Settings.self, forKey: .settings)

--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+DropinMustUsePlugin.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+DropinMustUsePlugin.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public extension SystemStatus {
+    /// Detail about drop-in / must-use plugin, which has minimal details compared to SystemPlugin
+    ///
+    struct DropinMustUsePlugin: Decodable {
+        let plugin: String
+        let name: String
+    }
+}

--- a/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
@@ -31,6 +31,10 @@ final class SystemStatusMapperTests: XCTestCase {
         XCTAssertEqual(report.activePlugins[0].siteID, dummySiteID)
         XCTAssertEqual(report.inactivePlugins.count, 2)
         XCTAssertEqual(report.inactivePlugins[1].siteID, dummySiteID)
+        XCTAssertEqual(report.dropinPlugins.count, 2)
+        XCTAssertEqual(report.dropinPlugins[0].name, "advanced-cache.php")
+        XCTAssertEqual(report.mustUsePlugins.count, 1)
+        XCTAssertEqual(report.mustUsePlugins[0].name, "WP.com Site Helper")
 
         XCTAssertEqual(report.theme?.name, "Twenty Twenty-One")
         XCTAssertEqual(report.theme?.version, "1.4")

--- a/Networking/NetworkingTests/Responses/systemStatus.json
+++ b/Networking/NetworkingTests/Responses/systemStatus.json
@@ -329,8 +329,26 @@
             }
         ],
         "dropins_mu_plugins": {
-            "dropins": [],
-            "mu_plugins": []
+            "dropins": [
+                {
+                    "plugin": "advanced-cache.php",
+                    "name": "advanced-cache.php"
+                },
+                {
+                    "plugin": "object-cache.php",
+                    "name": "Memcached"
+                }
+            ],
+            "mu_plugins": [
+                {
+                    "plugin": "wpcomsh-loader.php",
+                    "name": "WP.com Site Helper",
+                    "version": "",
+                    "url": "",
+                    "author_name": "",
+                    "author_url": ""
+                }
+            ]
         },
         "theme": {
             "name": "Twenty Twenty-One",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5071 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Since drop-in and must-use plugins in system status report has only minimal details (name and plugins), I created a new model for these instead of reusing `SystemPlugin` to avoid complications with optional fields.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Test JSON and unit test for `SystemStatusMapper` have been updated, so CI should pass.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
