### PR TITLE
Remove quote icon from refund details

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -659,12 +659,6 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Quote Image
-    ///
-    static var quoteImage: UIImage {
-        return UIImage.gridicon(.quote)
-    }
-
     /// Pages Icon
     ///
     static var pagesImage: UIImage {

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
@@ -196,7 +196,6 @@ private extension RefundDetailsDataSource {
         cell.update(with: .imageAndTitleOnly(fontStyle: .body),
                     data: .init(title: refundReason ?? "",
                                 textTintColor: .text,
-                                image: .quoteImage,
                                 imageTintColor: .text,
                                 numberOfLinesForTitle: 0,
                                 isActionable: false))

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -372,10 +372,6 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.pencilImage)
     }
 
-    func testQuoteImageIconIsNotNil() {
-        XCTAssertNotNil(UIImage.quoteImage)
-    }
-
     func testPagesImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.pagesImage)
     }


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/1739

## Description

Original issue describes non-localized "quote" icon usage in customer note and refund reason fields.
Customer note UI already updated earlier + localized in https://github.com/woocommerce/woocommerce-ios/pull/5643.
This PR removes quote icon from refund details. Internal discussion ref: p1639049276086900-slack-C6H8C3G23.

## Changes

- Removes quote icon from refunds details.
- Removes quote icon from UIImage extension.

## Testing

1. Open details for existing completed order and tap "Issue Refund".
2. Select some products, tap "Next".
3. Fill in "Optional reason" field.
4. Tap "Refund" button and confirm.
5. On order details tap "Refunded" cell.
6. On refund details screen confirm that "Reason for refund" field doesn't have any icon.

## Screenshots

before|after
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/147475506-abf44726-150d-4b2a-9407-d76e6a6d0a2f.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/147475513-3faad209-e5db-4840-8969-2a9dcce8ff97.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.