### PR TITLE
[Mobile Payments] Pass reader model when creating a payment intent

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderType.swift
+++ b/Hardware/Hardware/CardReader/CardReaderType.swift
@@ -8,3 +8,16 @@ public enum CardReaderType {
     /// Other
     case other
 }
+
+extension CardReaderType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .chipper:
+            return "chipper_2x"
+        case .stripeM2:
+            return "stripe_m2"
+        default:
+            return "other"
+        }
+    }
+}

--- a/Hardware/Hardware/CardReader/CardReaderType.swift
+++ b/Hardware/Hardware/CardReader/CardReaderType.swift
@@ -9,8 +9,8 @@ public enum CardReaderType {
     case other
 }
 
-extension CardReaderType: CustomStringConvertible {
-    public var description: String {
+extension CardReaderType {
+    var model: String {
         switch self {
         case .chipper:
             return "chipper_2x"

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -344,7 +344,7 @@ private extension StripeCardReaderService {
     }
 
     func readerModelForIntent() -> String? {
-        connectedReadersSubject.value.first?.readerType.description
+        connectedReadersSubject.value.first?.readerType.model
     }
 
     func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<StripeTerminal.PaymentIntent, Error> {

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -340,12 +340,11 @@ private extension StripeCardReaderService {
     /// Returns the id of the connected reader, if any
     ///
     func readerIDForIntent() -> String? {
-        let connectedReaders = connectedReadersSubject.value
-        guard connectedReaders.count == 1 else {
-            return nil
-        }
+        connectedReadersSubject.value.first?.id
+    }
 
-        return connectedReaders.first?.id
+    func readerModelForIntent() -> String? {
+        connectedReadersSubject.value.first?.readerType.description
     }
 
     func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<StripeTerminal.PaymentIntent, Error> {
@@ -359,6 +358,7 @@ private extension StripeCardReaderService {
             /// Add the reader_ID to the request metadata so we can attribute this intent to the connected reader
             ///
             parameters.metadata?[Constants.readerIDMetadataKey] = self?.readerIDForIntent()
+            parameters.metadata?[Constants.readerModelMetadataKey] = self?.readerModelForIntent()
 
             Terminal.shared.createPaymentIntent(parameters) { (intent, error) in
                 if let error = error {
@@ -621,6 +621,7 @@ private extension StripeCardReaderService {
         /// by the Android app.
         ///
         static let readerIDMetadataKey = "reader_ID"
+        static let readerModelMetadataKey = "reader_model"
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5706 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add the reader model to the metadata passed when creating a payment intent.

For context, see pbUcTB-r9-p2#comment-2113

Changes
1. Declare a property in CardReaderType that returns the string the backend expects. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

At this point, the best way to test this is attempt to create a payment intent, and inspect the metadata that is passed to the PaymentIntentParameters. The best way to do that might be adding a breakpoint in StripeCardReaderService, line 363 and `po parameters.metadata`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
