### PR TITLE
Jetpack CP: Add auto-retry for checking Jetpack connection and update copies for error state

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallSteps.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallSteps.swift
@@ -39,10 +39,51 @@ extension JetpackInstallStep {
         }
     }
 
+    /// Error message to display when Jetpack install fails on the step
+    ///
+    var errorMessage: String? {
+        switch self {
+        case .installation:
+            return Localization.installErrorMessage
+        case .activation:
+            return Localization.activationErrorMessage
+        case .connection:
+            return Localization.connectionErrorMessage
+        case .done:
+            return nil
+        }
+    }
+
+    /// Title of the CTA to display when Jetpack install fails on the step
+    ///
+    var errorActionTitle: String? {
+        switch self {
+        case .installation:
+            return Localization.wpAdminInstallAction
+        case .activation:
+            return Localization.wpAdminActivateAction
+        case .connection:
+            return Localization.checkConnectionAction
+        case .done:
+            return nil
+        }
+    }
+
     private enum Localization {
         static let installationStep = NSLocalizedString("Installing Jetpack", comment: "Name of installing Jetpack plugin step")
         static let activationStep = NSLocalizedString("Activating", comment: "Name of the activation Jetpack plugin step")
         static let connectionStep = NSLocalizedString("Connecting your store", comment: "Name of the step to connect the store to Jetpack")
         static let finalStep = NSLocalizedString("All done", comment: "Name of final step in Install Jetpack flow.")
+        static let installErrorMessage = NSLocalizedString("Please try again. Alternatively, you can install Jetpack through your WP-Admin.",
+                                                    comment: "Error message when Jetpack install fails")
+        static let activationErrorMessage = NSLocalizedString("Please try again. Alternatively, you can activate Jetpack through your WP-Admin.",
+                                                    comment: "Error message when Jetpack activation fails")
+        static let connectionErrorMessage = NSLocalizedString("Please try again or contact us for support.",
+                                                              comment: "Error message when Jetpack connection fails")
+        static let wpAdminInstallAction = NSLocalizedString("Install Jetpack in WP-Admin",
+                                                            comment: "Action button to install Jetpack on WP-Admin instead of on app")
+        static let wpAdminActivateAction = NSLocalizedString("Activate Jetpack in WP-Admin",
+                                                             comment: "Action button to activate Jetpack on WP-Admin instead of on app")
+        static let checkConnectionAction = NSLocalizedString("Retry Connection", comment: "Action button to check site's connection again.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
@@ -109,7 +109,7 @@ struct JetpackInstallStepsView: View {
                         .fixedSize(horizontal: false, vertical: true)
 
                     if viewModel.installFailed {
-                        Text(viewModel.currentStep == .connection ? Localization.connectionErrorMessage :  Localization.installErrorMessage)
+                        viewModel.currentStep?.errorMessage.map(Text.init)
                             .fixedSize(horizontal: false, vertical: true)
                     } else {
                         AttributedText(descriptionAttributedString)
@@ -169,15 +169,13 @@ struct JetpackInstallStepsView: View {
             // Error state action buttons
             if viewModel.installFailed {
                 VStack(spacing: Constants.actionButtonMargin) {
-                    if viewModel.currentStep == .connection {
-                        Button(Localization.checkConnectionAction) {
-                            viewModel.checkSiteConnection()
-                        }
-                        .buttonStyle(SecondaryButtonStyle())
-                        .fixedSize(horizontal: false, vertical: true)
-                    } else {
-                        Button(Localization.wpAdminAction) {
-                            showingWPAdminWebview = true
+                    viewModel.currentStep?.errorActionTitle.map { title in
+                        Button(title) {
+                            if viewModel.currentStep == .connection {
+                                viewModel.checkSiteConnection()
+                            } else {
+                                showingWPAdminWebview = true
+                            }
                         }
                         .buttonStyle(SecondaryButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
@@ -226,13 +224,7 @@ private extension JetpackInstallStepsView {
                                                           comment: "Message on the Jetpack Install Progress screen. The %1$@ is the site address.")
         static let doneButton = NSLocalizedString("Done", comment: "Done button on the Jetpack Install Progress screen.")
         static let errorTitle = NSLocalizedString("Sorry, something went wrong during install", comment: "Error title when Jetpack install fails")
-        static let installErrorMessage = NSLocalizedString("Please try again. Alternatively, you can install Jetpack through your WP-Admin.",
-                                                    comment: "Error message when Jetpack install fails")
-        static let connectionErrorMessage = NSLocalizedString("Please try again or contact us for support.",
-                                                              comment: "Error message when Jetpack connection fails")
-        static let wpAdminAction = NSLocalizedString("Install Jetpack in WP-Admin", comment: "Action button to install Jetpack win WP-Admin instead of on app")
         static let supportAction = NSLocalizedString("Contact Support", comment: "Action button to contact support when Jetpack install fails")
-        static let checkConnectionAction = NSLocalizedString("Retry Connection", comment: "Action button to check site's connection again.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -129,13 +129,16 @@ final class JetpackInstallStepsViewModel: ObservableObject {
             switch result {
             case .success(let site):
                 guard site.isWooCommerceActive, !site.isJetpackCPConnected else {
-                    self.installFailed = true
+                    self.retryCount += 1
+                    self.checkJetpackPluginDetailsAndProceed()
                     return
                 }
                 self.currentStep = .done
+                self.retryCount = 0
                 self.stores.updateDefaultStore(site)
             case .failure:
-                self.installFailed = true
+                self.retryCount += 1
+                self.checkJetpackPluginDetailsAndProceed()
             }
         }
         stores.dispatch(siteFetch)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
@@ -273,20 +273,19 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
         // When
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
             switch action {
-            case .installSitePlugin(_, _, let onCompletion):
-                onCompletion(.success(()))
-            case .activateSitePlugin(_, _, let onCompletion):
-                onCompletion(.success(()))
-            case .getPluginDetails(_, _, let onCompletion):
-                onCompletion(.failure(NSError(domain: "Not Found", code: 404)))
+            case .getPluginDetails(let siteID, let pluginName, let onCompletion):
+                let jetpack = SitePlugin.fake().copy(siteID: siteID, plugin: pluginName, status: .active)
+                onCompletion(.success(jetpack))
             default:
                 break
             }
         }
+        var checkConnectionInvokedCount = 0
         storesManager.whenReceivingAction(ofType: AccountAction.self) { [weak self] action in
             guard let self = self else { return }
             switch action {
             case .loadAndSynchronizeSite(_, _, _, let onCompletion):
+                checkConnectionInvokedCount += 1
                 let fetchedSite = Site.fake().copy(siteID: self.testSiteID,
                                                    isJetpackThePluginInstalled: true,
                                                    isJetpackConnected: true,
@@ -301,5 +300,6 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.currentStep, .connection)
         XCTAssertTrue(viewModel.installFailed)
+        XCTAssertEqual(checkConnectionInvokedCount, 3) // 1 initial time plus 2 retries
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5365 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously we're marking the Jetpack install as failure immediately when checking connection fails (when `isWooCommerceActive` is false). However, after installing Jetpack, a full sync for the site will be executed and it may take a bit for `isWooCommerceActive` to return correctly.

To avoid showing error state immediately, this PR adds auto-retry mechanism to the Jetpack connection check. The maximum number of retries is 2, similar to how we handle retrying installation and activation.

Additionally, this PR also updates the error messages and CTAs for different steps of the install.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23).
- Follow Kim's comment in p91TBi-6EK-p2#comment-7821 to install the beta version of Jetpack plugin (that has the full sync fix) to the JCP site.
- Open the app and switch to the JCP site if needed.
- Open install Jetpack flow by tapping Jetpack benefit banner on My Store tab if it's visible, or follow Settings > Install Jetpack.
- Proceed to Get Started to get the installation started.
- Notice that the install will start from Activation step. After this step succeeds, you'll be brought to Checking Connection.
- Under good / usual condition, the full sync should complete after 2 site check calls. You should then be brought to the final step: Done. No error state should be displayed.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/146896529-8d503b85-558d-4d20-9145-051f09fe0d0c.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->