### PR TITLE
Order Creation: Maintain stepper size when product quantity changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -60,7 +60,7 @@ private struct ProductStepper: View {
     @ScaledMetric private var scale: CGFloat = 1
 
     var body: some View {
-        HStack(spacing: Layout.stepperSpacing * scale) {
+        HStack {
             Button {
                 viewModel.decrementQuantity()
             } label: {
@@ -71,7 +71,11 @@ private struct ProductStepper: View {
             }
             .disabled(viewModel.shouldDisableQuantityDecrementer)
 
+            Spacer()
+
             Text(viewModel.quantity.description)
+
+            Spacer()
 
             Button {
                 viewModel.incrementQuantity()
@@ -82,7 +86,8 @@ private struct ProductStepper: View {
                     .frame(height: Layout.stepperButtonSize * scale)
             }
         }
-        .padding(Layout.stepperSpacing/2 * scale)
+        .padding(Layout.stepperPadding * scale)
+        .frame(width: Layout.stepperWidth * scale)
         .overlay(
             RoundedRectangle(cornerRadius: Layout.stepperBorderRadius)
                 .stroke(Color(UIColor.separator), lineWidth: Layout.stepperBorderWidth)
@@ -109,7 +114,8 @@ private enum Layout {
     static let stepperBorderWidth: CGFloat = 1.0
     static let stepperBorderRadius: CGFloat = 4.0
     static let stepperButtonSize: CGFloat = 22.0
-    static let stepperSpacing: CGFloat = 22.0
+    static let stepperPadding: CGFloat = 11.0
+    static let stepperWidth: CGFloat = 112.0
 }
 
 private enum Localization {


### PR DESCRIPTION
Closes: #5697
⚠️ Based on #5683 ⚠️ 

## Description

This fixes the product quantity stepper (for changing the quantity of a product in an order during order creation) so that it maintains the same size when the quantity changes. The stepper still scales according to the font size, but it maintains the same width at each scale.

## Changes

Previously, the stepper had a variable width and fixed spacing between the quantity and +/- buttons. Now, the spacing is adjusted within a fixed width that scales to match dynamic type changes.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, tap to select a product.
6. Back on the New Order screen, tap the +/- buttons in the stepper to change the product quantity in the order. Confirm the stepper maintains the same size.
7. Change the font size on the device and confirm the stepper scales with the font size.

## Screenshots

iPhone with default font size | iPhone with large font size | iPod touch (small screen)
-|-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-12-17 at 18 49 48](https://user-images.githubusercontent.com/8658164/146595655-b0e00631-00d7-4146-b54d-290b65b3e41d.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-12-17 at 19 00 45](https://user-images.githubusercontent.com/8658164/146595650-b6e6de8f-e036-49f6-8927-f6190636ffb0.png)|![Simulator Screen Shot - iPod touch (7th generation) - 2021-12-17 at 18 56 49](https://user-images.githubusercontent.com/8658164/146595653-4bc202d9-7f62-471e-aefc-673cbf42cdb2.png)





## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
