### PR TITLE
Created view for Analytics

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct AnalyticsView: View {
-    
+
     var body: some View {
         ZStack {
             Text("Title")

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct AnalyticsView: View {
+    
+    var body: some View {
+        ZStack {
+            Text("Title")
+        }
+        .navigationTitle(Localization.title)
+    }
+}
+
+struct AnalyticsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AnalyticsView()
+    }
+}
+
+private extension AnalyticsView {
+    enum Localization {
+        static let title = NSLocalizedString("Analytics", comment: "Title of the analytics view.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -50,7 +50,7 @@ struct HubMenu: View {
 
             // Go to the Analytics screen
             NavigationLink(destination:
-                            EmptyView(),
+                            AnalyticsView(),
                            isActive: $showAnalytics) {
                 EmptyView()
             }.hidden()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -891,6 +891,7 @@
 		7E7C5F8F2719BA7300315B61 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F8E2719BA7300315B61 /* ProductCategoryCellViewModel.swift */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
+		8E0822FD27711EFF006C9E84 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0822FC27711EFF006C9E84 /* AnalyticsView.swift */; };
 		933A27372222354600C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27362222354600C2143A /* Logging.swift */; };
 		934CB123224EAB150005CCB9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934CB122224EAB150005CCB9 /* main.swift */; };
 		9379E1A32255365F006A6BE4 /* TestingMode.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9379E1A22255365F006A6BE4 /* TestingMode.storyboard */; };
@@ -2368,6 +2369,7 @@
 		8CA4F6DE220B257000A47B5D /* WooCommerce.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.release.xcconfig; path = ../config/WooCommerce.release.xcconfig; sourceTree = "<group>"; };
 		8CA4F6E1220B259100A47B5D /* Version.Public.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Version.Public.xcconfig; path = ../config/Version.Public.xcconfig; sourceTree = "<group>"; };
 		8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "RELEASE-NOTES.txt"; path = "../RELEASE-NOTES.txt"; sourceTree = "<group>"; };
+		8E0822FC27711EFF006C9E84 /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
 		90AC1C0B391E04A837BDC64E /* Pods-WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.debug.xcconfig"; sourceTree = "<group>"; };
 		933A27362222354600C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		934CB122224EAB150005CCB9 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -5207,6 +5209,14 @@
 			path = ../config;
 			sourceTree = "<group>";
 		};
+		8E0822F92770EC72006C9E84 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				8E0822FC27711EFF006C9E84 /* AnalyticsView.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		AEB73C1525CD8E3100A8454A /* Edit Product Variation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5474,6 +5484,7 @@
 				CE85FD5120F677460080B73E /* Dashboard */,
 				CE1CCB4920570B05000EE3AC /* Orders */,
 				B59C09DA2188D6E800AB41D6 /* Reviews */,
+				8E0822F92770EC72006C9E84 /* Analytics */,
 				45BBFBBF274FD92B00213001 /* Hub Menu */,
 				74EC34A3225FE1F3004BBC2E /* Products */,
 				022BF7FA23B9D681000A1DFB /* Progress */,
@@ -7856,6 +7867,7 @@
 				57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */,
 				CE21B3D720FE669A00A259D5 /* BasicTableViewCell.swift in Sources */,
 				451A04EA2386D28300E368C9 /* ProductImagesHeaderViewModel.swift in Sources */,
+				8E0822FD27711EFF006C9E84 /* AnalyticsView.swift in Sources */,
 				02307924258731B2008EADEE /* PrintShippingLabelViewModel.swift in Sources */,
 				D843D5D92248EE91001BFA55 /* ManualTrackingViewModel.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,


### PR DESCRIPTION
Merge the PR #5666 before this

Closes: #5651 

### Description
This is a PR draft. I'm going to create the Analytics screen in the hub.
For a start, my main focus is to create all the data flow and display them (without the Graphs) on the UI. Later on, I will add the graphs, the animation while loading the data (ghosting), and dark mode support.

### Screenshots
**From Prototype**
<img src="https://user-images.githubusercontent.com/11445928/146958320-3f0a79d9-68ad-4ec9-83d0-1ba00c92bb4d.png" width="400px" height="100%">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.