### PR TITLE
Simple Payments: Accessibility enhancements 

### DIFF
--- a/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
+++ b/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Environment key that allow use to obtain safe areas insets from a environment value.
+/// By `default` it provides the first window safe areas insets.
+/// Provide your custom inset with  the `environment(_:_:)` modifier when dealing with multiple windows or specific screens.
+///
+struct SafeAreaInsetsKey: EnvironmentKey {
+    /// Returns the safe areas of the main window.
+    ///
+    static var defaultValue: EdgeInsets {
+        guard let window = UIApplication.shared.windows.first else {
+            return .zero
+        }
+
+        // Converts the non-directional UIEdgeInstets into direcional EdgeInsets
+        let safeInsets = window.safeAreaInsets
+        if UIView.userInterfaceLayoutDirection(for: window.semanticContentAttribute) == .rightToLeft {
+            return EdgeInsets(top: safeInsets.top, leading: safeInsets.left, bottom: safeInsets.bottom, trailing: safeInsets.right)
+        } else {
+            return EdgeInsets(top: safeInsets.top, leading: safeInsets.right, bottom: safeInsets.bottom, trailing: safeInsets.left)
+        }
+    }
+}
+
+extension EnvironmentValues {
+    /// Sets a custom safe area inset.
+    ///
+    var safeAreaInsets: EdgeInsets {
+        get {
+            self[SafeAreaInsetsKey.self]
+        }
+        set {
+            self[SafeAreaInsetsKey.self] = newValue
+        }
+    }
+}

--- a/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
+++ b/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
@@ -12,7 +12,7 @@ struct SafeAreaInsetsKey: EnvironmentKey {
             return .zero
         }
 
