### PR TITLE
Simple Payments: Fetch Payments Page from the Store Settings

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		2665032E261F4FBF0079A159 /* ProductAddOnOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2665032D261F4FBF0079A159 /* ProductAddOnOption.swift */; };
 		26650332261FFA1A0079A159 /* ProductAddOnEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26650331261FFA1A0079A159 /* ProductAddOnEnvelope.swift */; };
 		266C7F9225AD3C88006ED243 /* attribute-term.json in Resources */ = {isa = PBXBuildFile; fileRef = 266C7F9125AD3C87006ED243 /* attribute-term.json */; };
+		267066092774BF3B008E1F68 /* settings-advanced.json in Resources */ = {isa = PBXBuildFile; fileRef = 267066082774BF3B008E1F68 /* settings-advanced.json */; };
 		2670C3FC270F4E06002FE931 /* SiteListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2670C3FB270F4E06002FE931 /* SiteListMapperTests.swift */; };
 		2670C3FE270F4E6A002FE931 /* sites-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = 2670C3FD270F4E6A002FE931 /* sites-malformed.json */; };
 		267313312559CC930026F7EF /* PaymentGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267313302559CC930026F7EF /* PaymentGateway.swift */; };
@@ -705,6 +706,7 @@
 		2665032D261F4FBF0079A159 /* ProductAddOnOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnOption.swift; sourceTree = "<group>"; };
 		26650331261FFA1A0079A159 /* ProductAddOnEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnEnvelope.swift; sourceTree = "<group>"; };
 		266C7F9125AD3C87006ED243 /* attribute-term.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "attribute-term.json"; sourceTree = "<group>"; };
+		267066082774BF3B008E1F68 /* settings-advanced.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-advanced.json"; sourceTree = "<group>"; };
 		2670C3FB270F4E06002FE931 /* SiteListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteListMapperTests.swift; sourceTree = "<group>"; };
 		2670C3FD270F4E6A002FE931 /* sites-malformed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "sites-malformed.json"; sourceTree = "<group>"; };
 		267313302559CC930026F7EF /* PaymentGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGateway.swift; sourceTree = "<group>"; };
@@ -1737,6 +1739,7 @@
 				D88D5A40230BC5DA007B6E01 /* reviews-all.json */,
 				57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */,
 				D88D5A42230BC668007B6E01 /* reviews-single.json */,
+				267066082774BF3B008E1F68 /* settings-advanced.json */,
 				74046E20217A73D0007DD7BF /* settings-general.json */,
 				7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */,
 				74159622224D2C86003C21CF /* settings-product.json */,
@@ -2265,6 +2268,7 @@
 				CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */,
 				D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */,
 				74C947862193A6C70024CB60 /* comment-moderate-unapproved.json in Resources */,
+				267066092774BF3B008E1F68 /* settings-advanced.json in Resources */,
 				3105472C262E303400C5C02B /* wcpay-payment-intent-unknown-status.json in Resources */,
 				B559EBAA20A0B5CD00836CD4 /* orders-load-all.json in Resources */,
 				3158A4A12729F40F00C3CFA8 /* wcpay-account-live-test.json in Resources */,

--- a/Networking/Networking/Model/SiteSettingGroup.swift
+++ b/Networking/Networking/Model/SiteSettingGroup.swift
@@ -6,6 +6,7 @@ import Codegen
 public enum SiteSettingGroup: Decodable, Hashable, GeneratedFakeable {
     case general
     case product
+    case advanced
     case custom(String) // catch-all
 }
 
@@ -22,6 +23,8 @@ extension SiteSettingGroup: RawRepresentable {
             self = .general
         case Keys.product:
             self = .product
+        case Keys.advanged:
+            self = .advanced
         default:
             self = .custom(rawValue)
         }
@@ -33,6 +36,7 @@ extension SiteSettingGroup: RawRepresentable {
         switch self {
         case .general: return Keys.general
         case .product: return Keys.product
+        case .advanced: return Keys.advanged
         case .custom(let payload):  return payload
         }
     }
@@ -44,4 +48,5 @@ extension SiteSettingGroup: RawRepresentable {
 private enum Keys {
     static let general = "general"
     static let product = "product"
+    static let advanged = "advanced"
 }

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -32,6 +32,20 @@ public class SiteSettingsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Retrieves all of the advanced `SiteSetting`s for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the advanced settings.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadAdvancedSettings(for siteID: Int64, completion: @escaping (Result<[SiteSetting], Error>) -> Void) {
+        let path = Constants.siteSettingsPath + Constants.advancedSettingsGroup
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.advanced)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -42,5 +56,6 @@ private extension SiteSettingsRemote {
         static let siteSettingsPath: String       = "settings/"
         static let generalSettingsGroup: String   = "general"
         static let productSettingsGroup: String   = "products"
+        static let advancedSettingsGroup: String   = "advanced"
     }
 }

