### PR TITLE
Order Creation: Scroll to bottom of product list after adding a product to order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -46,17 +46,19 @@ struct NewOrder: View {
 
     var body: some View {
         GeometryReader { geometry in
-            ScrollView {
-                VStack(spacing: Layout.noSpacing) {
-                    OrderStatusSection(geometry: geometry, viewModel: viewModel)
+            ScrollViewReader { scroll in
+                ScrollView {
+                    VStack(spacing: Layout.noSpacing) {
+                        OrderStatusSection(geometry: geometry, viewModel: viewModel)
 
-                    Spacer(minLength: Layout.sectionSpacing)
+                        Spacer(minLength: Layout.sectionSpacing)
 
-                    ProductsSection(geometry: geometry, viewModel: viewModel)
+                        ProductsSection(geometry: geometry, scroll: scroll, viewModel: viewModel)
+                    }
                 }
+                .background(Color(.listBackground))
+                .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             }
-            .background(Color(.listBackground))
-            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
@@ -83,6 +85,7 @@ struct NewOrder: View {
 ///
 private struct ProductsSection: View {
     let geometry: GeometryProxy
+    let scroll: ScrollViewProxy
 
     /// View model to drive the view content
     @ObservedObject var viewModel: NewOrderViewModel
@@ -90,6 +93,10 @@ private struct ProductsSection: View {
     /// Defines whether `AddProduct` modal is presented.
     ///
     @State private var showAddProduct: Bool = false
+
+    /// ID for Add Product button
+    ///
+    @Namespace var addProductButton
 
     var body: some View {
         Group {
@@ -107,10 +114,13 @@ private struct ProductsSection: View {
                 Button(NewOrder.Localization.addProduct) {
                     showAddProduct.toggle()
                 }
+                .id(addProductButton)
                 .buttonStyle(PlusButtonStyle())
-                .sheet(isPresented: $showAddProduct) {
+                .sheet(isPresented: $showAddProduct, onDismiss: {
+                    scroll.scrollTo(addProductButton)
+                }, content: {
                     AddProductToOrder(isPresented: $showAddProduct, viewModel: viewModel.addProductViewModel)
-                }
+                })
             }
             .padding(.horizontal, insets: geometry.safeAreaInsets)
             .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -55,6 +55,7 @@ struct NewOrder: View {
 
                         ProductsSection(geometry: geometry, scroll: scroll, viewModel: viewModel)
                     }
+                    .padding(.bottom, insets: geometry.safeAreaInsets)
                 }
                 .background(Color(.listBackground))
                 .ignoresSafeArea(.container, edges: [.horizontal, .bottom])

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -55,10 +55,9 @@ struct NewOrder: View {
 
                         ProductsSection(geometry: geometry, scroll: scroll, viewModel: viewModel)
                     }
-                    .padding(.bottom, insets: geometry.safeAreaInsets)
                 }
-                .background(Color(.listBackground))
-                .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+                .background(Color(.listBackground).ignoresSafeArea())
+                .ignoresSafeArea(.container, edges: [.horizontal])
             }
         }
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -61,7 +61,7 @@ struct AddProductToOrder: View {
                     EmptyView()
                 }
             }
-            .background(Color(.listBackground))
+            .background(Color(.listBackground).ignoresSafeArea())
             .ignoresSafeArea(.container, edges: .horizontal)
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -62,7 +62,7 @@ struct AddProductToOrder: View {
                 }
             }
             .background(Color(.listBackground))
-            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+            .ignoresSafeArea(.container, edges: .horizontal)
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {


### PR DESCRIPTION
Closes: #5676, #5677

## Description

In the order creation flow, after adding a new product to the order the screen now autoscrolls down to the Add Product button to make it easier to add another product to the order.

This also fixes an issue where the bottom of the New Order and Add Product screens did not have a bottom margin (making the home indicator overlap the content).

## Changes

* Adds a `ScrollViewReader` to `NewOrder` and passes the `ScrollViewProxy` to the `ProductsSection` child view.
* Uses the scroll view proxy to scroll to the Add Product button when the `AddProductToOrder` sheet is dismissed.
* Adds safe area bottom padding back to the `NewOrder` and `AddProductToOrder` views, visible when you scroll to the bottom of the screen.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, scroll to the bottom of the screen and confirm there is sufficient bottom padding so the home indicator doesn't overlap the content.
6. Select a product to add it to the order.
7. Repeat steps 4-6 to add multiple products to the order, and notice that the "Add Product" button is always visible on screen, even after adding more than a page of products.
8. Notice that when you scroll on the New Order screen, after adding products, there is sufficient bottom padding so the home indicator doesn't overlap the content.

## Screenshots

https://user-images.githubusercontent.com/8658164/146586790-122500b9-97f8-46c4-af68-ac73f98eb9ce.mp4

New Order bottom padding|Add Product bottom padding
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-12-17 at 17 42 03](https://user-images.githubusercontent.com/8658164/146586807-4b1715a6-2d69-430a-a757-a1b13d23e9c0.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-12-17 at 18 23 15](https://user-images.githubusercontent.com/8658164/146590788-75c79de4-6e8a-49da-aa69-bedd3617dee5.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
