### PR TITLE
Hub Menu: display user's avatar in the Navigation Bar

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -21,6 +21,7 @@ struct HubMenu: View {
                    storeURL: viewModel.storeURL.absoluteString) {
                 viewModel.presentSwitchStore()
             }
+                   .padding([.leading, .trailing], Constants.padding)
 
             ScrollView {
                 let gridItemLayout = [GridItem(.adaptive(minimum: Constants.itemSize), spacing: Constants.itemSpacing)]
@@ -80,10 +81,13 @@ struct HubMenu: View {
 
                 VStack(alignment: .leading,
                        spacing: Constants.topBarSpacing) {
-                    Text(storeTitle).headlineStyle()
+                    Text(storeTitle)
+                        .headlineStyle()
+                        .lineLimit(1)
                     if let storeURL = storeURL {
                         Text(storeURL)
                             .subheadlineStyle()
+                            .lineLimit(1)
                     }
                     Button(Localization.switchStore) {
                         presenSwitchStore?()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Kingfisher
 
 /// This view will be embedded inside the `HubMenuViewController`
 /// and will be the entry point of the `Menu` Tab.
@@ -15,7 +16,8 @@ struct HubMenu: View {
 
     var body: some View {
         VStack {
-            TopBar(storeTitle: viewModel.storeTitle,
+            TopBar(avatarURL: viewModel.avatarURL,
+                   storeTitle: viewModel.storeTitle,
                    storeURL: viewModel.storeURL.absoluteString) {
                 viewModel.presentSwitchStore()
             }
@@ -58,6 +60,7 @@ struct HubMenu: View {
     }
 
     private struct TopBar: View {
+        let avatarURL: URL?
         let storeTitle: String
         let storeURL: String?
         var presenSwitchStore: (() -> Void)?
@@ -67,7 +70,14 @@ struct HubMenu: View {
         @ScaledMetric private var settingsIconSize: CGFloat = 20
 
         var body: some View {
-            HStack() {
+            HStack(spacing: Constants.padding) {
+                if let avatarURL = avatarURL {
+                    KFImage(avatarURL)
+                        .resizable()
+                        .clipShape(Circle())
+                        .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+                }
+
                 VStack(alignment: .leading,
                        spacing: Constants.topBarSpacing) {
                     Text(storeTitle).headlineStyle()
@@ -117,6 +127,7 @@ struct HubMenu: View {
         static let itemSize: CGFloat = 160
         static let padding: CGFloat = 16
         static let topBarSpacing: CGFloat = 2
+        static let avatarSize: CGFloat = 40
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -73,10 +73,14 @@ struct HubMenu: View {
         var body: some View {
             HStack(spacing: Constants.padding) {
                 if let avatarURL = avatarURL {
-                    KFImage(avatarURL)
-                        .resizable()
-                        .clipShape(Circle())
-                        .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+                    VStack {
+                        KFImage(avatarURL)
+                            .resizable()
+                            .clipShape(Circle())
+                            .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+                        Spacer()
+                    }
+                    .fixedSize()
                 }
 
                 VStack(alignment: .leading,

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -13,6 +13,12 @@ final class HubMenuViewModel: ObservableObject {
     ///
     private(set) unowned var navigationController: UINavigationController?
 
+    var avatarURL: URL? {
+        guard let urlString = ServiceLocator.stores.sessionManager.defaultAccount?.gravatarUrl, let url = URL(string: urlString) else {
+            return nil
+        }
+        return url
+    }
     var storeTitle: String {
         ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.myStore
     }


### PR DESCRIPTION
Part of #5509 

### Description
In this PR I added the user's avatar in the Navigation Bar of the Hub Menu if available.
Plus, I fixed the leading and trailing padding of the navigation bar, that now is aligned with the grid view below.

### Testing instructions
1. Launch the app in debug mode (because of the feature flag).
2. You should be able to see the new tab "Menu". Select it.
3. The user avatar should be visible in the navigation bar.

### Screenshots
| Without Avatar             |  With Avatar |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2021-12-23 at 16 58 47](https://user-images.githubusercontent.com/495617/147265448-d85d9331-a5ff-4700-8c63-de492599fe7e.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2021-12-23 at 16 58 27](https://user-images.githubusercontent.com/495617/147265461-1bab712d-5c69-414c-9a7f-ba666b88fe62.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
