### PR TITLE
[My Store Updates] Create feature flag and show duplicated dashboard UI view controller when feature flag is enabled

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -33,6 +33,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .stripeExtensionInPersonPayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .myStoreTabUpdates:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -65,4 +65,8 @@ public enum FeatureFlag: Int {
     /// Allows sites using the WooCommerce Stripe Payment Gateway extension to accept In-Person Payments
     ///
     case stripeExtensionInPersonPayments
+
+    /// Home Screen project milestone 2: design updates to the My Store tab
+    ///
+    case myStoreTabUpdates
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -52,7 +52,7 @@ final class DashboardUIFactory {
         if let lastStatsV4DashboardUI = lastStatsV4DashboardUI {
             return lastStatsV4DashboardUI
         }
-        let dashboardUI = StoreStatsAndTopPerformersViewController(siteID: siteID)
+        let dashboardUI = OldStoreStatsAndTopPerformersViewController(siteID: siteID)
         lastStatsV4DashboardUI = dashboardUI
         return dashboardUI
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -1,6 +1,7 @@
 import Storage
 import UIKit
 import Yosemite
+import Experiments
 
 /// Contains all UI content to show on Dashboard
 ///
@@ -33,10 +34,12 @@ final class DashboardUIFactory {
 
     private var lastStatsV4DashboardUI: DashboardUI?
     private lazy var deprecatedStatsViewController = DeprecatedDashboardStatsViewController()
+    private let featureFlagService: FeatureFlagService
 
-    init(siteID: Int64, currentDateProvider: @escaping () -> Date = Date.init) {
+    init(siteID: Int64, currentDateProvider: @escaping () -> Date = Date.init, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
         self.statsVersionCoordinator = StatsVersionCoordinator(siteID: siteID)
+        self.featureFlagService = featureFlagService
     }
 
     func reloadDashboardUI(onUIUpdate: @escaping (_ dashboardUI: DashboardUI) -> Void) {
@@ -52,7 +55,12 @@ final class DashboardUIFactory {
         if let lastStatsV4DashboardUI = lastStatsV4DashboardUI {
             return lastStatsV4DashboardUI
         }
-        let dashboardUI = OldStoreStatsAndTopPerformersViewController(siteID: siteID)
+        let dashboardUI: DashboardUI
+        if featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) {
+            dashboardUI = StoreStatsAndTopPerformersViewController(siteID: siteID)
+        } else {
+            dashboardUI = OldStoreStatsAndTopPerformersViewController(siteID: siteID)
+        }
         lastStatsV4DashboardUI = dashboardUI
         return dashboardUI
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersViewController.swift
@@ -1,0 +1,474 @@
+import UIKit
+import XLPagerTabStrip
+import Yosemite
+
+/// Top-level stats container view controller that consists of a button bar with 4 time ranges.
+/// Each time range tab is managed by a `OldStoreStatsAndTopPerformersViewController`.
+///
+final class OldStoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripViewController {
+    /// For navigation bar large title workaround.
+    weak var scrollDelegate: DashboardUIScrollDelegate?
+
+    // MARK: - DashboardUI protocol
+
+    var displaySyncingError: () -> Void = {}
+
+    var onPullToRefresh: () -> Void = {}
+
+    // MARK: - Subviews
+
+    private lazy var buttonBarBottomBorder: UIView = {
+        return createBorderView()
+    }()
+
+    // MARK: - Calculated Properties
+
+    private var visibleChildViewController: StoreStatsAndTopPerformersPeriodViewController {
+        return periodVCs[currentIndex]
+    }
+
+    // MARK: - Private Properties
+
+    private var periodVCs = [StoreStatsAndTopPerformersPeriodViewController]()
+    private let siteID: Int64
+    private var isSyncing = false
+
+    // MARK: - View Lifecycle
+
+    init(siteID: Int64) {
+        self.siteID = siteID
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        configurePeriodViewControllers()
+        configureTabStrip()
+        // 👆 must be called before super.viewDidLoad()
+
+        super.viewDidLoad()
+        configureView()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        ensureGhostContentIsAnimated()
+    }
+
+    // MARK: - PagerTabStripDataSource
+
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+        return periodVCs
+    }
+
+    override func configureCell(_ cell: ButtonBarViewCell, indicatorInfo: IndicatorInfo) {
+        /// Hide the ImageView:
+        /// We don't use it, and if / when "Ghostified" produces a quite awful placeholder UI!
+        cell.imageView.isHidden = true
+        cell.accessibilityIdentifier = indicatorInfo.accessibilityIdentifier
+
+        /// Flip the cells back to their proper state for RTL languages.
+        if traitCollection.layoutDirection == .rightToLeft {
+            cell.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
+    }
+}
+
+extension OldStoreStatsAndTopPerformersViewController: DashboardUI {
+    func reloadData(forced: Bool, completion: @escaping () -> Void) {
+        syncAllStats(forced: forced, onCompletion: { _ in
+            completion()
+        })
+    }
+
+    func remindStatsUpgradeLater() {
+        // No op as this VC represents the latest stats version to date.
+    }
+}
+
+// MARK: - Syncing Data
+//
+private extension OldStoreStatsAndTopPerformersViewController {
+    func syncAllStats(forced: Bool, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        guard !isSyncing else {
+            return
+        }
+
+        isSyncing = true
+
+        let group = DispatchGroup()
+
+        var syncError: Error? = nil
+
+        ensureGhostContentIsDisplayed()
+        showSpinner(shouldShowSpinner: true)
+
+        defer {
+            group.notify(queue: .main) { [weak self] in
+                self?.isSyncing = false
+                self?.removeGhostContent()
+                self?.showSpinner(shouldShowSpinner: false)
+                if let error = syncError {
+                    DDLogError("⛔️ Error loading dashboard: \(error)")
+                    self?.handleSyncError(error: error)
+                    onCompletion?(.failure(error))
+                } else {
+                    self?.updateSiteVisitors(mode: .default)
+                    onCompletion?(.success(()))
+                }
+            }
+        }
+
+        // Since the stats charts are based on site time zone, we set the time zone for the stats UI to be the site time zone.
+        // On the other hand, when syncing the stats data with the API, we want to use the device time zone to find the time range since the API date parameters
+        // have no time zone information and are relative to the site time zone (e.g. 12:00am-11:59pm for "Today" tab).
+        let timezoneForStatsDates = TimeZone.siteTimezone
+        let timezoneForSync = TimeZone.current
+
+        periodVCs.forEach { [weak self] (vc) in
+            guard let self = self else {
+                return
+            }
+
+            if !forced, let lastFullSyncTimestamp = vc.lastFullSyncTimestamp, Date().timeIntervalSince(lastFullSyncTimestamp) < vc.minimalIntervalBetweenSync {
+                // data refresh is not required
+                return
+            }
+
+            // local var to catch sync error for period
+            var periodSyncError: Error? = nil
+
+            vc.siteTimezone = timezoneForStatsDates
+
+            let currentDate = Date()
+            vc.currentDate = currentDate
+            let latestDateToInclude = vc.timeRange.latestDate(currentDate: currentDate, siteTimezone: timezoneForSync)
+
+            // For tasks dispatched for each time period.
+            let periodGroup = DispatchGroup()
+
+            group.enter()
+            periodGroup.enter()
+            self.syncStats(for: siteID,
+                           siteTimezone: timezoneForSync,
+                           timeRange: vc.timeRange,
+                           latestDateToInclude: latestDateToInclude) { [weak self] result in
+                switch result {
+                case .success:
+                    self?.trackStatsLoaded(for: vc.granularity)
+                case .failure(let error):
+                    DDLogError("⛔️ Error synchronizing order stats: \(error)")
+                    periodSyncError = error
+                }
+                group.leave()
+                periodGroup.leave()
+            }
+
+            group.enter()
+            periodGroup.enter()
+            self.syncSiteVisitStats(for: siteID,
+                                    siteTimezone: timezoneForSync,
+                                    timeRange: vc.timeRange,
+                                    latestDateToInclude: latestDateToInclude) { result in
+                if case let .failure(error) = result {
+                    DDLogError("⛔️ Error synchronizing visitor stats: \(error)")
+                    periodSyncError = error
+                }
+                group.leave()
+                periodGroup.leave()
+            }
+
+            group.enter()
+            periodGroup.enter()
+            self.syncTopEarnersStats(for: siteID,
+                                     siteTimezone: timezoneForSync,
+                                     timeRange: vc.timeRange,
+                                     latestDateToInclude: latestDateToInclude) { result in
+                if case let .failure(error) = result {
+                    DDLogError("⛔️ Error synchronizing top earners stats: \(error)")
+                    periodSyncError = error
+                }
+                group.leave()
+                periodGroup.leave()
+            }
+
+            periodGroup.notify(queue: .main) {
+                // Update last successful data sync timestamp
+                if periodSyncError == nil {
+                    vc.lastFullSyncTimestamp = Date()
+                } else {
+                    syncError = periodSyncError
+                }
+            }
+        }
+    }
+
+    func showSpinner(shouldShowSpinner: Bool) {
+        periodVCs.forEach { (vc) in
+            if shouldShowSpinner {
+                vc.refreshControl.beginRefreshing()
+            } else {
+                vc.refreshControl.endRefreshing()
+            }
+        }
+    }
+}
+
+// MARK: - Placeholders
+//
+private extension OldStoreStatsAndTopPerformersViewController {
+
+    /// Displays the Ghost Placeholder whenever there is no visible data.
+    ///
+    func ensureGhostContentIsDisplayed() {
+        guard visibleChildViewController.shouldDisplayStoreStatsGhostContent else {
+            return
+        }
+
+        displayGhostContent()
+    }
+
+    /// Locks UI Interaction and displays Ghost Placeholder animations.
+    ///
+    func displayGhostContent() {
+        view.isUserInteractionEnabled = false
+        buttonBarView.startGhostAnimation(style: .wooDefaultGhostStyle)
+        visibleChildViewController.displayGhostContent()
+    }
+
+    /// Unlocks the and removes the Placeholder Content
+    ///
+    func removeGhostContent() {
+        view.isUserInteractionEnabled = true
+        buttonBarView.stopGhostAnimation()
+        visibleChildViewController.removeGhostContent()
+    }
+
+    /// If the Ghost Content was previously onscreen, this method will restart the animations.
+    ///
+    func ensureGhostContentIsAnimated() {
+        view.restartGhostAnimation(style: .wooDefaultGhostStyle)
+    }
+}
+
+
+// MARK: - User Interface Configuration
+//
+private extension OldStoreStatsAndTopPerformersViewController {
+    func createBorderView() -> UIView {
+        let view = UIView(frame: .zero)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemColor(.separator)
+        NSLayoutConstraint.activate([
+            view.heightAnchor.constraint(equalToConstant: 0.5)
+            ])
+        return view
+    }
+
+    func configureButtonBarBottomBorder() {
+        view.addSubview(buttonBarBottomBorder)
+        NSLayoutConstraint.activate([
+            buttonBarBottomBorder.topAnchor.constraint(equalTo: buttonBarView.bottomAnchor),
+            buttonBarBottomBorder.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            buttonBarBottomBorder.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
+    }
+
+    func configureView() {
+        view.backgroundColor = .listBackground
+        configureButtonBarBottomBorder()
+
+        // Disables any content inset adjustment since `XLPagerTabStrip` doesn't seem to support safe area insets.
+        containerView.contentInsetAdjustmentBehavior = .never
+
+        /// ButtonBarView is a collection view, and it should flip to support
+        /// RTL languages automatically. And yet it doesn't.
+        /// So, for RTL languages, we flip it. This also flips the cells
+        if traitCollection.layoutDirection == .rightToLeft {
+            buttonBarView.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
+    }
+
+    func configurePeriodViewControllers() {
+        let currentDate = Date()
+        let dayVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+                                                                   timeRange: .today,
+                                                                   currentDate: currentDate,
+                                                                   canDisplayInAppFeedbackCard: true)
+        let weekVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+                                                                    timeRange: .thisWeek,
+                                                                    currentDate: currentDate,
+                                                                    canDisplayInAppFeedbackCard: false)
+        let monthVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+                                                                     timeRange: .thisMonth,
+                                                                     currentDate: currentDate,
+                                                                     canDisplayInAppFeedbackCard: false)
+        let yearVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+                                                                    timeRange: .thisYear,
+                                                                    currentDate: currentDate,
+                                                                    canDisplayInAppFeedbackCard: false)
+
+        periodVCs.append(dayVC)
+        periodVCs.append(weekVC)
+        periodVCs.append(monthVC)
+        periodVCs.append(yearVC)
+
+        periodVCs.forEach { (vc) in
+            vc.scrollDelegate = scrollDelegate
+            vc.onPullToRefresh = { [weak self] in
+                self?.onPullToRefresh()
+            }
+        }
+    }
+
+    func configureTabStrip() {
+        settings.style.buttonBarBackgroundColor = .systemColor(.secondarySystemGroupedBackground)
+        settings.style.buttonBarItemBackgroundColor = .systemColor(.secondarySystemGroupedBackground)
+        settings.style.selectedBarBackgroundColor = .primary
+        settings.style.buttonBarItemFont = StyleManager.subheadlineFont
+        settings.style.selectedBarHeight = TabStrip.selectedBarHeight
+        settings.style.buttonBarItemTitleColor = .textSubtle
+        settings.style.buttonBarItemsShouldFillAvailableWidth = false
+        settings.style.buttonBarItemLeftRightMargin = TabStrip.buttonLeftRightMargin
+
+        changeCurrentIndexProgressive = {
+            (oldCell: ButtonBarViewCell?,
+            newCell: ButtonBarViewCell?,
+            progressPercentage: CGFloat,
+            changeCurrentIndex: Bool,
+            animated: Bool) -> Void in
+
+            guard changeCurrentIndex == true else { return }
+            oldCell?.label.textColor = .textSubtle
+            newCell?.label.textColor = .primary
+        }
+    }
+}
+
+// MARK: - Sync'ing Helpers
+//
+private extension OldStoreStatsAndTopPerformersViewController {
+    func syncStats(for siteID: Int64,
+                   siteTimezone: TimeZone,
+                   timeRange: StatsTimeRangeV4,
+                   latestDateToInclude: Date,
+                   onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
+        let action = StatsActionV4.retrieveStats(siteID: siteID,
+                                                 timeRange: timeRange,
+                                                 earliestDateToInclude: earliestDateToInclude,
+                                                 latestDateToInclude: latestDateToInclude,
+                                                 quantity: timeRange.maxNumberOfIntervals,
+                                                 onCompletion: { result in
+                                                    if case let .failure(error) = result {
+                                                        DDLogError("⛔️ Dashboard (Order Stats) — Error synchronizing order stats v4: \(error)")
+                                                    }
+                                                    onCompletion?(result)
+        })
+
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    func syncSiteVisitStats(for siteID: Int64,
+                            siteTimezone: TimeZone,
+                            timeRange: StatsTimeRangeV4,
+                            latestDateToInclude: Date,
+                            onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        let action = StatsActionV4.retrieveSiteVisitStats(siteID: siteID,
+                                                          siteTimezone: siteTimezone,
+                                                          timeRange: timeRange,
+                                                          latestDateToInclude: latestDateToInclude,
+                                                          onCompletion: { result in
+                                                            if case let .failure(error) = result {
+                                                                DDLogError("⛔️ Error synchronizing visitor stats: \(error)")
+                                                            }
+                                                            onCompletion?(result)
+        })
+
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    func syncTopEarnersStats(for siteID: Int64,
+                             siteTimezone: TimeZone,
+                             timeRange: StatsTimeRangeV4,
+                             latestDateToInclude: Date,
+                             onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
+        let action = StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
+                                                          timeRange: timeRange,
+                                                          earliestDateToInclude: earliestDateToInclude,
+                                                          latestDateToInclude: latestDateToInclude,
+                                                          onCompletion: { result in
+                                                            switch result {
+                                                            case .success:
+                                                                ServiceLocator.analytics.track(.dashboardTopPerformersLoaded,
+                                                                                               withProperties: [
+                                                                                                "granularity": timeRange.topEarnerStatsGranularity.rawValue
+                                                                                               ])
+                                                            case .failure(let error):
+                                                                DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
+                                                            }
+                                                            onCompletion?(result)
+        })
+
+        ServiceLocator.stores.dispatch(action)
+    }
+}
+
+private extension OldStoreStatsAndTopPerformersViewController {
+    func updateSiteVisitors(mode: SiteVisitStatsMode) {
+        periodVCs.forEach { vc in
+            vc.siteVisitStatsMode = mode
+        }
+    }
+
+    func handleSiteVisitStatsStoreError(error: SiteVisitStatsStoreError) {
+        switch error {
+        case .noPermission:
+            updateSiteVisitors(mode: .hidden)
+        case .statsModuleDisabled:
+            let defaultSite = ServiceLocator.stores.sessionManager.defaultSite
+            let jcpFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport)
+            if defaultSite?.isJetpackCPConnected == true, jcpFeatureFlagEnabled {
+                updateSiteVisitors(mode: .redactedDueToJetpack)
+            } else {
+                updateSiteVisitors(mode: .hidden)
+            }
+        default:
+            displaySyncingError()
+        }
+    }
+
+    private func handleSyncError(error: Error) {
+        switch error {
+        case let siteVisitStatsStoreError as SiteVisitStatsStoreError:
+            handleSiteVisitStatsStoreError(error: siteVisitStatsStoreError)
+        default:
+            displaySyncingError()
+        }
+    }
+}
+
+// MARK: - Private Helpers
+//
+private extension OldStoreStatsAndTopPerformersViewController {
+    func trackStatsLoaded(for granularity: StatsGranularityV4) {
+        guard ServiceLocator.stores.isAuthenticated else {
+            return
+        }
+
+        ServiceLocator.analytics.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
+    }
+}
+
+// MARK: - Constants!
+//
+private extension OldStoreStatsAndTopPerformersViewController {
+    enum TabStrip {
+        static let buttonLeftRightMargin: CGFloat   = 14.0
+        static let selectedBarHeight: CGFloat       = 3.0
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		02162727237963AF000208D2 /* ProductFormViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02162725237963AF000208D2 /* ProductFormViewController.xib */; };
 		02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02162728237965E8000208D2 /* ProductFormTableViewModel.swift */; };
 		0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */; };
+		021739982772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021739972772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift */; };
 		0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4EB242E06F00083A847 /* MediaType+WPMediaType.swift */; };
 		0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */; };
 		021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */; };
