### PR TITLE
Order Creation: Add customer section with action button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -54,6 +54,10 @@ struct NewOrder: View {
                         Spacer(minLength: Layout.sectionSpacing)
 
                         ProductsSection(geometry: geometry, scroll: scroll, viewModel: viewModel)
+
+                        Spacer(minLength: Layout.sectionSpacing)
+
+                        CustomerSection(geometry: geometry)
                     }
                 }
                 .background(Color(.listBackground).ignoresSafeArea())
@@ -131,6 +135,31 @@ private struct ProductsSection: View {
     }
 }
 
+/// Represents the Customer section
+///
+private struct CustomerSection: View {
+    let geometry: GeometryProxy
+
+    var body: some View {
+        Group {
+            Divider()
+
+            VStack(alignment: .leading, spacing: NewOrder.Layout.verticalSpacing) {
+                Text(NewOrder.Localization.customer)
+                    .headlineStyle()
+
+                Button(NewOrder.Localization.addCustomer) { }
+                .buttonStyle(PlusButtonStyle())
+            }
+            .padding(.horizontal, insets: geometry.safeAreaInsets)
+            .padding()
+            .background(Color(.listForeground))
+
+            Divider()
+        }
+    }
+}
+
 // MARK: Constants
 private extension NewOrder {
     enum Layout {
@@ -145,6 +174,8 @@ private extension NewOrder {
         static let errorMessage = NSLocalizedString("Unable to create new order", comment: "Notice displayed when order creation fails")
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating a new order")
         static let addProduct = NSLocalizedString("Add product", comment: "Title text of the button that adds a product when creating a new order")
+        static let customer = NSLocalizedString("Customer", comment: "Title text of the section that shows Customer details when creating a new order")
+        static let addCustomer = NSLocalizedString("Add customer", comment: "Title text of the button that adds a customer when creating a new order")
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/5412.

## Description

This PR adds customer section with action button.
Button tap won't trigger anything now, it will present address form in later PR.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Confirm that Customer section with "Add customer button" displayed correctly.

## Screenshots
<img width=350 src="https://user-images.githubusercontent.com/3132438/146769879-daa632cf-7184-4eb8-be17-9b02c5754dfa.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.