### PR TITLE
Duplicate dashboard & stats view controllers for feature-flagged UI updates 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersPeriodViewController.swift
@@ -1,0 +1,363 @@
+import UIKit
+import XLPagerTabStrip
+import Yosemite
+import Observables
+
+/// Container view controller for a stats v4 time range that consists of a scrollable stack view of:
+/// - Store stats data view (managed by child view controller `OldStoreStatsV4PeriodViewController`)
+/// - Top performers header view (`TopPerformersSectionHeaderView`)
+/// - Top performers data view (managed by child view controller `TopPerformerDataViewController`)
+///
+final class OldStoreStatsAndTopPerformersPeriodViewController: UIViewController {
+
+    // MARK: Public Interface
+
+    /// For navigation bar large title workaround.
+    weak var scrollDelegate: DashboardUIScrollDelegate?
+
+    /// Time range for this period
+    let timeRange: StatsTimeRangeV4
+
+    /// Stats interval granularity
+    let granularity: StatsGranularityV4
+
+    /// Whether site visit stats can be shown
+    var siteVisitStatsMode: SiteVisitStatsMode = .default {
+        didSet {
+            storeStatsPeriodViewController.siteVisitStatsMode = siteVisitStatsMode
+        }
+    }
+
+    /// Called when user pulls down to refresh
+    var onPullToRefresh: () -> Void = {}
+
+    /// Updated when reloading data.
+    var currentDate: Date {
+        didSet {
+            storeStatsPeriodViewController.currentDate = currentDate
+        }
+    }
+
+    /// Updated when reloading data.
+    var siteTimezone: TimeZone = .current {
+        didSet {
+            storeStatsPeriodViewController.siteTimezone = siteTimezone
+        }
+    }
+
+    /// Timestamp for last successful data sync
+    var lastFullSyncTimestamp: Date?
+
+    /// Minimal time interval for data refresh
+    var minimalIntervalBetweenSync: TimeInterval {
+        switch timeRange {
+        case .today:
+            return 60
+        case .thisWeek, .thisMonth:
+            return 60*60
+        case .thisYear:
+            return 60*60*12
+        }
+    }
+
+    // MARK: Subviews
+
+    var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl(frame: .zero)
+        refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
+        return refreshControl
+    }()
+
+    private var scrollView: UIScrollView = {
+        return UIScrollView(frame: .zero)
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [])
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    // MARK: Child View Controllers
+
+    private lazy var storeStatsPeriodViewController: OldStoreStatsV4PeriodViewController = {
+        return OldStoreStatsV4PeriodViewController(timeRange: timeRange, currentDate: currentDate)
+    }()
+
+    private lazy var inAppFeedbackCardViewController = InAppFeedbackCardViewController()
+
+    /// An array of UIViews for the In-app Feedback Card. This will be dynamically shown
+    /// or hidden depending on the configuration.
+    private lazy var inAppFeedbackCardViewsForStackView: [UIView] = createInAppFeedbackCardViewsForStackView()
+
+    private lazy var topPerformersPeriodViewController: TopPerformerDataViewController = {
+        return TopPerformerDataViewController(siteID: siteID,
+                                              siteTimeZone: siteTimezone,
+                                              currentDate: currentDate,
+                                              timeRange: timeRange)
+    }()
+
+    // MARK: Internal Properties
+
+    private var childViewContrllers: [UIViewController] {
+        return [storeStatsPeriodViewController, inAppFeedbackCardViewController, topPerformersPeriodViewController]
+    }
+
+    private let viewModel: StoreStatsAndTopPerformersPeriodViewModel
+
+    private let siteID: Int64
+
+    /// Subscriptions that should be cancelled on `deinit`.
+    private var cancellables = [ObservationToken]()
+
+    /// Create an instance of `self`.
+    ///
+    /// - Parameter canDisplayInAppFeedbackCard: If applicable, present the in-app feedback card.
+    ///     The in-app feedback card may still not be presented depending on the constraints. But
+    ///     setting this to `false`, will ensure that it will never be presented.
+    ///
+    init(siteID: Int64,
+         timeRange: StatsTimeRangeV4,
+         currentDate: Date,
+         canDisplayInAppFeedbackCard: Bool) {
+        self.siteID = siteID
+        self.timeRange = timeRange
+        self.granularity = timeRange.intervalGranularity
+        self.currentDate = currentDate
+        self.viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: canDisplayInAppFeedbackCard)
+
+        super.init(nibName: nil, bundle: nil)
+
+        configureInAppFeedbackCardViews()
+        configureChildViewControllers()
+        configureInAppFeedbackViewControllerAction()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        cancellables.forEach {
+            $0.cancel()
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureSubviews()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        // Fix any incomplete animation of the refresh control
+        // when switching tabs mid-animation
+        refreshControl.resetAnimation(in: scrollView)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel.onViewDidAppear()
+    }
+}
+
+extension OldStoreStatsAndTopPerformersPeriodViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollDelegate?.dashboardUIScrollViewDidScroll(scrollView)
+    }
+}
+
+// MARK: Public Interface
+extension OldStoreStatsAndTopPerformersPeriodViewController {
+    func clearAllFields() {
+        storeStatsPeriodViewController.clearAllFields()
+    }
+
+    func displayGhostContent() {
+        storeStatsPeriodViewController.displayGhostContent()
+        topPerformersPeriodViewController.displayGhostContent()
+    }
+
+    /// Unlocks the and removes the Placeholder Content
+    ///
+    func removeGhostContent() {
+        storeStatsPeriodViewController.removeGhostContent()
+        topPerformersPeriodViewController.removeGhostContent()
+    }
+
+    /// Indicates if the receiver has Remote Stats, or not.
+    ///
+    var shouldDisplayStoreStatsGhostContent: Bool {
+        return storeStatsPeriodViewController.shouldDisplayGhostContent
+    }
+}
+
+// MARK: - IndicatorInfoProvider Conformance (Tab Bar)
+//
+extension OldStoreStatsAndTopPerformersPeriodViewController: IndicatorInfoProvider {
+    func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        return IndicatorInfo(
+            title: timeRange.tabTitle,
+            accessibilityIdentifier: "period-data-" + timeRange.rawValue + "-tab"
+        )
+    }
+}
+
+// MARK: - Provisioning and Utils
+
+private extension OldStoreStatsAndTopPerformersPeriodViewController {
+    func configureChildViewControllers() {
+        childViewContrllers.forEach { childViewController in
+            addChild(childViewController)
+            childViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+
+    /// Observe and react to visibility events for the in-app feedback card.
+    func configureInAppFeedbackCardViews() {
+        guard viewModel.canDisplayInAppFeedbackCard else {
+            return
+        }
+
+        let cancellable = viewModel.isInAppFeedbackCardVisible.subscribe { [weak self] isVisible in
+            guard let self = self else {
+                return
+            }
+
+            let isHidden = !isVisible
+
+            self.inAppFeedbackCardViewsForStackView.forEach { subView in
+                // Check if the subView will change first. It looks like if we don't do this,
+                // then StackView will not animate the change correctly.
+                if subView.isHidden != isHidden {
+                    UIView.animate(withDuration: 0.2) {
+                        subView.isHidden = isHidden
+                        self.stackView.setNeedsLayout()
+                    }
+                }
+            }
+        }
+        cancellables.append(cancellable)
+    }
+
+    func configureSubviews() {
+        view.addSubview(scrollView)
+        view.pinSubviewToSafeArea(scrollView)
+
+        scrollView.refreshControl = refreshControl
+        scrollView.delegate = self
+
+        scrollView.addSubview(stackView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.pinSubviewToAllEdges(stackView)
+        NSLayoutConstraint.activate([
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+            ])
+
+        childViewContrllers.forEach { childViewController in
+            childViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        // Store stats.
+        let storeStatsPeriodView = storeStatsPeriodViewController.view!
+        stackView.addArrangedSubview(storeStatsPeriodView)
+        NSLayoutConstraint.activate([
+            storeStatsPeriodView.heightAnchor.constraint(equalToConstant: 380),
+            ])
+
+        // In-app Feedback Card
+        stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)
+
+        // Top performers header.
+        let topPerformersHeaderView = TopPerformersSectionHeaderView(title:
+            NSLocalizedString("Top Performers",
+                              comment: "Header label for Top Performers section of My Store tab.")
+                .uppercased())
+        stackView.addArrangedSubview(topPerformersHeaderView)
+        let headerTopBorderView = createBorderView()
+        let headerBottomBorderView = createBorderView()
+        topPerformersHeaderView.addSubview(headerTopBorderView)
+        topPerformersHeaderView.addSubview(headerBottomBorderView)
+        NSLayoutConstraint.activate([
+            topPerformersHeaderView.heightAnchor.constraint(equalToConstant: 44),
+            // Top border view
+            headerTopBorderView.topAnchor.constraint(equalTo: topPerformersHeaderView.topAnchor),
+            headerTopBorderView.leadingAnchor.constraint(equalTo: topPerformersHeaderView.leadingAnchor),
+            headerTopBorderView.trailingAnchor.constraint(equalTo: topPerformersHeaderView.trailingAnchor),
+            // Bottom border view
+            headerBottomBorderView.bottomAnchor.constraint(equalTo: topPerformersHeaderView.bottomAnchor),
+            headerBottomBorderView.leadingAnchor.constraint(equalTo: topPerformersHeaderView.leadingAnchor),
+            headerBottomBorderView.trailingAnchor.constraint(equalTo: topPerformersHeaderView.trailingAnchor),
+            ])
+
+        // Top performers.
+        let topPerformersPeriodView = topPerformersPeriodViewController.view!
+        stackView.addArrangedSubview(topPerformersPeriodView)
+        stackView.addArrangedSubview(createBorderView())
+
+        // Empty padding view at the bottom.
+        let emptyView = UIView(frame: .zero)
+        emptyView.translatesAutoresizingMaskIntoConstraints = false
+        emptyView.backgroundColor = .clear
+        NSLayoutConstraint.activate([
+            emptyView.heightAnchor.constraint(equalToConstant: 44),
+            ])
+        stackView.addArrangedSubview(emptyView)
+
+        childViewContrllers.forEach { childViewController in
+            childViewController.didMove(toParent: self)
+        }
+    }
+
+    /// Create in-app feedback views to be added to the main `stackView`.
+    ///
+    /// The views created are an empty space and the `inAppFeedbackCardViewController.view`.
+    ///
+    /// - SeeAlso: configureSubviews
+    /// - Returns: The views or an empty array if something catastrophic happened.
+    ///
+    func createInAppFeedbackCardViewsForStackView() -> [UIView] {
+        guard viewModel.canDisplayInAppFeedbackCard,
+            let cardView = inAppFeedbackCardViewController.view else {
+            return []
+        }
+
+        let emptySpaceView: UIView = {
+            let view = UIView(frame: .zero)
+            view.backgroundColor = nil
+            NSLayoutConstraint.activate([
+                view.heightAnchor.constraint(equalToConstant: 8)
+            ])
+            return view
+        }()
+
+        return [emptySpaceView, cardView]
+    }
+
+    func createBorderView() -> UIView {
+        let view = UIView(frame: .zero)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemColor(.separator)
+        NSLayoutConstraint.activate([
+            view.heightAnchor.constraint(equalToConstant: 0.5)
+            ])
+        return view
+    }
+
+    func configureInAppFeedbackViewControllerAction() {
+        inAppFeedbackCardViewController.onFeedbackGiven = { [weak self] in
+            self?.viewModel.onInAppFeedbackCardAction()
+        }
+    }
+}
+
+// MARK: Actions
+//
+private extension OldStoreStatsAndTopPerformersPeriodViewController {
+    @objc func pullToRefresh() {
+        onPullToRefresh()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersViewController.swift
@@ -23,13 +23,13 @@ final class OldStoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripV
 
     // MARK: - Calculated Properties
 
-    private var visibleChildViewController: StoreStatsAndTopPerformersPeriodViewController {
+    private var visibleChildViewController: OldStoreStatsAndTopPerformersPeriodViewController {
         return periodVCs[currentIndex]
     }
 
     // MARK: - Private Properties
 
-    private var periodVCs = [StoreStatsAndTopPerformersPeriodViewController]()
+    private var periodVCs = [OldStoreStatsAndTopPerformersPeriodViewController]()
     private let siteID: Int64
     private var isSyncing = false
 
@@ -294,19 +294,19 @@ private extension OldStoreStatsAndTopPerformersViewController {
 
     func configurePeriodViewControllers() {
         let currentDate = Date()
-        let dayVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+        let dayVC = OldStoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
                                                                    timeRange: .today,
                                                                    currentDate: currentDate,
                                                                    canDisplayInAppFeedbackCard: true)
-        let weekVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+        let weekVC = OldStoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
                                                                     timeRange: .thisWeek,
                                                                     currentDate: currentDate,
                                                                     canDisplayInAppFeedbackCard: false)
-        let monthVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+        let monthVC = OldStoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
                                                                      timeRange: .thisMonth,
                                                                      currentDate: currentDate,
                                                                      canDisplayInAppFeedbackCard: false)
-        let yearVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+        let yearVC = OldStoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
                                                                     timeRange: .thisYear,
                                                                     currentDate: currentDate,
                                                                     canDisplayInAppFeedbackCard: false)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.swift
@@ -1,0 +1,817 @@
+import Charts
+import UIKit
+import Yosemite
+
+/// Shows the store stats with v4 API for a time range.
+///
+final class OldStoreStatsV4PeriodViewController: UIViewController {
+
+    // MARK: - Public Properties
+
+    let granularity: StatsGranularityV4
+
+    var siteVisitStatsMode: SiteVisitStatsMode = .default {
+        didSet {
+            updateSiteVisitStats(mode: siteVisitStatsMode)
+        }
+    }
+
+    var currentDate: Date {
+        didSet {
+            if currentDate != oldValue {
+                let currentDateForSiteVisitStats = timeRange.latestDate(currentDate: currentDate, siteTimezone: siteTimezone)
+                siteStatsResultsController = updateSiteVisitStatsResultsController(currentDate: currentDateForSiteVisitStats)
+                configureSiteStatsResultsController()
+            }
+        }
+    }
+
+    /// Updated when reloading data.
+    var siteTimezone: TimeZone = .current
+
+    // MARK: - Private Properties
+    private let timeRange: StatsTimeRangeV4
+    private var orderStatsIntervals: [OrderStatsV4Interval] = [] {
+        didSet {
+            let helper = StoreStatsV4ChartAxisHelper()
+            let intervalDates = orderStatsIntervals.map({ $0.dateStart(timeZone: siteTimezone) })
+            orderStatsIntervalLabels = helper.generateLabelText(for: intervalDates,
+                                                                timeRange: timeRange,
+                                                                siteTimezone: siteTimezone)
+        }
+    }
+    private var orderStatsIntervalLabels: [String] = []
+
+    private var orderStats: OrderStatsV4? {
+        return orderStatsResultsController.fetchedObjects.first
+    }
+    private var siteStats: SiteVisitStats? {
+        return siteStatsResultsController.fetchedObjects.first
+    }
+    private var siteStatsItems: [SiteVisitStatsItem] = []
+
+    // MARK: - Subviews
+
+    @IBOutlet private weak var containerStackView: UIStackView!
+    @IBOutlet private weak var visitorsStackView: UIStackView!
+    @IBOutlet private weak var visitorsTitle: UILabel!
+    @IBOutlet private weak var visitorsData: UILabel!
+    @IBOutlet private weak var ordersTitle: UILabel!
+    @IBOutlet private weak var ordersData: UILabel!
+    @IBOutlet private weak var revenueTitle: UILabel!
+    @IBOutlet private weak var revenueData: UILabel!
+    @IBOutlet private weak var barChartView: BarChartView!
+    @IBOutlet private weak var lastUpdated: UILabel!
+    @IBOutlet private weak var yAxisAccessibilityView: UIView!
+    @IBOutlet private weak var xAxisAccessibilityView: UIView!
+    @IBOutlet private weak var chartAccessibilityView: UIView!
+    @IBOutlet private weak var noRevenueView: UIView!
+    @IBOutlet private weak var noRevenueLabel: UILabel!
+    @IBOutlet private weak var timeRangeBarView: StatsTimeRangeBarView!
+    @IBOutlet private weak var timeRangeBarBottomBorderView: UIView!
+
+    private var lastUpdatedDate: Date?
+
+    private var currencyCode: String {
+        return ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
+    }
+
+    private var revenueItems: [Double] {
+        return orderStatsIntervals.map({ ($0.revenueValue as NSDecimalNumber).doubleValue })
+    }
+
+    private var isInitialLoad: Bool = true  // Used in trackChangedTabIfNeeded()
+
+    /// SiteVisitStats ResultsController: Loads site visit stats from the Storage Layer
+    ///
+    private lazy var siteStatsResultsController: ResultsController<StorageSiteVisitStats> = {
+        return updateSiteVisitStatsResultsController(currentDate: currentDate)
+    }()
+
+    /// OrderStats ResultsController: Loads order stats from the Storage Layer
+    ///
+    private lazy var orderStatsResultsController: ResultsController<StorageOrderStatsV4> = {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "timeRange ==[c] %@", timeRange.rawValue)
+        return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
+    /// Placeholder: Mockup Charts View
+    ///
+    private lazy var placeholderChartsView: ChartPlaceholderView = ChartPlaceholderView.instantiateFromNib()
+
+
+    // MARK: - Computed Properties
+
+    private var currencySymbol: String {
+        let code = ServiceLocator.currencySettings.currencyCode
+        return ServiceLocator.currencySettings.symbol(from: code)
+    }
+
+    private var summaryDateUpdated: String {
+        guard let lastUpdatedDate = lastUpdatedDate else {
+            return ""
+        }
+        return lastUpdatedDate.relativelyFormattedUpdateString
+    }
+
+    // MARK: x/y-Axis Values
+
+    private var xAxisMinimum: String {
+        guard let item = orderStatsIntervals.first else {
+            return ""
+        }
+        return formattedAxisPeriodString(for: item)
+    }
+
+    private var xAxisMaximum: String {
+        guard let item = orderStatsIntervals.last else {
+            return ""
+        }
+        return formattedAxisPeriodString(for: item)
+    }
+
+    private var yAxisMinimum: String {
+        let min = revenueItems.min() ?? 0
+        return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatHumanReadableAmount(String(min),
+                                                             with: currencyCode,
+                                                             roundSmallNumbers: false) ?? String()
+    }
+
+    private var yAxisMaximum: String {
+        let max = revenueItems.max() ?? 0
+        return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatHumanReadableAmount(String(max),
+                                                             with: currencyCode,
+                                                             roundSmallNumbers: false) ?? String()
+    }
+
+    private lazy var visitorsEmptyView = StoreStatsSiteVisitEmptyView()
+    // MARK: - Initialization
+
+    /// Designated Initializer
+    ///
+    init(timeRange: StatsTimeRangeV4, currentDate: Date) {
+        self.timeRange = timeRange
+        self.granularity = timeRange.intervalGranularity
+        self.currentDate = currentDate
+        super.init(nibName: type(of: self).nibName, bundle: nil)
+
+        // Make sure the ResultsControllers are ready to observe changes to the data even before the view loads
+        self.configureResultsControllers()
+    }
+
+    /// NSCoder Conformance
+    ///
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+        configureBarChart()
+        configureNoRevenueView()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        reloadAllFields()
+        trackChangedTabIfNeeded()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        barChartView?.clear()
+    }
+}
+
+// MARK: - Public Interface
+//
+extension OldStoreStatsV4PeriodViewController {
+    func clearAllFields() {
+        barChartView?.clear()
+        reloadAllFields(animateChart: false)
+    }
+}
+
+// MARK: - Ghosts API
+
+extension OldStoreStatsV4PeriodViewController {
+
+    /// Indicates if the receiver has Remote Stats, or not.
+    ///
+    var shouldDisplayGhostContent: Bool {
+        return orderStatsIntervals.isEmpty
+    }
+
+    /// Displays the Placeholder Period Graph + Starts the Animation.
+    /// Why is this public? Because the actual Sync OP is handled by StoreStatsViewController. We coordinate multiple
+    /// placeholder animations from that spot!
+    ///
+    func displayGhostContent() {
+        ensurePlaceholderIsVisible()
+        placeholderChartsView.startGhostAnimation(style: .wooDefaultGhostStyle)
+    }
+
+    /// Removes the Placeholder Content.
+    /// Why is this public? Because the actual Sync OP is handled by StoreStatsViewController. We coordinate multiple
+    /// placeholder animations from that spot!
+    ///
+    func removeGhostContent() {
+        placeholderChartsView.stopGhostAnimation()
+        placeholderChartsView.removeFromSuperview()
+    }
+
+    /// Ensures the Placeholder Charts UI is onscreen.
+    ///
+    private func ensurePlaceholderIsVisible() {
+        guard placeholderChartsView.superview == nil else {
+            return
+        }
+
+        placeholderChartsView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(placeholderChartsView)
+        view.pinSubviewToAllEdges(placeholderChartsView)
+    }
+
+}
+
+// MARK: - Configuration
+//
+private extension OldStoreStatsV4PeriodViewController {
+
+    func configureResultsControllers() {
+        configureSiteStatsResultsController()
+
+        // Order Stats
+        orderStatsResultsController.onDidChangeContent = { [weak self] in
+            self?.updateOrderDataIfNeeded()
+        }
+        orderStatsResultsController.onDidResetContent = { [weak self] in
+            self?.updateOrderDataIfNeeded()
+        }
+        try? orderStatsResultsController.performFetch()
+    }
+
+    func configureSiteStatsResultsController() {
+        siteStatsResultsController.onDidChangeContent = { [weak self] in
+            self?.updateSiteVisitDataIfNeeded()
+        }
+        siteStatsResultsController.onDidResetContent = { [weak self] in
+            self?.updateSiteVisitDataIfNeeded()
+        }
+        try? siteStatsResultsController.performFetch()
+    }
+
+    func configureView() {
+        view.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
+        containerStackView.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
+        timeRangeBarView.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
+        visitorsStackView.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
+
+        // Visitor empty view - insert it at the second-to-last index,
+        // since we need the footer view (with height = 20) as the last item in the stack view.
+        let emptyViewIndex = max(0, visitorsStackView.arrangedSubviews.count - 2)
+        visitorsStackView.insertArrangedSubview(visitorsEmptyView, at: emptyViewIndex)
+        visitorsEmptyView.isHidden = true
+
+        // Time range bar bottom border view
+        timeRangeBarBottomBorderView.backgroundColor = .systemColor(.separator)
+
+        // Titles
+        visitorsTitle.text = NSLocalizedString("Visitors", comment: "Visitors stat label on dashboard - should be plural.")
+        visitorsTitle.applyFootnoteStyle()
+        ordersTitle.text = NSLocalizedString("Orders", comment: "Orders stat label on dashboard - should be plural.")
+        ordersTitle.applyFootnoteStyle()
+        revenueTitle.text = NSLocalizedString("Revenue", comment: "Revenue stat label on dashboard.")
+        revenueTitle.applyFootnoteStyle()
+
+        // Data
+        visitorsData.applyTitleStyle()
+        ordersData.applyTitleStyle()
+        revenueData.applyTitleStyle()
+
+        // Footer
+        lastUpdated.font = UIFont.footnote
+        lastUpdated.textColor = .textSubtle
+        lastUpdated.backgroundColor = .listForeground
+
+        // Visibility
+        updateSiteVisitStats(mode: siteVisitStatsMode)
+
+        // Accessibility elements
+        xAxisAccessibilityView.isAccessibilityElement = true
+        xAxisAccessibilityView.accessibilityTraits = .staticText
+        xAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: X Axis",
+                                                                      comment: "VoiceOver accessibility label for the store revenue chart's X-axis.")
+        yAxisAccessibilityView.isAccessibilityElement = true
+        yAxisAccessibilityView.accessibilityTraits = .staticText
+        yAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: Y Axis",
+                                                                      comment: "VoiceOver accessibility label for the store revenue chart's Y-axis.")
+        chartAccessibilityView.isAccessibilityElement = true
+        chartAccessibilityView.accessibilityTraits = .image
+        chartAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart",
+                                                                      comment: "VoiceOver accessibility label for the store revenue chart.")
+        chartAccessibilityView.accessibilityLabel = String.localizedStringWithFormat(
+            NSLocalizedString("Store revenue chart %@",
+                              comment: "VoiceOver accessibility label for the store revenue chart. It reads: Store revenue chart {chart granularity}."),
+            timeRange.tabTitle
+        )
+    }
+
+    func configureNoRevenueView() {
+        noRevenueView.isHidden = true
+        noRevenueView.backgroundColor = .listForeground
+        noRevenueLabel.text = NSLocalizedString("No revenue this period",
+                                                comment: "Text displayed when no order data are available for the selected time range.")
+        noRevenueLabel.font = StyleManager.subheadlineFont
+        noRevenueLabel.textColor = .text
+    }
+
+    func configureBarChart() {
+        barChartView.chartDescription?.enabled = false
+        barChartView.dragEnabled = true
+        barChartView.setScaleEnabled(false)
+        barChartView.pinchZoomEnabled = false
+        barChartView.rightAxis.enabled = false
+        barChartView.legend.enabled = false
+        barChartView.drawValueAboveBarEnabled = true
+        barChartView.noDataText = NSLocalizedString("No data available", comment: "Text displayed when no data is available for revenue chart.")
+        barChartView.noDataFont = StyleManager.chartLabelFont
+        barChartView.noDataTextColor = .textSubtle
+        barChartView.extraRightOffset = Constants.chartExtraRightOffset
+        barChartView.extraTopOffset = Constants.chartExtraTopOffset
+        barChartView.delegate = self
+
+        let xAxis = barChartView.xAxis
+        xAxis.labelPosition = .bottom
+        xAxis.labelFont = StyleManager.chartLabelFont
+        xAxis.labelTextColor = .textSubtle
+        xAxis.axisLineColor = .systemColor(.separator)
+        xAxis.gridColor = .systemColor(.separator)
+        xAxis.drawLabelsEnabled = true
+        xAxis.drawGridLinesEnabled = false
+        xAxis.drawAxisLineEnabled = false
+        xAxis.granularity = Constants.chartXAxisGranularity
+        xAxis.granularityEnabled = true
+        xAxis.valueFormatter = self
+        updateChartXAxisLabelCount(xAxis: xAxis, timeRange: timeRange)
+
+        let yAxis = barChartView.leftAxis
+        yAxis.labelFont = StyleManager.chartLabelFont
+        yAxis.labelTextColor = .textSubtle
+        yAxis.axisLineColor = .systemColor(.separator)
+        yAxis.gridColor = .systemColor(.separator)
+        yAxis.zeroLineColor = .systemColor(.separator)
+        yAxis.drawLabelsEnabled = true
+        yAxis.drawGridLinesEnabled = true
+        yAxis.drawAxisLineEnabled = false
+        yAxis.drawZeroLineEnabled = true
+        yAxis.valueFormatter = self
+        yAxis.setLabelCount(3, force: true)
+    }
+}
+
+// MARK: - Internal Updates
+private extension OldStoreStatsV4PeriodViewController {
+    func updateSiteVisitStatsResultsController(currentDate: Date) -> ResultsController<StorageSiteVisitStats> {
+        let storageManager = ServiceLocator.storageManager
+        let dateFormatter = DateFormatter.Stats.statsDayFormatter
+        dateFormatter.timeZone = siteTimezone
+        let predicate = NSPredicate(format: "granularity ==[c] %@ AND timeRange == %@",
+                                    timeRange.siteVisitStatsGranularity.rawValue,
+                                    timeRange.rawValue)
+        let descriptor = NSSortDescriptor(keyPath: \StorageSiteVisitStats.date, ascending: false)
+        return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }
+
+    func updateChartXAxisLabelCount(xAxis: XAxis, timeRange: StatsTimeRangeV4) {
+        let helper = StoreStatsV4ChartAxisHelper()
+        let labelCount = helper.labelCount(timeRange: timeRange)
+        xAxis.setLabelCount(labelCount, force: false)
+    }
+
+    func updateUI(hasRevenue: Bool) {
+        noRevenueView.isHidden = hasRevenue
+        updateBarChartAxisUI(hasRevenue: hasRevenue)
+    }
+
+    func updateBarChartAxisUI(hasRevenue: Bool) {
+        let xAxis = barChartView.xAxis
+        xAxis.labelTextColor = .textSubtle
+
+        let yAxis = barChartView.leftAxis
+        yAxis.labelTextColor = .textSubtle
+    }
+}
+
+// MARK: - UI Updates
+//
+private extension OldStoreStatsV4PeriodViewController {
+    func updateSiteVisitStats(mode: SiteVisitStatsMode) {
+        visitorsStackView.isHidden = mode == .hidden
+        reloadSiteFields()
+    }
+}
+
+// MARK: - ChartViewDelegate Conformance (Charts)
+//
+extension OldStoreStatsV4PeriodViewController: ChartViewDelegate {
+    func chartViewDidEndPanning(_ chartView: ChartViewBase) {
+        updateUI(selectedBarIndex: nil)
+    }
+
+    func chartValueNothingSelected(_ chartView: ChartViewBase) {
+        updateUI(selectedBarIndex: nil)
+    }
+
+    func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) {
+        let selectedIndex = Int(entry.x)
+        updateUI(selectedBarIndex: selectedIndex)
+    }
+}
+
+private extension OldStoreStatsV4PeriodViewController {
+    /// Updates all stats and time range bar text based on the selected bar index.
+    ///
+    /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
+    func updateUI(selectedBarIndex selectedIndex: Int?) {
+        updateSiteVisitStats(selectedIndex: selectedIndex)
+        updateOrderStats(selectedIndex: selectedIndex)
+        updateTimeRangeBar(selectedIndex: selectedIndex)
+    }
+
+    /// Updates order stats based on the selected bar index.
+    ///
+    /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
+    func updateOrderStats(selectedIndex: Int?) {
+        guard let selectedIndex = selectedIndex else {
+            reloadOrderFields()
+            return
+        }
+        guard ordersData != nil, revenueData != nil else {
+            return
+        }
+        var totalOrdersText = Constants.placeholderText
+        var totalRevenueText = Constants.placeholderText
+        let currencyCode = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
+        if selectedIndex < orderStatsIntervals.count {
+            let orderStats = orderStatsIntervals[selectedIndex]
+            totalOrdersText = Double(orderStats.subtotals.totalOrders).humanReadableString()
+            let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+            totalRevenueText = currencyFormatter.formatHumanReadableAmount(String("\(orderStats.subtotals.grossRevenue)"), with: currencyCode) ?? String()
+        }
+        ordersData.text = totalOrdersText
+        revenueData.text = totalRevenueText
+    }
+
+    /// Updates stats based on the selected bar index.
+    ///
+    /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
+    func updateSiteVisitStats(selectedIndex: Int?) {
+        let mode: SiteVisitStatsMode
+
+        // Hides site visit stats for "today" when an interval bar is selected.
+        if timeRange == .today, selectedIndex != nil {
+            mode = .hidden
+        } else {
+            mode = siteVisitStatsMode
+        }
+
+        updateSiteVisitStats(mode: mode)
+
+        switch siteVisitStatsMode {
+        case .hidden, .redactedDueToJetpack:
+            break
+        case .default:
+            guard let selectedIndex = selectedIndex else {
+                reloadSiteFields()
+                return
+            }
+            guard visitorsData != nil else {
+                return
+            }
+            var visitorsText = Constants.placeholderText
+            if selectedIndex < siteStatsItems.count {
+                let siteStatsItem = siteStatsItems[selectedIndex]
+                visitorsText = Double(siteStatsItem.visitors).humanReadableString()
+            }
+            visitorsData.text = visitorsText
+            visitorsData.isHidden = false
+            visitorsEmptyView.isHidden = true
+        }
+    }
+
+    /// Updates date bar based on the selected bar index.
+    ///
+    /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
+    func updateTimeRangeBar(selectedIndex: Int?) {
+        guard let startDate = orderStatsIntervals.first?.dateStart(timeZone: siteTimezone),
+            let endDate = orderStatsIntervals.last?.dateStart(timeZone: siteTimezone) else {
+                return
+        }
+        guard let selectedIndex = selectedIndex else {
+            let timeRangeBarViewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                                   endDate: endDate,
+                                                                   timeRange: timeRange,
+                                                                   timezone: siteTimezone)
+            timeRangeBarView.updateUI(viewModel: timeRangeBarViewModel)
+            return
+        }
+        let date = orderStatsIntervals[selectedIndex].dateStart(timeZone: siteTimezone)
+        let timeRangeBarViewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                               endDate: endDate,
+                                                               selectedDate: date,
+                                                               timeRange: timeRange,
+                                                               timezone: siteTimezone)
+        timeRangeBarView.updateUI(viewModel: timeRangeBarViewModel)
+    }
+}
+
+// MARK: - IAxisValueFormatter Conformance (Charts)
+//
+extension OldStoreStatsV4PeriodViewController: IAxisValueFormatter {
+    func stringForValue(_ value: Double, axis: AxisBase?) -> String {
+        guard let axis = axis else {
+            return ""
+        }
+
+        if axis is XAxis {
+            return orderStatsIntervalLabels[Int(value)]
+        } else {
+            if value == 0.0 {
+                // Do not show the "0" label on the Y axis
+                return ""
+            } else {
+                return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+                                    .formatCurrency(using: value.humanReadableString(),
+                                    at: ServiceLocator.currencySettings.currencyPosition,
+                                    with: currencySymbol,
+                                    isNegative: value.sign == .minus)
+            }
+        }
+    }
+}
+
+
+// MARK: - Accessibility Helpers
+//
+private extension OldStoreStatsV4PeriodViewController {
+
+    func updateChartAccessibilityValues() {
+        let format = NSLocalizedString(
+            "Minimum value %@, maximum value %@",
+            comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."
+        )
+        yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(
+            format,
+            yAxisMinimum,
+            yAxisMaximum
+        )
+
+        xAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Starting period %@, ending period %@",
+                comment: "VoiceOver accessibility value, informs the user about the X-axis min/max values. It reads: Starting date {date}, ending date {date}."
+            ),
+            xAxisMinimum,
+            xAxisMaximum
+        )
+
+        chartAccessibilityView.accessibilityValue = chartSummaryString()
+    }
+
+
+    func chartSummaryString() -> String {
+        guard let dataSet = barChartView.barData?.dataSets.first as? BarChartDataSet, dataSet.count > 0 else {
+            return barChartView.noDataText
+        }
+
+        var chartSummaryString = ""
+        for i in 0..<dataSet.count {
+            // We are not including zero value bars here to keep things shorter
+            guard let entry = dataSet[safe: i], entry.y != 0.0 else {
+                continue
+            }
+
+            let entrySummaryString = (entry.accessibilityValue ?? String(entry.y))
+            let format = NSLocalizedString(
+                "Bar number %i, %@, ",
+                comment: "VoiceOver accessibility value about a specific bar in the revenue chart.It reads: Bar number {bar number} {summary of bar}."
+            )
+            chartSummaryString += String.localizedStringWithFormat(
+                format,
+                i+1,
+                entrySummaryString
+            )
+        }
+        return chartSummaryString
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension OldStoreStatsV4PeriodViewController {
+
+    func updateSiteVisitDataIfNeeded() {
+        if siteStats != nil {
+            lastUpdatedDate = Date()
+        } else {
+            lastUpdatedDate = nil
+        }
+        siteStatsItems = siteStats?.items?.sorted(by: { (lhs, rhs) -> Bool in
+            return lhs.period < rhs.period
+        }) ?? []
+        reloadSiteFields()
+        reloadLastUpdatedField()
+    }
+
+    func updateOrderDataIfNeeded() {
+        orderStatsIntervals = orderStats?.intervals.sorted(by: { (lhs, rhs) -> Bool in
+            return lhs.dateStart(timeZone: siteTimezone) < rhs.dateStart(timeZone: siteTimezone)
+        }) ?? []
+        if let startDate = orderStatsIntervals.first?.dateStart(timeZone: siteTimezone),
+            let endDate = orderStatsIntervals.last?.dateStart(timeZone: siteTimezone) {
+            let timeRangeBarViewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                                   endDate: endDate,
+                                                                   timeRange: timeRange,
+                                                                   timezone: siteTimezone)
+            timeRangeBarView.updateUI(viewModel: timeRangeBarViewModel)
+        }
+
+        if !orderStatsIntervals.isEmpty {
+            lastUpdatedDate = Date()
+        } else {
+            lastUpdatedDate = nil
+        }
+        reloadOrderFields()
+
+        // Don't animate the chart here - this helps avoid a "double animation" effect if a
+        // small number of values change (the chart WILL be updated correctly however)
+        reloadChart(animateChart: false)
+        reloadLastUpdatedField()
+    }
+
+    func trackChangedTabIfNeeded() {
+        // This is a little bit of a workaround to prevent the "tab tapped" tracks event from firing when launching the app.
+        if granularity == .hourly && isInitialLoad {
+            isInitialLoad = false
+            return
+        }
+        ServiceLocator.analytics.track(.dashboardMainStatsDate, withProperties: ["range": granularity.rawValue])
+        isInitialLoad = false
+    }
+
+    func reloadAllFields(animateChart: Bool = true) {
+        reloadOrderFields()
+        reloadSiteFields()
+        reloadChart(animateChart: animateChart)
+        reloadLastUpdatedField()
+        let visitStatsElements: [Any] = {
+            switch siteVisitStatsMode {
+            case .default:
+                return [visitorsTitle as Any,
+                        visitorsData as Any]
+            case .redactedDueToJetpack:
+                return [visitorsTitle as Any,
+                        visitorsEmptyView as Any]
+            case .hidden:
+                return []
+            }
+        }()
+
+        view.accessibilityElements = visitStatsElements + [ordersTitle as Any,
+                                                           ordersData as Any,
+                                                           revenueTitle as Any,
+                                                           revenueData as Any,
+                                                           lastUpdated as Any,
+                                                           yAxisAccessibilityView as Any,
+                                                           xAxisAccessibilityView as Any,
+                                                           chartAccessibilityView as Any]
+    }
+
+    func reloadOrderFields() {
+        guard ordersData != nil, revenueData != nil else {
+            return
+        }
+
+        var totalOrdersText = Constants.placeholderText
+        var totalRevenueText = Constants.placeholderText
+        let currencyCode = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
+        if let orderStats = orderStats {
+            totalOrdersText = Double(orderStats.totals.totalOrders).humanReadableString()
+            let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+            totalRevenueText = currencyFormatter.formatHumanReadableAmount(String("\(orderStats.totals.grossRevenue)"), with: currencyCode) ?? String()
+        }
+        ordersData.text = totalOrdersText
+        revenueData.text = totalRevenueText
+    }
+
+    func reloadSiteFields() {
+        switch siteVisitStatsMode {
+        case .hidden:
+            break
+        case .redactedDueToJetpack:
+            visitorsData.isHidden = true
+            visitorsEmptyView.isHidden = false
+        case .default:
+            guard visitorsData != nil else {
+                return
+            }
+
+            var visitorsText = Constants.placeholderText
+            if let siteStats = siteStats {
+                visitorsText = Double(siteStats.totalVisitors).humanReadableString()
+            }
+            visitorsData.text = visitorsText
+            visitorsData.isHidden = false
+            visitorsEmptyView.isHidden = true
+        }
+    }
+
+    func reloadChart(animateChart: Bool = true) {
+        guard barChartView != nil else {
+            return
+        }
+        barChartView.data = generateBarDataSet()
+        barChartView.fitBars = true
+        barChartView.notifyDataSetChanged()
+        if animateChart {
+            barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
+        }
+        updateChartAccessibilityValues()
+
+        updateUI(hasRevenue: hasRevenue())
+    }
+
+    func hasRevenue() -> Bool {
+        return revenueItems.contains { $0 != 0 }
+    }
+
+    func reloadLastUpdatedField() {
+        if lastUpdated != nil { lastUpdated.text = summaryDateUpdated }
+    }
+
+    func generateBarDataSet() -> BarChartData? {
+        guard !orderStatsIntervals.isEmpty else {
+            return nil
+        }
+
+        var barCount = 0
+        var barColors: [UIColor] = []
+        var dataEntries: [BarChartDataEntry] = []
+        let currencyCode = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
+        orderStatsIntervals.forEach { (item) in
+            let entry = BarChartDataEntry(x: Double(barCount), y: (item.revenueValue as NSDecimalNumber).doubleValue)
+            let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+            let formattedAmount = currencyFormatter.formatHumanReadableAmount(String("\(item.revenueValue)"),
+                                                                                with: currencyCode,
+                                                                                roundSmallNumbers: false) ?? String()
+            entry.accessibilityValue = "\(formattedChartMarkerPeriodString(for: item)): \(formattedAmount)"
+            barColors.append(.chartDataBar)
+            dataEntries.append(entry)
+            barCount += 1
+        }
+
+        let dataSet = BarChartDataSet(entries: dataEntries, label: "Data")
+        dataSet.colors = barColors
+        dataSet.highlightEnabled = true
+        dataSet.highlightColor = .chartDataBarHighlighted
+        dataSet.highlightAlpha = Constants.chartHighlightAlpha
+        dataSet.drawValuesEnabled = false // Do not draw value labels on the top of the bars
+        return BarChartData(dataSet: dataSet)
+    }
+
+    func formattedAxisPeriodString(for item: OrderStatsV4Interval) -> String {
+        let chartDateFormatter = timeRange.chartDateFormatter(siteTimezone: siteTimezone)
+        return chartDateFormatter.string(from: item.dateStart(timeZone: siteTimezone))
+    }
+
+    func formattedChartMarkerPeriodString(for item: OrderStatsV4Interval) -> String {
+        let chartDateFormatter = timeRange.chartDateFormatter(siteTimezone: siteTimezone)
+        return chartDateFormatter.string(from: item.dateStart(timeZone: siteTimezone))
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension OldStoreStatsV4PeriodViewController {
+    enum Constants {
+        static let placeholderText                      = "-"
+
+        static let chartAnimationDuration: TimeInterval = 0.75
+        static let chartExtraRightOffset: CGFloat       = 25.0
+        static let chartExtraTopOffset: CGFloat         = 20.0
+        static let chartHighlightAlpha: CGFloat         = 1.0
+
+        static let chartMarkerInsets: UIEdgeInsets      = UIEdgeInsets(top: 5.0, left: 2.0, bottom: 5.0, right: 2.0)
+        static let chartMarkerMinimumSize: CGSize       = CGSize(width: 50.0, height: 30.0)
+        static let chartMarkerArrowSize: CGSize         = CGSize(width: 8, height: 6)
+
+        static let chartXAxisGranularity: Double        = 1.0
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.xib
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OldStoreStatsV4PeriodViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="barChartView" destination="zPE-Y0-ax8" id="3VU-s1-JmV"/>
+                <outlet property="chartAccessibilityView" destination="NEo-bw-gS4" id="Ep1-tI-L3J"/>
+                <outlet property="containerStackView" destination="0he-5g-kXa" id="ni7-uB-XHh"/>
+                <outlet property="lastUpdated" destination="0Wi-nd-Ucs" id="XPO-tH-TLR"/>
+                <outlet property="noRevenueLabel" destination="5uh-zy-gDZ" id="ZRx-lP-Af2"/>
+                <outlet property="noRevenueView" destination="fg2-ey-bVn" id="LBf-aq-yXB"/>
+                <outlet property="ordersData" destination="6HA-Qe-PkT" id="zOF-dV-3LN"/>
+                <outlet property="ordersTitle" destination="vlW-do-oXj" id="zdd-DS-zvJ"/>
+                <outlet property="revenueData" destination="ukd-qU-WVq" id="ydx-PH-lcl"/>
+                <outlet property="revenueTitle" destination="Sam-pk-BxI" id="HI1-z6-dRL"/>
+                <outlet property="timeRangeBarBottomBorderView" destination="XXt-Kt-RL6" id="oeb-lG-wY3"/>
+                <outlet property="timeRangeBarView" destination="8nR-qE-vPw" id="vbk-sJ-3jq"/>
+                <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
+                <outlet property="visitorsData" destination="SZF-f7-8Va" id="ZY0-s6-PDq"/>
+                <outlet property="visitorsStackView" destination="e8D-G2-abm" id="4R3-bN-edz"/>
+                <outlet property="visitorsTitle" destination="rHw-ak-fRR" id="VJk-10-Z09"/>
+                <outlet property="xAxisAccessibilityView" destination="TTF-Fx-NHe" id="cdX-lJ-DWe"/>
+                <outlet property="yAxisAccessibilityView" destination="yvj-Kj-G3f" id="MRf-C4-jUk"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="Wvk-wb-yYI">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0he-5g-kXa">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8nR-qE-vPw" customClass="StatsTimeRangeBarView" customModule="WooCommerce" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="23"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" priority="250" constant="20" placeholder="YES" id="Hdx-tY-N2P"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XXt-Kt-RL6" userLabel="Border view">
+                            <rect key="frame" x="0.0" y="23" width="375" height="0.5"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.5" id="VSv-HK-GcX"/>
+                            </constraints>
+                        </view>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
+                            <rect key="frame" x="0.0" y="23.5" width="375" height="84.5"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="e8D-G2-abm">
+                                    <rect key="frame" x="0.0" y="0.0" width="125.5" height="84.5"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gN3-Vd-CTd">
+                                            <rect key="frame" x="25.5" y="0.0" width="75" height="20"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="20" id="Tc1-gQ-pfk"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Visitors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rHw-ak-fRR">
+                                            <rect key="frame" x="41.5" y="20" width="42.5" height="14.5"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SZF-f7-8Va">
+                                            <rect key="frame" x="57.5" y="34.5" width="11" height="30"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NaX-4V-XP2">
+                                            <rect key="frame" x="16" y="64.5" width="94" height="20"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="20" id="Ekr-OV-et5"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="g0M-FH-Icp">
+                                    <rect key="frame" x="124.5" y="0.0" width="126" height="84.5"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6wR-bB-SUi">
+                                            <rect key="frame" x="25.5" y="0.0" width="75" height="20"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="20" id="aSe-hj-qIc"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Orders" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vlW-do-oXj">
+                                            <rect key="frame" x="43.5" y="20" width="39" height="14.5"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6HA-Qe-PkT">
+                                            <rect key="frame" x="57.5" y="34.5" width="11" height="30"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZS1-zJ-gIn">
+                                            <rect key="frame" x="25.5" y="64.5" width="75" height="20"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="20" id="lpG-gr-MtT"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="EqQ-GQ-06J">
+                                    <rect key="frame" x="249.5" y="0.0" width="125.5" height="84.5"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Qe-3G-aXj">
+                                            <rect key="frame" x="25" y="0.0" width="75" height="20"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="20" id="GMI-hJ-Sxq"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Revenue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sam-pk-BxI">
+                                            <rect key="frame" x="38.5" y="20" width="48.5" height="14.5"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ukd-qU-WVq">
+                                            <rect key="frame" x="57" y="34.5" width="11" height="30"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B7G-os-a7y">
+                                            <rect key="frame" x="25" y="64.5" width="75" height="20"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="20" id="J5a-Si-2T4"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
+                            <rect key="frame" x="0.0" y="108" width="375" height="509"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
+                                    <rect key="frame" x="0.0" y="0.0" width="14" height="509"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="14" id="a3T-HU-g4E"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
+                                    <rect key="frame" x="14" y="0.0" width="347" height="509"/>
+                                    <subviews>
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">
+                                            <rect key="frame" x="0.0" y="8" width="32" height="485"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="32" id="sUS-FA-4ab"/>
+                                            </constraints>
+                                        </view>
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe">
+                                            <rect key="frame" x="0.0" y="493" width="347" height="16"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="16" id="feO-ed-bxp"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NEo-bw-gS4">
+                                            <rect key="frame" x="40" y="8" width="307" height="485"/>
+                                            <accessibility key="accessibilityConfiguration">
+                                                <accessibilityTraits key="traits" notEnabled="YES"/>
+                                            </accessibility>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fg2-ey-bVn" userLabel="Empty data view">
+                                            <rect key="frame" x="153" y="235.5" width="41.5" height="38.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5uh-zy-gDZ">
+                                                    <rect key="frame" x="0.0" y="9" width="41.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="5uh-zy-gDZ" secondAttribute="trailing" id="kKN-cg-YhY"/>
+                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="top" secondItem="fg2-ey-bVn" secondAttribute="top" constant="9" id="od2-Oi-xwq"/>
+                                                <constraint firstAttribute="bottom" secondItem="5uh-zy-gDZ" secondAttribute="bottom" constant="9" id="uQ7-1p-B6d"/>
+                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="leading" secondItem="fg2-ey-bVn" secondAttribute="leading" id="ylg-AY-x2q"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstItem="TTF-Fx-NHe" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="3m2-3S-Woi"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="175" id="7hy-0X-Qlw"/>
+                                        <constraint firstItem="NEo-bw-gS4" firstAttribute="leading" secondItem="yvj-Kj-G3f" secondAttribute="trailing" constant="8" id="EcA-ZK-LGL"/>
+                                        <constraint firstAttribute="trailing" secondItem="TTF-Fx-NHe" secondAttribute="trailing" id="JA8-YG-kdu"/>
+                                        <constraint firstItem="fg2-ey-bVn" firstAttribute="centerY" secondItem="zPE-Y0-ax8" secondAttribute="centerY" id="KX8-lm-OjL"/>
+                                        <constraint firstItem="yvj-Kj-G3f" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="TcO-x3-t7A"/>
+                                        <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="yvj-Kj-G3f" secondAttribute="bottom" id="X68-Fa-xY5"/>
+                                        <constraint firstItem="NEo-bw-gS4" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="Xsc-Oa-g5y"/>
+                                        <constraint firstItem="yvj-Kj-G3f" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="aCl-eO-awT"/>
+                                        <constraint firstItem="fg2-ey-bVn" firstAttribute="centerX" secondItem="zPE-Y0-ax8" secondAttribute="centerX" id="beQ-H2-7xo"/>
+                                        <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="NEo-bw-gS4" secondAttribute="bottom" id="mFp-ya-fbL"/>
+                                        <constraint firstAttribute="bottom" secondItem="TTF-Fx-NHe" secondAttribute="bottom" id="prr-z8-NDw"/>
+                                        <constraint firstAttribute="trailing" secondItem="NEo-bw-gS4" secondAttribute="trailing" id="y4j-07-4hx"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
+                                    <rect key="frame" x="361" y="0.0" width="14" height="509"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="14" id="KRJ-Jf-3tM"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                        </stackView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Wi-nd-Ucs">
+                            <rect key="frame" x="0.0" y="617" width="375" height="50"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="sz5-Uv-FMw" userLabel="height = 44"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" name="Orange40"/>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="dAO-9u-HGh"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="0he-5g-kXa" firstAttribute="leading" secondItem="dAO-9u-HGh" secondAttribute="leading" id="EHU-gU-caY"/>
+                <constraint firstItem="dAO-9u-HGh" firstAttribute="trailing" secondItem="0he-5g-kXa" secondAttribute="trailing" id="Qtm-iw-NSq"/>
+                <constraint firstItem="0he-5g-kXa" firstAttribute="top" secondItem="dAO-9u-HGh" secondAttribute="top" id="UR9-rP-D4A"/>
+                <constraint firstItem="dAO-9u-HGh" firstAttribute="bottom" secondItem="0he-5g-kXa" secondAttribute="bottom" id="YB7-vo-uKz"/>
+            </constraints>
+            <point key="canvasLocation" x="21.5" y="-428.5"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="Orange40">
+            <color red="0.83921568627450982" green="0.46666666666666667" blue="0.035294117647058823" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02162728237965E8000208D2 /* ProductFormTableViewModel.swift */; };
 		0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */; };
 		021739982772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021739972772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift */; };
+		0217399B2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021739992772F9DC0084CD89 /* StoreStatsV4PeriodViewController.xib */; };
+		0217399C2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0217399A2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.swift */; };
+		0217399E2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0217399D2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift */; };
 		0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4EB242E06F00083A847 /* MediaType+WPMediaType.swift */; };
 		0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */; };
 		021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */; };
