### PR TITLE
Reset app badge count (store order category) when visiting the orders tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [***] Now it's possible to filter Order List by multiple statuses and date ranges. Plus, we removed the top tab bar on Orders Tab. [https://github.com/woocommerce/woocommerce-ios/pull/5491]
 - [*] Login: Password AutoFill will suggest wordpress.com accounts. [https://github.com/woocommerce/woocommerce-ios/pull/5399]
 - [*] Store picker: after logging in with store address, the pre-selected store is now the currently selected store instead of the store from login flow. [https://github.com/woocommerce/woocommerce-ios/pull/5508]
+- [*] The application icon number from order push notifications is now cleared after visiting the orders tab. [https://github.com/woocommerce/woocommerce-ios/pull/5715]
 - [internal] Migrated Settings screen to MVVM [https://github.com/woocommerce/woocommerce-ios/pull/5393]
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -92,6 +92,8 @@ final class OrdersRootViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
         // Needed in ViewWillAppear because this View Controller is never recreated.
         fetchExperimentalTogglesAndConfigureNavigationButtons()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -94,6 +94,8 @@ final class OrdersRootViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         // Needed in ViewWillAppear because this View Controller is never recreated.
         fetchExperimentalTogglesAndConfigureNavigationButtons()
+
+        ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
     }
 
     override var shouldShowOfflineBanner: Bool {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #1388
<!-- Id number of the GitHub issue this PR addresses. -->

Please note that the PR is targeting release 8.1, since we want to do a hotfix release from a number of reports. cc @jkmassel 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Thanks to @ealeksandrov for the investigation! I PR'ed this before you're online so that we can make the hotfix for release 8.1 ASAP.

When we removed `OrdersTabbedViewController` for the order list filter project, there was a line where we reset the app badge count (application icon number) for the `storeOrder` category:

https://github.com/woocommerce/woocommerce-ios/blob/b408c91d05aa8a63aae9c3d1a1949688f6fd4256/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift#L94

Somehow this line wasn't added back to the root view controller `OrdersRootViewController` during the removal. Since this is the only place we reset the app badge count for store order notifications, once users receive any new order notifications they can't clear the badge number anymore.

This PR added back the same code above to `OrdersRootViewController` to reset the badge count when visiting the orders tab. We have similar logic for review notifications to reset its badge count when visiting the reviews tab.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please test this on a device, since remote push notifications aren't supported in simulators.

- Launch the app and make sure the app icon is clear and the app can receive push notifications. If not, please log out and in again to reset
- In web, place an order on the selected store --> the app should receive a new order push notification, and the app icon has a badge `1`
- Either tap on the push notification or go to the orders tab in the app --> the app icon badge should be cleared (before this PR, the app icon badge cannot be cleared either way)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
