### PR TITLE
Order Creation: Load real product image in ProductRow

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -199,14 +199,3 @@ private extension ProductDetailsCellViewModel {
         }
     }
 }
-
-private extension Product {
-    /// Returns the URL of the first image, if available. Otherwise, nil is returned.
-    var imageURL: URL? {
-        guard let productImageURLString = images.first?.src,
-              let encodedProductImageURLString = productImageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-            return nil
-        }
-        return URL(string: encodedProductImageURLString)
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -119,7 +119,8 @@ struct ProductRow_Previews: PreviewProvider {
                                             stockStatusKey: "instock",
                                             stockQuantity: 7,
                                             manageStock: true,
-                                            canChangeQuantity: true)
+                                            canChangeQuantity: true,
+                                            imageURL: nil)
         let viewModelWithoutStepper = ProductRowViewModel(id: 1,
                                                           name: "Love Ficus",
                                                           sku: "123456",
@@ -127,7 +128,8 @@ struct ProductRow_Previews: PreviewProvider {
                                                           stockStatusKey: "instock",
                                                           stockQuantity: 7,
                                                           manageStock: true,
-                                                          canChangeQuantity: false)
+                                                          canChangeQuantity: false,
+                                                          imageURL: nil)
 
         ProductRow(viewModel: viewModel)
             .previewDisplayName("ProductRow with stepper")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Kingfisher
 
 /// Represent a single product row in the Product section of a New Order
 ///
@@ -15,11 +16,14 @@ struct ProductRow: View {
             AdaptiveStack(horizontalAlignment: .leading) {
                 HStack(alignment: .top) {
                     // Product image
-                    // TODO: Display actual product image when available
-                    Image(uiImage: .productPlaceholderImage)
+                    KFImage.url(viewModel.imageURL)
+                        .placeholder {
+                            Image(uiImage: .productPlaceholderImage)
+                        }
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                         .frame(width: Layout.productImageSize * scale, height: Layout.productImageSize * scale)
+                        .cornerRadius(Layout.cornerRadius)
                         .foregroundColor(Color(UIColor.listSmallIcon))
                         .accessibilityHidden(true)
 
@@ -100,6 +104,7 @@ private struct ProductStepper: View {
 
 private enum Layout {
     static let productImageSize: CGFloat = 44.0
+    static let cornerRadius: CGFloat = 4.0
     static let stepperBorderWidth: CGFloat = 1.0
     static let stepperBorderRadius: CGFloat = 4.0
     static let stepperButtonSize: CGFloat = 22.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -17,6 +17,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable, Equatable {
     ///
     let id: Int64
 
+    /// The first available product image
+    ///
+    let imageURL: URL?
+
     /// Product name
     ///
     let name: String
@@ -73,6 +77,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable, Equatable {
          stockQuantity: Decimal?,
          manageStock: Bool,
          canChangeQuantity: Bool,
+         imageURL: URL?,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.id = id
         self.name = name
@@ -82,6 +87,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable, Equatable {
         self.stockQuantity = stockQuantity
         self.manageStock = manageStock
         self.canChangeQuantity = canChangeQuantity
+        self.imageURL = imageURL
         self.currencyFormatter = currencyFormatter
     }
 
@@ -96,6 +102,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable, Equatable {
                   stockQuantity: product.stockQuantity,
                   manageStock: product.manageStock,
                   canChangeQuantity: canChangeQuantity,
+                  imageURL: product.imageURL,
                   currencyFormatter: currencyFormatter)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/Product+Media.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/Product+Media.swift
@@ -11,4 +11,13 @@ extension Product {
     var imageStatuses: [ProductImageStatus] {
         return images.map({ ProductImageStatus.remote(image: $0) })
     }
+
+    /// Returns the URL of the first image, if available. Otherwise, nil is returned.
+    var imageURL: URL? {
+        guard let productImageURLString = images.first?.src,
+              let encodedProductImageURLString = productImageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            return nil
+        }
+        return URL(string: encodedProductImageURLString)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -6,7 +6,10 @@ class ProductRowViewModelTests: XCTestCase {
 
     func test_viewModel_is_created_with_correct_initial_values() {
         // Given
-        let product = Product.fake().copy(productID: 12, name: "Test Product")
+        let imageURLString = "https://woo.com/woo.jpg"
+        let product = Product.fake().copy(productID: 12,
+                                          name: "Test Product",
+                                          images: [ProductImage.fake().copy(src: imageURLString)])
 
         // When
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
@@ -14,6 +17,7 @@ class ProductRowViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.id, product.productID)
         XCTAssertEqual(viewModel.name, product.name)
+        XCTAssertEqual(viewModel.imageURL, URL(string: imageURLString))
         XCTAssertFalse(viewModel.canChangeQuantity)
         XCTAssertEqual(viewModel.quantity, 1)
     }


### PR DESCRIPTION
Part of #5408

## Description

In the order creation flow, this loads the first product image (when available) for each product on both the New Order and Add Product screens. If there is no product image, a placeholder is shown.

## Changes

* Moves the `imageURL` property from a private extension for `ProductDetailsCellViewModel` to a public extension so it can be reused in `ProductRowViewModel` to get the first product image URL.
* Uses the Kingfisher `KFImage` SwiftUI view to load and cache the product image in `ProductRow`.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, confirm the product list loads with the expected images for each product, showing a placeholder for any products without an image.
6. Tap to select a product.
7. Back on the New Order screen, confirm the Products section shows your selected product with its image.

## Screenshots

Add Product|New Order
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-12-16 at 16 00 22](https://user-images.githubusercontent.com/8658164/146407364-0afd637f-98c2-4f19-b289-a8967559ed2e.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-12-16 at 16 00 38](https://user-images.githubusercontent.com/8658164/146407360-ab41420f-6c4f-4662-bdf7-9bf1d52c80a7.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