@@ -250,9 +253,9 @@
 		028AFFB32484ED2800693C09 /* Dictionary+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028AFFB22484ED2800693C09 /* Dictionary+Logging.swift */; };
 		028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028AFFB52484EDA000693C09 /* Dictionary+LoggingTests.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
-		028BAC4022F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3F22F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift */; };
-		028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */; };
-		028BAC4522F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */; };
+		028BAC4022F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3F22F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift */; };
+		028BAC4222F30B05008BB4AF /* OldStoreStatsV4PeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4122F30B05008BB4AF /* OldStoreStatsV4PeriodViewController.swift */; };
+		028BAC4522F3AE5C008BB4AF /* OldStoreStatsV4PeriodViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 028BAC4422F3AE5C008BB4AF /* OldStoreStatsV4PeriodViewController.xib */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
 		028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */; };
 		028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */; };
@@ -1625,6 +1628,9 @@
 		02162728237965E8000208D2 /* ProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormTableViewModel.swift; sourceTree = "<group>"; };
 		0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModel.swift; sourceTree = "<group>"; };
 		021739972772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldStoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
+		021739992772F9DC0084CD89 /* StoreStatsV4PeriodViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StoreStatsV4PeriodViewController.xib; sourceTree = "<group>"; };
+		0217399A2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreStatsV4PeriodViewController.swift; sourceTree = "<group>"; };
+		0217399D2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewController.swift; sourceTree = "<group>"; };
 		0218B4EB242E06F00083A847 /* MediaType+WPMediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaType+WPMediaType.swift"; sourceTree = "<group>"; };
 		0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewController.swift; sourceTree = "<group>"; };
@@ -1803,9 +1809,9 @@
 		028AFFB22484ED2800693C09 /* Dictionary+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Logging.swift"; sourceTree = "<group>"; };
 		028AFFB52484EDA000693C09 /* Dictionary+LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+LoggingTests.swift"; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
-		028BAC3F22F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewController.swift; sourceTree = "<group>"; };
-		028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4PeriodViewController.swift; sourceTree = "<group>"; };
-		028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StoreStatsV4PeriodViewController.xib; sourceTree = "<group>"; };
+		028BAC3F22F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldStoreStatsAndTopPerformersPeriodViewController.swift; sourceTree = "<group>"; };
+		028BAC4122F30B05008BB4AF /* OldStoreStatsV4PeriodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldStoreStatsV4PeriodViewController.swift; sourceTree = "<group>"; };
+		028BAC4422F3AE5C008BB4AF /* OldStoreStatsV4PeriodViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OldStoreStatsV4PeriodViewController.xib; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
 		028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModel.swift; sourceTree = "<group>"; };
 		028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -3779,10 +3785,13 @@
 			isa = PBXGroup;
 			children = (
 				028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */,
