### PR TITLE
Made mock UI tests credentials shorter.

### DIFF
--- a/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
@@ -1,7 +1,7 @@
 // These are fake credentials used for the mocked UI tests
 struct TestCredentials {
-    static let emailAddress: String = "e2eflowtestingmobile@example.com"
-    static let password: String = "mocked_password"
+    static let emailAddress: String = "t@wp.com"
+    static let password: String = "pw"
     static let displayName: String = "WooCommerce Store Owner"
     static let siteUrl: String = "http://yourwoosite.com"
     static let storeName: String = "Your WooCommerce Store"


### PR DESCRIPTION
### Description
See wordpress-mobile/WordPress-iOS/pull/17700.

### Testing instructions
- CI is green.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.