--- a/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -1,7 +1,5 @@
 import XCTest
 @testable import Networking
-import Storage
-
 
 /// SiteSettingsRemote Unit Tests
 ///

--- a/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import Networking
+import Storage
 
 
 /// SiteSettingsRemote Unit Tests
@@ -86,5 +87,24 @@ class SiteSettingsRemoteTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    // MARK: - Load advanced settings tests
+
+    func test_load_advanced_settings_properly_returns_parsed_settings() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "settings/advanced", filename: "settings-advanced")
+        let remote = SiteSettingsRemote(network: network)
+
+        // When
+        let result: Result<[Networking.SiteSetting], Error> = waitFor { promise in
+            remote.loadAdvancedSettings(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let settings = try result.get()
+        XCTAssertEqual(settings.count, 2)
     }
 }

--- a/Networking/NetworkingTests/Responses/settings-advanced.json
+++ b/Networking/NetworkingTests/Responses/settings-advanced.json
@@ -3,7 +3,7 @@
         {
             "id": "woocommerce_checkout_pay_endpoint",
             "label": "Pay",
-            "description": "Endpoint for the \"Checkout &rarr; Pay\" page.",
+            "description": "Endpoint for the pay page",
             "type": "text",
             "default": "order-pay",
             "tip": "Endpoint for the \"Checkout &rarr; Pay\" page.",

--- a/Networking/NetworkingTests/Responses/settings-advanced.json
+++ b/Networking/NetworkingTests/Responses/settings-advanced.json
@@ -1,0 +1,46 @@
+{
+    "data": [
+        {
+            "id": "woocommerce_checkout_pay_endpoint",
+            "label": "Pay",
+            "description": "Endpoint for the \"Checkout &rarr; Pay\" page.",
+            "type": "text",
+            "default": "order-pay",
+            "tip": "Endpoint for the \"Checkout &rarr; Pay\" page.",
+            "value": "order-pay",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/settings/advanced/woocommerce_checkout_pay_endpoint"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/settings/advanced"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_checkout_order_received_endpoint",
+            "label": "Order received",
+            "description": "Endpoint for the \"Checkout &rarr; Order received\" page.",
+            "type": "text",
+            "default": "order-received",
+            "tip": "Endpoint for the \"Checkout &rarr; Order received\" page.",
+            "value": "order-received",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/settings/advanced/woocommerce_checkout_order_received_endpoint"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/settings/advanced"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/WooCommerce/Classes/Tools/PaymentLinkBuilder.swift
+++ b/WooCommerce/Classes/Tools/PaymentLinkBuilder.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Build a payment link for an order using the following format.
-/// `{:store_address}/checkout/order-pay/{:order_id}/?pay_for_order=true&key={:order_key}`
+/// `{:store_address}/checkout/{:payment_page_path}/{:order_id}/?pay_for_order=true&key={:order_key}`
 ///
 struct PaymentLinkBuilder {
     /// Default site url.
@@ -15,9 +15,13 @@ struct PaymentLinkBuilder {
     ///
     let orderKey: String
 
+    /// Stores custom payment page path
+    ///
+    let paymentPagePath: String
+
     /// Assembles the payment link with the provided values
     ///
     func build() -> String {
-        "\(host)/checkout/order-pay/\(orderID)/?pay_for_order=true&key=\(orderKey)"
+        "\(host)/checkout/\(paymentPagePath)/\(orderID)/?pay_for_order=true&key=\(orderKey)"
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -332,6 +332,15 @@ private extension DefaultStoresManager {
         dispatch(productSettingsAction)
 
         group.enter()
+        let advancedSettingsAction = SettingAction.synchronizeAdvancedSiteSettings(siteID: siteID) { error in
+            if let error = error {
+                errors.append(error)
+            }
+            group.leave()
+        }
+        dispatch(advancedSettingsAction)
+
+        group.enter()
         let sitePlanAction = AccountAction.synchronizeSitePlan(siteID: siteID) { result in
             if case let .failure(error) = result {
                 errors.append(error)

--- a/WooCommerce/WooCommerceTests/Tools/PaymentLinkBuilderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PaymentLinkBuilderTests.swift
@@ -7,7 +7,8 @@ final class PaymentLinkBuilderTests: XCTestCase {
         // Given
         let builder = PaymentLinkBuilder(host: "https://www.test-store.com",
                                          orderID: 123,
-                                         orderKey: "wc-456")
+                                         orderKey: "wc-456",
+                                         paymentPagePath: "order-pay")
 
         // When
         let paymentLink = builder.build()

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -22,7 +22,7 @@ public enum SettingAction: Action {
     ///
     case retrieveSiteAPI(siteID: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void)
 
-    /// Retrievs the store payments page path.
+    /// Retrieves the store payments page path.
     ///
     case getPaymentsPagePath(siteID: Int64, onCompletion: (Result<String, SettingStore.SettingError>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -14,6 +14,10 @@ public enum SettingAction: Action {
     ///
     case synchronizeProductSiteSettings(siteID: Int64, onCompletion: (Error?) -> Void)
 
+    /// Synchronizes the site's advanced settings
+    ///
+    case synchronizeAdvancedSiteSettings(siteID: Int64, onCompletion: (Error?) -> Void)
+
     /// Retrieves the site API details (used to determine the WC version)
     ///
     case retrieveSiteAPI(siteID: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void)

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -21,4 +21,8 @@ public enum SettingAction: Action {
     /// Retrieves the site API details (used to determine the WC version)
     ///
     case retrieveSiteAPI(siteID: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void)
+
+    /// Retrievs the store payments page path.
+    ///
+    case getPaymentsPagePath(siteID: Int64, onCompletion: (Result<String, SettingStore.SettingError>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -42,6 +42,8 @@ public class SettingStore: Store {
             synchronizeAdvancedSiteSettings(siteID: siteID, onCompletion: onCompletion)
         case .retrieveSiteAPI(let siteID, let onCompletion):
             retrieveSiteAPI(siteID: siteID, onCompletion: onCompletion)
+        case let .getPaymentsPagePath(siteID, onCompletion):
+            getPaymentsPagePath(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -101,6 +103,17 @@ private extension SettingStore {
     ///
     func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void) {
         siteAPIRemote.loadAPIInformation(for: siteID, completion: onCompletion)
+    }
+
+    /// Retrieves the store payments page path.
+    ///
+    func getPaymentsPagePath(siteID: Int64, onCompletion: @escaping (Result<String, SettingStore.SettingError>) -> Void) {
+        guard let paymentPageSettings = sharedDerivedStorage.loadSiteSetting(siteID: siteID, settingID: SettingKeys.paymentsPage),
+              let paymentPagePath = paymentPageSettings.value else {
+                  return onCompletion(.failure(SettingError.paymentsPageNotFound))
+              }
+
+        onCompletion(.success(paymentPagePath))
     }
 }
 
@@ -188,5 +201,22 @@ extension SettingStore {
     ///
     func upsertStoredProductSiteSettings(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
         upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.product)
+    }
+}
+
+// MARK: Definitions
+extension SettingStore {
+    /// Possible store errors.
+    ///
+    public enum SettingError: Swift.Error {
+        /// Payment page path was not found
+        ///
+        case paymentsPageNotFound
+    }
+
+    /// Settings keys.
+    ///
+    private enum SettingKeys {
+        static let paymentsPage = "woocommerce_checkout_pay_endpoint"
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -595,6 +595,41 @@ class SettingStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
     }
+
+    func test_getPaymentsPagePath_returns_page_when_setting_is_stored() throws {
+        // Given
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: sampleAdvancedSiteSetting())
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<String, SettingStore.SettingError> = waitFor { promise in
+            let action = SettingAction.getPaymentsPagePath(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let paymentPath = try result.get()
+        XCTAssertEqual(paymentPath, sampleAdvancedSiteSetting().value)
+    }
+
+    func test_getPaymentsPagePath_returns_error_when_setting_is_not_stored() throws {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<String, SettingStore.SettingError> = waitFor { promise in
+            let action = SettingAction.getPaymentsPagePath(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error, .paymentsPageNotFound)
+    }
 }
 
 


### PR DESCRIPTION
# Why

After speaking with the proton team, they informed us that the store can have a custom checkout payment page which could make the logic introduced in #5736 to fail.

To properly support payments links we need to fetch the customized(or not) payment page path from the store settings which is accessed via the `wc/v3/settings/advanced` endpoint.

# How

- Fetch the store advance settings and store them in our local storage.

- Create a Yosemite action to get the payments page path in `SimplePaymentsMethodViewModel`

- Update `PaymentLinkBuilder` to use the custom payment page path.

# Testing 

- Start the Simple Payments flow
- Go all the way until the payment methods screen
- See the payment link being printed in the console
- Copy the link in a browser and you should be able to pay for the order if you have some payment method enabled in your store.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