+				0217399D2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift */,
+				0217399A2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.swift */,
+				021739992772F9DC0084CD89 /* StoreStatsV4PeriodViewController.xib */,
 				021739972772CE220084CD89 /* OldStoreStatsAndTopPerformersViewController.swift */,
-				028BAC3F22F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift */,
-				028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */,
-				028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */,
+				028BAC3F22F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift */,
+				028BAC4122F30B05008BB4AF /* OldStoreStatsV4PeriodViewController.swift */,
+				028BAC4422F3AE5C008BB4AF /* OldStoreStatsV4PeriodViewController.xib */,
 				028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */,
 				0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */,
 				02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */,
@@ -7486,7 +7495,7 @@
 				4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */,
 				26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */,
 				D843D5D422485009001BFA55 /* ShipmentProvidersViewController.xib in Resources */,
-				028BAC4522F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib in Resources */,
+				028BAC4522F3AE5C008BB4AF /* OldStoreStatsV4PeriodViewController.xib in Resources */,
 				CE227099228F180B00C0626C /* WooBasicTableViewCell.xib in Resources */,
 				93BCF01F20DC2CE200EBF7A1 /* bash_secrets.tpl in Resources */,
 				02162727237963AF000208D2 /* ProductFormViewController.xib in Resources */,
