### PR TITLE
Simple Payments: Remember the state of the taxes toggle

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -37,14 +37,17 @@ extension GeneralAppSettings {
 extension GeneralStoreSettings {
     public func copy(
         isTelemetryAvailable: CopiableProp<Bool> = .copy,
-        telemetryLastReportedTime: NullableCopiableProp<Date> = .copy
+        telemetryLastReportedTime: NullableCopiableProp<Date> = .copy,
+        areSimplePaymentTaxesEnabled: CopiableProp<Bool> = .copy
     ) -> GeneralStoreSettings {
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
         let telemetryLastReportedTime = telemetryLastReportedTime ?? self.telemetryLastReportedTime
+        let areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled ?? self.areSimplePaymentTaxesEnabled
 
         return GeneralStoreSettings(
             isTelemetryAvailable: isTelemetryAvailable,
-            telemetryLastReportedTime: telemetryLastReportedTime
+            telemetryLastReportedTime: telemetryLastReportedTime,
+            areSimplePaymentTaxesEnabled: areSimplePaymentTaxesEnabled
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -25,10 +25,16 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let telemetryLastReportedTime: Date?
 
+    /// Stores the last simple payments toggle state.
+    ///
+    public let areSimplePaymentTaxesEnabled: Bool
+
     public init(isTelemetryAvailable: Bool = false,
-                telemetryLastReportedTime: Date? = nil) {
+                telemetryLastReportedTime: Date? = nil,
+                areSimplePaymentTaxesEnabled: Bool = false) {
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
+        self.areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled
     }
 }
 
@@ -41,6 +47,7 @@ extension GeneralStoreSettings {
 
         self.isTelemetryAvailable = try container.decodeIfPresent(Bool.self, forKey: .isTelemetryAvailable) ?? false
         self.telemetryLastReportedTime = try container.decodeIfPresent(Date.self, forKey: .telemetryLastReportedTime)
+        self.areSimplePaymentTaxesEnabled = try container.decodeIfPresent(Bool.self, forKey: .areSimplePaymentTaxesEnabled) ?? false
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -26,6 +26,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     @Published var enableTaxes: Bool = false {
         didSet {
+            storeTaxesToggleState()
             analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowTaxesToggled(isOn: enableTaxes))
         }
     }
@@ -132,6 +133,9 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         if let noteContent = noteContent {
             noteViewModel = SimplePaymentsNoteViewModel(originalNote: noteContent)
         }
+
+        // Loads the latest stored taxes toggle state.
+        loadCurrentTaxesToggleState()
     }
 
     convenience init(order: Order,
@@ -191,6 +195,30 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                                        formattedTotal: total,
                                        presentNoticeSubject: presentNoticeSubject,
                                        stores: stores)
+    }
+}
+
+// MARK: Helpers
+private extension SimplePaymentsSummaryViewModel {
+    /// Loads the current taxes toggle state.
+    ///
+    func loadCurrentTaxesToggleState() {
+        let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: siteID) { result in
+            guard case .success(let isOn) = result else {
+                return
+            }
+            self.enableTaxes = isOn
+        }
+        stores.dispatch(action)
+    }
+
+    /// Stores the current taxes toggle state for later query.
+    ///
+    func storeTaxesToggleState() {
+        let action = AppSettingsAction.setSimplePaymentsTaxesToggleState(siteID: siteID, isOn: enableTaxes) { _ in
+            // No op
+        }
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -253,4 +253,48 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         assertEqual(mockAnalytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowFailed.rawValue])
         assertEqual(mockAnalytics.receivedProperties.first?["source"] as? String, "summary")
     }
