### PR TITLE
Creating Analytics Date Range Selector

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -40,14 +40,17 @@ extension GeneralAppSettings {
 extension GeneralStoreSettings {
     public func copy(
         isTelemetryAvailable: CopiableProp<Bool> = .copy,
-        telemetryLastReportedTime: NullableCopiableProp<Date> = .copy
+        telemetryLastReportedTime: NullableCopiableProp<Date> = .copy,
+        selectedDateRange: CopiableProp<String> = .copy
     ) -> GeneralStoreSettings {
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
         let telemetryLastReportedTime = telemetryLastReportedTime ?? self.telemetryLastReportedTime
+        let selectedDateRange = selectedDateRange ?? self.selectedDateRange
 
         return GeneralStoreSettings(
             isTelemetryAvailable: isTelemetryAvailable,
-            telemetryLastReportedTime: telemetryLastReportedTime
+            telemetryLastReportedTime: telemetryLastReportedTime,
+            selectedDateRange: selectedDateRange
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -25,10 +25,15 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let telemetryLastReportedTime: Date?
 
+    /// The selected date range value from the Analytics.
+    ///
+    public let selectedDateRange: String
+
     public init(isTelemetryAvailable: Bool = false,
-                telemetryLastReportedTime: Date? = nil) {
+                telemetryLastReportedTime: Date? = nil, selectedDateRange: String = "Today") {
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
+        self.selectedDateRange = selectedDateRange
     }
 }
 
@@ -41,6 +46,8 @@ extension GeneralStoreSettings {
 
         self.isTelemetryAvailable = try container.decodeIfPresent(Bool.self, forKey: .isTelemetryAvailable) ?? false
         self.telemetryLastReportedTime = try container.decodeIfPresent(Date.self, forKey: .telemetryLastReportedTime)
+
+        self.selectedDateRange = try container.decodeIfPresent(String.self, forKey: .selectedDateRange) ?? "Today"
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsRange+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsRange+UI.swift
@@ -1,0 +1,89 @@
+import Yosemite
+
+extension AnalyticsRange {
+    /// The maximum number of stats intervals a time range could have.
+    var maxNumberOfIntervals: Int {
+        switch self {
+        case .today:
+            return 24
+        case .yesterday:
+            return 24
+        case .lastWeek:
+            return 7
+        case .lastMonth:
+            return 31
+        case .lastQuarter:
+            return 4
+        case .lastYear:
+            return 12
+        case .weekToDate:
+            return 7
+        case .monthToDate:
+            return 31
+        case .quarterToDate:
+            return 4
+        case .yearToDate:
+            return 12
+        }
+    }
+
+    /// Returns the latest date to be shown for the time range, given the current date and site time zone
+    ///
+    /// - Parameters:
+    ///   - currentDate: the date which the latest date is based on
+    ///   - siteTimezone: site time zone, which the stats data are based on
+    func latestDate(currentDate: Date, siteTimezone: TimeZone) -> Date {
+        switch self {
+        case .today:
+            return currentDate.endOfDay(timezone: siteTimezone)
+        case .yesterday:
+            return currentDate.endOfDay(timezone: siteTimezone)
+        case .lastWeek:
+            return currentDate.endOfWeek(timezone: siteTimezone)
+        case .lastMonth:
+            return currentDate.endOfMonth(timezone: siteTimezone)
+        case .lastQuarter:
+            return currentDate.endOfMonth(timezone: siteTimezone)
+        case .lastYear:
+            return currentDate.endOfYear(timezone: siteTimezone)
+        case .weekToDate:
+            return currentDate.endOfWeek(timezone: siteTimezone)
+        case .monthToDate:
+            return currentDate.endOfMonth(timezone: siteTimezone)
+        case .quarterToDate:
+            return currentDate.endOfMonth(timezone: siteTimezone)
+        case .yearToDate:
+            return currentDate.endOfYear(timezone: siteTimezone)
+        }
+    }
+
+    /// Returns the earliest date to be shown for the time range, given the latest date and site time zone
+    ///
+    /// - Parameters:
+    ///   - latestDate: the date which the earliest date is based on
+    ///   - siteTimezone: site time zone, which the stats data are based on
+    func earliestDate(latestDate: Date, siteTimezone: TimeZone) -> Date {
+        switch self {
+        case .today:
+            return latestDate.startOfDay(timezone: siteTimezone)
+        case .yesterday:
+            return latestDate.startOfDay(timezone: siteTimezone)
+        case .lastWeek:
+            return latestDate.startOfWeek(timezone: siteTimezone)
+        case .lastMonth:
+            return latestDate.startOfMonth(timezone: siteTimezone)
+        case .lastQuarter:
+            return latestDate.startOfMonth(timezone: siteTimezone)
+        case .lastYear:
+            return latestDate.startOfYear(timezone: siteTimezone)
+        case .weekToDate:
+            return latestDate.startOfWeek(timezone: siteTimezone)
+        case .monthToDate:
+            return latestDate.startOfMonth(timezone: siteTimezone)
+        case .quarterToDate:
+            return latestDate.startOfMonth(timezone: siteTimezone)
+        case .yearToDate:
+            return latestDate.startOfYear(timezone: siteTimezone)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 struct AnalyticsView: View {
     var body: some View {
         ZStack {
-            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            VStack {
+                DateRangeView()
+                Spacer()
+            }
         }
         .navigationTitle(Localization.title)
     }

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -4,7 +4,7 @@ struct AnalyticsView: View {
     var body: some View {
         ZStack {
             VStack {
-                DateRangeView()
+                DateRangeView(selectedRange: "Today")
                 Spacer()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct AnalyticsView: View {
+    var body: some View {
+        ZStack {
+            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        }
+        .navigationTitle(Localization.title)
+    }
+}
+
+struct AnalyticsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AnalyticsView()
+    }
+}
+
+private extension AnalyticsView {
+    enum Localization {
+        static let title = NSLocalizedString("Analytics", comment: "Title of the analytics view.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
+// MARK: - AnalyticsView
+//
 struct AnalyticsView: View {
     var body: some View {
         ZStack {
             VStack {
-                DateRangeView(selectedRange: "Today")
+                DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Yesterday")
                 Spacer()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -3,20 +3,30 @@ import SwiftUI
 // MARK: - AnalyticsView
 //
 struct AnalyticsView: View {
+
+    let siteID: Int64
+    @ObservedObject var viewModel = AnalyticsViewModel()
+
     var body: some View {
         ZStack {
             VStack {
-                DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Yesterday")
+                DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: $viewModel.selectedRange)
                 Spacer()
             }
         }
         .navigationTitle(Localization.title)
+        .onChange(of: viewModel.selectedRange) { newValue in
+            viewModel.saveSelectedDateRange(siteID: siteID, range: newValue)
+        }
+        .onAppear {
+            viewModel.getSelectedDateRange(siteID: siteID)
+        }
     }
 }
 
 struct AnalyticsView_Previews: PreviewProvider {
     static var previews: some View {
-        AnalyticsView()
+        AnalyticsView(siteID: 0, viewModel: AnalyticsViewModel())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsViewModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Yosemite
+
+// MARK: - AnalyticsViewModel
+//
+class AnalyticsViewModel: ObservableObject {
+    private let stores: StoresManager
+    @Published var selectedRange: String = "Today"
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+    }
+
+    func saveSelectedDateRange(siteID: Int64, range: String) {
+        let saveSelectedDateRangeAction = AppSettingsAction.setSelectedDateRange(siteID: siteID, range: range)
+        stores.dispatch(saveSelectedDateRangeAction)
+    }
+
+    func getSelectedDateRange(siteID: Int64) {
+        let action = AppSettingsAction.getSelectedDateRange(siteID: siteID) { [weak self] range in
+            guard let self = self else { return }
+            self.selectedRange = range
+        }
+        stores.dispatch(action)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
@@ -3,7 +3,6 @@ import SwiftUI
 // MARK: - DateRangeSheetRow
 //
 struct DateRangeSheetRow: View {
-
     let dateRange: String
     @Binding var selectedDateRange: String
 
@@ -33,9 +32,6 @@ struct DateRangeSheetRow: View {
         .onTapGesture {
             self.selectedDateRange = self.dateRange
         }
-        .onAppear(perform: {
-            selectedDateRange = dateRange
-        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+// MARK: - DateRangeSheetRow
+//
+struct DateRangeSheetRow: View {
+
+    let dateRange: String
+    @Binding var selectedDateRange: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0, content: {
+            HStack(alignment: .center, spacing: 10, content: {
+                if dateRange == selectedDateRange {
+                    Image(systemName: "checkmark.circle.fill")
+                        .resizable()
+                        .frame(width: 20, height: 20)
+                        .foregroundColor(Color(UIColor.accent))
+                } else {
+                    Image(systemName: "circle")
+                        .resizable()
+                        .frame(width: 20, height: 20)
+                        .foregroundColor(Color(UIColor.accent))
+                }
+                Text(dateRange)
+                    .foregroundColor(Color(UIColor.text))
+            })
+            .padding(.vertical, 18)
+            Divider()
+                .foregroundColor(Color(UIColor.text))
+        })
+        .padding(.horizontal, 10)
+        .background(Color(.listForeground))
+        .onTapGesture {
+            self.selectedDateRange = self.dateRange
+        }
+        .onAppear(perform: {
+            selectedDateRange = dateRange
+        })
+    }
+}
+
+struct DateRangeSheetCell_Previews: PreviewProvider {
+    static var previews: some View {
+        DateRangeSheetRow(dateRange: "Today", selectedDateRange: .constant("Today"))
+            .previewLayout(.fixed(width: 375, height: 44))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,11 +1,16 @@
 import SwiftUI
 
+// MARK: - DateRangeView
+//
 struct DateRangeView: View {
+
+    @State private var showingSheet = false
+
     var body: some View {
         VStack {
             Divider()
             Button {
-                // Open Date Range Sheet
+                showingSheet.toggle()
             } label: {
                 HStack {
                     VStack(alignment: .leading, spacing: 12, content: {
@@ -22,6 +27,9 @@ struct DateRangeView: View {
                         .foregroundColor(Color(UIColor.accent))
                 }
                 .padding(EdgeInsets(top: 18, leading: 16, bottom: 13, trailing: 16))
+            }
+            .sheet(isPresented: $showingSheet) {
+                DateRangeSheet()
             }
             Divider()
         }

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct DateRangeView: View {
+    var body: some View {
+        VStack {
+            Divider()
+            Button {
+                // Open Date Range Sheet
+            } label: {
+                HStack {
+                    VStack(alignment: .leading, spacing: 12, content: {
+                        Text("Today (Sep 10, 2020)")
+                            .font(.system(size: 17))
+                            .foregroundColor(Color(UIColor.text))
+                        Text("vs Previous Period (Sep 9, 2020)")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color(UIColor.text))
+                    })
+                    Spacer()
+                    Image(systemName: "calendar")
+                        .renderingMode(.template)
+                        .foregroundColor(Color(UIColor.accent))
+                }
+                .padding(EdgeInsets(top: 18, leading: 16, bottom: 13, trailing: 16))
+            }
+            Divider()
+        }
+        .background(Color(.listForeground))
+    }
+}
+
+struct DateRangeView_Previews: PreviewProvider {
+    static var previews: some View {
+        DateRangeView().previewLayout(.fixed(width: 375, height: 83))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 // MARK: - DateRangeView
+
 //
 struct DateRangeView: View {
-
+    @State var selectedRange: String
     @State private var showingSheet = false
 
     var body: some View {
@@ -26,10 +27,13 @@ struct DateRangeView: View {
                         .renderingMode(.template)
                         .foregroundColor(Color(UIColor.accent))
                 }
-                .padding(EdgeInsets(top: 18, leading: 16, bottom: 13, trailing: 16))
+                .padding(EdgeInsets(top: Constants.buttonContentTop,
+                                    leading: Constants.buttonContentLeading,
+                                    bottom: Constants.buttonContentBottom,
+                                    trailing: Constants.buttonContentTrailing))
             }
             .sheet(isPresented: $showingSheet) {
-                DateRangeSheet()
+                DateRangeSheet(selectedDateRange: $selectedRange)
             }
             Divider()
         }
@@ -39,6 +43,15 @@ struct DateRangeView: View {
 
 struct DateRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeView().previewLayout(.fixed(width: 375, height: 83))
+        DateRangeView(selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
+    }
+}
+
+private extension DateRangeView {
+    enum Constants {
+        static let buttonContentTop: CGFloat = 18
+        static let buttonContentLeading: CGFloat = 16
+        static let buttonContentBottom: CGFloat = 13
+        static let buttonContentTrailing: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 // MARK: - DateRangeView
-
 //
 struct DateRangeView: View {
+    @State var dateRangeText: String
     @State var selectedRange: String
     @State private var showingSheet = false
 
@@ -15,12 +15,12 @@ struct DateRangeView: View {
             } label: {
                 HStack {
                     VStack(alignment: .leading, spacing: 12, content: {
-                        Text("Today (Sep 10, 2020)")
+                        Text(dateRangeText)
                             .font(.system(size: 17))
                             .foregroundColor(Color(UIColor.text))
-                        Text("vs Previous Period (Sep 9, 2020)")
-                            .font(.system(size: 13))
-                            .foregroundColor(Color(UIColor.text))
+//                        Text("vs Previous Period (Sep 9, 2020)")
+//                            .font(.system(size: 13))
+//                            .foregroundColor(Color(UIColor.text))
                     })
                     Spacer()
                     Image(systemName: "calendar")
@@ -43,7 +43,7 @@ struct DateRangeView: View {
 
 struct DateRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeView(selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
+        DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 //
 struct DateRangeView: View {
     @State var dateRangeText: String
-    @State var selectedRange: String
+    @Binding var selectedRange: String
     @State private var showingSheet = false
 
     var body: some View {
@@ -18,9 +18,9 @@ struct DateRangeView: View {
                         Text(dateRangeText)
                             .font(.system(size: 17))
                             .foregroundColor(Color(UIColor.text))
-//                        Text("vs Previous Period (Sep 9, 2020)")
-//                            .font(.system(size: 13))
-//                            .foregroundColor(Color(UIColor.text))
+                        Text("vs Previous Period (Sep 9, 2020)")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color(UIColor.text))
                     })
                     Spacer()
                     Image(systemName: "calendar")
@@ -43,7 +43,7 @@ struct DateRangeView: View {
 
 struct DateRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
+        DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: .constant("Today")).previewLayout(.fixed(width: 375, height: 83))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeModel.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Yosemite
+
+// MARK: - DateRangeModel
+//
+struct DateRangeModel: Hashable {
+    var title: String
+    var range: AnalyticsRange
+}
+
+struct DateRanges {
+    var objectsArray: [DateRangeModel] = [
+        DateRangeModel(title: Localization.today, range: .today),
+        DateRangeModel(title: Localization.yesterday, range: .yesterday),
+        DateRangeModel(title: Localization.lastWeek, range: .lastWeek),
+        DateRangeModel(title: Localization.lastMonth, range: .lastMonth),
+        DateRangeModel(title: Localization.lastQuarter, range: .lastQuarter),
+        DateRangeModel(title: Localization.lastYear, range: .lastYear),
+        DateRangeModel(title: Localization.weekToDate, range: .weekToDate),
+        DateRangeModel(title: Localization.monthToDate, range: .monthToDate),
+        DateRangeModel(title: Localization.quarterToDate, range: .quarterToDate),
+        DateRangeModel(title: Localization.yearToDate, range: .yearToDate),
+    ]
+}
+
+private extension DateRanges {
+    enum Localization {
+        static let today = NSLocalizedString("Today", comment: "Title of today date range.")
+        static let yesterday = NSLocalizedString("Yesterday", comment: "Title of yesterday date range.")
+        static let lastWeek = NSLocalizedString("Last Week", comment: "Title of yesterday date range.")
+        static let lastMonth = NSLocalizedString("Last Month", comment: "Title of last month date range.")
+        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "Title of last quarter date range.")
+        static let lastYear = NSLocalizedString("Last Year", comment: "Title of last year date range.")
+        static let weekToDate = NSLocalizedString("Week to date", comment: "Title of week to date date range.")
+        static let monthToDate = NSLocalizedString("Month to date", comment: "Title of month to date date range.")
+        static let quarterToDate = NSLocalizedString("Quarter to date", comment: "Title of quarter to date date range.")
+        static let yearToDate = NSLocalizedString("Year to date", comment: "Title of year to date date range.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -3,18 +3,9 @@ import SwiftUI
 // MARK: - DateRangeSheet
 //
 struct DateRangeSheet: View {
-    var dateRanges: [String] = [
-        Localization.today,
-        Localization.yesterday,
-        Localization.lastWeek,
-        Localization.lastMonth,
-        Localization.lastQuarter,
-        Localization.lastYear,
-        Localization.weekToDate,
-        Localization.monthToDate,
-        Localization.quarterToDate,
-        Localization.yearToDate
-    ]
+
+    // Array with all date range options
+    var dateRanges = DateRanges().objectsArray
 
     @Environment(\.presentationMode) var presentationMode
 
@@ -28,7 +19,7 @@ struct DateRangeSheet: View {
                     Spacer()
                         .frame(height: 8)
                     ForEach(dateRanges, id: \.self) { item in
-                        DateRangeSheetRow(dateRange: item, selectedDateRange: $selectedDateRange)
+                        DateRangeSheetRow(dateRange: item.title, selectedDateRange: $selectedDateRange)
                     }
                     Spacer()
                 })
@@ -53,17 +44,7 @@ struct DateRangeSheet_Previews: PreviewProvider {
 
 private extension DateRangeSheet {
     enum Localization {
-        static let title = NSLocalizedString("Select Date Range", comment: "Title of date range sheet.")
+        static let title = NSLocalizedString("Select a Date Range", comment: "Title of date range sheet.")
         static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
-        static let today = NSLocalizedString("Today", comment: "The date range option title that shows the statistics for today.")
-        static let yesterday = NSLocalizedString("Yesterday", comment: "The date range option title that shows the statistics for yesterday.")
-        static let lastWeek = NSLocalizedString("Last Week", comment: "The date range option title that shows the statistics for last week.")
-        static let lastMonth = NSLocalizedString("Last Month", comment: "The date range option title that shows the statistics for last month.")
-        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "The date range option title that shows the statistics for last quarter.")
-        static let lastYear = NSLocalizedString("Last Year", comment: "The date range option title that shows the statistics for last year.")
-        static let weekToDate = NSLocalizedString("Week to date", comment: "The date range option title that shows the statistics for week to date.")
-        static let monthToDate = NSLocalizedString("Month to date", comment: "The date range option title that shows the statistics for month to date.")
-        static let quarterToDate = NSLocalizedString("Quarter to date", comment: "The date range option title that shows the statistics for quarter to date.")
-        static let yearToDate = NSLocalizedString("Year to date", comment: "The date range option title that shows the statistics for year to date.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+// MARK: - DateRangeSheet
+//
+struct DateRangeSheet: View {
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(UIColor.listBackground).edgesIgnoringSafeArea(.all)
+                VStack(alignment: .leading, spacing: 0, content: {
+                    Spacer()
+                        .frame(height: 8)
+                    // Loop through the date range options
+                    Spacer()
+                })
+            }
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+struct DateRangeSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        DateRangeSheet()
+    }
+}
+
+private extension DateRangeSheet {
+    enum Localization {
+        static let title = NSLocalizedString("Select Date Range", comment: "Title of date range sheet.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -3,6 +3,23 @@ import SwiftUI
 // MARK: - DateRangeSheet
 //
 struct DateRangeSheet: View {
+    var dateRanges: [String] = [
+        Localization.today,
+        Localization.yesterday,
+        Localization.lastWeek,
+        Localization.lastMonth,
+        Localization.lastQuarter,
+        Localization.lastYear,
+        Localization.weekToDate,
+        Localization.monthToDate,
+        Localization.quarterToDate,
+        Localization.yearToDate
+    ]
+
+    @Environment(\.presentationMode) var presentationMode
+
+    @Binding var selectedDateRange: String
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -10,9 +27,17 @@ struct DateRangeSheet: View {
                 VStack(alignment: .leading, spacing: 0, content: {
                     Spacer()
                         .frame(height: 8)
-                    // Loop through the date range options
+                    ForEach(dateRanges, id: \.self) { item in
+                        DateRangeSheetRow(dateRange: item, selectedDateRange: $selectedDateRange)
+                    }
                     Spacer()
                 })
+            }
+            .toolbar {
+                Button(Localization.apply) {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .foregroundColor(Color(.accent))
             }
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
@@ -22,12 +47,23 @@ struct DateRangeSheet: View {
 
 struct DateRangeSheet_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeSheet()
+        DateRangeSheet(selectedDateRange: .constant("Today"))
     }
 }
 
 private extension DateRangeSheet {
     enum Localization {
         static let title = NSLocalizedString("Select Date Range", comment: "Title of date range sheet.")
+        static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
+        static let today = NSLocalizedString("Today", comment: "The date range option title that shows the statistics for today.")
+        static let yesterday = NSLocalizedString("Yesterday", comment: "The date range option title that shows the statistics for yesterday.")
+        static let lastWeek = NSLocalizedString("Last Week", comment: "The date range option title that shows the statistics for last week.")
+        static let lastMonth = NSLocalizedString("Last Month", comment: "The date range option title that shows the statistics for last month.")
+        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "The date range option title that shows the statistics for last quarter.")
+        static let lastYear = NSLocalizedString("Last Year", comment: "The date range option title that shows the statistics for last year.")
+        static let weekToDate = NSLocalizedString("Week to date", comment: "The date range option title that shows the statistics for week to date.")
+        static let monthToDate = NSLocalizedString("Month to date", comment: "The date range option title that shows the statistics for month to date.")
+        static let quarterToDate = NSLocalizedString("Quarter to date", comment: "The date range option title that shows the statistics for quarter to date.")
+        static let yearToDate = NSLocalizedString("Year to date", comment: "The date range option title that shows the statistics for year to date.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -4,11 +4,12 @@ import SwiftUI
 //
 struct DateRangeSheet: View {
 
-    // Array with all date range options
+    // Array with all date range options.
     var dateRanges = DateRanges().objectsArray
-
+    // For closing the sheet.
     @Environment(\.presentationMode) var presentationMode
 
+    @State var tempSelectedDateRange: String = "Yesterday"
     @Binding var selectedDateRange: String
 
     var body: some View {
@@ -19,32 +20,36 @@ struct DateRangeSheet: View {
                     Spacer()
                         .frame(height: 8)
                     ForEach(dateRanges, id: \.self) { item in
-                        DateRangeSheetRow(dateRange: item.title, selectedDateRange: $selectedDateRange)
+                        DateRangeSheetRow(dateRange: item.title, selectedDateRange: $tempSelectedDateRange)
                     }
                     Spacer()
                 })
             }
             .toolbar {
                 Button(Localization.apply) {
+                    // After pressing 'Apply' we confirm that the temporary date range is the date range we want to select.
+                    selectedDateRange = tempSelectedDateRange
+                    // Close the sheet.
                     presentationMode.wrappedValue.dismiss()
                 }
                 .foregroundColor(Color(.accent))
-            }
+            }.onAppear(perform: {
+                // Pass the previous selected date range to temporary.
+                self.tempSelectedDateRange = selectedDateRange
+            })
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
         }
+    }
+
+    private enum Localization {
+        static let title = NSLocalizedString("Select a Date Range", comment: "Title of date range sheet.")
+        static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
     }
 }
 
 struct DateRangeSheet_Previews: PreviewProvider {
     static var previews: some View {
         DateRangeSheet(selectedDateRange: .constant("Today"))
-    }
-}
-
-private extension DateRangeSheet {
-    enum Localization {
-        static let title = NSLocalizedString("Select a Date Range", comment: "Title of date range sheet.")
-        static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -50,7 +50,7 @@ struct HubMenu: View {
 
             // Go to the Analytics screen
             NavigationLink(destination:
-                            AnalyticsView(),
+                            AnalyticsView(siteID: viewModel.siteID),
                            isActive: $showAnalytics) {
                 EmptyView()
             }.hidden()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -50,7 +50,7 @@ struct HubMenu: View {
 
             // Go to the Analytics screen
             NavigationLink(destination:
-                            EmptyView(),
+                            AnalyticsView(),
                            isActive: $showAnalytics) {
                 EmptyView()
             }.hidden()

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -28,6 +28,7 @@ class AuthenticatedState: StoresManagerState {
 
         services = [
             AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            AnalyticsStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             AppSettingsStore(dispatcher: dispatcher, storageManager: storageManager, fileStorage: PListFileStorage()),
             AddOnGroupStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             AvailabilityStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
+		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -1996,6 +1997,7 @@
 		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -4255,6 +4257,14 @@
 			path = inAppFeedback;
 			sourceTree = "<group>";
 		};
+		306F943C277A526E00DC6111 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				306F943A277A526900DC6111 /* DateRangeView.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
 		318853452639FE7F00F66A9C /* CardReadersV2 */ = {
 			isa = PBXGroup;
 			children = (
@@ -5212,6 +5222,7 @@
 		8EEEB78427728F460089BFF3 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				306F943C277A526E00DC6111 /* Cells */,
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
 			);
 			path = Analytics;
@@ -8234,6 +8245,7 @@
 				4590CEE4249BA46700949F05 /* AddProductCategoryViewController.swift in Sources */,
 				CE37C04422984E81008DCB39 /* PickListTableViewCell.swift in Sources */,
 				020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */,
+				306F943B277A526900DC6111 /* DateRangeView.swift in Sources */,
 				B5A56BF5219F5AB20065A902 /* NSNotificationName+Woo.swift in Sources */,
 				D449C51B26DE6B5000D75B02 /* ReportList.swift in Sources */,
 				CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
+		30419930277B9A0F004A317E /* DateRangeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992F277B9A0F004A317E /* DateRangeModel.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
 		306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */; };
@@ -1999,6 +2000,7 @@
 		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		3041992F277B9A0F004A317E /* DateRangeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeModel.swift; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
 		306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheetRow.swift; sourceTree = "<group>"; };
@@ -5230,6 +5232,7 @@
 				306F943C277A526E00DC6111 /* Cells */,
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
 				306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */,
+				3041992F277B9A0F004A317E /* DateRangeModel.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -8004,6 +8007,7 @@
 				D82BB3AA26454F3300A82741 /* CardPresentModalProcessing.swift in Sources */,
 				0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
+				30419930277B9A0F004A317E /* DateRangeModel.swift in Sources */,
 				7E7C5F792719A8F900315B61 /* EditProductCategoryListViewModel.swift in Sources */,
 				DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
+		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -1998,6 +1999,7 @@
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
+		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -5224,6 +5226,7 @@
 			children = (
 				306F943C277A526E00DC6111 /* Cells */,
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
+				306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -8378,6 +8381,7 @@
 				F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */,
 				D8C2A28B231931D100F503E9 /* ReviewViewModel.swift in Sources */,
 				B541B223218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift in Sources */,
+				306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */,
 				E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */,
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
 				D8610CE2257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
+		300E2E2C277E3BE60008DDF4 /* AnalyticsRange+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300E2E2B277E3BE60008DDF4 /* AnalyticsRange+UI.swift */; };
 		30419930277B9A0F004A317E /* DateRangeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992F277B9A0F004A317E /* DateRangeModel.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
@@ -2001,6 +2002,7 @@
 		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		300E2E2B277E3BE60008DDF4 /* AnalyticsRange+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsRange+UI.swift"; sourceTree = "<group>"; };
 		3041992F277B9A0F004A317E /* DateRangeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeModel.swift; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
@@ -5236,6 +5238,7 @@
 				306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */,
 				3041992F277B9A0F004A317E /* DateRangeModel.swift */,
 				30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */,
+				300E2E2B277E3BE60008DDF4 /* AnalyticsRange+UI.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -7743,6 +7746,7 @@
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
 				025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */,
 				456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */,
+				300E2E2C277E3BE60008DDF4 /* AnalyticsRange+UI.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -891,6 +891,7 @@
 		7E7C5F8F2719BA7300315B61 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F8E2719BA7300315B61 /* ProductCategoryCellViewModel.swift */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
+		8EEEB78627728F5C0089BFF3 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */; };
 		933A27372222354600C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27362222354600C2143A /* Logging.swift */; };
 		934CB123224EAB150005CCB9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934CB122224EAB150005CCB9 /* main.swift */; };
 		9379E1A32255365F006A6BE4 /* TestingMode.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9379E1A22255365F006A6BE4 /* TestingMode.storyboard */; };
@@ -2368,6 +2369,7 @@
 		8CA4F6DE220B257000A47B5D /* WooCommerce.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.release.xcconfig; path = ../config/WooCommerce.release.xcconfig; sourceTree = "<group>"; };
 		8CA4F6E1220B259100A47B5D /* Version.Public.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Version.Public.xcconfig; path = ../config/Version.Public.xcconfig; sourceTree = "<group>"; };
 		8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "RELEASE-NOTES.txt"; path = "../RELEASE-NOTES.txt"; sourceTree = "<group>"; };
+		8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
 		90AC1C0B391E04A837BDC64E /* Pods-WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.debug.xcconfig"; sourceTree = "<group>"; };
 		933A27362222354600C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		934CB122224EAB150005CCB9 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -5207,6 +5209,14 @@
 			path = ../config;
 			sourceTree = "<group>";
 		};
+		8EEEB78427728F460089BFF3 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		AEB73C1525CD8E3100A8454A /* Edit Product Variation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5474,6 +5484,7 @@
 				CE85FD5120F677460080B73E /* Dashboard */,
 				CE1CCB4920570B05000EE3AC /* Orders */,
 				B59C09DA2188D6E800AB41D6 /* Reviews */,
+				8EEEB78427728F460089BFF3 /* Analytics */,
 				45BBFBBF274FD92B00213001 /* Hub Menu */,
 				74EC34A3225FE1F3004BBC2E /* Products */,
 				022BF7FA23B9D681000A1DFB /* Progress */,
@@ -8006,6 +8017,7 @@
 				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,
 				311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */,
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
+				8EEEB78627728F5C0089BFF3 /* AnalyticsView.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
 				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
 		306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */; };
+		30F5C00A277CB16300025EF9 /* AnalyticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -2004,6 +2005,7 @@
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
 		306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheetRow.swift; sourceTree = "<group>"; };
+		30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModel.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -5233,6 +5235,7 @@
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
 				306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */,
 				3041992F277B9A0F004A317E /* DateRangeModel.swift */,
+				30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -7968,6 +7971,7 @@
 				31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSource.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
+				30F5C00A277CB16300025EF9 /* AnalyticsViewModel.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
 				7E7C5F7A2719A8F900315B61 /* EditProductCategoryListViewController.swift in Sources */,
 				77E53EC82510FE07003D385F /* ProductDownloadsEditableData.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
+		306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -2000,6 +2001,7 @@
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
+		306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheetRow.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -4263,6 +4265,7 @@
 			isa = PBXGroup;
 			children = (
 				306F943A277A526900DC6111 /* DateRangeView.swift */,
+				306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -7683,6 +7686,7 @@
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,
 				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */,
+				306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
 				31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */,
 				025FA38B2522CB4D0054CA57 /* AppCoordinator.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		26E5A08225A66868000DF8F6 /* ProductAttributeTermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */; };
 		26E5A09225A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */; };
 		26FB056A25F6CB7600A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056925F6CB7600A40B26 /* Fakes.framework */; };
+		3041992C277B71D0004A317E /* AnalyticsRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992B277B71D0004A317E /* AnalyticsRange.swift */; };
+		3041992E277B8DA2004A317E /* AnalyticsStatsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */; };
 		312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */; };
 		312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */; };
 		3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */; };
@@ -535,6 +537,8 @@
 		26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStore.swift; sourceTree = "<group>"; };
 		26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStoreTests.swift; sourceTree = "<group>"; };
 		26FB056925F6CB7600A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3041992B277B71D0004A317E /* AnalyticsRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsRange.swift; sourceTree = "<group>"; };
+		3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsStatsAction.swift; sourceTree = "<group>"; };
 		312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGatewayAccount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettingsStoreTests+CardReaderSettings.swift"; sourceTree = "<group>"; };
 		3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountAction.swift; sourceTree = "<group>"; };
@@ -857,6 +861,7 @@
 			children = (
 				0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */,
 				E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */,
+				3041992B277B71D0004A317E /* AnalyticsRange.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1526,6 +1531,7 @@
 				DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */,
 				077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */,
 				FE28F6ED268440B1004465C7 /* UserAction.swift */,
+				3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -1846,6 +1852,7 @@
 				0271E1662509CF0100633F7A /* AnyError.swift in Sources */,
 				45ED6096257E7472007B4AC6 /* ProductAttributeStore.swift in Sources */,
 				077F39E026A5A6F500ABEADC /* SystemStatusStore.swift in Sources */,
+				3041992E277B8DA2004A317E /* AnalyticsStatsAction.swift in Sources */,
 				02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */,
 				02137901270AB204006430F7 /* MockUserActionHandler.swift in Sources */,
 				B56C1EC220EAE2E500D749F9 /* ReadOnlyConvertible.swift in Sources */,
@@ -1926,6 +1933,7 @@
 				026CF628237D8F30009563D4 /* ProductVariationAction.swift in Sources */,
 				24163B9E257F41A600F94EC3 /* StoresManager.swift in Sources */,
 				247CE8442582F3BB00F9D9D1 /* MockSettingActionHandler.swift in Sources */,
+				3041992C277B71D0004A317E /* AnalyticsRange.swift in Sources */,
 				B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */,
 				5726456F250BD4E4005BBD7C /* OrdersUpsertUseCase.swift in Sources */,
 				3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		26E5A08225A66868000DF8F6 /* ProductAttributeTermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */; };
 		26E5A09225A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */; };
 		26FB056A25F6CB7600A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056925F6CB7600A40B26 /* Fakes.framework */; };
+		300E2E2E277E4E5C0008DDF4 /* AnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300E2E2D277E4E5C0008DDF4 /* AnalyticsStore.swift */; };
 		3041992C277B71D0004A317E /* AnalyticsRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992B277B71D0004A317E /* AnalyticsRange.swift */; };
 		3041992E277B8DA2004A317E /* AnalyticsStatsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */; };
 		312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */; };
@@ -537,6 +538,7 @@
 		26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStore.swift; sourceTree = "<group>"; };
 		26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStoreTests.swift; sourceTree = "<group>"; };
 		26FB056925F6CB7600A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		300E2E2D277E4E5C0008DDF4 /* AnalyticsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsStore.swift; sourceTree = "<group>"; };
 		3041992B277B71D0004A317E /* AnalyticsRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsRange.swift; sourceTree = "<group>"; };
 		3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsStatsAction.swift; sourceTree = "<group>"; };
 		312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGatewayAccount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1261,6 +1263,7 @@
 				570B05CD246B6A2F00C186AE /* ProductReview */,
 				0212AC5F242C680800C51F6C /* Enums */,
 				B5BC736420D1A98500B5B6FA /* AccountStore.swift */,
+				300E2E2D277E4E5C0008DDF4 /* AnalyticsStore.swift */,
 				D87F614B22657B150031A13B /* AppSettingsStore.swift */,
 				2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */,
 				02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */,
@@ -1940,6 +1943,7 @@
 				B5C9DE162087FF0E006B910A /* Store.swift in Sources */,
 				02FF056123D98FD40058E6E7 /* ImageSourceWriter.swift in Sources */,
 				0212AC5E242C67FA00C51F6C /* ProductsSortOrder.swift in Sources */,
+				300E2E2E277E4E5C0008DDF4 /* AnalyticsStore.swift in Sources */,
 				026CF626237D8EFB009563D4 /* ProductVariationStore.swift in Sources */,
 				B52E0034211A449600700FDE /* Site+ReadOnlyType.swift in Sources */,
 				247CE86C25832D5800F9D9D1 /* MockShipmentActionHandler.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AnalyticsStatsAction.swift
+++ b/Yosemite/Yosemite/Actions/AnalyticsStatsAction.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Networking
+
+// MARK: - AnalyticsStatsAction: Defines stats operations.
+//
+public enum AnalyticsStatsAction: Action {
+
+    /// Clears all of the stats data.
+    ///
+    case resetStoredStats(onCompletion: () -> Void)
+
+    /// Synchronizes `OrderStats` for the provided siteID, time range, and date.
+    ///
+    case retrieveStats(siteID: Int64,
+        timeRange: AnalyticsRange,
+        earliestDateToInclude: Date,
+        latestDateToInclude: Date,
+        quantity: Int,
+        onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
+    ///
+    case retrieveSiteVisitStats(siteID: Int64,
+        siteTimezone: TimeZone,
+        timeRange: AnalyticsRange,
+        latestDateToInclude: Date,
+        onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Synchronizes `TopEarnerStats` for the provided siteID, time range, and date.
+    ///
+    case retrieveTopEarnerStats(siteID: Int64,
+        timeRange: AnalyticsRange,
+        earliestDateToInclude: Date,
+        latestDateToInclude: Date,
+        onCompletion: (Result<Void, Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -187,6 +187,14 @@ public enum AppSettingsAction: Action {
     ///
     case getTelemetryInfo(siteID: Int64, onCompletion: (Bool, Date?) -> Void)
 
+    /// Sets selected date range value for Analytics.
+    ///
+    case setSelectedDateRange(siteID: Int64, range: String)
+
+    /// Loads selected date range value for Analytics.
+    ///
+    case getSelectedDateRange(siteID: Int64, onCompletion: (String) -> Void)
+
     /// Clears all the products settings
     ///
     case resetGeneralStoreSettings

--- a/Yosemite/Yosemite/Model/Enums/AnalyticsRange.swift
+++ b/Yosemite/Yosemite/Model/Enums/AnalyticsRange.swift
@@ -23,3 +23,143 @@ public enum AnalyticsRange: String {
     case quarterToDate
     case yearToDate
 }
+
+extension AnalyticsRange {
+
+
+    /// Represents the period unit of the store stats using Stats v4 API given a time range.
+    public var intervalGranularity: StatsGranularityV4 {
+        switch self {
+        case .today:
+        return .hourly
+        case .yesterday:
+        return .hourly
+        case .lastWeek:
+        return .daily
+        case .lastMonth:
+        return .daily
+        case .lastQuarter:
+        return .monthly
+        case .lastYear:
+        return .monthly
+        case .weekToDate:
+        return .daily
+        case .monthToDate:
+        return .daily
+        case .quarterToDate:
+        return .monthly
+        case .yearToDate:
+        return .monthly
+        }
+    }
+
+    /// Represents the period unit of the site visit stats given a time range.
+    public var siteVisitStatsGranularity: StatGranularity {
+        switch self {
+        case .today, .yesterday, .lastWeek, .lastMonth, .lastQuarter, .weekToDate, .monthToDate, .quarterToDate:
+            return .day
+        case .lastYear, .yearToDate:
+            return .month
+        }
+    }
+
+    /// Represents the period unit of the top earners stats given a time range.
+    public var topEarnerStatsGranularity: StatGranularity {
+        switch self {
+        case .today:
+        return .day
+        case .yesterday:
+        return .day
+        case .lastWeek:
+        return .week
+        case .lastMonth:
+        return .month
+        case .lastQuarter:
+        return .month
+        case .lastYear:
+        return .year
+        case .weekToDate:
+        return .week
+        case .monthToDate:
+        return .month
+        case .quarterToDate:
+        return .month
+        case .yearToDate:
+        return .year
+        }
+    }
+
+    /// Represents the period unit of the leaderboards v4 API  given a time range.
+    public var leaderboardsGranularity: StatsGranularityV4 {
+        switch self {
+        case .today:
+        return .daily
+        case .yesterday:
+        return .daily
+        case .lastWeek:
+        return .weekly
+        case .lastMonth:
+        return .monthly
+        case .lastQuarter:
+        return .monthly
+        case .lastYear:
+        return .yearly
+        case .weekToDate:
+        return .weekly
+        case .monthToDate:
+        return .monthly
+        case .quarterToDate:
+        return .monthly
+        case .yearToDate:
+        return .yearly
+        }
+    }
+
+    /// The number of intervals for site visit stats to fetch given a time range.
+    /// The interval unit is in `siteVisitStatsGranularity`.
+    func siteVisitStatsQuantity(date: Date, siteTimezone: TimeZone) -> Int {
+        switch self {
+        case .today:
+        return 1
+        case .yesterday:
+        return 1
+        case .lastWeek:
+        return 7
+        case .lastMonth:
+            var calendar = Calendar.current
+            calendar.timeZone = siteTimezone
+            let daysThisMonth = calendar.range(of: .day, in: .month, for: date)
+            return daysThisMonth?.count ?? 0
+        case .lastQuarter:
+        return 4
+        case .lastYear:
+        return 12
+        case .weekToDate:
+        return 7
+        case .monthToDate:
+            var calendar = Calendar.current
+            calendar.timeZone = siteTimezone
+            let daysThisMonth = calendar.range(of: .day, in: .month, for: date)
+            return daysThisMonth?.count ?? 0
+        case .quarterToDate:
+        return 4
+        case .yearToDate:
+        return 12
+        }
+    }
+}
+
+private extension AnalyticsRange {
+    enum Localization {
+        static let today = NSLocalizedString("Today", comment: "Title of today date range.")
+        static let yesterday = NSLocalizedString("Yesterday", comment: "Title of yesterday date range.")
+        static let lastWeek = NSLocalizedString("Last Week", comment: "Title of yesterday date range.")
+        static let lastMonth = NSLocalizedString("Last Month", comment: "Title of last month date range.")
+        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "Title of last quarter date range.")
+        static let lastYear = NSLocalizedString("Last Year", comment: "Title of last year date range.")
+        static let weekToDate = NSLocalizedString("Week to date", comment: "Title of week to date date range.")
+        static let monthToDate = NSLocalizedString("Month to date", comment: "Title of month to date date range.")
+        static let quarterToDate = NSLocalizedString("Quarter to date", comment: "Title of quarter to date date range.")
+        static let yearToDate = NSLocalizedString("Year to date", comment: "Title of year to date date range.")
+    }
+}

--- a/Yosemite/Yosemite/Model/Enums/AnalyticsRange.swift
+++ b/Yosemite/Yosemite/Model/Enums/AnalyticsRange.swift
@@ -1,0 +1,25 @@
+/// Represents the date range for Analytics.
+/// This is a local property and not in the remote response.
+///
+/// - today: hourly data starting midnight today until now.
+/// - yesterday: hourly data starting midnight yesterday until 23:59:59 of yesterday.
+/// - lastWeek: daily data starting Sunday of previous week until 23:59:59 of the following Saturday.
+/// - lastMonth: daily data starting 1st of previous month until the last day of previous month.
+/// - lastQuarter: monthly data showing the previous quarter (e.g if right now is December 12, the last quarter will be Jul 1 - Sep 30).
+/// - lastYear: monthly data starting January of the previous year until December of the previous year.
+/// - weekToDate: daily data starting Sunday of this week until now.
+/// - monthToDate: daily data starting 1st of this month until now.
+/// - quarterToDate: monthly data showing the current quarter until now (e.g if right now is December 12, the last quarter will be Oct 1 - December 12).
+/// - yearToDate: monthly data starting January of this year until now.
+public enum AnalyticsRange: String {
+    case today
+    case yesterday
+    case lastWeek
+    case lastMonth
+    case lastQuarter
+    case lastYear
+    case weekToDate
+    case monthToDate
+    case quarterToDate
+    case yearToDate
+}

--- a/Yosemite/Yosemite/Stores/AnalyticsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnalyticsStore.swift
@@ -1,0 +1,467 @@
+import Foundation
+import Networking
+import Storage
+
+
+// MARK: - AnalyticsStore
+//
+public final class AnalyticsStore: Store {
+    private let siteVisitStatsRemote: SiteVisitStatsRemote
+    private let leaderboardsRemote: LeaderboardsRemote
+    private let orderStatsRemote: OrderStatsRemoteV4
+    private let productsRemote: ProductsRemote
+
+    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        self.siteVisitStatsRemote = SiteVisitStatsRemote(network: network)
+        self.leaderboardsRemote = LeaderboardsRemote(network: network)
+        self.orderStatsRemote = OrderStatsRemoteV4(network: network)
+        self.productsRemote = ProductsRemote(network: network)
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: AnalyticsStatsAction.self)
+    }
+
+    /// Receives and executes Actions.
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? AnalyticsStatsAction else {
+            assertionFailure("OrderStatsStoreV4 received an unsupported action")
+            return
+        }
+
+        switch action {
+        case .resetStoredStats(let onCompletion):
+            resetStoredStats(onCompletion: onCompletion)
+        case .retrieveStats(let siteID,
+                            let timeRange,
+                            let earliestDateToInclude,
+                            let latestDateToInclude,
+                            let quantity,
+                            let onCompletion):
+            retrieveStats(siteID: siteID,
+                          timeRange: timeRange,
+                          earliestDateToInclude: earliestDateToInclude,
+                          latestDateToInclude: latestDateToInclude,
+                          quantity: quantity,
+                          onCompletion: onCompletion)
+        case .retrieveSiteVisitStats(let siteID,
+                                     let siteTimezone,
+                                     let timeRange,
+                                     let latestDateToInclude,
+                                     let onCompletion):
+            retrieveSiteVisitStats(siteID: siteID,
+                                   siteTimezone: siteTimezone,
+                                   timeRange: timeRange,
+                                   latestDateToInclude: latestDateToInclude,
+                                   onCompletion: onCompletion)
+        case .retrieveTopEarnerStats(let siteID,
+                                     let timeRange,
+                                     let earliestDateToInclude,
+                                     let latestDateToInclude,
+                                     let onCompletion):
+            retrieveTopEarnerStats(siteID: siteID,
+                                   timeRange: timeRange,
+                                   earliestDateToInclude: earliestDateToInclude,
+                                   latestDateToInclude: latestDateToInclude,
+                                   onCompletion: onCompletion)
+        }
+    }
+}
+
+
+// MARK: - Services!
+//
+public extension AnalyticsStore {
+    /// Deletes all of the Stats data.
+    ///
+    func resetStoredStats(onCompletion: () -> Void) {
+        let storage = storageManager.viewStorage
+        storage.deleteAllObjects(ofType: Storage.OrderStatsV4.self)
+        storage.deleteAllObjects(ofType: Storage.OrderStatsV4Totals.self)
+        storage.deleteAllObjects(ofType: Storage.OrderStatsV4Interval.self)
+        storage.saveIfNeeded()
+        DDLogDebug("Stats V4 deleted")
+
+        onCompletion()
+    }
+
+    /// Retrieves the order stats associated with the provided Site ID (if any!).
+    ///
+    func retrieveStats(siteID: Int64,
+                       timeRange: AnalyticsRange,
+                       earliestDateToInclude: Date,
+                       latestDateToInclude: Date,
+                       quantity: Int,
+                       onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        orderStatsRemote.loadOrderStats(for: siteID,
+                              unit: timeRange.intervalGranularity,
+                              earliestDateToInclude: earliestDateToInclude,
+                              latestDateToInclude: latestDateToInclude,
+                              quantity: quantity) { [weak self] result in
+            switch result {
+            case .success(let orderStatsV4):
+                self?.upsertStoredOrderStats(readOnlyStats: orderStatsV4, timeRange: timeRange)
+                onCompletion(.success(()))
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Retrieves the site visit stats associated with the provided Site ID (if any!).
+    ///
+    func retrieveSiteVisitStats(siteID: Int64,
+                                siteTimezone: TimeZone,
+                                timeRange: AnalyticsRange,
+                                latestDateToInclude: Date,
+                                onCompletion: @escaping (Result<Void, Error>) -> Void) {
+
+        let quantity = timeRange.siteVisitStatsQuantity(date: latestDateToInclude, siteTimezone: siteTimezone)
+
+        siteVisitStatsRemote.loadSiteVisitorStats(for: siteID,
+                                    siteTimezone: siteTimezone,
+                                    unit: timeRange.siteVisitStatsGranularity,
+                                    latestDateToInclude: latestDateToInclude,
+                                    quantity: quantity) { [weak self] result in
+            switch result {
+            case .success(let siteVisitStats):
+                self?.upsertStoredSiteVisitStats(readOnlyStats: siteVisitStats, timeRange: timeRange)
+                onCompletion(.success(()))
+            case .failure(let error):
+                onCompletion(.failure(SiteVisitStatsStoreError(error: error)))
+            }
+        }
+    }
+
+    /// Retrieves the top earner stats associated with the provided Site ID (if any!).
+    ///
+    func retrieveTopEarnerStats(siteID: Int64,
+                                timeRange: AnalyticsRange,
+                                earliestDateToInclude: Date,
+                                latestDateToInclude: Date,
+                                onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
+        let earliestDate = dateFormatter.string(from: earliestDateToInclude)
+        let latestDate = dateFormatter.string(from: latestDateToInclude)
+        leaderboardsRemote.loadLeaderboards(for: siteID,
+                                unit: timeRange.leaderboardsGranularity,
+                                earliestDateToInclude: earliestDate,
+                                latestDateToInclude: latestDate,
+                                quantity: Constants.defaultTopEarnerStatsLimit) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let leaderboards):
+                self.convertAndStoreLeaderboardsIntoTopEarners(siteID: siteID,
+                                                               granularity: timeRange.topEarnerStatsGranularity,
+                                                               date: latestDateToInclude,
+                                                               leaderboards: leaderboards,
+                                                               onCompletion: onCompletion)
+
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+}
+
+
+// MARK: - Persistence
+//
+extension AnalyticsStore {
+    /// Updates (OR Inserts) the specified ReadOnly OrderStatsV4 Entity into the Storage Layer.
+    ///
+    func upsertStoredOrderStats(readOnlyStats: Networking.OrderStatsV4, timeRange: AnalyticsRange) {
+        assert(Thread.isMainThread)
+
+        let storage = storageManager.viewStorage
+
+        let storageOrderStats = storage.loadOrderStatsV4(siteID: readOnlyStats.siteID, timeRange: timeRange.rawValue) ??
+            storage.insertNewObject(ofType: Storage.OrderStatsV4.self)
+
+        storageOrderStats.timeRange = timeRange.rawValue
+        storageOrderStats.totals = storage.insertNewObject(ofType: Storage.OrderStatsV4Totals.self)
+        storageOrderStats.update(with: readOnlyStats)
+        handleOrderStatsIntervals(readOnlyStats, storageOrderStats, storage)
+        storage.saveIfNeeded()
+    }
+
+    /// Updates the provided StorageOrderStats items using the provided read-only OrderStats items
+    ///
+    private func handleOrderStatsIntervals(_ readOnlyStats: Networking.OrderStatsV4, _ storageStats: Storage.OrderStatsV4, _ storage: StorageType) {
+        let readOnlyIntervals = readOnlyStats.intervals
+
+        if readOnlyIntervals.isEmpty {
+            // No items in the read-only order stats, so remove all the intervals in Storage.OrderStatsV4
+            storageStats.intervals?.forEach {
+                storageStats.removeFromIntervals($0)
+                storage.deleteObject($0)
+            }
+            return
+        }
+
+        // Upsert the items from the read-only order stats item
+        for readOnlyInterval in readOnlyIntervals {
+            if let existingStorageInterval = storage.loadOrderStatsInterval(interval: readOnlyInterval.interval,
+                                                                            orderStats: storageStats) {
+                existingStorageInterval.update(with: readOnlyInterval)
+                existingStorageInterval.stats = storageStats
+            } else {
+                let newStorageInterval = storage.insertNewObject(ofType: Storage.OrderStatsV4Interval.self)
+                newStorageInterval.subtotals = storage.insertNewObject(ofType: Storage.OrderStatsV4Totals.self)
+                newStorageInterval.update(with: readOnlyInterval)
+                storageStats.addToIntervals(newStorageInterval)
+            }
+        }
+
+        // Now, remove any objects that exist in storageStats.intervals but not in readOnlyStats.intervals
+        storageStats.intervals?.forEach({ storageInterval in
+            if readOnlyIntervals.first(where: { $0.interval == storageInterval.interval } ) == nil {
+                storageStats.removeFromIntervals(storageInterval)
+                storage.deleteObject(storageInterval)
+            }
+        })
+    }
+}
+
+// MARK: Site visit stats
+//
+extension AnalyticsStore {
+    /// Updates (OR Inserts) the specified ReadOnly SiteVisitStats Entity into the Storage Layer.
+    ///
+    func upsertStoredSiteVisitStats(readOnlyStats: Networking.SiteVisitStats, timeRange: AnalyticsRange) {
+        assert(Thread.isMainThread)
+
+        let storage = storageManager.viewStorage
+        let storageSiteVisitStats = storage.loadSiteVisitStats(
+            granularity: readOnlyStats.granularity.rawValue, timeRange: timeRange.rawValue) ?? storage.insertNewObject(ofType: Storage.SiteVisitStats.self)
+        storageSiteVisitStats.update(with: readOnlyStats)
+        storageSiteVisitStats.timeRange = timeRange.rawValue
+        handleSiteVisitStatsItems(readOnlyStats, storageSiteVisitStats, storage)
+        storage.saveIfNeeded()
+    }
+
+    /// Updates the provided StorageSiteVisitStats items using the provided read-only SiteVisitStats items
+    ///
+    private func handleSiteVisitStatsItems(_ readOnlyStats: Networking.SiteVisitStats,
+                                           _ storageSiteVisitStats: Storage.SiteVisitStats,
+                                           _ storage: StorageType) {
+
+        // Since we are treating the items in core data like a dumb cache, start by nuking all of the existing stored SiteVisitStatsItems
+        storageSiteVisitStats.items?.forEach {
+            storageSiteVisitStats.removeFromItems($0)
+            storage.deleteObject($0)
+        }
+
+        // Insert the items from the read-only stats
+        readOnlyStats.items?.forEach({ readOnlyItem in
+            let newStorageItem = storage.insertNewObject(ofType: Storage.SiteVisitStatsItem.self)
+            newStorageItem.update(with: readOnlyItem)
+            storageSiteVisitStats.addToItems(newStorageItem)
+        })
+    }
+}
+
+extension AnalyticsStore {
+    /// Updates (OR Inserts) the specified ReadOnly TopEarnerStats Entity into the Storage Layer.
+    ///
+    func upsertStoredTopEarnerStats(readOnlyStats: Networking.TopEarnerStats) {
+        assert(Thread.isMainThread)
+
+        let storage = storageManager.viewStorage
+        let storageTopEarnerStats = storage.loadTopEarnerStats(date: readOnlyStats.date,
+                                                               granularity: readOnlyStats.granularity.rawValue)
+            ?? storage.insertNewObject(ofType: Storage.TopEarnerStats.self)
+        storageTopEarnerStats.update(with: readOnlyStats)
+        handleTopEarnerStatsItems(readOnlyStats, storageTopEarnerStats, storage)
+        storage.saveIfNeeded()
+    }
+
+    /// Updates the provided StorageTopEarnerStats items using the provided read-only TopEarnerStats items
+    ///
+    private func handleTopEarnerStatsItems(_ readOnlyStats: Networking.TopEarnerStats,
+                                           _ storageTopEarnerStats: Storage.TopEarnerStats,
+                                           _ storage: StorageType) {
+
+        // Since we are treating the items in core data like a dumb cache, start by nuking all of the existing stored TopEarnerStatsItems
+        storageTopEarnerStats.items?.forEach {
+            storageTopEarnerStats.removeFromItems($0)
+            storage.deleteObject($0)
+        }
+
+        // Insert the items from the read-only stats
+        readOnlyStats.items?.forEach({ readOnlyItem in
+            let newStorageItem = storage.insertNewObject(ofType: Storage.TopEarnerStatsItem.self)
+            newStorageItem.update(with: readOnlyItem)
+            storageTopEarnerStats.addToItems(newStorageItem)
+        })
+    }
+}
+
+
+// MARK: Convert Leaderboard into TopEarnerStats
+//
+private extension AnalyticsStore {
+
+    /// Converts and stores a top-product `leaderboard` into a `StatsTopEarner`
+    /// Since  a `leaderboard` does not containt  the necesary product information, this method fetches the related product before starting the convertion.
+    ///
+    func convertAndStoreLeaderboardsIntoTopEarners(siteID: Int64,
+                                                   granularity: StatGranularity,
+                                                   date: Date,
+                                                   leaderboards: [Leaderboard],
+                                                   onCompletion: @escaping (Result<Void, Error>) -> Void) {
+
+        // Find the top products leaderboard by its ID
+        guard let topProducts = leaderboards.first(where: { $0.id == Constants.topProductsID }) else {
+            onCompletion(.failure(AnalyticsStoreError.missingTopProducts))
+            return
+        }
+
+        // Make sure we have all the necesary product data before converting and storing top earners.
+        loadProducts(for: topProducts, siteID: siteID) { [weak self] topProductsResult in
+            guard let self = self else { return }
+
+            switch topProductsResult {
+            case .success(let products):
+                self.mergeAndStoreTopProductsAndStoredProductsIntoTopEarners(siteID: siteID,
+                                                                             granularity: granularity,
+                                                                             date: date,
+                                                                             topProducts: topProducts,
+                                                                             storedProducts: products)
+                onCompletion(.success(()))
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Loads product objects that relates to the top products on a `leaderboard`
+    /// If product objects can't be found in the storage layer, they will be fetched from the remote layer.
+    ///
+    func loadProducts(for topProducts: Leaderboard, siteID: Int64, completion: @escaping (Result<[Product], Error>) -> Void) {
+
+        // Workout if we have stored all products that relate to the given leaderboard
+        let topProductIDs = LeaderboardStatsConverter.topProductsIDs(from: topProducts)
+        let topStoredProducts = loadStoredProducts(siteID: siteID, productIDs: topProductIDs)
+        let missingProductsIDs = LeaderboardStatsConverter.missingProductsIDs(from: topProducts, in: topStoredProducts)
+
+        // Return if we have all the products that we need
+        guard !missingProductsIDs.isEmpty else {
+            completion(.success(topStoredProducts))
+            return
+        }
+
+        // Fetch the products that we have not downloaded and stored yet
+        productsRemote.loadProducts(for: siteID, by: missingProductsIDs) { result in
+            switch result {
+            case .success(let products):
+                // Return the complete array of products that corresponds to a top product leaderboard
+                let completeTopProducts = products + topStoredProducts
+                completion(.success(completeTopProducts))
+
+            case .failure:
+                completion(result)
+            }
+        }
+    }
+
+    /// Returns all stored products for a given site ID
+    ///
+    func loadStoredProducts(siteID: Int64, productIDs: [Int64] ) -> [Networking.Product] {
+        let products = storageManager.viewStorage.loadProducts(siteID: siteID, productsIDs: productIDs)
+        return products.map { $0.toReadOnly() }
+    }
+
+    /// Merges and stores a top-product leaderboard with an array of stored products into  a `TopEarnerStats` object
+    ///
+    func mergeAndStoreTopProductsAndStoredProductsIntoTopEarners(siteID: Int64,
+                                                                 granularity: StatGranularity,
+                                                                 date: Date,
+                                                                 topProducts: Leaderboard,
+                                                                 storedProducts: [Product]) {
+        let statsDate = Self.buildDateString(from: date, with: granularity)
+        let statsItems = LeaderboardStatsConverter.topEarnerStatsItems(from: topProducts, using: storedProducts)
+        let stats = TopEarnerStats(siteID: siteID,
+                                   date: statsDate,
+                                   granularity: granularity,
+                                   limit: String(Constants.defaultTopEarnerStatsLimit),
+                                   items: statsItems
+        )
+
+        upsertStoredTopEarnerStats(readOnlyStats: stats)
+    }
+}
+
+// MARK: - Public Helpers
+//
+public extension AnalyticsStore {
+
+    /// Converts a Date into the appropriately formatted string based on the `OrderStatGranularity`
+    ///
+    static func buildDateString(from date: Date, with granularity: StatGranularity) -> String {
+        switch granularity {
+        case .day:
+            return DateFormatter.Stats.statsDayFormatter.string(from: date)
+        case .week:
+            return DateFormatter.Stats.statsWeekFormatter.string(from: date)
+        case .month:
+            return DateFormatter.Stats.statsMonthFormatter.string(from: date)
+        case .year:
+            return DateFormatter.Stats.statsYearFormatter.string(from: date)
+        }
+    }
+}
+
+// MARK: - Constants!
+//
+private extension AnalyticsStore {
+
+    enum Constants {
+
+        /// Default limit value for TopEarnerStats
+        ///
+        static let defaultTopEarnerStatsLimit: Int = 3
+
+        /// ID of top products section in leaderboards API
+        ///
+        static let topProductsID = "products"
+    }
+}
+
+// MARK: Errors
+//
+public enum AnalyticsStoreError: Error {
+    case missingTopProducts
+}
+
+/// An error that occurs while fetching site visit stats.
+///
+/// - noPermission: the user has no permission to view site stats.
+/// - statsModuleDisabled: Jetpack site stats module is disabled for the site.
+/// - unknown: other error cases.
+///
+public enum SiteVisitAnalyticsStoreError: Error {
+    case statsModuleDisabled
+    case noPermission
+    case unknown
+
+    init(error: Error) {
+        guard let dotcomError = error as? DotcomError else {
+            self = .unknown
+            return
+        }
+        switch dotcomError {
+        case .noStatsPermission:
+            self = .noPermission
+        case .statsModuleDisabled:
+            self = .statsModuleDisabled
+        default:
+            self = .unknown
+        }
+    }
+}

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -191,6 +191,10 @@ public class AppSettingsStore: Store {
             setTelemetryLastReportedTime(siteID: siteID, time: time)
         case .getTelemetryInfo(siteID: let siteID, onCompletion: let onCompletion):
             getTelemetryInfo(siteID: siteID, onCompletion: onCompletion)
+        case .setSelectedDateRange(siteID: let siteID, range: let range):
+            setSelectedDateRange(siteID: siteID, range: range)
+        case .getSelectedDateRange(siteID: let siteID, onCompletion: let onCompletion):
+            getSelectedDateRange(siteID: siteID, onCompletion: onCompletion)
         case .resetGeneralStoreSettings:
             resetGeneralStoreSettings()
         }
@@ -820,6 +824,19 @@ private extension AppSettingsStore {
     func getTelemetryInfo(siteID: Int64, onCompletion: (Bool, Date?) -> Void) {
         let storeSettings = getStoreSettings(for: siteID)
         onCompletion(storeSettings.isTelemetryAvailable, storeSettings.telemetryLastReportedTime)
+    }
+
+    // Analytics selected date range
+
+    func setSelectedDateRange(siteID: Int64, range: String, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(selectedDateRange: range)
+        setStoreSettings(settings: updatedSettings, for: siteID, onCompletion: onCompletion)
+    }
+
+    func getSelectedDateRange(siteID: Int64, onCompletion: (String) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        onCompletion(storeSettings.selectedDateRange)
     }
 
     func resetGeneralStoreSettings() {


### PR DESCRIPTION
Closes: #5728

### Description
This is a draft PR.
The analytics hub has a date range view at the top where the user can select a date range for the stats. When they press it, a sheet appears with many date range options, like _'Today', 'Yesterday', 'Last Week'_ e.t.c. After they pick one, the option stored in the device using [App Local Settings](https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/app-local-settings.md)

### Screenshots
<img src="https://user-images.githubusercontent.com/11445928/147505039-315a418b-ba90-4884-9730-37b3031bcb58.png" width="350px" height="100%" >

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