@@ -7536,6 +7545,7 @@
 				02E6B97923853D81000A36F0 /* TitleAndValueTableViewCell.xib in Resources */,
 				CE37C04522984E81008DCB39 /* PickListTableViewCell.xib in Resources */,
 				31C21FA626D994B700916E2E /* SeveralReadersFoundViewController.xib in Resources */,
+				0217399B2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.xib in Resources */,
 				D85B8334222FABD1002168F3 /* StatusListTableViewCell.xib in Resources */,
 				4546E09B271F0942003836F3 /* FilteredOrdersHeaderBar.xib in Resources */,
 				45B9C63F23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib in Resources */,
@@ -7938,6 +7948,7 @@
 				E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
+				0217399E2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,
 				035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */,
 				31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */,
@@ -8045,7 +8056,7 @@
 				45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */,
 				DEC51A9D274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift in Sources */,
 				455DC3A327393C7E00D4644C /* OrderDatesFilterViewController.swift in Sources */,
-				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
+				028BAC4222F30B05008BB4AF /* OldStoreStatsV4PeriodViewController.swift in Sources */,
 				268FD44727580A81008FDF9B /* CollectOrderPaymentUseCase.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				45F627B6253603AE00894B86 /* Product+DownloadSettingsViewModels.swift in Sources */,
