### PR TITLE
[Mobile Payments] Add feature flag for In-Person Payments with the Stripe Payment Gateway extension

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -31,6 +31,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .systemStatusReport:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .stripeExtensionInPersonPayments:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -61,4 +61,8 @@ public enum FeatureFlag: Int {
     /// Displays the System Status Report on Settings/Help screen
     ///
     case systemStatusReport
+
+    /// Allows sites using the WooCommerce Stripe Payment Gateway extension to accept In-Person Payments
+    ///
+    case stripeExtensionInPersonPayments
 }

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -10,6 +10,7 @@ extension GeneralAppSettings {
         feedbacks: CopiableProp<[FeedbackType: FeedbackSettings]> = .copy,
         isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy,
         isOrderCreationSwitchEnabled: CopiableProp<Bool> = .copy,
+        isStripeInPersonPaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
         knownCardReaders: CopiableProp<[String]> = .copy,
         lastEligibilityErrorInfo: NullableCopiableProp<EligibilityErrorInfo> = .copy,
         lastJetpackBenefitsBannerDismissedTime: NullableCopiableProp<Date> = .copy
@@ -18,6 +19,7 @@ extension GeneralAppSettings {
         let feedbacks = feedbacks ?? self.feedbacks
         let isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled ?? self.isViewAddOnsSwitchEnabled
         let isOrderCreationSwitchEnabled = isOrderCreationSwitchEnabled ?? self.isOrderCreationSwitchEnabled
+        let isStripeInPersonPaymentsSwitchEnabled = isStripeInPersonPaymentsSwitchEnabled ?? self.isStripeInPersonPaymentsSwitchEnabled
         let knownCardReaders = knownCardReaders ?? self.knownCardReaders
         let lastEligibilityErrorInfo = lastEligibilityErrorInfo ?? self.lastEligibilityErrorInfo
         let lastJetpackBenefitsBannerDismissedTime = lastJetpackBenefitsBannerDismissedTime ?? self.lastJetpackBenefitsBannerDismissedTime
@@ -27,6 +29,7 @@ extension GeneralAppSettings {
             feedbacks: feedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
             isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
+            isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -28,6 +28,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isOrderCreationSwitchEnabled: Bool
 
+    /// Thes state for the Stripe Gateway Extension IPP feature switch
+    ///
+    public let isStripeInPersonPaymentsSwitchEnabled: Bool
+
     /// A list (possibly empty) of known card reader IDs - i.e. IDs of card readers that should be reconnected to automatically
     /// e.g. ["CHB204909005931"]
     ///
@@ -44,6 +48,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
                 isOrderCreationSwitchEnabled: Bool,
+                isStripeInPersonPaymentsSwitchEnabled: Bool,
                 knownCardReaders: [String],
                 lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
                 lastJetpackBenefitsBannerDismissedTime: Date? = nil) {
@@ -51,6 +56,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
         self.isOrderCreationSwitchEnabled = isOrderCreationSwitchEnabled
+        self.isStripeInPersonPaymentsSwitchEnabled = isStripeInPersonPaymentsSwitchEnabled
         self.knownCardReaders = knownCardReaders
         self.lastEligibilityErrorInfo = lastEligibilityErrorInfo
         self.lastJetpackBenefitsBannerDismissedTime = lastJetpackBenefitsBannerDismissedTime
@@ -78,6 +84,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             feedbacks: updatedFeedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
             isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
+            isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )
@@ -95,6 +102,7 @@ extension GeneralAppSettings {
         self.feedbacks = try container.decodeIfPresent([FeedbackType: FeedbackSettings].self, forKey: .feedbacks) ?? [:]
         self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
         self.isOrderCreationSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isOrderCreationSwitchEnabled) ?? false
+        self.isStripeInPersonPaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isStripeInPersonPaymentsSwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
         self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)
         self.lastJetpackBenefitsBannerDismissedTime = try container.decodeIfPresent(Date.self, forKey: .lastJetpackBenefitsBannerDismissedTime)

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -6,11 +6,7 @@ final class GeneralAppSettingsTests: XCTestCase {
     func test_it_returns_the_correct_status_of_a_stored_feedback() {
         // Given
         let feedback = FeedbackSettings(name: .general, status: .dismissed)
-        let settings = GeneralAppSettings(installationDate: nil,
-                                          feedbacks: [.general: feedback],
-                                          isViewAddOnsSwitchEnabled: false,
-                                          isOrderCreationSwitchEnabled: false,
-                                          knownCardReaders: [])
+        let settings = createGeneralAppSettings(feedbacks: [.general: feedback])
 
         // When
         let loadedStatus = settings.feedbackStatus(of: .general)
@@ -21,11 +17,7 @@ final class GeneralAppSettingsTests: XCTestCase {
 
     func test_it_returns_pending_status_of_a_non_stored_feedback() {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil,
-                                          feedbacks: [:],
-                                          isViewAddOnsSwitchEnabled: false,
-                                          isOrderCreationSwitchEnabled: false,
-                                          knownCardReaders: [])
+        let settings = createGeneralAppSettings()
 
         // When
         let loadedStatus = settings.feedbackStatus(of: .general)
@@ -37,13 +29,7 @@ final class GeneralAppSettingsTests: XCTestCase {
     func test_it_replaces_feedback_when_feedback_exists() {
         // Given
         let existingFeedback = FeedbackSettings(name: .general, status: .dismissed)
-        let settings = GeneralAppSettings(
-            installationDate: nil,
-            feedbacks: [.general: existingFeedback],
-            isViewAddOnsSwitchEnabled: false,
-            isOrderCreationSwitchEnabled: false,
-            knownCardReaders: []
-        )
+        let settings = createGeneralAppSettings(feedbacks: [.general: existingFeedback])
 
         // When
         let newFeedback = FeedbackSettings(name: .general, status: .given(Date()))
@@ -55,11 +41,7 @@ final class GeneralAppSettingsTests: XCTestCase {
 
     func test_it_adds_new_feedback_when_replacing_empty_feedback_store() {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil,
-                                          feedbacks: [:],
-                                          isViewAddOnsSwitchEnabled: false,
-                                          isOrderCreationSwitchEnabled: false,
-                                          knownCardReaders: [])
+        let settings = createGeneralAppSettings()
 
         // When
         let newFeedback = FeedbackSettings(name: .general, status: .given(Date()))
@@ -97,5 +79,23 @@ final class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
         assertEqual(newSettings.isOrderCreationSwitchEnabled, true)
+    }
+}
+
+private extension GeneralAppSettingsTests {
+    func createGeneralAppSettings(installationDate: Date? = nil,
+                                  feedbacks: [FeedbackType: FeedbackSettings] = [:],
+                                  isViewAddOnsSwitchEnabled: Bool = false,
+                                  isOrderCreationSwitchEnabled: Bool = false,
+                                  knownCardReaders: [String] = [],
+                                  lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
+                                  lastJetpackBenefitsBannerDismissedTime: Date? = nil) -> GeneralAppSettings {
+        GeneralAppSettings(installationDate: installationDate,
+                           feedbacks: feedbacks,
+                           isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
+                           isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
+                           knownCardReaders: knownCardReaders,
+                           lastEligibilityErrorInfo: lastEligibilityErrorInfo,
+                           lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime)
     }
 }

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -62,6 +62,7 @@ final class GeneralAppSettingsTests: XCTestCase {
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
                                                   isOrderCreationSwitchEnabled: true,
+                                                  isStripeInPersonPaymentsSwitchEnabled: true,
                                                   knownCardReaders: readers,
                                                   lastEligibilityErrorInfo: eligibilityInfo,
                                                   lastJetpackBenefitsBannerDismissedTime: jetpackBannerDismissedDate)
@@ -81,6 +82,7 @@ final class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
         assertEqual(newSettings.isOrderCreationSwitchEnabled, true)
+        assertEqual(newSettings.isStripeInPersonPaymentsSwitchEnabled, true)
         assertEqual(newSettings.lastJetpackBenefitsBannerDismissedTime, jetpackBannerDismissedDate)
     }
 }
@@ -90,6 +92,7 @@ private extension GeneralAppSettingsTests {
                                   feedbacks: [FeedbackType: FeedbackSettings] = [:],
                                   isViewAddOnsSwitchEnabled: Bool = false,
                                   isOrderCreationSwitchEnabled: Bool = false,
+                                  isStripeInPersonPaymentsSwitchEnabled: Bool = false,
                                   knownCardReaders: [String] = [],
                                   lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
                                   lastJetpackBenefitsBannerDismissedTime: Date? = nil) -> GeneralAppSettings {
@@ -97,6 +100,7 @@ private extension GeneralAppSettingsTests {
                            feedbacks: feedbacks,
                            isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
                            isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
+                           isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
                            knownCardReaders: knownCardReaders,
                            lastEligibilityErrorInfo: lastEligibilityErrorInfo,
                            lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime)

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -53,16 +53,18 @@ final class GeneralAppSettingsTests: XCTestCase {
 
     func test_updating_properties_to_generalAppSettings_does_not_breaks_decoding() throws {
         // Given
-        let currentDate = Date()
+        let installationDate = Date(timeIntervalSince1970: 1630314000) // Mon Aug 30 2021 09:00:00 UTC+0000
+        let jetpackBannerDismissedDate = Date(timeIntervalSince1970: 1631523600) // Mon Sep 13 2021 09:00:00 UTC+0000
         let feedbackSettings = [FeedbackType.general: FeedbackSettings(name: .general, status: .pending)]
         let readers = ["aaaaa", "bbbbbb"]
         let eligibilityInfo = EligibilityErrorInfo(name: "user", roles: ["admin"])
-        let previousSettings = GeneralAppSettings(installationDate: currentDate,
+        let previousSettings = GeneralAppSettings(installationDate: installationDate,
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
                                                   isOrderCreationSwitchEnabled: true,
                                                   knownCardReaders: readers,
-                                                  lastEligibilityErrorInfo: eligibilityInfo)
+                                                  lastEligibilityErrorInfo: eligibilityInfo,
+                                                  lastJetpackBenefitsBannerDismissedTime: jetpackBannerDismissedDate)
 
         let previousEncodedSettings = try JSONEncoder().encode(previousSettings)
         var previousSettingsJson = try JSONSerialization.jsonObject(with: previousEncodedSettings, options: .allowFragments) as? [String: Any]
@@ -73,12 +75,13 @@ final class GeneralAppSettingsTests: XCTestCase {
         let newSettings = try JSONDecoder().decode(GeneralAppSettings.self, from: newEncodedSettings)
 
         // Then
-        assertEqual(newSettings.installationDate, currentDate)
+        assertEqual(newSettings.installationDate, installationDate)
         assertEqual(newSettings.feedbacks, feedbackSettings)
         assertEqual(newSettings.knownCardReaders, readers)
         assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
         assertEqual(newSettings.isOrderCreationSwitchEnabled, true)
+        assertEqual(newSettings.lastJetpackBenefitsBannerDismissedTime, jetpackBannerDismissedDate)
     }
 }
 

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -128,6 +128,14 @@ public enum AppSettingsAction: Action {
     ///
     case setOrderCreationFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
 
+    /// Loads the most recent state for the WooCommerce Stripe Payment Gateway extension In-Person Payments beta feature switch
+    ///
+    case loadStripeInPersonPaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Sets the state for the WooCommerce Stripe Payment Gateway extension In-Person Payments beta feature switch
+    ///
+    case setStripeInPersonPaymentsSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
+
     /// Remember the given card reader (to support automatic reconnection)
     /// where `cardReaderID` is a String e.g. "CHB204909005931"
     ///

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -189,6 +189,10 @@ public class AppSettingsStore: Store {
             getTelemetryInfo(siteID: siteID, onCompletion: onCompletion)
         case .resetGeneralStoreSettings:
             resetGeneralStoreSettings()
+        case .loadStripeInPersonPaymentsSwitchState(onCompletion: let onCompletion):
+            loadStripeInPersonPaymentsSwitchState(onCompletion: onCompletion)
+        case .setStripeInPersonPaymentsSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
+            setStripeInPersonPaymentsSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         }
     }
 }
@@ -284,6 +288,26 @@ private extension AppSettingsStore {
 
     }
 
+    /// Loads the current WooCommerce Stripe Payment Gateway extension In-Person Payments beta feature switch state from `GeneralAppSettings`
+    ///
+    func loadStripeInPersonPaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
+        let settings = loadOrCreateGeneralAppSettings()
+        onCompletion(.success(settings.isStripeInPersonPaymentsSwitchEnabled))
+    }
+
+    /// Sets the provided WooCommerce Stripe Payment Gateway extension In-Person Payments  beta feature switch state into `GeneralAppSettings`
+    ///
+    func setStripeInPersonPaymentsSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            let settings = loadOrCreateGeneralAppSettings().copy(isStripeInPersonPaymentsSwitchEnabled: isEnabled)
+            try saveGeneralAppSettings(settings)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+
+    }
+
     /// Loads the last persisted eligibility error information from `GeneralAppSettings`
     ///
     func loadEligibilityErrorInfo(onCompletion: (Result<EligibilityErrorInfo, Error>) -> Void) {
@@ -341,6 +365,7 @@ private extension AppSettingsStore {
                                       feedbacks: [:],
                                       isViewAddOnsSwitchEnabled: false,
                                       isOrderCreationSwitchEnabled: false,
+                                      isStripeInPersonPaymentsSwitchEnabled: false,
                                       knownCardReaders: [],
                                       lastEligibilityErrorInfo: nil)
         }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -160,6 +160,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         let settings = GeneralAppSettings(installationDate: nil,
                                           feedbacks: [:], isViewAddOnsSwitchEnabled: false,
                                           isOrderCreationSwitchEnabled: false,
+                                          isStripeInPersonPaymentsSwitchEnabled: false,
                                           knownCardReaders: [])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
@@ -225,6 +226,7 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
             isOrderCreationSwitchEnabled: false,
+            isStripeInPersonPaymentsSwitchEnabled: false,
             knownCardReaders: []
         )
         return settings

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -607,6 +607,42 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertFalse(isVisible)
     }
 
