### PR TITLE
Order Creation: Remove product from order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -98,6 +98,10 @@ private struct ProductsSection: View {
     ///
     @Namespace var addProductButton
 
+    /// View model for the selected product row
+    ///
+    @State private var selectedProduct: ProductRowViewModel? = nil
+
     var body: some View {
         Group {
             Divider()
@@ -108,6 +112,15 @@ private struct ProductsSection: View {
 
                 ForEach(viewModel.productRows) { productRowViewModel in
                     ProductRow(viewModel: productRowViewModel)
+                        .onTapGesture {
+                            selectedProduct = productRowViewModel
+                        }
+                        .sheet(item: $selectedProduct) { product in
+                            ProductInOrder(productRowViewModel: product) {
+                                // Remove the selected product from the order
+                            }
+                        }
+
                     Divider()
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -98,10 +98,6 @@ private struct ProductsSection: View {
     ///
     @Namespace var addProductButton
 
-    /// View model for the selected product row
-    ///
-    @State private var selectedProductVM: ProductRowViewModel? = nil
-
     var body: some View {
         Group {
             Divider()
@@ -110,19 +106,16 @@ private struct ProductsSection: View {
                 Text(NewOrder.Localization.products)
                     .headlineStyle()
 
-                ForEach(viewModel.productRows.indices, id: \.self) { index in
-                    ProductRow(viewModel: viewModel.productRows[index])
+                ForEach(viewModel.productRows) { productRow in
+                    ProductRow(viewModel: productRow)
                         .onTapGesture {
-                            guard viewModel.orderDetails.items.indices.contains(index) else {
-                                return
-                            }
-                            let selectedProduct = viewModel.orderDetails.items[index].product
-                            selectedProductVM = ProductRowViewModel(product: selectedProduct, canChangeQuantity: false)
+                            viewModel.selectOrderItem(productRow.id)
                         }
-                        .sheet(item: $selectedProductVM) { product in
-                            ProductInOrder(productRowViewModel: product) {
-                                // Remove the selected product from the order
+                        .sheet(item: $viewModel.selectedOrderItem) { item in
+                            let productInOrderVM = ProductInOrderViewModel(product: item.product) {
+                                viewModel.removeItemFromOrder(item)
                             }
+                            ProductInOrder(viewModel: productInOrderVM)
                         }
 
                     Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -100,7 +100,7 @@ private struct ProductsSection: View {
 
     /// View model for the selected product row
     ///
-    @State private var selectedProduct: ProductRowViewModel? = nil
+    @State private var selectedProductVM: ProductRowViewModel? = nil
 
     var body: some View {
         Group {
@@ -110,12 +110,16 @@ private struct ProductsSection: View {
                 Text(NewOrder.Localization.products)
                     .headlineStyle()
 
-                ForEach(viewModel.productRows) { productRowViewModel in
-                    ProductRow(viewModel: productRowViewModel)
+                ForEach(viewModel.productRows.indices, id: \.self) { index in
+                    ProductRow(viewModel: viewModel.productRows[index])
                         .onTapGesture {
-                            selectedProduct = productRowViewModel
+                            guard viewModel.orderDetails.items.indices.contains(index) else {
+                                return
+                            }
+                            let selectedProduct = viewModel.orderDetails.items[index].product
+                            selectedProductVM = ProductRowViewModel(product: selectedProduct, canChangeQuantity: false)
                         }
-                        .sheet(item: $selectedProduct) { product in
+                        .sheet(item: $selectedProductVM) { product in
                             ProductInOrder(productRowViewModel: product) {
                                 // Remove the selected product from the order
                             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -86,6 +86,11 @@ final class NewOrderViewModel: ObservableObject {
     ///
     @Published private(set) var productRows: [ProductRowViewModel] = []
 
+    /// Item selected from the list of products in the order.
+    /// Used to open the product details in `ProductInOrder`.
+    ///
+    @Published var selectedOrderItem: NewOrderItem? = nil
+
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
         self.stores = stores
@@ -93,6 +98,21 @@ final class NewOrderViewModel: ObservableObject {
 
         configureNavigationTrailingItem()
         configureStatusBadgeViewModel()
+        configureProductRowViewModels()
+    }
+
+    /// Selects an order item.
+    ///
+    /// - Parameter id: ID of the order item to select
+    func selectOrderItem(_ id: String) {
+        selectedOrderItem = orderDetails.items.first(where: { $0.id == id })
+    }
+
+    /// Removes an item from the order.
+    ///
+    /// - Parameter item: Item to remove from the order
+    func removeItemFromOrder(_ item: NewOrderItem) {
+        orderDetails.items.removeAll(where: { $0 == item })
         configureProductRowViewModels()
     }
 
@@ -187,7 +207,8 @@ extension NewOrderViewModel {
 
     /// Representation of new items in an order.
     ///
-    struct NewOrderItem {
+    struct NewOrderItem: Equatable, Identifiable {
+        var id: String
         let product: Product
         var quantity: Decimal
 
@@ -196,6 +217,7 @@ extension NewOrderViewModel {
         }
 
         init(product: Product, quantity: Decimal) {
+            self.id = UUID().uuidString
             self.product = product
             self.quantity = quantity
         }
@@ -247,7 +269,7 @@ private extension NewOrderViewModel {
     ///
     func configureProductRowViewModels() {
         productRows = orderDetails.items.enumerated().map { index, item in
-            let productRowViewModel = ProductRowViewModel(id: index.description, product: item.product, canChangeQuantity: true)
+            let productRowViewModel = ProductRowViewModel(id: item.id, product: item.product, canChangeQuantity: true)
 
             // Observe changes to the product quantity
             productRowViewModel.$quantity

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -3,15 +3,11 @@ import Yosemite
 
 struct ProductInOrder: View {
 
-    @Environment(\.presentationMode) var presentation
+    @Environment(\.presentationMode) private var presentation
 
-    /// The product being edited.
+    /// View model to drive the view content
     ///
-    let productRowViewModel: ProductRowViewModel
-
-    /// Closure invoked when the product is removed.
-    ///
-    let onRemoveProduct: (() -> Void)?
+    let viewModel: ProductInOrderViewModel
 
     var body: some View {
         NavigationView {
@@ -19,7 +15,7 @@ struct ProductInOrder: View {
                 VStack(spacing: Layout.noSpacing) {
                     Section {
                         Divider()
-                        ProductRow(viewModel: productRowViewModel)
+                        ProductRow(viewModel: viewModel.productRowViewModel)
                             .padding()
                         Divider()
                     }
@@ -30,7 +26,7 @@ struct ProductInOrder: View {
                     Section {
                         Divider()
                         Button(Localization.remove) {
-                            onRemoveProduct?()
+                            viewModel.onRemoveProduct()
                             presentation.wrappedValue.dismiss()
                         }
                         .padding()
@@ -74,7 +70,7 @@ private extension ProductInOrder {
 
 struct ProductInOrder_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ProductRowViewModel(productID: 1,
+        let productRowVM = ProductRowViewModel(productID: 1,
                                             name: "Love Ficus",
                                             sku: "123456",
                                             price: "20",
@@ -83,6 +79,8 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             manageStock: true,
                                             canChangeQuantity: false,
                                             imageURL: nil)
-        ProductInOrder(productRowViewModel: viewModel, onRemoveProduct: {})
+        let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
+                                                onRemoveProduct: {})
+        ProductInOrder(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -1,13 +1,86 @@
 import SwiftUI
+import Yosemite
 
 struct ProductInOrder: View {
+
+    /// Defines whether the view is presented.
+    ///
+    @Binding var isPresented: Bool
+
+    /// The product being edited.
+    ///
+    let productRowViewModel: ProductRowViewModel
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            ScrollView {
+                VStack(spacing: Layout.noSpacing) {
+                    Section {
+                        Divider()
+                        ProductRow(viewModel: productRowViewModel)
+                            .padding()
+                        Divider()
+                    }
+                    .background(Color(.listForeground))
+
+                    Spacer(minLength: Layout.sectionSpacing)
+
+                    Section {
+                        Divider()
+                        Button(Localization.remove) {
+                            // Remove product from order
+                            isPresented.toggle()
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .foregroundColor(Color(.error))
+                        Divider()
+                    }
+                    .background(Color(.listForeground))
+                }
+            }
+            .background(Color(.listBackground))
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.close) {
+                        isPresented.toggle()
+                    }
+                }
+            }
+        }
+        .wooNavigationBarStyle()
+    }
+}
+
+// MARK: Constants
+private extension ProductInOrder {
+    enum Layout {
+        static let sectionSpacing: CGFloat = 16.0
+        static let noSpacing: CGFloat = 0.0
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString("Product", comment: "Title for the Product screen during order creation")
+        static let close = NSLocalizedString("Close", comment: "Text for the close button in the Product screen")
+        static let remove = NSLocalizedString("Remove product from order",
+                                              comment: "Text for the button to remove a product from the order during order creation")
     }
 }
 
 struct ProductInOrder_Previews: PreviewProvider {
     static var previews: some View {
-        ProductInOrder()
+        let viewModel = ProductRowViewModel(productID: 1,
+                                            name: "Love Ficus",
+                                            sku: "123456",
+                                            price: "20",
+                                            stockStatusKey: "instock",
+                                            stockQuantity: 7,
+                                            manageStock: true,
+                                            canChangeQuantity: false,
+                                            imageURL: nil)
+        ProductInOrder(isPresented: .constant(true), productRowViewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct ProductInOrder: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct ProductInOrder_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductInOrder()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import Yosemite
 
+/// View to show a single product in an order, with the option to remove it from the order.
+///
 struct ProductInOrder: View {
 
     @Environment(\.presentationMode) private var presentation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -3,13 +3,15 @@ import Yosemite
 
 struct ProductInOrder: View {
 
-    /// Defines whether the view is presented.
-    ///
-    @Binding var isPresented: Bool
+    @Environment(\.presentationMode) var presentation
 
     /// The product being edited.
     ///
     let productRowViewModel: ProductRowViewModel
+
+    /// Closure invoked when the product is removed.
+    ///
+    let onRemoveProduct: (() -> Void)?
 
     var body: some View {
         NavigationView {
@@ -28,8 +30,8 @@ struct ProductInOrder: View {
                     Section {
                         Divider()
                         Button(Localization.remove) {
-                            // Remove product from order
-                            isPresented.toggle()
+                            onRemoveProduct?()
+                            presentation.wrappedValue.dismiss()
                         }
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -46,7 +48,7 @@ struct ProductInOrder: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.close) {
-                        isPresented.toggle()
+                        presentation.wrappedValue.dismiss()
                     }
                 }
             }
@@ -81,6 +83,6 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             manageStock: true,
                                             canChangeQuantity: false,
                                             imageURL: nil)
-        ProductInOrder(isPresented: .constant(true), productRowViewModel: viewModel)
+        ProductInOrder(productRowViewModel: viewModel, onRemoveProduct: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -1,5 +1,7 @@
 import Yosemite
 
+/// View model for `ProductInOrder`.
+///
 final class ProductInOrderViewModel {
 
     /// The product being edited.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -1,0 +1,25 @@
+import Yosemite
+
+final class ProductInOrderViewModel {
+
+    /// The product being edited.
+    ///
+    let productRowViewModel: ProductRowViewModel
+
+    /// Closure invoked when the product is removed.
+    ///
+    let onRemoveProduct: () -> Void
+
+    init(productRowViewModel: ProductRowViewModel,
+         onRemoveProduct: @escaping () -> Void) {
+        self.productRowViewModel = productRowViewModel
+        self.onRemoveProduct = onRemoveProduct
+    }
+
+    convenience init(product: Product,
+         onRemoveProduct: @escaping () -> Void) {
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        self.init(productRowViewModel: viewModel,
+                  onRemoveProduct: onRemoveProduct)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1102,6 +1102,7 @@
 		CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */; };
 		CC254F3626C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */; };
 		CC254F3826C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */; };
+		CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
 		CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */; };
 		CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */; };
@@ -2646,6 +2647,7 @@
 		CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageSelection.swift; sourceTree = "<group>"; };
 		CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageForm.swift; sourceTree = "<group>"; };
 		CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModel.swift; sourceTree = "<group>"; };
+		CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrderViewModel.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
 		CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndToggleRow.swift; sourceTree = "<group>"; };
@@ -5968,6 +5970,7 @@
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
 				CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */,
 				CCC284102768C18500F6CC8B /* ProductInOrder.swift */,
+				CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */,
 			);
 			path = ProductsSection;
 			sourceTree = "<group>";
@@ -8116,6 +8119,7 @@
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
 				D8B4D5F226C2CF5B00F34E94 /* InPersonPaymentsStripeAccountOverdueView.swift in Sources */,
 				021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */,
+				CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */,
 				D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */,
 				317F679826420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift in Sources */,
 				DE279BA426E9C4DC002BA963 /* ShippingLabelPackagesForm.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1121,6 +1121,7 @@
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
 		CCB366AF274518EC007D437A /* NewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */; };
+		CCC284112768C18500F6CC8B /* ProductInOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC284102768C18500F6CC8B /* ProductInOrder.swift */; };
 		CCCC29DD25E5757C0046B96F /* RenameAttributesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */; };
 		CCCC29E325E576810046B96F /* RenameAttributesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC29E225E576810046B96F /* RenameAttributesViewController.swift */; };
 		CCCC5B1326CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC5B1226CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift */; };
@@ -2662,6 +2663,7 @@
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderViewModelTests.swift; sourceTree = "<group>"; };
+		CCC284102768C18500F6CC8B /* ProductInOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrder.swift; sourceTree = "<group>"; };
 		CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RenameAttributesViewController.xib; sourceTree = "<group>"; };
 		CCCC29E225E576810046B96F /* RenameAttributesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewController.swift; sourceTree = "<group>"; };
 		CCCC5B1226CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -5965,6 +5967,7 @@
 				CC53FB3B2757EC7200C4CA4F /* AddProductToOrderViewModel.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
 				CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */,
+				CCC284102768C18500F6CC8B /* ProductInOrder.swift */,
 			);
 			path = ProductsSection;
 			sourceTree = "<group>";
@@ -7900,6 +7903,7 @@
 				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */,
+				CCC284112768C18500F6CC8B /* ProductInOrder.swift in Sources */,
 				451A9963260E31480059D135 /* ShippingLabelPackageDetailsViewModel.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -138,9 +138,8 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product.productID)
 
         // Then
-        let expectedProductRow = ProductRowViewModel(id: "0", product: product, canChangeQuantity: true)
         let expectedOrderItem = product.toOrderItem(quantity: 1)
-        XCTAssertTrue(viewModel.productRows.contains(expectedProductRow), "Product rows do not contain expected product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == sampleProductID }), "Product rows do not contain expected product")
         XCTAssertTrue(viewModel.orderDetails.items.contains(where: { $0.orderItem == expectedOrderItem }), "Order details do not contain expected order item")
     }
 
@@ -159,6 +158,44 @@ class NewOrderViewModelTests: XCTestCase {
         let expectedOrderItem = product.toOrderItem(quantity: 2)
         XCTAssertTrue(viewModel.orderDetails.items.contains(where: { $0.orderItem == expectedOrderItem }), "Order details do not contain expected order item")
     }
+
+    func test_selectOrderItem_selects_expected_order_item() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish")
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+        viewModel.addProductViewModel.selectProduct(product.productID)
+
+        // When
+        let expectedOrderItem = viewModel.orderDetails.items[0]
+        viewModel.selectOrderItem(expectedOrderItem.id)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedOrderItem, expectedOrderItem)
+    }
+
+    func test_view_model_is_updated_when_product_is_removed_from_order() {
+        // Given
+        let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, statusKey: "publish")
+        let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, statusKey: "publish")
+        let storageManager = MockStorageManager()
+        storageManager.insertProducts([product0, product1])
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // Given products are added to order
+        viewModel.addProductViewModel.selectProduct(product0.productID)
+        viewModel.addProductViewModel.selectProduct(product1.productID)
+
+        // When
+        let expectedRemainingItem = viewModel.orderDetails.items[1]
+        viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
+
+        // Then
+        let expectedProductRow = ProductRowViewModel(id: expectedRemainingItem.id, product: product1, canChangeQuantity: true)
+        XCTAssertEqual(viewModel.productRows, [expectedProductRow])
+        XCTAssertEqual(viewModel.orderDetails.items, [expectedRemainingItem])
+    }
 }
 
 private extension MockStorageManager {
@@ -167,5 +204,13 @@ private extension MockStorageManager {
         let orderStatus = viewStorage.insertNewObject(ofType: StorageOrderStatus.self)
         orderStatus.update(with: readOnlyOrderStatus)
         viewStorage.saveIfNeeded()
+    }
+
+    func insertProducts(_ readOnlyProducts: [Product]) {
+        for readOnlyProduct in readOnlyProducts {
+            let product = viewStorage.insertNewObject(ofType: StorageProduct.self)
+            product.update(with: readOnlyProduct)
+            viewStorage.saveIfNeeded()
+        }
     }
 }


### PR DESCRIPTION
Closes: #5408

## Description

This adds support for removing a product from the order during the order creation flow. From the list of the products in the order, you can tap on a product and then tap a button to remove it from the order.

## Changes

* New `ProductInOrder` view and view model to display the selected product with the option to remove it from the order.
* In the `NewOrder` view, each product row now has `onTapGesture()` to select that product. The selected product is then opened in the `ProductInOrder` modal view using [`.sheet(item:onDismiss:content:)`](https://developer.apple.com/documentation/swiftui/view/sheet(item:ondismiss:content:)) (which allows the same sheet to be opened with a different data source for each product row).
* In `NewOrderViewModel`:
   * `selectedOrderItem` keeps a reference to the order item relating to the product row that was tapped. The selected item is set with `selectOrderItem(id:)` and unset when the `ProductInOrder` modal is closed.
   * `removeItemFromOrder(item:)` removes the provided item from the order and refreshes the list of product rows.
   * `NewOrderItem` now conforms to `Identifiable`. This is required by SwiftUI so that `selectedOrderItem` can be used as a data source for the `ProductInOrder` sheet.
* Adds unit tests for selecting and removing items from the order.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. (If Simple Payments is also enabled, tap "Create order" in the bottom sheet that appears.)
4. On the New Order screen, confirm you see the Products section with no products listed yet.
5. Tap the "Add product" button.
6. On the Add Product screen, tap to select a product.
7. On the New Order screen, tap the product in the order and confirm the expected Product screen opens.
8. Select "Remove product from order" and confirm the product is removed from the order.

Note: You can add multiple copies of the same product to the order, with the same or different quantities, and removing a product should remove _only_ the selected copy of the product (leaving other copies of the product in the order).

## Screenshots

<img src="https://user-images.githubusercontent.com/8658164/146816930-79517fec-7da1-4608-84b7-27bdb92c62c0.png" width="300px">

https://user-images.githubusercontent.com/8658164/146816938-fc3a52a8-dd95-4f90-8b3a-cb7862f3b222.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
