### PR TITLE
System Status Report: Add copy feature and tracks

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -119,6 +119,8 @@ public enum WooAnalyticsStat: String {
     case supportHelpCenterUserSearched = "support_help_center_user_searched"
     case supportIdentityFormViewed = "support_identity_form_viewed"
     case supportIdentitySet = "support_identity_set"
+    case supportSSROpened = "support_ssr_opened"
+    case supportSSRCopyButtonTapped = "support_ssr_copy_button_tapped"
 
     // MARK: Settings View Events
     //

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -157,6 +157,13 @@ extension UIImage {
         return UIImage.gridicon(.cloudOutline)
     }
 
+    /// Coooy Icon - used in `UIBarButtonItem`
+    ///
+    static var copyBarButtonItemImage: UIImage {
+        return UIImage(systemName: "doc.on.doc", withConfiguration: Configurations.barButtonItemSymbol)!
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// Connection Icon
     ///
     static var connectionImage: UIImage {
@@ -690,6 +697,12 @@ extension UIImage {
     static var searchBarButtonItemImage: UIImage {
         return UIImage(systemName: "magnifyingglass", withConfiguration: Configurations.barButtonItemSymbol)!
             .imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Share Icon - used in `UIBarButtonItem`
+    ///
+    static var shareBarButtonItemImage: UIImage {
+        return UIImage(systemName: "square.and.arrow.up", withConfiguration: Configurations.barButtonItemSymbol)!
     }
 
     /// Shipping Icon

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -160,8 +160,7 @@ extension UIImage {
     /// Coooy Icon - used in `UIBarButtonItem`
     ///
     static var copyBarButtonItemImage: UIImage {
-        return UIImage(systemName: "doc.on.doc", withConfiguration: Configurations.barButtonItemSymbol)!
-            .imageFlippedForRightToLeftLayoutDirection()
+        return UIImage(systemName: "doc.on.doc")!
     }
 
     /// Connection Icon
@@ -702,7 +701,7 @@ extension UIImage {
     /// Share Icon - used in `UIBarButtonItem`
     ///
     static var shareBarButtonItemImage: UIImage {
-        return UIImage(systemName: "square.and.arrow.up", withConfiguration: Configurations.barButtonItemSymbol)!
+        return UIImage(systemName: "square.and.arrow.up")!
     }
 
     /// Shipping Icon

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -698,12 +698,6 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Share Icon - used in `UIBarButtonItem`
-    ///
-    static var shareBarButtonItemImage: UIImage {
-        return UIImage(systemName: "square.and.arrow.up")!
-    }
-
     /// Shipping Icon
     ///
     static var shippingImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -382,6 +382,7 @@ private extension HelpAndSupportViewController {
             self?.navigationController?.popViewController(animated: true)
         }
         navigationController?.pushViewController(controller, animated: true)
+        ServiceLocator.analytics.track(.supportSSROpened)
     }
 
     @objc func dismissWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -76,10 +76,11 @@ struct SystemStatusReportView: View {
                     Image(uiImage: .copyBarButtonItemImage)
                         .renderingMode(.template)
                         .flipsForRightToLeftLayoutDirection(true)
-                        .foregroundColor(Color(.accent))
                 }
+                .disabled(viewModel.statusReport.isEmpty)
             }
         }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -56,6 +56,28 @@ struct SystemStatusReportView: View {
         .onChange(of: viewModel.errorFetchingReport) { newValue in
             showingErrorAlert = newValue
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    UIPasteboard.general.string = viewModel.statusReport
+                }) {
+                    Image(uiImage: .copyBarButtonItemImage)
+                        .renderingMode(.template)
+                        .flipsForRightToLeftLayoutDirection(true)
+                        .foregroundColor(Color(.accent))
+                }
+            }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    // TODO: share the report
+                }) {
+                    Image(uiImage: .shareBarButtonItemImage)
+                        .renderingMode(.template)
+                        .foregroundColor(Color(.accent))
+                }
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -60,6 +60,8 @@ struct SystemStatusReportView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
                     UIPasteboard.general.string = viewModel.statusReport
+                    let notice = Notice(title: Localization.copiedToClipboard, feedbackType: .success)
+                    ServiceLocator.noticePresenter.enqueue(notice: notice)
                 }) {
                     Image(uiImage: .copyBarButtonItemImage)
                         .renderingMode(.template)
@@ -88,6 +90,10 @@ private extension SystemStatusReportView {
         static let cancelButton = NSLocalizedString(
             "Cancel",
             comment: "Cancel button on the error alert when fetching system status report fails"
+        )
+        static let copiedToClipboard = NSLocalizedString(
+            "System status report copied to clipboard",
+            comment: "Toast message showing up when tapping Copy button on System Status Report screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -3,12 +3,24 @@ import SwiftUI
 /// Hosting controller wrapper for `SystemStatusReportView`
 ///
 final class SystemStatusReportHostingController: UIHostingController<SystemStatusReportView> {
+
+    /// Notice presenter to present notice from the rootview
+    ///
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     init(siteID: Int64) {
         let viewModel = SystemStatusReportViewModel(siteID: siteID)
         super.init(rootView: SystemStatusReportView(viewModel: viewModel))
         // The navigation title is set here instead of the SwiftUI view's `navigationTitle`
         // to avoid the blinking of the title label when pushed from UIKit view.
         title = NSLocalizedString("System Status Report", comment: "Navigation title of system status report screen")
+
+        // Use custom notice presenter to avoid extra space for tab bar
+        rootView.noticePresenter = noticePresenter
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -26,6 +38,10 @@ struct SystemStatusReportView: View {
     /// Dismiss action to be triggered when tapping Cancel button on error alert
     ///
     var dismissAction: () -> Void = {}
+
+    /// Notice presenter to present successful copy message
+    ///
+    var noticePresenter: NoticePresenter = ServiceLocator.noticePresenter
 
     @ObservedObject private var viewModel: SystemStatusReportViewModel
     @State private var showingErrorAlert = false
@@ -61,7 +77,7 @@ struct SystemStatusReportView: View {
                 Button(action: {
                     UIPasteboard.general.string = viewModel.statusReport
                     let notice = Notice(title: Localization.copiedToClipboard, feedbackType: .success)
-                    ServiceLocator.noticePresenter.enqueue(notice: notice)
+                    noticePresenter.enqueue(notice: notice)
                     ServiceLocator.analytics.track(.supportSSRCopyButtonTapped)
                 }) {
                     Image(uiImage: .copyBarButtonItemImage)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -4,14 +4,6 @@ import SwiftUI
 ///
 final class SystemStatusReportHostingController: UIHostingController<SystemStatusReportView> {
 
-    /// Notice presenter to present notice from the rootview
-    ///
-    private lazy var noticePresenter: DefaultNoticePresenter = {
-        let noticePresenter = DefaultNoticePresenter()
-        noticePresenter.presentingViewController = self
-        return noticePresenter
-    }()
-
     init(siteID: Int64) {
         let viewModel = SystemStatusReportViewModel(siteID: siteID)
         super.init(rootView: SystemStatusReportView(viewModel: viewModel))
@@ -19,8 +11,8 @@ final class SystemStatusReportHostingController: UIHostingController<SystemStatu
         // to avoid the blinking of the title label when pushed from UIKit view.
         title = NSLocalizedString("System Status Report", comment: "Navigation title of system status report screen")
 
-        // Use custom notice presenter to avoid extra space for tab bar
-        rootView.noticePresenter = noticePresenter
+        // Set presenting view controller to show the notice presenter here
+        rootView.noticePresenter.presentingViewController = self
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -41,7 +33,7 @@ struct SystemStatusReportView: View {
 
     /// Notice presenter to present successful copy message
     ///
-    var noticePresenter: NoticePresenter = ServiceLocator.noticePresenter
+    let noticePresenter: DefaultNoticePresenter
 
     @ObservedObject private var viewModel: SystemStatusReportViewModel
     @State private var showingErrorAlert = false
@@ -49,6 +41,7 @@ struct SystemStatusReportView: View {
     init(viewModel: SystemStatusReportViewModel) {
         self.viewModel = viewModel
         viewModel.fetchReport()
+        noticePresenter = DefaultNoticePresenter()
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -67,16 +67,6 @@ struct SystemStatusReportView: View {
                         .foregroundColor(Color(.accent))
                 }
             }
-
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    // TODO: share the report
-                }) {
-                    Image(uiImage: .shareBarButtonItemImage)
-                        .renderingMode(.template)
-                        .foregroundColor(Color(.accent))
-                }
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -62,6 +62,7 @@ struct SystemStatusReportView: View {
                     UIPasteboard.general.string = viewModel.statusReport
                     let notice = Notice(title: Localization.copiedToClipboard, feedbackType: .success)
                     ServiceLocator.noticePresenter.enqueue(notice: notice)
+                    ServiceLocator.analytics.track(.supportSSRCopyButtonTapped)
                 }) {
                     Image(uiImage: .copyBarButtonItemImage)
                         .renderingMode(.template)

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -384,6 +384,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.searchBarButtonItemImage)
     }
 
+    func testShareBarButtonItemImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.shareBarButtonItemImage)
+    }
+
     func testShippingImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.shippingImage)
     }
@@ -503,6 +507,10 @@ final class IconsTests: XCTestCase {
 
     func testCloudImageIsNotNil() {
         XCTAssertNotNil(UIImage.cloudImage)
+    }
+
+    func testCopyBarButtonItemImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.copyBarButtonItemImage)
     }
 
     func testHubMenuIconIsNotNil() {

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -384,10 +384,6 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.searchBarButtonItemImage)
     }
 
-    func testShareBarButtonItemImageIconIsNotNil() {
-        XCTAssertNotNil(UIImage.shareBarButtonItemImage)
-    }
-
     func testShippingImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.shippingImage)
     }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -505,7 +505,7 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.cloudImage)
     }
 
-    func testCopyBarButtonItemImageIconIsNotNil() {
+    func test_copy_bar_button_item_image_icon_is_not_nil() {
         XCTAssertNotNil(UIImage.copyBarButtonItemImage)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5701
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds new navigation item on System Status Report screen to copy report to clipboard. Track events for when the screen is opened and the copy button is tapped are also added.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a valid account
- On My Store tab select Settings
- Select Help & Support > System Status Report. Notice a new track event in the console: `🔵 Tracked support_ssr_opened`
- Notice the screen now has a copy button on top right, tapping on that shows a notice saying the report has been copied. A new track event shows up too: `🔵 Tracked support_ssr_copy_button_tapped`.
- Navigate back to Help screen then select Customer Support. Try pasting the content in the text field - make sure that it works.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/146525481-39557c94-e057-4a04-ba24-d3efce8b4a58.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
