### PR TITLE
Fixes UI Tests on trunk

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -12,7 +12,6 @@ public final class ProductsScreen: ScreenObject {
             expectedElementGetters: [
                 // swiftlint:disable next opening_brace
                 { $0.buttons["product-add-button"] },
-                { $0.buttons["product-scan-button"] },
                 { $0.buttons["product-search-button"]}
                 // swiftlint:enable next opening_brace
             ],


### PR DESCRIPTION
# Why 

Some of our UI Tests are looking for the barcode scan navigation button on the product list screen. 

However, we [recently updated that code](https://github.com/woocommerce/woocommerce-ios/commit/51c0cb0d11621a09dae31b7cf27872211a83b46f) to only display the barcode scan button when a camera source is available.

Since the simulator does not have a camera source, the button is hidden and the test fails.

# How

A simple fix is to remove the barcode scan button expectation. 

An improvement could be to inject the camera source validation dependency and try to fake it in UI Tests but it is probably not worth it right now as we only want to fix `trunk`.

cc @jostnes 

# Testing Steps

- Make sure UI Tests pass

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
