### PR TITLE
Order Creation: Fix Simple Payments label on create order bottom sheet

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
@@ -9,7 +9,7 @@ public enum BottomSheetOrderType: Hashable {
     var actionSheetTitle: String {
         switch self {
         case .simple:
-            return NSLocalizedString("Simple Payments",
+            return NSLocalizedString("Simple payment",
                                      comment: "Action sheet option when the user wants to create Simple Payments order")
         case .full:
             return NSLocalizedString("Create order",


### PR DESCRIPTION
## Description

While doing some visual checks in order creation, I noticed that the labels in the create order bottom sheet (after tapping the new order + button) didn't match case. This fixes the bottom sheet so the labels are correct and match the Android bottom sheet (see https://github.com/woocommerce/woocommerce-android/pull/5354).

## Changes

String update from `Simple Payments` to `Simple payment` in the bottom sheet.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button.
4. Notice that the labels are now correct, with matching case.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-12-21 at 11 38 04](https://user-images.githubusercontent.com/8658164/146924835-516eb1a6-afb1-4ab3-9700-b470640e1e98.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-12-21 at 11 40 35](https://user-images.githubusercontent.com/8658164/146924841-24a16a75-fefe-4b6f-bce1-31a2c50beb0d.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
