### PR TITLE
Jetpack CP: Add tracks for Jetpack Install flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -544,6 +544,7 @@ public enum WooAnalyticsStat: String {
     case jetpackBenefitsBanner = "feature_jetpack_benefits_banner"
     case jetpackInstallButtonTapped = "jetpack_install_button_tapped"
     case jetpackCPSitesFetched = "jetpack_cp_sites_fetched"
+    case jetpackInstallGetStartedButtonTapped = "jetpack_install_get_started_button_tapped"
     case jetpackInstallSucceeded = "jetpack_install_succeeded"
     case jetpackInstallFailed = "jetpack_install_failed"
     case jetpackInstallInWPAdminButtonTapped = "jetpack_install_in_wpadmin_button_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -544,6 +544,10 @@ public enum WooAnalyticsStat: String {
     case jetpackBenefitsBanner = "feature_jetpack_benefits_banner"
     case jetpackInstallButtonTapped = "jetpack_install_button_tapped"
     case jetpackCPSitesFetched = "jetpack_cp_sites_fetched"
+    case jetpackInstallSucceeded = "jetpack_install_succeeded"
+    case jetpackInstallFailed = "jetpack_install_failed"
+    case jetpackInstallInWPAdminButtonTapped = "jetpack_install_in_wpadmin_button_tapped"
+    case jetpackInstallContactSupportButtonTapped = "jetpack_install_contact_support_button_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
@@ -175,13 +175,17 @@ struct JetpackInstallStepsView: View {
                                 viewModel.checkSiteConnection()
                             } else {
                                 showingWPAdminWebview = true
+                                ServiceLocator.analytics.track(.jetpackInstallInWPAdminButtonTapped)
                             }
                         }
                         .buttonStyle(SecondaryButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    Button(Localization.supportAction, action: supportAction)
+                    Button(Localization.supportAction) {
+                        supportAction()
+                        ServiceLocator.analytics.track(.jetpackInstallContactSupportButtonTapped)
+                    }
                     .buttonStyle(SecondaryButtonStyle())
                     .fixedSize(horizontal: false, vertical: true)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -78,9 +78,10 @@ final class JetpackInstallStepsViewModel: ObservableObject {
                 } else {
                     self.activateJetpack()
                 }
-            case .failure:
+            case .failure(let error):
                 // plugin is likely to not have been installed, so proceed to install it.
                 self.installJetpackPlugin()
+                self.installError = error
             }
         }
         stores.dispatch(pluginInfoAction)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -25,6 +25,10 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     ///
     private var retryCount: Int = 0
 
+    /// Error occurred in any install step
+    ///
+    private var installError: Error?
+
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.stores = stores
@@ -62,6 +66,7 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     private func checkJetpackPluginDetailsAndProceed() {
         guard retryCount <= Constants.maxRetryCount else {
             installFailed = true
+            ServiceLocator.analytics.track(.jetpackInstallFailed, properties: nil, error: installError)
             return
         }
         let pluginInfoAction = SitePluginAction.getPluginDetails(siteID: siteID, pluginName: Constants.jetpackPluginName) { [weak self] result in
@@ -91,7 +96,8 @@ final class JetpackInstallStepsViewModel: ObservableObject {
             case .success:
                 self.retryCount = 0
                 self.activateJetpack()
-            case .failure:
+            case .failure(let error):
+                self.installError = error
                 self.retryCount += 1
                 self.checkJetpackPluginDetailsAndProceed()
             }
@@ -109,7 +115,8 @@ final class JetpackInstallStepsViewModel: ObservableObject {
             case .success:
                 self.retryCount = 0
                 self.checkSiteConnection()
-            case .failure:
+            case .failure(let error):
+                self.installError = error
                 self.retryCount += 1
                 self.checkJetpackPluginDetailsAndProceed()
             }
@@ -137,7 +144,8 @@ final class JetpackInstallStepsViewModel: ObservableObject {
                 self.retryCount = 0
                 self.stores.updateDefaultStore(site)
                 ServiceLocator.analytics.track(.jetpackInstallSucceeded)
-            case .failure:
+            case .failure(let error):
+                self.installError = error
                 self.retryCount += 1
                 self.checkJetpackPluginDetailsAndProceed()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -136,6 +136,7 @@ final class JetpackInstallStepsViewModel: ObservableObject {
                 self.currentStep = .done
                 self.retryCount = 0
                 self.stores.updateDefaultStore(site)
+                ServiceLocator.analytics.track(.jetpackInstallSucceeded)
             case .failure:
                 self.retryCount += 1
                 self.checkJetpackPluginDetailsAndProceed()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
@@ -55,6 +55,7 @@ struct JetpackInstallView: View {
         } else {
             JetpackInstallIntroView(siteURL: siteURL, dismissAction: dismissAction) {
                 hasStarted = true
+                ServiceLocator.analytics.track(.jetpackInstallGetStartedButtonTapped)
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5402 and #5365
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking events for Jetpack Install flow to track the following:
- When the "Get Started" button on Jetpack Install Intro view is tapped 
- When Jetpack install succeeds or fails
- When users tap on the action button to install or activate Jetpack-the-plugin on WPAdmin
- When users tap on the "Contact Support" button on the error state view of Jetpack Install flow.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23).
- Open the app and switch to the JCP site if needed.
- Open install Jetpack flow by tapping the Jetpack benefit banner on the My Store tab if it's visible, or follow Settings > Install Jetpack.
- Turn off Internet connection to test install failure case.
- Proceed to tap the "Get Started" button to get the installation started. Notice in the console `🔵 Tracked jetpack_install_get_started_button_tapped`.
- When all requests time out, notice in the console: `🔵 Tracked jetpack_install_failed` with error information.
- When tapping the "Install Jetpack in WP-Admin" button, notice in the console: `🔵 Tracked jetpack_install_in_wpadmin_button_tapped`.
- When tapping the "Contact Support" button, notice in the console: `🔵 Tracked jetpack_install_contact_support_button_tapped`.
- Turn on Internet connection, repeat step 1 and 3. When all steps succeed, notice in the console: `🔵 Tracked jetpack_install_succeeded`.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
