### PR TITLE
Order Creation: Connect address form to new order view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -34,7 +34,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     var sectionTitle: String {
-        Localization.billingAddressSection
+        Localization.addressSection
     }
 
     var showAlternativeUsageToggle: Bool {
@@ -63,6 +63,8 @@ private extension CreateOrderAddressFormViewModel {
 
         static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address Form")
         static let billingTitle = NSLocalizedString("Billing Address", comment: "Title for the Edit Billing Address Form")
+
+        static let addressSection = NSLocalizedString("Address", comment: "Details section title in the Edit Address Form")
 
         static let shippingAddressSection = NSLocalizedString("SHIPPING ADDRESS", comment: "Details section title in the Edit Address Form")
         static let billingAddressSection = NSLocalizedString("BILLING ADDRESS", comment: "Details section title in the Edit Address Form")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -37,7 +37,11 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
         Localization.billingAddressSection
     }
 
-    var toggleTitle: String {
+    var showAlternativeUsageToggle: Bool {
+        false
+    }
+
+    var alternativeUsageToggleTitle: String {
         ""
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -1,0 +1,66 @@
+import Combine
+import Yosemite
+import protocol Storage.StorageManagerType
+
+final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormViewModelProtocol {
+
+    /// Address update callback
+    ///
+    private let onAddressUpdate: ((Address) -> Void)?
+
+    init(siteID: Int64,
+         address: Address?,
+         onAddressUpdate: ((Address) -> Void)?,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.onAddressUpdate = onAddressUpdate
+
+        super.init(siteID: siteID,
+                   address: address ?? .empty,
+                   storageManager: storageManager,
+                   stores: stores,
+                   analytics: analytics)
+    }
+
+    // MARK: - Protocol conformance
+
+    var showEmailField: Bool {
+        true
+    }
+
+    var viewTitle: String {
+        Localization.newCustomerTitle
+    }
+
+    var sectionTitle: String {
+        Localization.billingAddressSection
+    }
+
+    var toggleTitle: String {
+        String()
+    }
+
+    func saveAddress(onFinish: @escaping (Bool) -> Void) {
+        onAddressUpdate?(updatedAddress)
+        onFinish(true)
+    }
+
+    override func trackOnLoad() { }
+
+    func userDidCancelFlow() { }
+}
+
+private extension CreateOrderAddressFormViewModel {
+
+    // MARK: Constants
+    enum Localization {
+        static let newCustomerTitle = NSLocalizedString("New Customer", comment: "Title for the Shipping Address Form for New Customer")
+
+        static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address Form")
+        static let billingTitle = NSLocalizedString("Billing Address", comment: "Title for the Edit Billing Address Form")
+
+        static let shippingAddressSection = NSLocalizedString("SHIPPING ADDRESS", comment: "Details section title in the Edit Address Form")
+        static let billingAddressSection = NSLocalizedString("BILLING ADDRESS", comment: "Details section title in the Edit Address Form")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -38,7 +38,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     var toggleTitle: String {
-        String()
+        ""
     }
 
     func saveAddress(onFinish: @escaping (Bool) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -184,6 +184,7 @@ private struct CustomerSection: View {
                                                                       address: viewModel.orderDetails.billingAddress,
                                                                       onAddressUpdate: { updatedAddress in
                             viewModel.orderDetails.billingAddress = updatedAddress
+                            viewModel.orderDetails.shippingAddress = updatedAddress
                         }))
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -178,9 +178,11 @@ private struct CustomerSection: View {
                 .buttonStyle(PlusButtonStyle())
                 .sheet(isPresented: $showAddressForm) {
                     NavigationView {
-                        EditOrderAddressForm(viewModel: CreateOrderAddressFormViewModel(siteID: viewModel.siteID,
-                                                                                        address: viewModel.orderDetails.billingAddress,
-                                                                                        onAddressUpdate: { updatedAddress in
+                        EditOrderAddressForm(dismiss: {
+                            showAddressForm.toggle()
+                        }, viewModel: CreateOrderAddressFormViewModel(siteID: viewModel.siteID,
+                                                                      address: viewModel.orderDetails.billingAddress,
+                                                                      onAddressUpdate: { updatedAddress in
                             viewModel.orderDetails.billingAddress = updatedAddress
                         }))
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -60,7 +60,7 @@ struct NewOrder: View {
 
                         Spacer(minLength: Layout.sectionSpacing)
 
-                        CustomerSection(geometry: geometry)
+                        CustomerSection(geometry: geometry, viewModel: viewModel)
                     }
                 }
                 .background(Color(.listBackground).ignoresSafeArea())
@@ -159,6 +159,11 @@ private struct ProductsSection: View {
 private struct CustomerSection: View {
     let geometry: GeometryProxy
 
+    /// View model to drive the view content
+    @ObservedObject var viewModel: NewOrderViewModel
+
+    @State private var showAddressForm: Bool = false
+
     var body: some View {
         Group {
             Divider()
@@ -167,8 +172,19 @@ private struct CustomerSection: View {
                 Text(NewOrder.Localization.customer)
                     .headlineStyle()
 
-                Button(NewOrder.Localization.addCustomer) { }
+                Button(NewOrder.Localization.addCustomer) {
+                    showAddressForm.toggle()
+                }
                 .buttonStyle(PlusButtonStyle())
+                .sheet(isPresented: $showAddressForm) {
+                    NavigationView {
+                        EditOrderAddressForm(viewModel: CreateOrderAddressFormViewModel(siteID: viewModel.siteID,
+                                                                                        address: viewModel.orderDetails.billingAddress,
+                                                                                        onAddressUpdate: { updatedAddress in
+                            viewModel.orderDetails.billingAddress = updatedAddress
+                        }))
+                    }
+                }
             }
             .padding(.horizontal, insets: geometry.safeAreaInsets)
             .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -180,12 +180,7 @@ private struct CustomerSection: View {
                     NavigationView {
                         EditOrderAddressForm(dismiss: {
                             showAddressForm.toggle()
-                        }, viewModel: CreateOrderAddressFormViewModel(siteID: viewModel.siteID,
-                                                                      address: viewModel.orderDetails.billingAddress,
-                                                                      onAddressUpdate: { updatedAddress in
-                            viewModel.orderDetails.billingAddress = updatedAddress
-                            viewModel.orderDetails.shippingAddress = updatedAddress
-                        }))
+                        }, viewModel: viewModel.createOrderAddressFormViewModel())
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -116,6 +116,17 @@ final class NewOrderViewModel: ObservableObject {
         configureProductRowViewModels()
     }
 
+    /// Creates a view model to be used in Address Form for customer address.
+    ///
+    func createOrderAddressFormViewModel() -> CreateOrderAddressFormViewModel {
+        CreateOrderAddressFormViewModel(siteID: siteID,
+                                        address: orderDetails.billingAddress,
+                                        onAddressUpdate: { [weak self] updatedAddress in
+            self?.orderDetails.billingAddress = updatedAddress
+            self?.orderDetails.shippingAddress = updatedAddress
+        })
+    }
+
     // MARK: - API Requests
     /// Creates an order remotely using the provided order details.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -39,9 +39,13 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     ///
     var sectionTitle: String { get }
 
-    /// Defines bottom toggle title
+    /// Defines if "use as billing/shipping" toggle should be displayed.
     ///
-    var toggleTitle: String { get }
+    var showAlternativeUsageToggle: Bool { get }
+
+    /// Defines "use as billing/shipping" toggle title
+    ///
+    var alternativeUsageToggleTitle: String { get }
 
     /// Save the address and invoke a completion block when finished
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -109,19 +109,17 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
     ///
     var dismiss: (() -> Void) = {}
 
+    /// View Model for the view
+    ///
     @ObservedObject private(set) var viewModel: ViewModel
 
     /// Set it to `true` to present the country selector.
     ///
-    @State var showCountrySelector: Bool = false
-
-    init(viewModel: ViewModel) {
-        self.viewModel = viewModel
-    }
+    @State private var showCountrySelector: Bool = false
 
     /// Set it to `true` to present the state selector.
     ///
-    @State var showStateSelector = false
+    @State private var showStateSelector = false
 
     var body: some View {
         GeometryReader { geometry in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -224,6 +224,27 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
             }
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+
+            // Go to edit country
+            LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
+                EmptyView()
+            }
+
+            // Go to edit state
+            LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createStateViewModel()), isActive: $showStateSelector) {
+                EmptyView()
+            }
+
+            ///
+            /// iOS 14.5 has a bug where
+            /// Pushing a view while having "exactly two" navigation links makes the pushed view to be popped when the initial view changes its state.
+            /// EG: AddressForm -> CountrySelector -> Country is selected -> AddressForm updates country -> CountrySelector is popped automatically.
+            /// Adding an extra and useless navigation link fixes the problem but throws a warning in the console.
+            /// Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279
+            ///
+            NavigationLink(destination: EmptyView()) {
+                EmptyView()
+            }
         }
         .navigationTitle(viewModel.viewTitle)
         .navigationBarTitleDisplayMode(.inline)
@@ -243,27 +264,6 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
         .shimmering(active: viewModel.showPlaceholders)
         .onAppear {
             viewModel.onLoadTrigger.send()
-        }
-
-        // Go to edit country
-        LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
-            EmptyView()
-        }
-
-        // Go to edit state
-        LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createStateViewModel()), isActive: $showStateSelector) {
-            EmptyView()
-        }
-
-        ///
-        /// iOS 14.5 has a bug where
-        /// Pushing a view while having "exactly two" navigation links makes the pushed view to be popped when the initial view changes its state.
-        /// EG: AddressForm -> CountrySelector -> Country is selected -> AddressForm updates country -> CountrySelector is popped automatically.
-        /// Adding an extra and useless navigation link fixes the problem but throws a warning in the console.
-        /// Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279
-        ///
-        NavigationLink(destination: EmptyView()) {
-            EmptyView()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -251,7 +251,6 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
         }
 
         // Go to edit state
-        // TODO: Move `StateSelectorViewModel` creation to the VM when it exists.
         LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createStateViewModel()), isActive: $showStateSelector) {
             EmptyView()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -214,13 +214,13 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                 .padding(.horizontal, insets: geometry.safeAreaInsets)
                 .background(Color(.systemBackground))
 
-                Group {
-                    TitleAndToggleRow(title: viewModel.toggleTitle, isOn: $viewModel.fields.useAsToggle)
+                if viewModel.showAlternativeUsageToggle {
+                    TitleAndToggleRow(title: viewModel.alternativeUsageToggleTitle, isOn: $viewModel.fields.useAsToggle)
                         .padding(.horizontal, Constants.horizontalPadding)
                         .padding(.vertical, Constants.verticalPadding)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        .background(Color(.systemBackground))
                 }
-                .padding(.horizontal, insets: geometry.safeAreaInsets)
-                .background(Color(.systemBackground))
             }
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -81,7 +81,11 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
         }
     }
 
-    var toggleTitle: String {
+    var showAlternativeUsageToggle: Bool {
+        true
+    }
+
+    var alternativeUsageToggleTitle: String {
         switch type {
         case .shipping:
             return Localization.useAsBillingToggle

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -955,6 +955,7 @@
 		AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */; };
 		AEC12B7A2758D55900845F97 /* OrderStatusList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC12B792758D55900845F97 /* OrderStatusList.swift */; };
 		AEC95D412774C5AE001571F5 /* AddressFormViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC95D402774C5AE001571F5 /* AddressFormViewModelProtocol.swift */; };
+		AEC95D432774D07B001571F5 /* CreateOrderAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */; };
 		AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
@@ -2485,6 +2486,7 @@
 		AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModelTests.swift; sourceTree = "<group>"; };
 		AEC12B792758D55900845F97 /* OrderStatusList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusList.swift; sourceTree = "<group>"; };
 		AEC95D402774C5AE001571F5 /* AddressFormViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressFormViewModelProtocol.swift; sourceTree = "<group>"; };
+		AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrderAddressFormViewModel.swift; sourceTree = "<group>"; };
 		AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressForm.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
@@ -5383,6 +5385,14 @@
 			path = FlowCoordinator;
 			sourceTree = "<group>";
 		};
+		AE9E04732776034B003FA09E /* CustomerSection */ = {
+			isa = PBXGroup;
+			children = (
+				AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */,
+			);
+			path = CustomerSection;
+			sourceTree = "<group>";
+		};
 		AEB73C1525CD8E3100A8454A /* Edit Product Variation */ = {
 			isa = PBXGroup;
 			children = (
@@ -6237,6 +6247,7 @@
 				CCFC50582743E021001E505F /* NewOrderViewModel.swift */,
 				AE264C05275A495E00B52996 /* FlowCoordinator */,
 				CC53FB3627551A8700C4CA4F /* ProductsSection */,
+				AE9E04732776034B003FA09E /* CustomerSection */,
 				AE264C04275A493800B52996 /* StatusSection */,
 			);
 			path = "Order Creation";
@@ -8269,6 +8280,7 @@
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				D8610D762570AE1F00A5DF27 /* NotWPErrorViewModel.swift in Sources */,
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,
+				AEC95D432774D07B001571F5 /* CreateOrderAddressFormViewModel.swift in Sources */,
 				024DF31B23742E1C006658FE /* FormatBarItemViewProperties.swift in Sources */,
 				26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */,
 				CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */,


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-ios/issues/5412.
Based on: https://github.com/woocommerce/woocommerce-ios/pull/5756.

## Description

This PR adds navigation and data flow from New Order view to Address Form.

## Changes

- Adds `CreateOrderAddressFormViewModel` to use in Order Create flow.
- Connects `EditOrderAddressForm` to `NewOrder` view.

### Known Issues

- Existing address form notices (countries loading error, for example) are not supported - they were handled in `EditOrderAddressHostingController`.

## Testing 

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "+ Add customer" button to display Address Form.
5. Confirm that all fields (but country field) work, enter some data.
6. Tap "Done" to save and close address form.
7. Tap "+ Add customer" button again and confirm that previously updated address is prefilled in address form.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

