### PR TITLE
Analytics for product SKU input scanner

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -378,6 +378,8 @@ public enum WooAnalyticsStat: String {
     case productDetailViewLinkedProductsTapped = "product_detail_view_linked_products_tapped"
     case productDetailProductDeleted = "product_detail_product_deleted"
     case productDetailViewProductAddOnsTapped = "product_detail_view_product_addons_tapped"
+    case productInventorySettingsSKUScannerButtonTapped = "product_inventory_settings_sku_scanner_button_tapped"
+    case productInventorySettingsSKUScanned = "product_inventory_settings_sku_scanned"
 
     // MARK: Edit Product Variation Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -341,7 +341,11 @@ private extension ProductInventorySettingsViewController {
         guard let navigationController = navigationController else {
             return
         }
+
+        ServiceLocator.analytics.track(.productInventorySettingsSKUScannerButtonTapped)
+
         let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController) { [weak self] barcode in
+            ServiceLocator.analytics.track(.productInventorySettingsSKUScanned)
             self?.onSKUBarcodeScanned(barcode: barcode)
         }
         view.endEditing(true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1086,7 +1086,8 @@ private extension ProductFormViewController {
         }
         let originalData = ProductInventoryEditableData(productModel: product)
         let hasChangedData = originalData != data
-        //TODO: Add analytics
+
+        ServiceLocator.analytics.track(.productInventorySettingsDoneButtonTapped, withProperties: ["has_changed_data": hasChangedData])
 
         guard hasChangedData else {
             return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #2407 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As we plan to release the product SKU input scanner as the first feature of barcode scanner, we want to understand its usage. This can help us determine whether it's worth the effort to complete the second and much more complicated flow of inventory scanner.

I added two new events to track for the feature, please feel free to suggest anything!
- `*_product_inventory_settings_sku_scanner_button_tapped`: In product inventory settings, user tapped on the scanner button to scan a barcode to use as the product's SKU
- `*_product_inventory_settings_sku_scanned`: In product inventory settings, user scanned a barcode to use as the product's SKU

In addition, I noticed that the event that tracks when the user taps "Done" in inventory settings is missing (`*_product_inventory_settings_done_button_tapped`). From Tracks, it looks like this event was last tracked in release 5.2. Maybe some refactoring removed this event, and it's added back in the PR. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the products tab
- Tap on a product whose SKU is editable
- Tap on the inventory/SKU row --> in the console, you should see `🔵 Tracked product_detail_view_inventory_settings_tapped`
- Tap on the scan CTA in the accessory view of the SKU row, and grant camera permission if needed  --> in the console, you should see `🔵 Tracked product_inventory_settings_sku_scanner_button_tapped`
- Scan any barcode that is available to you, make sure it's only scanned when the barcode is in the scan area --> after a barcode is detected, you should see `🔵 Tracked product_inventory_settings_sku_scanned`
- Tap "Done" --> in the console, you should see `🔵 Tracked product_inventory_settings_done_button_tapped, properties: [AnyHashable("has_changed_data"): true, ...]` in the console

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
