### PR TITLE
Order Creation: Add API mapping for addresses on order creation

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -139,6 +139,14 @@ public class OrdersRemote: Remote {
                             [OrderItem.CodingKeys.productID.rawValue: item.productID,
                              OrderItem.CodingKeys.quantity.rawValue: Int64(truncating: item.quantity as NSDecimalNumber)]
                         }
+                    case .billingAddress:
+                        if let billingAddress = order.billingAddress {
+                            params[Order.CodingKeys.billingAddress.rawValue] = try billingAddress.toDictionary()
+                        }
+                    case .shippingAddress:
+                        if let shippingAddress = order.shippingAddress {
+                            params[Order.CodingKeys.shippingAddress.rawValue] = try shippingAddress.toDictionary()
+                        }
                     }
                 }
             }()
@@ -283,5 +291,7 @@ public extension OrdersRemote {
         case feeLines
         case status
         case items
+        case billingAddress
+        case shippingAddress
     }
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -315,7 +315,7 @@ private extension OrderStore {
     /// Creates a manual order with the provided order details.
     ///
     func createOrder(siteID: Int64, order: Order, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        remote.createOrder(siteID: siteID, order: order, fields: [.status, .items]) { [weak self] result in
+        remote.createOrder(siteID: siteID, order: order, fields: [.status, .items, .billingAddress, .shippingAddress]) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/5413.

## Description

This PR adds network mapping for customer data entered in order creation flow.

## Changes

- Adds mapping for 2 fields - `billingAddress` and `shippingAddress` in `OrdersRemote`.
- Adds tests.

## Testing 

1. On [line 157](https://github.com/woocommerce/woocommerce-ios/blob/ba4161ea554ae66fbbd9c8410a820fe8245c5b9b/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/NewOrderViewModel.swift#L156-L157) of `NewOrderViewModel` add some hardcoded addresses (copy from tests) as initial values.
2. Build and run the app in debug mode (to ensure the feature flag is enabled).
3. Make sure Order Creation is enabled under Settings > Experimental Features.
4. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
5. Add some products to enable "Create" button.
6. Tap "Create" button.
7. Confirm that in order details customer section shows earlier hardcoded address data.

Bonus: merge with https://github.com/woocommerce/woocommerce-ios/pull/5758 locally to update address in UI of order creation instead of hardcoding. But it will work only for billing address.

## Screenshots

customer data in order creation flow (needs https://github.com/woocommerce/woocommerce-ios/pull/5758)|customer data in created order details
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/147369937-228c8dbe-082f-40de-aebd-b68327af2a95.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/147369939-fb021932-53a8-42be-b16e-0cb2f7f698de.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