-        // Converts the non-directional UIEdgeInstets into direcional EdgeInsets
+        // Converts the non-directional UIEdgeInstets into directional EdgeInsets
         let safeInsets = window.safeAreaInsets
         if UIView.userInterfaceLayoutDirection(for: window.semanticContentAttribute) == .rightToLeft {
             return EdgeInsets(top: safeInsets.top, leading: safeInsets.left, bottom: safeInsets.bottom, trailing: safeInsets.right)

--- a/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
+++ b/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
@@ -15,9 +15,9 @@ struct SafeAreaInsetsKey: EnvironmentKey {
         // Converts the non-directional UIEdgeInstets into directional EdgeInsets
         let safeInsets = window.safeAreaInsets
         if UIView.userInterfaceLayoutDirection(for: window.semanticContentAttribute) == .rightToLeft {
-            return EdgeInsets(top: safeInsets.top, leading: safeInsets.left, bottom: safeInsets.bottom, trailing: safeInsets.right)
-        } else {
             return EdgeInsets(top: safeInsets.top, leading: safeInsets.right, bottom: safeInsets.bottom, trailing: safeInsets.left)
+        } else {
+            return EdgeInsets(top: safeInsets.top, leading: safeInsets.left, bottom: safeInsets.bottom, trailing: safeInsets.right)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
@@ -64,6 +64,7 @@ final class OrderTypeBottomSheetListSelectorCommand: BottomSheetListSelectorComm
                                                                     text: model.actionSheetDescription,
                                                                     image: model.actionSheetImage,
                                                                     imageTintColor: .gray(.shade20),
+                                                                    numberOfLinesForTitle: 0,
                                                                     numberOfLinesForText: 0,
                                                                     isActionable: false)
         cell.updateUI(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -135,6 +135,7 @@ private struct MethodRow: View {
                     .frame(width: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale),
                            height: SimplePaymentsMethod.Layout.iconWidthHeight(scale: scale))
                     .foregroundColor(Color(.systemGray))
+                    .accessibility(hidden: true)
 
                 Text(title)
                     .bodyStyle()
@@ -146,6 +147,7 @@ private struct MethodRow: View {
                     .frame(width: SimplePaymentsMethod.Layout.chevronWidthHeight(scale: scale),
                            height: SimplePaymentsMethod.Layout.chevronWidthHeight(scale: scale))
                     .foregroundColor(Color(.systemGray))
+                    .accessibility(hidden: true)
             }
             .padding(.vertical, SimplePaymentsMethod.Layout.verticalPadding)
             .padding(.horizontal, insets: safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -25,12 +25,17 @@ struct SimplePaymentsMethod: View {
     ///
     @State var sharingPaymentLink = false
 
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.noSpacing) {
 
             Text(Localization.header)
                 .subheadlineStyle()
                 .padding()
+                .padding(.horizontal, insets: safeAreaInsets)
 
             Divider()
 
@@ -65,6 +70,7 @@ struct SimplePaymentsMethod: View {
             // Pushes content to the top
             Spacer()
         }
+        .ignoresSafeArea(edges: .horizontal)
         .disabled(viewModel.disableViewActions)
         .background(Color(.listBackground).ignoresSafeArea())
         .navigationTitle(viewModel.title)
@@ -116,6 +122,10 @@ private struct MethodRow: View {
     ///
     @ScaledMetric private var scale = 1
 
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     var body: some View {
         Button(action: action) {
             HStack {
@@ -138,6 +148,7 @@ private struct MethodRow: View {
                     .foregroundColor(Color(.systemGray))
             }
             .padding(.vertical, SimplePaymentsMethod.Layout.verticalPadding)
+            .padding(.horizontal, insets: safeAreaInsets)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -95,6 +95,7 @@ private struct CustomAmountSection: View {
                     .padding()
                     .foregroundColor(Color(.systemGray))
                     .background(Color(.listBackground))
+                    .accessibilityHidden(true)
 
                 Text(SimplePaymentsSummary.Localization.customAmount)
                     .headlineStyle()
@@ -107,6 +108,7 @@ private struct CustomAmountSection: View {
             .padding()
             .padding(.horizontal, insets: safeAreaInsets)
             .background(Color(.listForeground))
+            .accessibilityElement(children: .combine)
 
             Divider()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -40,6 +40,7 @@ struct SimplePaymentsSummary: View {
                     NoteSection(viewModel: viewModel, showEditNote: $showEditNote)
                 }
             }
+            .ignoresSafeArea(edges: .horizontal)
 
             TakePaymentSection(viewModel: viewModel)
 
@@ -80,6 +81,11 @@ private struct CustomAmountSection: View {
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
 
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
+
     var body: some View {
         Group {
             Divider()
@@ -99,6 +105,7 @@ private struct CustomAmountSection: View {
             }
             .bodyStyle()
             .padding()
+            .padding(.horizontal, insets: safeAreaInsets)
             .background(Color(.listForeground))
 
             Divider()
@@ -114,6 +121,10 @@ private struct EmailSection: View {
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
 
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     var body: some View {
         Group {
             Divider()
@@ -123,6 +134,7 @@ private struct EmailSection: View {
                                  text: $viewModel.email,
                                  keyboardType: .emailAddress)
                 .autocapitalization(.none)
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.listForeground))
 
             Divider()
@@ -137,6 +149,10 @@ private struct PaymentsSection: View {
     /// ViewModel to drive the view content.
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
+
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
     var body: some View {
         Group {
@@ -167,6 +183,7 @@ private struct PaymentsSection: View {
 
                 TitleAndValueRow(title: SimplePaymentsSummary.Localization.total, value: .content(viewModel.total), bold: true, selectable: false) {}
             }
+            .padding(.horizontal, insets: safeAreaInsets)
             .background(Color(.listForeground))
 
             Divider()
@@ -181,6 +198,10 @@ private struct NoteSection: View {
     /// ViewModel to drive the view content.
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
+
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
     /// Defines if the order note screen should be shown or not.
     ///
@@ -209,6 +230,7 @@ private struct NoteSection: View {
 
             }
             .padding()
+            .padding(.horizontal, insets: safeAreaInsets)
             .background(Color(.listForeground))
 
             Divider()
@@ -253,6 +275,7 @@ private struct TakePaymentSection: View {
     var body: some View {
         VStack {
             Divider()
+                .ignoresSafeArea()
 
             Button(SimplePaymentsSummary.Localization.takePayment(total: viewModel.total), action: {
                 viewModel.updateOrder()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -21,7 +21,7 @@ struct SimplePaymentsSummary: View {
     @ObservedObject private(set) var viewModel: SimplePaymentsSummaryViewModel
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: Layout.noSpacing) {
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		262AF38A2713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF3892713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift */; };
 		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
 		262C922126F1370000011F92 /* StorePickerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C922026F1370000011F92 /* StorePickerError.swift */; };
+		26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		263E38462641FF3400260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; };
@@ -1989,6 +1990,7 @@
 		262AF3892713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmountViewModelTests.swift; sourceTree = "<group>"; };
 		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		262C922026F1370000011F92 /* StorePickerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerError.swift; sourceTree = "<group>"; };
+		26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaInsetsKey.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
 		265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceTests.swift; sourceTree = "<group>"; };
@@ -4177,6 +4179,14 @@
 			path = "Simple Payments";
 			sourceTree = "<group>";
 		};
+		26309F15277D0ACE0012797F /* Environment Keys */ = {
+			isa = PBXGroup;
+			children = (
+				26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */,
+			);
+			path = "Environment Keys";
+			sourceTree = "<group>";
+		};
 		265284002624933B00F91BA1 /* AddOns */ = {
 			isa = PBXGroup;
 			children = (
@@ -5736,6 +5746,7 @@
 				CE1CCB3E2056F204000EE3AC /* Styles */,
 				B5D1AFBE20BC67B500DB0E8C /* System */,
 				B55D4C2220B716CE00D7A50F /* Tools */,
+				26309F15277D0ACE0012797F /* Environment Keys */,
 				262A097F2628A8BF0033AD20 /* View Modifiers */,
 				CE85535B209B5B6A00938BDC /* ViewModels */,
 				B56DB3EF2049C06D00D4AA8E /* ViewRelated */,
@@ -8341,6 +8352,7 @@
 				02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */,
 				7E7C5F8F2719BA7300315B61 /* ProductCategoryCellViewModel.swift in Sources */,
 				DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
+				26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */,
 				023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */,
 				0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */,
 				022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */,


### PR DESCRIPTION
closes #5352

# Why

This PR makes a few adjustments to the SImple Payments screens in order to make them more accessible, specifically it:
- Updates the order creation bottom sheet to work well with big fonts.
- Update Summary And PaymentMethod screens to look well in landscape orientation.
- Hide some images from voice-over to reduce noise.

# How

The main change here is the introduction of `SafeAreaInsetsKey`.

I noticed how other areas of the app handled backgrounds ignoring safe areas and it seems quite cumbersome, especially when views are broken in several subviews as we need to start passing safe areas insets of a geometry reader from the main view all the way down through the view hierarchy.

`SafeAreaInsetsKey` registers the first window's safe areas insets as an environment value so it's easily accessible by any view by just defining that environment property.

```swift
@Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
```

This pattern still allows us to set custom safe areas, in the future scenario where we support multiple windows, so I think we are safe here!

# Screenshots

Before | After
--- | ---
<img width="436" alt="before-sheet" src="https://user-images.githubusercontent.com/562080/147758489-a2951c88-e419-43f1-9bc4-96bebba9d042.png"> | <img width="432" alt="after-sheet" src="https://user-images.githubusercontent.com/562080/147758486-2a44a340-c2a7-4275-886f-78d0db1fd707.png">


Before | After
--- | ---
<img width="880" alt="before-summary" src="https://user-images.githubusercontent.com/562080/147758512-85ec77e5-5305-423c-a0f5-8f8ce7163e24.png"> | <img width="886" alt="after-summary" src="https://user-images.githubusercontent.com/562080/147758516-e3077134-24da-4491-8c5f-8a837770ef7e.png">


Before | After
--- | ---
<img width="883" alt="before-payment-method" src="https://user-images.githubusercontent.com/562080/147758552-018150e7-abd5-4c17-9732-f6ba92aaeccc.png"> | <img width="873" alt="after-payment-method" src="https://user-images.githubusercontent.com/562080/147758549-8df01a99-683b-452a-bca4-9b8c87c0eefe.png">

# Testing Steps

- Tests Simple Payments flow with big fonts and on landscape and see that everything looks correct.

Note: There is a known issue with big fonts on the Summary Screen that will be tackled as a separate issue https://github.com/woocommerce/woocommerce-ios/issues/5783

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