@@ -8505,7 +8516,7 @@
 				B5C3876421C41B9F006CE970 /* UIApplication+Woo.swift in Sources */,
 				D85136B9231CED5800DD0539 /* ReviewAge.swift in Sources */,
 				5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */,
-				028BAC4022F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
+				028BAC4022F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
 				26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */,
 				DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */,
 				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,
@@ -8615,6 +8626,7 @@
 				3120491726DD807900A4EC4F /* LabelAndButtonTableViewCell.swift in Sources */,
 				024DF31423742B7A006658FE /* AztecUnderlineFormatBarCommand.swift in Sources */,
 				CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */,
+				0217399C2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.swift in Sources */,
 				4520A15C2721B2A9001FA573 /* FilterOrderListViewModel.swift in Sources */,
 				D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */,
 				B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */,


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #5729 
- [x] ⚠️ make sure its dependent PR https://github.com/woocommerce/woocommerce-ios/pull/5730 is reviewed first ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Because the My Store tab design updates are scattered across view controllers, I thought it is the easiest to duplicate the existing view controllers, make updates on the new version, and remove the old version after M2 is fully launched. This ensures that the old version is not affected while the new version is WIP, and prevents potential regressions. The use of nib also makes it difficult to make changes behind a feature flag.

This PR duplicates `StoreStatsAndTopPerformersPeriodViewController` and `StoreStatsV4PeriodViewController` with its nib.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Feature flag enabled

- Launch the app in logged-in state --> the My Store tab should function as before
- Enter view debugger in Xcode --> the view hierarchy should show `StoreStatsAndTopPerformersPeriodViewController` and `StoreStatsV4PeriodViewController`

#### Feature flag enabled

- In code `DefaultFeatureFlagService`, return `false` for `myStoreTabUpdates` flag to simulate release build configuration
- Launch the app in logged-in state --> the My Store tab should function as before
- Enter view debugger in Xcode --> the view hierarchy should show `OldStoreStatsAndTopPerformersPeriodViewController` and `OldStoreStatsV4PeriodViewController`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

feature flag on | feature flag off
-- | --
<img width="608" alt="Screen Shot 2021-12-22 at 2 32 45 PM" src="https://user-images.githubusercontent.com/1945542/147048564-51fa34dc-0d1f-4165-a106-d12468de1b30.png"> | <img width="606" alt="Screen Shot 2021-12-22 at 2 39 16 PM" src="https://user-images.githubusercontent.com/1945542/147048576-176a3e17-6aa5-4361-81e4-08e842f1d595.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
