### PR TITLE
Order Creation: Refactor address form viewmodel

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -124,7 +124,10 @@ enum AddressFormNavigationItem: Equatable {
     case loading
 }
 
-class AddressFormViewModel: ObservableObject {
+/// Parent class for AddressFormViewModelProtocol implementations. Holds shared sync/management logic.
+/// Not to be used on its own, so it doesn't conform to AddressFormViewModelProtocol.
+///
+open class AddressFormViewModel: ObservableObject {
     /// ResultsController for stored countries.
     ///
     private lazy var countriesResultsController: ResultsController<StorageCountry> = {
@@ -253,7 +256,7 @@ class AddressFormViewModel: ObservableObject {
         return StateSelectorViewModel(states: states, selected: selectedStateBinding)
     }
 
-    /// Track the flow start.
+    /// Track the flow start. Override in subclass.
     ///
     func trackOnLoad() {
         // override in subclass

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -59,3 +59,362 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     ///
     func createStateViewModel() -> StateSelectorViewModel
 }
+
+class AddressFormViewModel: ObservableObject {
+
+    /// ResultsController for stored countries.
+    ///
+    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
+        let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
+        return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
+    }()
+
+    /// Trigger to sync countries.
+    ///
+    private let syncCountriesTrigger = PassthroughSubject<Void, Never>()
+
+    /// Storage to fetch countries
+    ///
+    private let storageManager: StorageManagerType
+
+    /// Stores to sync countries
+    ///
+    let stores: StoresManager
+
+    /// Analytics center.
+    ///
+    let analytics: Analytics
+
+    /// Store for publishers subscriptions
+    ///
+    private var subscriptions = Set<AnyCancellable>()
+
+    init(siteID: Int64,
+         address: Address,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.originalAddress = address
+
+        self.storageManager = storageManager
+        self.stores = stores
+        self.analytics = analytics
+
+        // Listen only to the first emitted event.
+        onLoadTrigger.first().sink { [weak self] in
+            guard let self = self else { return }
+            self.bindSyncTrigger()
+            self.bindSelectedCountryAndStateIntoFields()
+            self.bindNavigationTrailingItemPublisher()
+
+            self.fetchStoredCountriesAndTriggerSyncIfNeeded()
+            self.setFieldsInitialValues()
+
+            self.trackOnLoad()
+        }.store(in: &subscriptions)
+    }
+
+    private let siteID: Int64
+
+    /// Original `Address` model.
+    ///
+    private let originalAddress: Address
+
+    /// Updated `Address`, constructed from `fields`,  `selectedCountry`, `selectedState`.
+    ///
+    var updatedAddress: Address {
+        fields.toAddress(country: selectedCountry, state: selectedState)
+    }
+
+    /// Current selected country.
+    ///
+    @Published private var selectedCountry: Yosemite.Country?
+
+    /// Current selected state.
+    ///
+    @Published private var selectedState: Yosemite.StateOfACountry?
+
+    /// Address form fields
+    ///
+    @Published var fields = FormFields()
+
+    /// Trigger to perform any one time setups.
+    ///
+    let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
+
+    /// Tracks if a network request is being performed.
+    ///
+    let performingNetworkRequest: CurrentValueSubject<Bool, Never> = .init(false)
+
+    /// Active navigation bar trailing item.
+    /// Defaults to a disabled done button.
+    ///
+    @Published private(set) var navigationTrailingItem: NavigationItem = .done(enabled: false)
+
+    /// Define if the view should show placeholders instead of the real elements.
+    ///
+    @Published private(set) var showPlaceholders: Bool = false
+
+    /// Defines the current notice that should be shown.
+    /// Defaults to `nil`.
+    ///
+    @Published var presentNotice: Notice?
+
+    /// Defines if the state field should be defined as a list selector.
+    ///
+    var showStateFieldAsSelector: Bool {
+        selectedCountry?.states.isNotEmpty ?? false
+    }
+
+    /// Creates a view model to be used when selecting a country
+    ///
+    func createCountryViewModel() -> CountrySelectorViewModel {
+        print("created country view model")
+        let selectedCountryBinding = Binding(
+            get: { self.selectedCountry },
+            set: { self.selectedCountry = $0 }
+        )
+        return CountrySelectorViewModel(countries: countriesResultsController.fetchedObjects, selected: selectedCountryBinding)
+    }
+
+    /// Creates a view model to be used when selecting a state
+    ///
+    func createStateViewModel() -> StateSelectorViewModel {
+        let selectedStateBinding = Binding(
+            get: { self.selectedState },
+            set: { self.selectedState = $0 }
+        )
+
+        // Sort states from the selected country
+        let states = selectedCountry?.states.sorted { $0.name < $1.name } ?? []
+        return StateSelectorViewModel(states: states, selected: selectedStateBinding)
+    }
+
+    /// Track the flow start.
+    ///
+    func trackOnLoad() {
+        // override in subclass
+    }
+}
+
+extension AddressFormViewModel {
+    /// Representation of possible navigation bar trailing buttons
+    ///
+    enum NavigationItem: Equatable {
+        case done(enabled: Bool)
+        case loading
+    }
+
+    /// Type to hold values from all the form fields
+    ///
+    struct FormFields {
+        // MARK: User Fields
+        var firstName: String = ""
+        var lastName: String = ""
+        var email: String = ""
+        var phone: String = ""
+
+        // MARK: Address Fields
+        var company: String = ""
+        var address1: String = ""
+        var address2: String = ""
+        var city: String = ""
+        var postcode: String = ""
+        var country: String = ""
+        var state: String = ""
+
+        var useAsToggle: Bool = false
+
+        mutating func update(with address: Address) {
+            firstName = address.firstName
+            lastName = address.lastName
+            email = address.email ?? ""
+            phone = address.phone ?? ""
+
+            company = address.company ?? ""
+            address1 = address.address1
+            address2 = address.address2 ?? ""
+            city = address.city
+            postcode = address.postcode
+
+            // Only use the address.state if we haven't set a value before.
+            // Like when selecting a state from the picker
+            state = state.isEmpty ? address.state : state
+        }
+
+        mutating func update(with country: Country?, and state: StateOfACountry?) {
+            self.country = country?.name ?? self.country
+            self.state = state?.name ?? self.state
+        }
+
+        func toAddress(country: Country?, state: StateOfACountry?) -> Yosemite.Address {
+            Address(firstName: firstName,
+                    lastName: lastName,
+                    company: company,
+                    address1: address1,
+                    address2: address2,
+                    city: city,
+                    state: state?.code ?? self.state,
+                    postcode: postcode,
+                    country: country?.code ?? self.country,
+                    phone: phone,
+                    email: email)
+        }
+    }
+
+    /// Representation of possible notices that can be displayed
+    enum Notice: Equatable {
+        case success
+        case error(EditAddressError)
+    }
+
+    /// Representation of possible errors that can happen
+    enum EditAddressError: LocalizedError {
+        case unableToLoadCountries
+        case unableToUpdateAddress
+
+        var errorDescription: String? {
+            switch self {
+            case .unableToLoadCountries:
+                return NSLocalizedString("Unable to fetch country information, please try again later.",
+                                         comment: "Error notice when we fail to load country information in the edit address screen.")
+            case .unableToUpdateAddress:
+                return NSLocalizedString("Unable to update address.",
+                                         comment: "Error notice title when we fail to update an address in the edit address screen.")
+            }
+        }
+
+        var recoverySuggestion: String? {
+            switch self {
+            case .unableToLoadCountries:
+                return nil
+            case .unableToUpdateAddress:
+                return NSLocalizedString("Please make sure you are running the latest version of WooCommerce and try again later.",
+                                         comment: "Error notice recovery suggestion when we fail to update an address in the edit address screen.")
+            }
+        }
+    }
+}
+
+private extension AddressFormViewModel {
+    /// Set initial values from `originalAddress` using the stored countries to compute the current selected country & state.
+    ///
+    func setFieldsInitialValues() {
+        selectedCountry = countriesResultsController.fetchedObjects.first { $0.code == originalAddress.country }
+        selectedState = selectedCountry?.states.first { $0.code == originalAddress.state }
+        fields.update(with: originalAddress)
+    }
+
+    /// Calculates what navigation trailing item should be shown depending on our internal state.
+    ///
+    func bindNavigationTrailingItemPublisher() {
+        Publishers.CombineLatest4($fields, performingNetworkRequest, $selectedCountry, $selectedState)
+            .map { [originalAddress] fields, performingNetworkRequest, selectedCountry, selectedState -> NavigationItem in
+                guard !performingNetworkRequest else {
+                    return .loading
+                }
+
+                guard !fields.useAsToggle else {
+                    return .done(enabled: true)
+                }
+
+                return .done(enabled: originalAddress != fields.toAddress(country: selectedCountry, state: selectedState))
+            }
+            .assign(to: &$navigationTrailingItem)
+    }
+
+    /// Update published fields when the selected country and state is updated.
+    /// If the selected country changes and it has a specific state to choose, clear the previous selected state.
+    ///
+    func bindSelectedCountryAndStateIntoFields() {
+
+        typealias StatePublisher = AnyPublisher<Yosemite.StateOfACountry?, Never>
+
+        // When a country is selected, check if the new country has a state list.
+        // If it has, clear the selected state and the state field.
+        // If it doesn't only clear the selected state
+        $selectedCountry
+            .withLatestFrom($selectedState)
+            .map { country, state -> String in
+                guard let country = country else {
+                    return ""
+                }
+                let currentStateName = state?.name ?? ""
+                return country.states.isEmpty ? currentStateName : ""
+            }
+            .sink { stateName in
+                self.selectedState = nil
+                self.fields.state = stateName
+            }
+            .store(in: &subscriptions)
+
+        // Update fields with new selections.
+        Publishers.CombineLatest($selectedCountry, $selectedState)
+            .sink { [weak self] country, state in
+                self?.fields.update(with: country, and: state)
+            }
+            .store(in: &subscriptions)
+    }
+
+    /// Fetches countries from storage, If there are no stored countries, trigger a sync request.
+    ///
+    func fetchStoredCountriesAndTriggerSyncIfNeeded() {
+        // Initial fetch
+        try? countriesResultsController.performFetch()
+
+        // Updates the initial fields when/if the data store changes(after sync).
+        countriesResultsController.onDidChangeContent = { [weak self] in
+            self?.setFieldsInitialValues()
+        }
+
+        // Trigger a sync request if there are no countries.
+        guard !countriesResultsController.isEmpty else {
+            return syncCountriesTrigger.send()
+        }
+    }
+
+    /// Sync countries when requested. Defines the `showPlaceholderState` value depending if countries are being synced or not.
+    ///
+    func bindSyncTrigger() {
+
+        // Sends an error notice presentation request and hides the publisher error.
+        let syncCountries = makeSyncCountriesFuture()
+            .catch { [weak self] error -> AnyPublisher<Void, Never> in
+                DDLogError("⛔️ Failed to load countries with: \(error)")
+                self?.presentNotice = .error(error)
+                return Just(()).eraseToAnyPublisher()
+            }
+
+        // Perform `syncCountries` when a sync trigger is requested.
+        syncCountriesTrigger
+            .handleEvents(receiveOutput: { // Set `showPlaceholders` to `true` before initiating sync.
+                self.showPlaceholders = true // I could not find a way to assign this using combine operators. :-(
+            })
+            .map { // Sync countries
+                syncCountries
+            }
+            .switchToLatest()
+            .map { _ in // Set `showPlaceholders` to `false` after sync is done.
+                false
+            }
+            .assign(to: &$showPlaceholders)
+    }
+
+    /// Creates a publisher that syncs countries into our storage layer.
+    ///
+    func makeSyncCountriesFuture() -> AnyPublisher<Void, EditAddressError> {
+        Future<Void, EditAddressError> { [weak self] promise in
+            guard let self = self else { return }
+
+            let action = DataAction.synchronizeCountries(siteID: self.siteID) { result in
+                let newResult = result
+                    .map { _ in } // Hides the result success type because we don't need it.
+                    .mapError { _ in EditAddressError.unableToLoadCountries }
+                promise(newResult)
+            }
+            self.stores.dispatch(action)
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -1,0 +1,61 @@
+import Combine
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// Protocol to describe viewmodel of editable address
+///
+protocol AddressFormViewModelProtocol: ObservableObject {
+
+    /// Address form fields
+    ///
+    var fields: AddressFormViewModel.FormFields { get set }
+
+    /// Active navigation bar trailing item.
+    /// Defaults to a disabled done button.
+    ///
+    var navigationTrailingItem: AddressFormViewModel.NavigationItem { get }
+
+    /// Trigger to perform any one time setups.
+    ///
+    var onLoadTrigger: PassthroughSubject<Void, Never> { get }
+
+    /// Define if the view should show placeholders instead of the real elements.
+    ///
+    var showPlaceholders: Bool { get }
+
+    /// Defines if the state field should be defined as a list selector.
+    ///
+    var showStateFieldAsSelector: Bool { get }
+
+    /// Defines if the email field should be shown
+    ///
+    var showEmailField: Bool { get }
+
+    /// Defines navbar title
+    ///
+    var viewTitle: String { get }
+
+    /// Defines address section title
+    ///
+    var sectionTitle: String { get }
+
+    /// Defines bottom toggle title
+    ///
+    var toggleTitle: String { get }
+
+    /// Save the address and invoke a completion block when finished
+    ///
+    func saveAddress(onFinish: @escaping (Bool) -> Void)
+
+    /// Track the flow cancel scenario.
+    ///
+    func userDidCancelFlow()
+
+    /// Creates a view model to be used when selecting a country
+    ///
+    func createCountryViewModel() -> CountrySelectorViewModel
+
+    /// Creates a view model to be used when selecting a state
+    ///
+    func createStateViewModel() -> StateSelectorViewModel
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -170,7 +170,6 @@ class AddressFormViewModel: ObservableObject {
     /// Creates a view model to be used when selecting a country
     ///
     func createCountryViewModel() -> CountrySelectorViewModel {
-        print("created country view model")
         let selectedCountryBinding = Binding(
             get: { self.selectedCountry },
             set: { self.selectedCountry = $0 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -1,48 +1,25 @@
-import Yosemite
-import Storage
 import Combine
+import Yosemite
+import protocol Storage.StorageManagerType
 
-final class EditOrderAddressFormViewModel: ObservableObject {
+final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormViewModelProtocol {
 
     enum AddressType {
         case shipping
         case billing
     }
 
+    /// Order to be edited.
+    ///
+    private let order: Yosemite.Order
+
     /// Type of order address to edit
     ///
-    let type: AddressType
+    private let type: AddressType
 
     /// Order update callback
     ///
     private let onOrderUpdate: ((Yosemite.Order) -> Void)?
-
-    /// ResultsController for stored countries.
-    ///
-    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
-        let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
-        return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
-    }()
-
-    /// Trigger to sync countries.
-    ///
-    private let syncCountriesTrigger = PassthroughSubject<Void, Never>()
-
-    /// Storage to fetch countries
-    ///
-    private let storageManager: StorageManagerType
-
-    /// Stores to sync countries
-    ///
-    private let stores: StoresManager
-
-    /// Analytics center.
-    ///
-    private let analytics: Analytics
-
-    /// Store for publishers subscriptions
-    ///
-    private var subscriptions = Set<AnyCancellable>()
 
     init(order: Yosemite.Order,
          type: AddressType,
@@ -61,70 +38,22 @@ final class EditOrderAddressFormViewModel: ObservableObject {
         case .billing:
             addressToEdit = order.billingAddress
         }
-        self.originalAddress = addressToEdit ?? .empty
 
-        self.storageManager = storageManager
-        self.stores = stores
-        self.analytics = analytics
-
-        // Listen only to the first emitted event.
-        onLoadTrigger.first().sink { [weak self] in
-            guard let self = self else { return }
-            self.bindSyncTrigger()
-            self.bindSelectedCountryAndStateIntoFields()
-            self.bindNavigationTrailingItemPublisher()
-
-            self.fetchStoredCountriesAndTriggerSyncIfNeeded()
-            self.setFieldsInitialValues()
-
-            self.trackOnLoad()
-        }.store(in: &subscriptions)
+        super.init(siteID: order.siteID,
+                   address: addressToEdit ?? .empty,
+                   storageManager: storageManager,
+                   stores: stores,
+                   analytics: analytics)
     }
 
-    /// Original `Address` model.
+    /// Returns `true` if there are changes pending to commit. `False` otherwise.
     ///
-    private let originalAddress: Address
+    func hasPendingChanges() -> Bool {
+        return navigationTrailingItem == .done(enabled: true)
+    }
 
-    /// Current selected country.
-    ///
-    @Published private var selectedCountry: Yosemite.Country?
+    // MARK: - Protocol conformance
 
-    /// Current selected state.
-    ///
-    @Published private var selectedState: Yosemite.StateOfACountry?
-
-    /// Address form fields
-    ///
-    @Published var fields = FormFields()
-
-    /// Order to be edited.
-    ///
-    private let order: Yosemite.Order
-
-    /// Trigger to perform any one time setups.
-    ///
-    let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
-
-    /// Tracks if a network request is being performed.
-    ///
-    private let performingNetworkRequest: CurrentValueSubject<Bool, Never> = .init(false)
-
-    /// Active navigation bar trailing item.
-    /// Defaults to a disabled done button.
-    ///
-    @Published private(set) var navigationTrailingItem: NavigationItem = .done(enabled: false)
-
-    /// Define if the view should show placeholders instead of the real elements.
-    ///
-    @Published private(set) var showPlaceholders: Bool = false
-
-    /// Defines the current notice that should be shown.
-    /// Defaults to `nil`.
-    ///
-    @Published var presentNotice: Notice?
-
-    /// Defines if the email field should be shown
-    ///
     var showEmailField: Bool {
         switch type {
         case .shipping:
@@ -134,39 +63,36 @@ final class EditOrderAddressFormViewModel: ObservableObject {
         }
     }
 
-    /// Defines if the state field should be defined as a list selector.
-    ///
-    var showStateFieldAsSelector: Bool {
-        selectedCountry?.states.isNotEmpty ?? false
+    var viewTitle: String {
+        switch type {
+        case .shipping:
+            return Localization.shippingTitle
+        case .billing:
+            return Localization.billingTitle
+        }
     }
 
-    /// Creates a view model to be used when selecting a country
-    ///
-    func createCountryViewModel() -> CountrySelectorViewModel {
-        let selectedCountryBinding = Binding(
-            get: { self.selectedCountry },
-            set: { self.selectedCountry = $0 }
-        )
-        return CountrySelectorViewModel(countries: countriesResultsController.fetchedObjects, selected: selectedCountryBinding)
+    var sectionTitle: String {
+        switch type {
+        case .shipping:
+            return Localization.shippingAddressSection
+        case .billing:
+            return Localization.billingAddressSection
+        }
     }
 
-    /// Creates a view model to be used when selecting a state
-    ///
-    func createStateViewModel() -> StateSelectorViewModel {
-        let selectedStateBinding = Binding(
-            get: { self.selectedState },
-            set: { self.selectedState = $0 }
-        )
-
-        // Sort states from the selected country
-        let states = selectedCountry?.states.sorted { $0.name < $1.name } ?? []
-        return StateSelectorViewModel(states: states, selected: selectedStateBinding)
+    var toggleTitle: String {
+        switch type {
+        case .shipping:
+            return Localization.useAsBillingToggle
+        case .billing:
+            return Localization.useAsShippingToggle
+        }
     }
 
     /// Update the address remotely and invoke a completion block when finished
     ///
-    func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {
-        let updatedAddress = fields.toAddress(country: selectedCountry, state: selectedState)
+    func saveAddress(onFinish: @escaping (Bool) -> Void) {
         let orderFields: [OrderUpdateField]
 
         let modifiedOrder: Yosemite.Order
@@ -199,7 +125,7 @@ final class EditOrderAddressFormViewModel: ObservableObject {
 
             case .failure(let error):
                 DDLogError("⛔️ Error updating order: \(error)")
-                if self.type == .billing, updatedAddress.hasEmailAddress == false {
+                if self.type == .billing, self.updatedAddress.hasEmailAddress == false {
                     DDLogError("⛔️ Email is nil in address. It won't work in WC < 5.9.0 (https://git.io/J68Gl)")
                 }
                 self.presentNotice = .error(.unableToUpdateAddress)
@@ -212,243 +138,20 @@ final class EditOrderAddressFormViewModel: ObservableObject {
         stores.dispatch(action)
     }
 
-    /// Returns `true` if there are changes pending to commit. `False` otherwise.
-    ///
-    func hasPendingChanges() -> Bool {
-        return navigationTrailingItem == .done(enabled: true)
+    override func trackOnLoad() {
+        analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowStarted(subject: self.analyticsFlowType()))
     }
 
-    /// Track the flow cancel scenario.
-    ///
     func userDidCancelFlow() {
         analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowCanceled(subject: self.analyticsFlowType()))
     }
 }
 
-extension EditOrderAddressFormViewModel {
-    /// Representation of possible navigation bar trailing buttons
-    ///
-    enum NavigationItem: Equatable {
-        case done(enabled: Bool)
-        case loading
-    }
-
-    /// Representation of possible notices that can be displayed
-    enum Notice: Equatable {
-        case success
-        case error(EditAddressError)
-    }
-
-    /// Representation of possible errors that can happen
-    enum EditAddressError: LocalizedError {
-        case unableToLoadCountries
-        case unableToUpdateAddress
-
-        var errorDescription: String? {
-            switch self {
-            case .unableToLoadCountries:
-                return NSLocalizedString("Unable to fetch country information, please try again later.",
-                                         comment: "Error notice when we fail to load country information in the edit address screen.")
-            case .unableToUpdateAddress:
-                return NSLocalizedString("Unable to update address.",
-                                         comment: "Error notice title when we fail to update an address in the edit address screen.")
-            }
-        }
-
-        var recoverySuggestion: String? {
-            switch self {
-            case .unableToLoadCountries:
-                return nil
-            case .unableToUpdateAddress:
-                return NSLocalizedString("Please make sure you are running the latest version of WooCommerce and try again later.",
-                                         comment: "Error notice recovery suggestion when we fail to update an address in the edit address screen.")
-            }
-        }
-    }
-
-    /// Type to hold values from all the form fields
-    ///
-    struct FormFields {
-        // MARK: User Fields
-        var firstName: String = ""
-        var lastName: String = ""
-        var email: String = ""
-        var phone: String = ""
-
-        // MARK: Address Fields
-
-        var company: String = ""
-        var address1: String = ""
-        var address2: String = ""
-        var city: String = ""
-        var postcode: String = ""
-        var country: String = ""
-        var state: String = ""
-
-        var useAsToggle: Bool = false
-
-        mutating func update(with address: Address) {
-            firstName = address.firstName
-            lastName = address.lastName
-            email = address.email ?? ""
-            phone = address.phone ?? ""
-
-            company = address.company ?? ""
-            address1 = address.address1
-            address2 = address.address2 ?? ""
-            city = address.city
-            postcode = address.postcode
-
-            // Only use the address.state if we haven't set a value before.
-            // Like when selecting a state from the picker
-            state = state.isEmpty ? address.state : state
-        }
-
-        mutating func update(with country: Yosemite.Country?, and state: Yosemite.StateOfACountry?) {
-            self.country = country?.name ?? self.country
-            self.state = state?.name ?? self.state
-        }
-
-        func toAddress(country: Yosemite.Country?, state: Yosemite.StateOfACountry?) -> Yosemite.Address {
-            Address(firstName: firstName,
-                    lastName: lastName,
-                    company: company,
-                    address1: address1,
-                    address2: address2,
-                    city: city,
-                    state: state?.code ?? self.state,
-                    postcode: postcode,
-                    country: country?.code ?? self.country,
-                    phone: phone,
-                    email: email)
-        }
-    }
-}
-
 private extension EditOrderAddressFormViewModel {
-    /// Set initial values from `originalAddress` using the stored countries to compute the current selected country & state.
-    ///
-    func setFieldsInitialValues() {
-        selectedCountry = countriesResultsController.fetchedObjects.first { $0.code == originalAddress.country }
-        selectedState = selectedCountry?.states.first { $0.code == originalAddress.state }
-        fields.update(with: originalAddress)
-    }
-
-    /// Calculates what navigation trailing item should be shown depending on our internal state.
-    ///
-    func bindNavigationTrailingItemPublisher() {
-        Publishers.CombineLatest4($fields, performingNetworkRequest, $selectedCountry, $selectedState)
-            .map { [originalAddress] fields, performingNetworkRequest, selectedCountry, selectedState -> NavigationItem in
-                guard !performingNetworkRequest else {
-                    return .loading
-                }
-
-                guard !fields.useAsToggle else {
-                    return .done(enabled: true)
-                }
-
-                return .done(enabled: originalAddress != fields.toAddress(country: selectedCountry, state: selectedState))
-            }
-            .assign(to: &$navigationTrailingItem)
-    }
-
-    /// Update published fields when the selected country and state is updated.
-    /// If the selected country changes and it has a specific state to choose, clear the previous selected state.
-    ///
-    func bindSelectedCountryAndStateIntoFields() {
-
-        typealias StatePublisher = AnyPublisher<Yosemite.StateOfACountry?, Never>
-
-        // When a country is selected, check if the new country has a state list.
-        // If it has, clear the selected state and the state field.
-        // If it doesn't only clear the selected state
-        $selectedCountry
-            .withLatestFrom($selectedState)
-            .map { country, state -> String in
-                guard let country = country else {
-                    return ""
-                }
-                let currentStateName = state?.name ?? ""
-                return country.states.isEmpty ? currentStateName : ""
-            }
-            .sink { stateName in
-                self.selectedState = nil
-                self.fields.state = stateName
-            }
-            .store(in: &subscriptions)
-
-        // Update fields with new selections.
-        Publishers.CombineLatest($selectedCountry, $selectedState)
-            .sink { [weak self] country, state in
-                self?.fields.update(with: country, and: state)
-            }
-            .store(in: &subscriptions)
-    }
-
-    /// Fetches countries from storage, If there are no stored countries, trigger a sync request.
-    ///
-    func fetchStoredCountriesAndTriggerSyncIfNeeded() {
-        // Initial fetch
-        try? countriesResultsController.performFetch()
-
-        // Updates the initial fields when/if the data store changes(after sync).
-        countriesResultsController.onDidChangeContent = { [weak self] in
-            self?.setFieldsInitialValues()
-        }
-
-        // Trigger a sync request if there are no countries.
-        guard !countriesResultsController.isEmpty else {
-            return syncCountriesTrigger.send()
-        }
-    }
-
-    /// Sync countries when requested. Defines the `showPlaceholderState` value depending if countries are being synced or not.
-    ///
-    func bindSyncTrigger() {
-
-        // Sends an error notice presentation request and hides the publisher error.
-        let syncCountries = makeSyncCountriesFuture()
-            .catch { [weak self] error -> AnyPublisher<Void, Never> in
-                DDLogError("⛔️ Failed to load countries with: \(error)")
-                self?.presentNotice = .error(error)
-                return Just(()).eraseToAnyPublisher()
-            }
-
-        // Perform `syncCountries` when a sync trigger is requested.
-        syncCountriesTrigger
-            .handleEvents(receiveOutput: { // Set `showPlaceholders` to `true` before initiating sync.
-                self.showPlaceholders = true // I could not find a way to assign this using combine operators. :-(
-            })
-            .map { // Sync countries
-                syncCountries
-            }
-            .switchToLatest()
-            .map { _ in // Set `showPlaceholders` to `false` after sync is done.
-                false
-            }
-            .assign(to: &$showPlaceholders)
-    }
-
-    /// Creates a publisher that syncs countries into our storage layer.
-    ///
-    func makeSyncCountriesFuture() -> AnyPublisher<Void, EditAddressError> {
-        Future<Void, EditAddressError> { [weak self] promise in
-            guard let self = self else { return }
-
-            let action = DataAction.synchronizeCountries(siteID: self.order.siteID) { result in
-                let newResult = result
-                    .map { _ in } // Hides the result success type because we don't need it.
-                    .mapError { _ in EditAddressError.unableToLoadCountries }
-                promise(newResult)
-            }
-            self.stores.dispatch(action)
-        }
-        .eraseToAnyPublisher()
-    }
 
     /// Returns the correct analytics subject for the current address form type.
     ///
-    private func analyticsFlowType() -> WooAnalyticsEvent.OrderDetailsEdit.Subject {
+    func analyticsFlowType() -> WooAnalyticsEvent.OrderDetailsEdit.Subject {
         switch type {
         case .shipping:
             return .shippingAddress
@@ -457,10 +160,18 @@ private extension EditOrderAddressFormViewModel {
         }
     }
 
-    /// Tracks the `orderDetailEditFlowStarted` event
-    ///
-    private func trackOnLoad() {
-        analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowStarted(subject: self.analyticsFlowType()))
+    // MARK: Constants
+    enum Localization {
+        static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address Form")
+        static let billingTitle = NSLocalizedString("Billing Address", comment: "Title for the Edit Billing Address Form")
+
+        static let shippingAddressSection = NSLocalizedString("SHIPPING ADDRESS", comment: "Details section title in the Edit Address Form")
+        static let billingAddressSection = NSLocalizedString("BILLING ADDRESS", comment: "Details section title in the Edit Address Form")
+
+        static let useAsBillingToggle = NSLocalizedString("Use as Billing Address",
+                                                          comment: "Title for the Use as Billing Address switch in the Address form")
+        static let useAsShippingToggle = NSLocalizedString("Use as Shipping Address",
+                                                           comment: "Title for the Use as Shipping Address switch in the Address form")
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -954,6 +954,7 @@
 		AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */; };
 		AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */; };
 		AEC12B7A2758D55900845F97 /* OrderStatusList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC12B792758D55900845F97 /* OrderStatusList.swift */; };
+		AEC95D412774C5AE001571F5 /* AddressFormViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC95D402774C5AE001571F5 /* AddressFormViewModelProtocol.swift */; };
 		AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
@@ -2483,6 +2484,7 @@
 		AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModel.swift; sourceTree = "<group>"; };
 		AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModelTests.swift; sourceTree = "<group>"; };
 		AEC12B792758D55900845F97 /* OrderStatusList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusList.swift; sourceTree = "<group>"; };
+		AEC95D402774C5AE001571F5 /* AddressFormViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressFormViewModelProtocol.swift; sourceTree = "<group>"; };
 		AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressForm.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
@@ -5395,6 +5397,7 @@
 			isa = PBXGroup;
 			children = (
 				AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */,
+				AEC95D402774C5AE001571F5 /* AddressFormViewModelProtocol.swift */,
 				AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */,
 				2662D90926E16B3600E25611 /* FilterListSelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
@@ -8295,6 +8298,7 @@
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
 				3142663F2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift in Sources */,
 				DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */,
+				AEC95D412774C5AE001571F5 /* AddressFormViewModelProtocol.swift in Sources */,
 				B6E851F5276330200041D1BA /* RefundFeesDetailsTableViewCell.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				45DB70602614C7E80064A6CF /* ShippingLabelPackageDetailsResultsControllers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -155,7 +155,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         viewModel.onLoadTrigger.send()
-        viewModel.updateRemoteAddress { _ in }
+        viewModel.saveAddress { _ in }
 
         // Then
         assertEqual(viewModel.navigationTrailingItem, .loading)
@@ -168,7 +168,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         // When
         viewModel.onLoadTrigger.send()
         let navigationItem = waitFor { promise in
-            viewModel.updateRemoteAddress { _ in
+            viewModel.saveAddress { _ in
                 promise(viewModel.navigationTrailingItem)
             }
         }
@@ -265,7 +265,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
                     XCTFail("Unsupported Action")
                 }
             }
-            viewModel.updateRemoteAddress { _ in }
+            viewModel.saveAddress { _ in }
         }
 
         // Then
@@ -291,7 +291,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
                     XCTFail("Unsupported Action")
                 }
             }
-            viewModel.updateRemoteAddress { _ in }
+            viewModel.saveAddress { _ in }
         }
 
         // Then
@@ -316,7 +316,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
                     XCTFail("Unsupported Action")
                 }
             }
-            viewModel.updateRemoteAddress { _ in }
+            viewModel.saveAddress { _ in }
         }
 
         // Then
@@ -358,7 +358,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
                     XCTFail("Unsupported Action")
                 }
             }
-            viewModel.updateRemoteAddress { _ in }
+            viewModel.saveAddress { _ in }
         }
 
         // Then
@@ -381,7 +381,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         let noticeRequest = waitFor { promise in
-            viewModel.updateRemoteAddress { _ in
+            viewModel.saveAddress { _ in
                 promise(viewModel.presentNotice)
             }
         }
@@ -404,7 +404,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         let noticeRequest = waitFor { promise in
-            viewModel.updateRemoteAddress { _ in
+            viewModel.saveAddress { _ in
                 promise(viewModel.presentNotice)
             }
         }
@@ -447,7 +447,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
                 }
             }
 
-            viewModel.updateRemoteAddress(onFinish: { _ in })
+            viewModel.saveAddress(onFinish: { _ in })
         }
 
         // Then
@@ -474,7 +474,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
                 }
             }
 
-            viewModel.updateRemoteAddress(onFinish: { _ in })
+            viewModel.saveAddress(onFinish: { _ in })
         }
 
         // Then
@@ -501,7 +501,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
                 }
             }
 
-            viewModel.updateRemoteAddress(onFinish: { _ in })
+            viewModel.saveAddress(onFinish: { _ in })
         }
 
         // Then
@@ -542,7 +542,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         _ = waitFor { promise in
-            viewModel.updateRemoteAddress(onFinish: { finished in
+            viewModel.saveAddress(onFinish: { finished in
                 promise(finished)
             })
         }
@@ -570,7 +570,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         _ = waitFor { promise in
-            viewModel.updateRemoteAddress(onFinish: { finished in
+            viewModel.saveAddress(onFinish: { finished in
                 promise(finished)
             })
         }
@@ -598,7 +598,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         _ = waitFor { promise in
-            viewModel.updateRemoteAddress(onFinish: { finished in
+            viewModel.saveAddress(onFinish: { finished in
                 promise(finished)
             })
         }
@@ -626,7 +626,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         _ = waitFor { promise in
-            viewModel.updateRemoteAddress(onFinish: { finished in
+            viewModel.saveAddress(onFinish: { finished in
                 promise(finished)
             })
         }


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-ios/issues/5412.

## Description

This is refactoring to support integration of Address Form in Order Creation flow.

Sorry for big set of changes! Next step for Order Creation integration can be seen in https://github.com/woocommerce/woocommerce-ios/pull/5757.

## Changes

- Adds `AddressFormViewModelProtocol` to use in both Order Edit and Create flows.
- Slices parent class out of `EditOrderAddressFormViewModel` to prevent duplication of country and state management.
- Updates `EditOrderAddressForm` to use new `AddressFormViewModelProtocol`.

## Testing 

No user-facing changes. Try updating billing and shipping addresses in existing order details.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

