### PR TITLE
Simple Payments: Trim email before updating an order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -160,6 +160,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     func updateOrder() {
         showLoadingIndicator = true
+
+        // Clean any whitespace as it is not allowed by the remote endpoint
+        email = email.trimmingCharacters(in: .whitespacesAndNewlines)
+
         // Don't send empty emails as older WC stores can't handle them.
         let action = OrderAction.updateSimplePaymentsOrder(siteID: siteID,
                                                            orderID: orderID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -166,6 +166,30 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.navigateToPaymentMethods)
     }
 
+    func test_when_order_is_updated_email_is_trimmed() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        viewModel.email = " some@email.com "
+
+        // When
+        let trimmedEmail: String? = waitFor { promise in
+            mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateSimplePaymentsOrder(_, _, _, _, _, _, email, _):
+                    promise(email)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+            viewModel.updateOrder()
+        }
+
+        // Then
+        XCTAssertEqual(trimmedEmail, "some@email.com")
+        XCTAssertEqual(trimmedEmail, viewModel.email)
+    }
+
     func test_empty_emails_are_send_as_nil_when_updating_orders() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
# Why 

While recording the Simple Payments demo. I noticed a bug where if a user autocompleted the last part of the email the order update will fail. This was happening because autocompleting a word adds an extra space that is not visible in the UI.

This or fixes that by trimming the email's whitespaces and newlines before updating the order.

# Demo


https://user-images.githubusercontent.com/562080/146830940-c185945b-7289-49c9-9174-b254d1e32ca2.mov


https://user-images.githubusercontent.com/562080/146830959-5e4cbbb2-c9f3-4124-902e-5b7088803d97.mov

# Testing Steps:

- Start the simple payments flow and enter an amount 
- In the Summary Screen enter an email but autocomplete the last bit of it. "eg: com"
- Tap the "Take Payment Button"
- See no error happening 

---
-  [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
