### PR TITLE
Correction for Yosemite documentation

### DIFF
--- a/docs/YOSEMITE.md
+++ b/docs/YOSEMITE.md
@@ -87,7 +87,7 @@ func syncTopPerformers(onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         onCompletion?(result)
     }
 
-    ServiceLocator.storesManager.dispatch(action)
+    ServiceLocator.stores.dispatch(action)
 }
 ```
 


### PR DESCRIPTION
The **storeManager** has been renamed to **stores** and this PR fixes the Yosemite framework documentation. 