+    func test_loadStripeInPersonPaymentsSwitchState_returns_false_on_new_generalAppSettings() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadStripeInPersonPaymentsSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_loadStripeInPersonPaymentsSwitchState_returns_true_after_updating_switch_state_to_true() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.setStripeInPersonPaymentsSwitchState(isEnabled: true, onCompletion: { _ in })
+        subject?.onAction(updateAction)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadStripeInPersonPaymentsSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertTrue(isEnabled)
+    }
+
     // MARK: - General Store Settings
 
     func test_saving_isTelemetryAvailable_works_correctly() throws {
@@ -766,6 +802,7 @@ private extension AppSettingsStoreTests {
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
             isOrderCreationSwitchEnabled: false,
+            isStripeInPersonPaymentsSwitchEnabled: false,
             knownCardReaders: []
         )
         return (settings, feedback)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5541

### Description
The work to support In-Person Payments with the Stripe extension is anticipated to take some time, and to avoid using a long-lived feature branch, we've opted to put the changes behind a feature flag.

This adds a boolean feature flag `.stripeExtensionInPersonPayments` which is turned on for alpha and local developer builds. The flag is only used for determining whether the toggle is shown in the `Experimental features` section of settings.

The new `IPP with Stripe Extension` switch in settings sets the state of `GeneralAppSettings.isStripeInPersonPaymentsSwitchEnabled`, which can be used in future work to determine whether or not the Stripe Extension should be included in the IPP flows.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
Using a local or alpha build:
1. Open the app, and navigate to `⚙️ > Experimental features`
2. Verify that the option `IPP with Stripe Extension` is visible, and turned off
3. Turn on the switch, then force-quit the app
4. Launch the app and navigate back to `Experimental features`, verify that the switch is still turned on.

Using a beta build:
1. Open the app, and navigate to `⚙️ > Experimental features`
2. Verify that the option `IPP with Stripe Extension` is not in the table.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