@@ -1623,6 +1624,7 @@
 		02162725237963AF000208D2 /* ProductFormViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductFormViewController.xib; sourceTree = "<group>"; };
 		02162728237965E8000208D2 /* ProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormTableViewModel.swift; sourceTree = "<group>"; };
 		0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModel.swift; sourceTree = "<group>"; };
+		021739972772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldStoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		0218B4EB242E06F00083A847 /* MediaType+WPMediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaType+WPMediaType.swift"; sourceTree = "<group>"; };
 		0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewController.swift; sourceTree = "<group>"; };
@@ -3777,6 +3779,7 @@
 			isa = PBXGroup;
 			children = (
 				028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */,
+				021739972772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift */,
 				028BAC3F22F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift */,
 				028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */,
 				028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */,
@@ -8228,6 +8231,7 @@
 				B5F8B7E02194759100DAB7E2 /* ReviewDetailsViewController.swift in Sources */,
 				262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */,
 				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
+				021739982772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift in Sources */,
 				D8EE9692264D328A0033B2F9 /* ReceiptViewController.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
 				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -10,6 +10,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isPushNotificationsForAllStoresOn: Bool
     private let isJetpackConnectionPackageSupportOn: Bool
     private let isHubMenuOn: Bool
+    private let isMyStoreTabUpdatesOn: Bool
 
     init(isShippingLabelsM2M3On: Bool = false,
          isInternationalShippingLabelsOn: Bool = false,
@@ -18,7 +19,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isShippingLabelsMultiPackageOn: Bool = false,
          isPushNotificationsForAllStoresOn: Bool = false,
          isJetpackConnectionPackageSupportOn: Bool = false,
-         isHubMenuOn: Bool = false) {
+         isHubMenuOn: Bool = false,
+         isMyStoreTabUpdatesOn: Bool = false) {
         self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
         self.isInternationalShippingLabelsOn = isInternationalShippingLabelsOn
         self.isShippingLabelsPaymentMethodCreationOn = isShippingLabelsPaymentMethodCreationOn
@@ -27,6 +29,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isPushNotificationsForAllStoresOn = isPushNotificationsForAllStoresOn
         self.isJetpackConnectionPackageSupportOn = isJetpackConnectionPackageSupportOn
         self.isHubMenuOn = isHubMenuOn
+        self.isMyStoreTabUpdatesOn = isMyStoreTabUpdatesOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -47,6 +50,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isJetpackConnectionPackageSupportOn
         case .hubMenu:
             return isHubMenuOn
+        case .myStoreTabUpdates:
+            return isMyStoreTabUpdatesOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -32,7 +32,7 @@ final class DashboardUIFactoryTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(dashboard is StoreStatsAndTopPerformersViewController)
+        XCTAssertTrue(dashboard is OldStoreStatsAndTopPerformersViewController)
     }
 
     func test_it_loads_deprecated_dashboard_when_V4_is_unavailable_while_no_stats_version_is_saved() {
@@ -44,7 +44,7 @@ final class DashboardUIFactoryTests: XCTestCase {
 
         // When
         var dashboardUITypes: [UIViewController.Type] = []
-        let expectedDashboardUITypes: [UIViewController.Type] = [StoreStatsAndTopPerformersViewController.self,
+        let expectedDashboardUITypes: [UIViewController.Type] = [OldStoreStatsAndTopPerformersViewController.self,
                                                                  DeprecatedDashboardStatsViewController.self]
 
         waitForExpectation(description: #function, count: expectedDashboardUITypes.count) { exp in
@@ -73,7 +73,7 @@ final class DashboardUIFactoryTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         dashboardUIFactory.reloadDashboardUI { dashboardUI in
-            XCTAssertTrue(dashboardUI is StoreStatsAndTopPerformersViewController)
+            XCTAssertTrue(dashboardUI is OldStoreStatsAndTopPerformersViewController)
             expectation.fulfill()
         }
         waitForExpectations(timeout: 0.1, handler: nil)
@@ -96,7 +96,7 @@ final class DashboardUIFactoryTests: XCTestCase {
             dashboardUIArray.append(dashboardUI)
             // The first updated view controller is v4, and the second view controller is reverted back to v3.
             if dashboardUIArray.count >= 2 {
-                XCTAssertTrue(dashboardUIArray[0] is StoreStatsAndTopPerformersViewController)
+                XCTAssertTrue(dashboardUIArray[0] is OldStoreStatsAndTopPerformersViewController)
                 XCTAssertTrue(dashboardUIArray[1] is DeprecatedDashboardStatsViewController)
 
                 guard let self = self else {
@@ -113,7 +113,7 @@ final class DashboardUIFactoryTests: XCTestCase {
                     // The first view controller is v4 -> v3 UI, and the second view controller is v3 -> v4 UI.
                     if dashboardUIArray.count >= 2 {
                         XCTAssertTrue(dashboardUIArray[0] is DeprecatedDashboardStatsViewController)
-                        XCTAssertTrue(dashboardUIArray[1] is StoreStatsAndTopPerformersViewController)
+                        XCTAssertTrue(dashboardUIArray[1] is OldStoreStatsAndTopPerformersViewController)
                         expectation.fulfill()
                     }
                 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Storage
+import TestKit
 import Yosemite
 @testable import WooCommerce
 
@@ -20,7 +21,8 @@ final class DashboardUIFactoryTests: XCTestCase {
         mockStoresManager = MockStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = true
         ServiceLocator.setStores(mockStoresManager)
-        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
+        let mockFeatureFlagService = MockFeatureFlagService(isMyStoreTabUpdatesOn: false)
+        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID, featureFlagService: mockFeatureFlagService)
 
         // When
         var dashboard: DashboardUI?
@@ -40,7 +42,8 @@ final class DashboardUIFactoryTests: XCTestCase {
         mockStoresManager = MockStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = false
         ServiceLocator.setStores(mockStoresManager)
-        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
+        let mockFeatureFlagService = MockFeatureFlagService(isMyStoreTabUpdatesOn: false)
+        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID, featureFlagService: mockFeatureFlagService)
 
         // When
         var dashboardUITypes: [UIViewController.Type] = []
@@ -67,7 +70,8 @@ final class DashboardUIFactoryTests: XCTestCase {
         mockStoresManager.isStatsV4Available = true
         ServiceLocator.setStores(mockStoresManager)
 
-        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
+        let mockFeatureFlagService = MockFeatureFlagService(isMyStoreTabUpdatesOn: false)
+        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID, featureFlagService: mockFeatureFlagService)
 
         let expectation = self.expectation(description: "Wait for the stats v4")
         expectation.expectedFulfillmentCount = 1
@@ -86,7 +90,8 @@ final class DashboardUIFactoryTests: XCTestCase {
         mockStoresManager.isStatsV4Available = false
         ServiceLocator.setStores(mockStoresManager)
 
-        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
+        let mockFeatureFlagService = MockFeatureFlagService(isMyStoreTabUpdatesOn: false)
+        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID, featureFlagService: mockFeatureFlagService)
 
         var dashboardUIArray: [DashboardUI] = []
         let expectation = self.expectation(description: "Wait for the stats v4")
@@ -128,7 +133,8 @@ final class DashboardUIFactoryTests: XCTestCase {
                                                             sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = false
         ServiceLocator.setStores(mockStoresManager)
-        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
+        let mockFeatureFlagService = MockFeatureFlagService(isMyStoreTabUpdatesOn: false)
+        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID, featureFlagService: mockFeatureFlagService)
 
         // When
         let exp = self.expectation(description: #function)
@@ -141,5 +147,25 @@ final class DashboardUIFactoryTests: XCTestCase {
 
         //Then
         XCTAssertTrue(renderedDashboard is DeprecatedDashboardStatsViewController)
+    }
+
+    func test_new_stats_screen_is_shown_if_V4_is_available_and_myStoreTabUpdates_feature_enabled() {
+        // Given
+        mockStoresManager = MockStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
+                                                            sessionManager: SessionManager.testingInstance)
+        mockStoresManager.isStatsV4Available = true
+        ServiceLocator.setStores(mockStoresManager)
+        let mockFeatureFlagService = MockFeatureFlagService(isMyStoreTabUpdatesOn: true)
+        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID, featureFlagService: mockFeatureFlagService)
+
+        // When
+        let renderedDashboard: DashboardUI = waitFor { promise in
+            self.dashboardUIFactory.reloadDashboardUI { dashboardUI in
+                promise(dashboardUI)
+            }
+        }
+
+        //Then
+        XCTAssertTrue(renderedDashboard is StoreStatsAndTopPerformersViewController)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5729 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As the first task of Home Screen M2, we want to keep WIP feature behind a new feature flag `myStoreTabUpdates`. When the feature flag is enabled, we show a duplicated version of dashboard UI using the same name `StoreStatsAndTopPerformersViewController` that hosts future updates. Otherwise, we show the old version `OldStoreStatsAndTopPerformersViewController` that we will only make maintenance changes and remove after the feature is fully launched.

Please note that `OldStoreStatsAndTopPerformersViewController` has exactly the same code as `StoreStatsAndTopPerformersViewController`, just a different name. Feel free to skip reviewing 474 diffs on `OldStoreStatsAndTopPerformersViewController`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Feature flag enabled

- Launch the app in logged-in state --> the My Store tab should function as before
- Enter view debugger in Xcode --> the view hierarchy should show `StoreStatsAndTopPerformersViewController`

#### Feature flag enabled

- In code `DefaultFeatureFlagService`, return `false` for `myStoreTabUpdates` flag to simulate release build configuration
- Launch the app in logged-in state --> the My Store tab should function as before
- Enter view debugger in Xcode --> the view hierarchy should show `OldStoreStatsAndTopPerformersViewController`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

feature flag on | feature flag off
-- | --
<img width="561" alt="Screen Shot 2021-12-22 at 11 36 11 AM" src="https://user-images.githubusercontent.com/1945542/147032246-ae9870dc-de52-43ee-b7c8-54f6ee028c24.png"> | <img width="559" alt="Screen Shot 2021-12-22 at 11 38 27 AM" src="https://user-images.githubusercontent.com/1945542/147032257-4d4efd87-a607-4d3a-816c-3d8c73e80af2.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
