### PR TITLE
Order Creation: Fix product list sync on Add Product screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -25,31 +25,10 @@ struct AddProductToOrder: View {
                                 }
                         }
 
-                        // Infinite scroll indicator
-                        if #available(iOS 15.0, *) {
-                            ProgressView()
-                                .frame(maxWidth: .infinity, alignment: .center)
-                                .listRowInsets(EdgeInsets())
-                                .listRowBackground(Color(.listBackground))
-                                .listRowSeparator(.hidden, edges: .bottom)
-                                .if(!viewModel.shouldShowScrollIndicator) {
-                                    $0.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger sync when needed
-                                }
-                                .onAppear {
-                                    viewModel.syncNextPage()
-                                }
-                        } else {
-                            ProgressView()
-                                .frame(maxWidth: .infinity, alignment: .center)
-                                .listRowInsets(EdgeInsets())
-                                .listRowBackground(Color(.listBackground))
-                                .if(!viewModel.shouldShowScrollIndicator) {
-                                    $0.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger sync when needed
-                                }
-                                .onAppear {
-                                    viewModel.syncNextPage()
-                                }
-                        }
+                        InfiniteScrollIndicator(showContent: viewModel.shouldShowScrollIndicator)
+                            .onAppear {
+                                viewModel.syncNextPage()
+                            }
                     }
                     .listStyle(PlainListStyle())
                 case .empty:
@@ -82,6 +61,30 @@ struct AddProductToOrder: View {
             }
         }
         .wooNavigationBarStyle()
+    }
+}
+
+private struct InfiniteScrollIndicator: View {
+
+    let showContent: Bool
+
+    var body: some View {
+        if #available(iOS 15.0, *) {
+            createProgressView()
+                .listRowSeparator(.hidden, edges: .bottom)
+        } else {
+            createProgressView()
+        }
+    }
+
+    @ViewBuilder func createProgressView() -> some View {
+        ProgressView()
+            .frame(maxWidth: .infinity, alignment: .center)
+            .listRowInsets(EdgeInsets())
+            .listRowBackground(Color(.listBackground))
+            .if(!showContent) { progressView in
+                progressView.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger sync when needed
+            }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -23,11 +23,6 @@ struct AddProductToOrder: View {
                                     viewModel.selectProduct(rowViewModel.productID)
                                     isPresented.toggle()
                                 }
-                                .onAppear {
-                                    if rowViewModel == viewModel.productRows.last {
-                                        viewModel.syncNextPage()
-                                    }
-                                }
                         }
 
                         // Infinite scroll indicator
@@ -37,13 +32,23 @@ struct AddProductToOrder: View {
                                 .listRowInsets(EdgeInsets())
                                 .listRowBackground(Color(.listBackground))
                                 .listRowSeparator(.hidden, edges: .bottom)
-                                .renderedIf(viewModel.shouldShowScrollIndicator)
+                                .if(!viewModel.shouldShowScrollIndicator) {
+                                    $0.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger sync when needed
+                                }
+                                .onAppear {
+                                    viewModel.syncNextPage()
+                                }
                         } else {
                             ProgressView()
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .listRowInsets(EdgeInsets())
                                 .listRowBackground(Color(.listBackground))
-                                .renderedIf(viewModel.shouldShowScrollIndicator)
+                                .if(!viewModel.shouldShowScrollIndicator) {
+                                    $0.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger sync when needed
+                                }
+                                .onAppear {
+                                    viewModel.syncNextPage()
+                                }
                         }
                     }
                     .listStyle(PlainListStyle())

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -83,7 +83,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         quantity <= minimumQuantity
     }
 
