### PR TITLE
[Mobile Payments] 5706 Match reader names with Android

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderType.swift
+++ b/Hardware/Hardware/CardReader/CardReaderType.swift
@@ -10,14 +10,20 @@ public enum CardReaderType {
 }
 
 extension CardReaderType {
+    /// A human-readable model name for the reader.
+    ///
     var model: String {
+        /// This should match the Android SDK deviceName, to simplify Analytics use
+        /// https://stripe.dev/stripe-terminal-android/external/external/com.stripe.stripeterminal.external.models/-device-type/index.html
+        /// pbUcTB-r9-p2#comment-2164
+        ///
         switch self {
         case .chipper:
-            return "chipper_2x"
+            return "CHIPPER_2X"
         case .stripeM2:
-            return "stripe_m2"
+            return "STRIPE_M2"
         default:
-            return "other"
+            return "UNKNOWN"
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5706 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Standardizing on the names which Android use will help us to have consistent analytics reporting and analysis between the platforms. Android get these names from the SDK, but we cannot, so at least 1 platform is getting the behaviour "for free."

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
Check that the `/payment_intents` request includes the `reader_model` in the metadata, with the new capitalized model names.

<img width="1166" alt="Proxyman payment_intents request and response including the correct reader_model metadata in each" src="https://user-images.githubusercontent.com/2472348/147269810-83ab7512-c96c-4038-97a2-dc7878243d69.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