+
+    func test_taxes_toggle_state_is_properly_loaded() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .getSimplePaymentsTaxesToggleState(_, onCompletion):
+                onCompletion(.success(true))
+            case .setSimplePaymentsTaxesToggleState:
+                break // No op
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+
+        // Then
+        XCTAssertTrue(viewModel.enableTaxes)
+    }
+
+    func test_taxes_toggle_state_is_stored_after_toggling_taxes() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+
+        // When
+        let stateStored: Bool = waitFor { promise in
+            mockStores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+                switch action {
+                case .setSimplePaymentsTaxesToggleState:
+                    promise(true)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            viewModel.enableTaxes = true
+        }
+
+        // Then
+        XCTAssertTrue(stateStored)
+    }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -179,6 +179,14 @@ public enum AppSettingsAction: Action {
     ///
     case getTelemetryInfo(siteID: Int64, onCompletion: (Bool, Date?) -> Void)
 
+    /// Sets the last state of the simple payments taxes toggle for a provided store.
+    ///
+    case setSimplePaymentsTaxesToggleState(siteID: Int64, isOn: Bool, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Get the last state of the simple payments taxes toggle for a provided store.
+    ///
+    case getSimplePaymentsTaxesToggleState(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void)
+
     /// Clears all the products settings
     ///
     case resetGeneralStoreSettings

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -187,6 +187,10 @@ public class AppSettingsStore: Store {
             setTelemetryLastReportedTime(siteID: siteID, time: time)
         case .getTelemetryInfo(siteID: let siteID, onCompletion: let onCompletion):
             getTelemetryInfo(siteID: siteID, onCompletion: onCompletion)
+        case let .setSimplePaymentsTaxesToggleState(siteID, isOn, onCompletion):
+            setSimplePaymentsTaxesToggleState(siteID: siteID, isOn: isOn, onCompletion: onCompletion)
+        case let .getSimplePaymentsTaxesToggleState(siteID, onCompletion):
+            getSimplePaymentsTaxesToggleState(siteID: siteID, onCompletion: onCompletion)
         case .resetGeneralStoreSettings:
             resetGeneralStoreSettings()
         }
@@ -803,6 +807,23 @@ private extension AppSettingsStore {
         } catch {
             DDLogError("⛔️ Deleting store settings file failed. Error: \(error)")
         }
+    }
+
+    // Simple Payments data
+
+    /// Sets the last state of the simple payments taxes toggle for a provided store.
+    ///
+    func setSimplePaymentsTaxesToggleState(siteID: Int64, isOn: Bool, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let newSettings = storeSettings.copy(areSimplePaymentTaxesEnabled: isOn)
+        setStoreSettings(settings: newSettings, for: siteID, onCompletion: onCompletion)
+    }
+
+    /// Get the last state of the simple payments taxes toggle for a provided store.
+    ///
+    func getSimplePaymentsTaxesToggleState(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        onCompletion(.success(storeSettings.areSimplePaymentTaxesEnabled))
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -731,6 +731,42 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertNil(data.telemetryLastReportedTime)
     }
 
+    func test_simplePaymentsToggleTaxes_returns_correct_default_data() throws {
+        // Given
+        let siteID: Int64 = 1234
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: siteID) { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        XCTAssertFalse(try result.get())
+    }
+
+    func test_simplePaymentsToggleTaxes_returns_correct_saved_data() throws {
+        // Given
+        let siteID: Int64 = 1234
+
+        let action = AppSettingsAction.setSimplePaymentsTaxesToggleState(siteID: siteID, isOn: true) { _ in }
+        self.subject?.onAction(action)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: siteID) { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(try result.get())
+    }
+
     func test_resetGeneralStoreSettings_resets_all_settings() throws {
         // Given
         let siteID: Int64 = 1234


### PR DESCRIPTION
closes #5654

# Why 

As we don't have enough information on how many merchants will charge taxes on simple payments, in order to define a default status for it, a good solution is to store the previous store merchant decision so they have to toggle it only once.

# How

- Add a new room for the taxes toggle state in `GeneralStoreSettings`

- Add the necessary actions in `AppSettingActions` in order to get and set the latest state.

- Update the `SummaryViewModel` to get the latest state at `init` and set the new state when the tax switch changes.

# Demo

https://user-images.githubusercontent.com/562080/146961222-be497d9a-4a90-4a24-ae86-a9925a61a017.mov

# Testing Steps

- Start a new simple payments order and enter an amount
- See the tax switch disabled
- Enabled the tax switch it and tap next
- Dismiss the flow

- Start a new simple payments order again and enter an amount
- See the tax switch enabled by default

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