-    init(id: String = UUID().uuidString,
+    init(id: String? = nil,
          productID: Int64,
          name: String,
          sku: String?,
@@ -94,7 +94,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          canChangeQuantity: Bool,
          imageURL: URL?,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
-        self.id = id
+        self.id = id ?? productID.description
         self.productID = productID
         self.name = name
         self.sku = sku
@@ -107,7 +107,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.currencyFormatter = currencyFormatter
     }
 
-    convenience init(id: String = UUID().uuidString,
+    convenience init(id: String? = nil,
                      product: Product,
                      canChangeQuantity: Bool,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// View model for `ProductRow`.
 ///
-final class ProductRowViewModel: ObservableObject, Identifiable, Equatable {
+final class ProductRowViewModel: ObservableObject, Identifiable {
     private let currencyFormatter: CurrencyFormatter
 
     /// Whether the product quantity can be changed.
@@ -170,8 +170,14 @@ private extension ProductRowViewModel {
     }
 }
 
-extension ProductRowViewModel {
+extension ProductRowViewModel: Equatable {
     static func == (lhs: ProductRowViewModel, rhs: ProductRowViewModel) -> Bool {
-        lhs.id == rhs.id
+        return lhs.productID == rhs.productID &&
+        lhs.imageURL == rhs.imageURL &&
+        lhs.name == rhs.name &&
+        lhs.stockAndPriceLabel == rhs.stockAndPriceLabel &&
+        lhs.skuLabel == rhs.skuLabel &&
+        lhs.quantity == rhs.quantity &&
+        lhs.canChangeQuantity == rhs.canChangeQuantity
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -173,15 +173,3 @@ private extension ProductRowViewModel {
         static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
     }
 }
-
-extension ProductRowViewModel: Equatable {
-    static func == (lhs: ProductRowViewModel, rhs: ProductRowViewModel) -> Bool {
-        return lhs.productID == rhs.productID &&
-        lhs.imageURL == rhs.imageURL &&
-        lhs.name == rhs.name &&
-        lhs.stockAndPriceLabel == rhs.stockAndPriceLabel &&
-        lhs.skuLabel == rhs.skuLabel &&
-        lhs.quantity == rhs.quantity &&
-        lhs.canChangeQuantity == rhs.canChangeQuantity
-    }
-}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -196,8 +196,7 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
 
         // Then
-        let expectedProductRow = ProductRowViewModel(id: expectedRemainingItem.id, product: product1, canChangeQuantity: true)
-        XCTAssertEqual(viewModel.productRows, [expectedProductRow])
+        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productID == product0.productID }))
         XCTAssertEqual(viewModel.orderDetails.items, [expectedRemainingItem])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -152,37 +152,4 @@ class ProductRowViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.quantity, 1)
     }
-
-    func test_view_models_equal_when_input_matches() {
-        // Given
-        let product = Product.fake()
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
-        let viewModel2 = ProductRowViewModel(product: product, canChangeQuantity: true)
-
-        // Then
-        XCTAssertEqual(viewModel, viewModel2)
-    }
-
-    func test_view_models_not_equal_when_canChangeQuantity_differs() {
-        // Given
-        let product = Product.fake()
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
-        let viewModel2 = ProductRowViewModel(product: product, canChangeQuantity: false)
-
-        // Then
-        XCTAssertNotEqual(viewModel, viewModel2)
-    }
-
-    func test_view_models_not_equal_after_quantity_changes() {
-        // Given
-        let product = Product.fake()
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
-        let viewModel2 = ProductRowViewModel(product: product, canChangeQuantity: true)
-
-        // When
-        viewModel2.incrementQuantity()
-
-        // Then
-        XCTAssertNotEqual(viewModel, viewModel2)
-    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -152,4 +152,37 @@ class ProductRowViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.quantity, 1)
     }
+
+    func test_view_models_equal_when_input_matches() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
+        let viewModel2 = ProductRowViewModel(product: product, canChangeQuantity: true)
+
+        // Then
+        XCTAssertEqual(viewModel, viewModel2)
+    }
+
+    func test_view_models_not_equal_when_canChangeQuantity_differs() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
+        let viewModel2 = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        XCTAssertNotEqual(viewModel, viewModel2)
+    }
+
+    func test_view_models_not_equal_after_quantity_changes() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
+        let viewModel2 = ProductRowViewModel(product: product, canChangeQuantity: true)
+
+        // When
+        viewModel2.incrementQuantity()
+
+        // Then
+        XCTAssertNotEqual(viewModel, viewModel2)
+    }
 }


### PR DESCRIPTION
Closes: #5725

_If I'm AFK when this PR is reviewed, please feel free to merge, update, or close it as needed. I can also follow up with it after my AFK._

## Description

Fixes the issue in order creation where only the first page of products was syncing in the product list. The product list now syncs more products when you reach the bottom of the list, as expected.

## Changes

1. Updates the equality (`==`) method in `ProductRowViewModel` to check all of the significant view model properties, instead of relying on the ID. Now, if two view models have the same product properties (e.g. name, imageURL), the same quantity, and the same ability to change the quantity, they are equal.
2. Updates `ProductRowViewModel` to base its default ID on the product ID by default. This avoids issues with the ID being dynamically generated, such as the `List` scrolling to the top when the data changes. The product ID will provide a unique ID for the list of products on the store, and can still be set to something unique when needed (such as on the `NewOrder` screen, where a product row can be created multiple times for the same product).

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "Add product" and confirm when you scroll to the bottom of the product list, the next page of products is synced and loaded smoothly (without scrolling you to the top of the product list).
5. Finish adding products and create the order, and confirm everything works as expected (e.g. adding, changing quantity, removing products).

## Screenshots


https://user-images.githubusercontent.com/8658164/146971270-551f40eb-1f0f-4ea7-9a0a-1d8efb0dcd6b.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
