### PR TITLE
Displaying Analytics Revenue Card

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -40,14 +40,17 @@ extension GeneralAppSettings {
 extension GeneralStoreSettings {
     public func copy(
         isTelemetryAvailable: CopiableProp<Bool> = .copy,
-        telemetryLastReportedTime: NullableCopiableProp<Date> = .copy
+        telemetryLastReportedTime: NullableCopiableProp<Date> = .copy,
+        selectedDateRange: CopiableProp<String> = .copy
     ) -> GeneralStoreSettings {
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
         let telemetryLastReportedTime = telemetryLastReportedTime ?? self.telemetryLastReportedTime
+        let selectedDateRange = selectedDateRange ?? self.selectedDateRange
 
         return GeneralStoreSettings(
             isTelemetryAvailable: isTelemetryAvailable,
-            telemetryLastReportedTime: telemetryLastReportedTime
+            telemetryLastReportedTime: telemetryLastReportedTime,
+            selectedDateRange: selectedDateRange
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -25,10 +25,15 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let telemetryLastReportedTime: Date?
 
+    /// The selected date range value from the Analytics.
+    ///
+    public let selectedDateRange: String
+
     public init(isTelemetryAvailable: Bool = false,
-                telemetryLastReportedTime: Date? = nil) {
+                telemetryLastReportedTime: Date? = nil, selectedDateRange: String = "Today") {
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
+        self.selectedDateRange = selectedDateRange
     }
 }
 
@@ -41,6 +46,8 @@ extension GeneralStoreSettings {
 
         self.isTelemetryAvailable = try container.decodeIfPresent(Bool.self, forKey: .isTelemetryAvailable) ?? false
         self.telemetryLastReportedTime = try container.decodeIfPresent(Date.self, forKey: .telemetryLastReportedTime)
+
+        self.selectedDateRange = try container.decodeIfPresent(String.self, forKey: .selectedDateRange) ?? "Today"
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -135,6 +135,13 @@ extension UIColor {
         return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
         dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
     }
+
+    /// Analytics Stats Value Title Color.
+    ///
+    static var statsValueTitle: UIColor {
+        return UIColor(light: UIColor(red: 60/255, green: 60/255, blue: 67/255, alpha: 0.6),
+                       dark: UIColor(red: 235/255, green: 235/255, blue: 245/255, alpha: 0.6))
+    }
 }
 
 
@@ -328,6 +335,27 @@ extension UIColor {
     static var chartDataBarHighlighted: UIColor {
         return UIColor(light: .withColorStudio(.pink, shade: .shade70),
                        dark: .withColorStudio(.pink, shade: .shade10))
+    }
+
+    /// Percentage box color for positive stats
+    ///
+    static var percentagePositive: UIColor {
+        return UIColor(light: UIColor(red: 105/255, green: 181/255, blue: 110/255, alpha: 1),
+                       dark: UIColor(red: 184/255, green: 230/255, blue: 191/255, alpha: 1))
+    }
+
+    /// Percentage box color for negative stats
+    ///
+    static var percentageNegative: UIColor {
+        return UIColor(light: UIColor(red: 201/255, green: 88/255, blue: 84/255, alpha: 1),
+                       dark: UIColor(red: 229/255, green: 159/255, blue: 162/255, alpha: 1))
+    }
+
+    /// Percentage box color for neutral stats
+    ///
+    static var percentageNeutral: UIColor {
+        return UIColor(light: UIColor(red: 246/255, green: 247/255, blue: 247/255, alpha: 1),
+                       dark: UIColor(red: 44/255, green: 44/255, blue: 46/255, alpha: 1))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 struct AnalyticsView: View {
     var body: some View {
         ZStack {
-            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            VStack {
+                DateRangeView()
+                Spacer()
+            }
         }
         .navigationTitle(Localization.title)
     }

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -4,7 +4,7 @@ struct AnalyticsView: View {
     var body: some View {
         ZStack {
             VStack {
-                DateRangeView()
+                DateRangeView(selectedRange: "Today")
                 Spacer()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct AnalyticsView: View {
+    var body: some View {
+        ZStack {
+            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        }
+        .navigationTitle(Localization.title)
+    }
+}
+
+struct AnalyticsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AnalyticsView()
+    }
+}
+
+private extension AnalyticsView {
+    enum Localization {
+        static let title = NSLocalizedString("Analytics", comment: "Title of the analytics view.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
+// MARK: - AnalyticsView
+//
 struct AnalyticsView: View {
     var body: some View {
         ZStack {
             VStack {
-                DateRangeView(selectedRange: "Today")
+                DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Yesterday")
                 Spacer()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsView.swift
@@ -3,20 +3,30 @@ import SwiftUI
 // MARK: - AnalyticsView
 //
 struct AnalyticsView: View {
+
+    let siteID: Int64
+    @ObservedObject var viewModel = AnalyticsViewModel()
+
     var body: some View {
         ZStack {
             VStack {
-                DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Yesterday")
+                DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: $viewModel.selectedRange)
                 Spacer()
             }
         }
         .navigationTitle(Localization.title)
+        .onChange(of: viewModel.selectedRange) { newValue in
+            viewModel.saveSelectedDateRange(siteID: siteID, range: newValue)
+        }
+        .onAppear {
+            viewModel.getSelectedDateRange(siteID: siteID)
+        }
     }
 }
 
 struct AnalyticsView_Previews: PreviewProvider {
     static var previews: some View {
-        AnalyticsView()
+        AnalyticsView(siteID: 0, viewModel: AnalyticsViewModel())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/AnalyticsViewModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Yosemite
+
+// MARK: - AnalyticsViewModel
+//
+class AnalyticsViewModel: ObservableObject {
+    private let stores: StoresManager
+    @Published var selectedRange: String = "Today"
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+    }
+
+    func saveSelectedDateRange(siteID: Int64, range: String) {
+        let saveSelectedDateRangeAction = AppSettingsAction.setSelectedDateRange(siteID: siteID, range: range)
+        stores.dispatch(saveSelectedDateRangeAction)
+    }
+
+    func getSelectedDateRange(siteID: Int64) {
+        let action = AppSettingsAction.getSelectedDateRange(siteID: siteID) { [weak self] range in
+            guard let self = self else { return }
+            self.selectedRange = range
+        }
+        stores.dispatch(action)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/AnalyticsCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/AnalyticsCardView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Renders a card showing analytics stats or a list of products that have been sold.
+///
+struct AnalyticsCardView<Main: View>: View {
+    private let topBarTitle: String
+    private let mainView: Main
+    private let bottomBarTitle: String
+    private let bottomBarLink: String
+
+    init(topBarTitle: String, @ViewBuilder content: () -> Main, bottomBarTitle: String, bottomBarLink: String) {
+        self.topBarTitle = topBarTitle
+        self.mainView = content()
+        self.bottomBarTitle = bottomBarTitle
+        self.bottomBarLink = bottomBarLink
+    }
+
+    /// We render cards with the same top and bottom bar and changing the main content.
+    ///
+    var body: some View {
+        TitleAndMoreButtonView(title: topBarTitle, moreButton: {
+            // Open action sheet
+        })
+        mainView
+        TitleAndLinkView(title: bottomBarTitle, link: bottomBarLink)
+    }
+}
+
+struct AnalyticsCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        AnalyticsCardView(topBarTitle: "REVENUE", content: {
+            VStack {
+                Text("Roses are red")
+                Divider()
+                Text("Violets are blue")
+            }
+        }, bottomBarTitle: "See Report", bottomBarLink: "https://github.com/woocommerce/woocommerce-ios")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/AnalyticsStatsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/AnalyticsStatsView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+// MARK: - AnalyticsStatsView
+//
+struct AnalyticsStatsView: View {
+    var leftGraphTitle: String
+    var leftGraphValue: String
+    var rightGraphTitle: String
+    var rightGraphValue: String
+
+    var body: some View {
+        ZStack {
+            HStack(alignment: .center, spacing: 0, content: {
+                StatsItem(valueTitle: leftGraphTitle, value: leftGraphValue)
+                StatsItem(valueTitle: rightGraphTitle, value: rightGraphValue)
+            })
+            .padding(EdgeInsets(top: Constants.contentInsetTop,
+                                leading: Constants.contentInsetLeading,
+                                bottom: Constants.contentInsetBottom,
+                                trailing: Constants.contentInsetTrailing))
+            .background(Color(.listForeground))
+        }
+    }
+}
+
+struct AnalyticsStatsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AnalyticsStatsView(leftGraphTitle: "Total Sales",
+                           leftGraphValue: "$3,678",
+                           rightGraphTitle: "Net Sales",
+                           rightGraphValue: "$3,234")
+            .preferredColorScheme(.light)
+            .previewLayout(.fixed(width: 375, height: 130))
+        AnalyticsStatsView(leftGraphTitle: "Total Sales",
+                           leftGraphValue: "$3,678",
+                           rightGraphTitle: "Net Sales",
+                           rightGraphValue: "$3,234")
+            .preferredColorScheme(.dark)
+            .previewLayout(.fixed(width: 375, height: 130))
+    }
+}
+
+extension AnalyticsStatsView {
+    private enum Constants {
+        static let contentInsetTop: CGFloat = 16
+        static let contentInsetLeading: CGFloat = 16
+        static let contentInsetBottom: CGFloat = 16
+        static let contentInsetTrailing: CGFloat = 16
+    }
+}
+
+private struct StatsItem: View {
+    let valueTitle: String
+    let value: String
+
+    var body: some View {
+        ZStack {
+            VStack(alignment: .leading, spacing: Constants.contentSpacing, content: {
+                Text(valueTitle)
+                    .foregroundColor(Color(.statsValueTitle))
+                Text(value)
+                    .font(Font.system(size: 28))
+                    .foregroundColor(Color(.text))
+                HStack {
+                    AnalyticsPercetageView(
+                        bgColor: .percentageNeutral,
+                        percentageTextColor: UIColor.white,
+                        percentageValue: "+23%")
+                    Spacer()
+                }
+            })
+        }
+    }
+}
+
+extension StatsItem {
+    private enum Constants {
+        static let contentSpacing: CGFloat = 10
+        static let contentInsetLeading: CGFloat = 16
+        static let contentInsetBottom: CGFloat = 16
+        static let contentInsetTrailing: CGFloat = 16
+    }
+}
+
+private struct AnalyticsPercetageView: View {
+    var bgColor: UIColor
+    var percentageTextColor: UIColor
+    var percentageValue: String
+    var body: some View {
+        ZStack(alignment: .center, content: {
+            Text(percentageValue)
+                .font(Font.system(size: 12))
+                .foregroundColor(Color(percentageTextColor))
+                .padding(EdgeInsets(top: 3, leading: 7, bottom: 3, trailing: 7))
+                .background(RoundedRectangle(cornerRadius: 4).foregroundColor(Color(bgColor)))
+        })
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
@@ -3,7 +3,6 @@ import SwiftUI
 // MARK: - DateRangeSheetRow
 //
 struct DateRangeSheetRow: View {
-
     let dateRange: String
     @Binding var selectedDateRange: String
 
@@ -33,9 +32,6 @@ struct DateRangeSheetRow: View {
         .onTapGesture {
             self.selectedDateRange = self.dateRange
         }
-        .onAppear(perform: {
-            selectedDateRange = dateRange
-        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeSheetRow.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+// MARK: - DateRangeSheetRow
+//
+struct DateRangeSheetRow: View {
+
+    let dateRange: String
+    @Binding var selectedDateRange: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0, content: {
+            HStack(alignment: .center, spacing: 10, content: {
+                if dateRange == selectedDateRange {
+                    Image(systemName: "checkmark.circle.fill")
+                        .resizable()
+                        .frame(width: 20, height: 20)
+                        .foregroundColor(Color(UIColor.accent))
+                } else {
+                    Image(systemName: "circle")
+                        .resizable()
+                        .frame(width: 20, height: 20)
+                        .foregroundColor(Color(UIColor.accent))
+                }
+                Text(dateRange)
+                    .foregroundColor(Color(UIColor.text))
+            })
+            .padding(.vertical, 18)
+            Divider()
+                .foregroundColor(Color(UIColor.text))
+        })
+        .padding(.horizontal, 10)
+        .background(Color(.listForeground))
+        .onTapGesture {
+            self.selectedDateRange = self.dateRange
+        }
+        .onAppear(perform: {
+            selectedDateRange = dateRange
+        })
+    }
+}
+
+struct DateRangeSheetCell_Previews: PreviewProvider {
+    static var previews: some View {
+        DateRangeSheetRow(dateRange: "Today", selectedDateRange: .constant("Today"))
+            .previewLayout(.fixed(width: 375, height: 44))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,11 +1,16 @@
 import SwiftUI
 
+// MARK: - DateRangeView
+//
 struct DateRangeView: View {
+
+    @State private var showingSheet = false
+
     var body: some View {
         VStack {
             Divider()
             Button {
-                // Open Date Range Sheet
+                showingSheet.toggle()
             } label: {
                 HStack {
                     VStack(alignment: .leading, spacing: 12, content: {
@@ -22,6 +27,9 @@ struct DateRangeView: View {
                         .foregroundColor(Color(UIColor.accent))
                 }
                 .padding(EdgeInsets(top: 18, leading: 16, bottom: 13, trailing: 16))
+            }
+            .sheet(isPresented: $showingSheet) {
+                DateRangeSheet()
             }
             Divider()
         }

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct DateRangeView: View {
+    var body: some View {
+        VStack {
+            Divider()
+            Button {
+                // Open Date Range Sheet
+            } label: {
+                HStack {
+                    VStack(alignment: .leading, spacing: 12, content: {
+                        Text("Today (Sep 10, 2020)")
+                            .font(.system(size: 17))
+                            .foregroundColor(Color(UIColor.text))
+                        Text("vs Previous Period (Sep 9, 2020)")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color(UIColor.text))
+                    })
+                    Spacer()
+                    Image(systemName: "calendar")
+                        .renderingMode(.template)
+                        .foregroundColor(Color(UIColor.accent))
+                }
+                .padding(EdgeInsets(top: 18, leading: 16, bottom: 13, trailing: 16))
+            }
+            Divider()
+        }
+        .background(Color(.listForeground))
+    }
+}
+
+struct DateRangeView_Previews: PreviewProvider {
+    static var previews: some View {
+        DateRangeView().previewLayout(.fixed(width: 375, height: 83))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 // MARK: - DateRangeView
+
 //
 struct DateRangeView: View {
-
+    @State var selectedRange: String
     @State private var showingSheet = false
 
     var body: some View {
@@ -26,10 +27,13 @@ struct DateRangeView: View {
                         .renderingMode(.template)
                         .foregroundColor(Color(UIColor.accent))
                 }
-                .padding(EdgeInsets(top: 18, leading: 16, bottom: 13, trailing: 16))
+                .padding(EdgeInsets(top: Constants.buttonContentTop,
+                                    leading: Constants.buttonContentLeading,
+                                    bottom: Constants.buttonContentBottom,
+                                    trailing: Constants.buttonContentTrailing))
             }
             .sheet(isPresented: $showingSheet) {
-                DateRangeSheet()
+                DateRangeSheet(selectedDateRange: $selectedRange)
             }
             Divider()
         }
@@ -39,6 +43,15 @@ struct DateRangeView: View {
 
 struct DateRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeView().previewLayout(.fixed(width: 375, height: 83))
+        DateRangeView(selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
+    }
+}
+
+private extension DateRangeView {
+    enum Constants {
+        static let buttonContentTop: CGFloat = 18
+        static let buttonContentLeading: CGFloat = 16
+        static let buttonContentBottom: CGFloat = 13
+        static let buttonContentTrailing: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 // MARK: - DateRangeView
-
 //
 struct DateRangeView: View {
+    @State var dateRangeText: String
     @State var selectedRange: String
     @State private var showingSheet = false
 
@@ -15,12 +15,12 @@ struct DateRangeView: View {
             } label: {
                 HStack {
                     VStack(alignment: .leading, spacing: 12, content: {
-                        Text("Today (Sep 10, 2020)")
+                        Text(dateRangeText)
                             .font(.system(size: 17))
                             .foregroundColor(Color(UIColor.text))
-                        Text("vs Previous Period (Sep 9, 2020)")
-                            .font(.system(size: 13))
-                            .foregroundColor(Color(UIColor.text))
+//                        Text("vs Previous Period (Sep 9, 2020)")
+//                            .font(.system(size: 13))
+//                            .foregroundColor(Color(UIColor.text))
                     })
                     Spacer()
                     Image(systemName: "calendar")
@@ -43,7 +43,7 @@ struct DateRangeView: View {
 
 struct DateRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeView(selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
+        DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/Cells/DateRangeView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 //
 struct DateRangeView: View {
     @State var dateRangeText: String
-    @State var selectedRange: String
+    @Binding var selectedRange: String
     @State private var showingSheet = false
 
     var body: some View {
@@ -18,9 +18,9 @@ struct DateRangeView: View {
                         Text(dateRangeText)
                             .font(.system(size: 17))
                             .foregroundColor(Color(UIColor.text))
-//                        Text("vs Previous Period (Sep 9, 2020)")
-//                            .font(.system(size: 13))
-//                            .foregroundColor(Color(UIColor.text))
+                        Text("vs Previous Period (Sep 9, 2020)")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color(UIColor.text))
                     })
                     Spacer()
                     Image(systemName: "calendar")
@@ -43,7 +43,7 @@ struct DateRangeView: View {
 
 struct DateRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: "Today").previewLayout(.fixed(width: 375, height: 83))
+        DateRangeView(dateRangeText: "Today (Sep 10, 2020)", selectedRange: .constant("Today")).previewLayout(.fixed(width: 375, height: 83))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeModel.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Yosemite
+
+// MARK: - DateRangeModel
+//
+struct DateRangeModel: Hashable {
+    var title: String
+    var range: AnalyticsRange
+}
+
+struct DateRanges {
+    var objectsArray: [DateRangeModel] = [
+        DateRangeModel(title: Localization.today, range: .today),
+        DateRangeModel(title: Localization.yesterday, range: .yesterday),
+        DateRangeModel(title: Localization.lastWeek, range: .lastWeek),
+        DateRangeModel(title: Localization.lastMonth, range: .lastMonth),
+        DateRangeModel(title: Localization.lastQuarter, range: .lastQuarter),
+        DateRangeModel(title: Localization.lastYear, range: .lastYear),
+        DateRangeModel(title: Localization.weekToDate, range: .weekToDate),
+        DateRangeModel(title: Localization.monthToDate, range: .monthToDate),
+        DateRangeModel(title: Localization.quarterToDate, range: .quarterToDate),
+        DateRangeModel(title: Localization.yearToDate, range: .yearToDate),
+    ]
+}
+
+private extension DateRanges {
+    enum Localization {
+        static let today = NSLocalizedString("Today", comment: "Title of today date range.")
+        static let yesterday = NSLocalizedString("Yesterday", comment: "Title of yesterday date range.")
+        static let lastWeek = NSLocalizedString("Last Week", comment: "Title of yesterday date range.")
+        static let lastMonth = NSLocalizedString("Last Month", comment: "Title of last month date range.")
+        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "Title of last quarter date range.")
+        static let lastYear = NSLocalizedString("Last Year", comment: "Title of last year date range.")
+        static let weekToDate = NSLocalizedString("Week to date", comment: "Title of week to date date range.")
+        static let monthToDate = NSLocalizedString("Month to date", comment: "Title of month to date date range.")
+        static let quarterToDate = NSLocalizedString("Quarter to date", comment: "Title of quarter to date date range.")
+        static let yearToDate = NSLocalizedString("Year to date", comment: "Title of year to date date range.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -3,18 +3,9 @@ import SwiftUI
 // MARK: - DateRangeSheet
 //
 struct DateRangeSheet: View {
-    var dateRanges: [String] = [
-        Localization.today,
-        Localization.yesterday,
-        Localization.lastWeek,
-        Localization.lastMonth,
-        Localization.lastQuarter,
-        Localization.lastYear,
-        Localization.weekToDate,
-        Localization.monthToDate,
-        Localization.quarterToDate,
-        Localization.yearToDate
-    ]
+
+    // Array with all date range options
+    var dateRanges = DateRanges().objectsArray
 
     @Environment(\.presentationMode) var presentationMode
 
@@ -28,7 +19,7 @@ struct DateRangeSheet: View {
                     Spacer()
                         .frame(height: 8)
                     ForEach(dateRanges, id: \.self) { item in
-                        DateRangeSheetRow(dateRange: item, selectedDateRange: $selectedDateRange)
+                        DateRangeSheetRow(dateRange: item.title, selectedDateRange: $selectedDateRange)
                     }
                     Spacer()
                 })
@@ -53,17 +44,7 @@ struct DateRangeSheet_Previews: PreviewProvider {
 
 private extension DateRangeSheet {
     enum Localization {
-        static let title = NSLocalizedString("Select Date Range", comment: "Title of date range sheet.")
+        static let title = NSLocalizedString("Select a Date Range", comment: "Title of date range sheet.")
         static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
-        static let today = NSLocalizedString("Today", comment: "The date range option title that shows the statistics for today.")
-        static let yesterday = NSLocalizedString("Yesterday", comment: "The date range option title that shows the statistics for yesterday.")
-        static let lastWeek = NSLocalizedString("Last Week", comment: "The date range option title that shows the statistics for last week.")
-        static let lastMonth = NSLocalizedString("Last Month", comment: "The date range option title that shows the statistics for last month.")
-        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "The date range option title that shows the statistics for last quarter.")
-        static let lastYear = NSLocalizedString("Last Year", comment: "The date range option title that shows the statistics for last year.")
-        static let weekToDate = NSLocalizedString("Week to date", comment: "The date range option title that shows the statistics for week to date.")
-        static let monthToDate = NSLocalizedString("Month to date", comment: "The date range option title that shows the statistics for month to date.")
-        static let quarterToDate = NSLocalizedString("Quarter to date", comment: "The date range option title that shows the statistics for quarter to date.")
-        static let yearToDate = NSLocalizedString("Year to date", comment: "The date range option title that shows the statistics for year to date.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+// MARK: - DateRangeSheet
+//
+struct DateRangeSheet: View {
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(UIColor.listBackground).edgesIgnoringSafeArea(.all)
+                VStack(alignment: .leading, spacing: 0, content: {
+                    Spacer()
+                        .frame(height: 8)
+                    // Loop through the date range options
+                    Spacer()
+                })
+            }
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+struct DateRangeSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        DateRangeSheet()
+    }
+}
+
+private extension DateRangeSheet {
+    enum Localization {
+        static let title = NSLocalizedString("Select Date Range", comment: "Title of date range sheet.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -3,6 +3,23 @@ import SwiftUI
 // MARK: - DateRangeSheet
 //
 struct DateRangeSheet: View {
+    var dateRanges: [String] = [
+        Localization.today,
+        Localization.yesterday,
+        Localization.lastWeek,
+        Localization.lastMonth,
+        Localization.lastQuarter,
+        Localization.lastYear,
+        Localization.weekToDate,
+        Localization.monthToDate,
+        Localization.quarterToDate,
+        Localization.yearToDate
+    ]
+
+    @Environment(\.presentationMode) var presentationMode
+
+    @Binding var selectedDateRange: String
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -10,9 +27,17 @@ struct DateRangeSheet: View {
                 VStack(alignment: .leading, spacing: 0, content: {
                     Spacer()
                         .frame(height: 8)
-                    // Loop through the date range options
+                    ForEach(dateRanges, id: \.self) { item in
+                        DateRangeSheetRow(dateRange: item, selectedDateRange: $selectedDateRange)
+                    }
                     Spacer()
                 })
+            }
+            .toolbar {
+                Button(Localization.apply) {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .foregroundColor(Color(.accent))
             }
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
@@ -22,12 +47,23 @@ struct DateRangeSheet: View {
 
 struct DateRangeSheet_Previews: PreviewProvider {
     static var previews: some View {
-        DateRangeSheet()
+        DateRangeSheet(selectedDateRange: .constant("Today"))
     }
 }
 
 private extension DateRangeSheet {
     enum Localization {
         static let title = NSLocalizedString("Select Date Range", comment: "Title of date range sheet.")
+        static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
+        static let today = NSLocalizedString("Today", comment: "The date range option title that shows the statistics for today.")
+        static let yesterday = NSLocalizedString("Yesterday", comment: "The date range option title that shows the statistics for yesterday.")
+        static let lastWeek = NSLocalizedString("Last Week", comment: "The date range option title that shows the statistics for last week.")
+        static let lastMonth = NSLocalizedString("Last Month", comment: "The date range option title that shows the statistics for last month.")
+        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "The date range option title that shows the statistics for last quarter.")
+        static let lastYear = NSLocalizedString("Last Year", comment: "The date range option title that shows the statistics for last year.")
+        static let weekToDate = NSLocalizedString("Week to date", comment: "The date range option title that shows the statistics for week to date.")
+        static let monthToDate = NSLocalizedString("Month to date", comment: "The date range option title that shows the statistics for month to date.")
+        static let quarterToDate = NSLocalizedString("Quarter to date", comment: "The date range option title that shows the statistics for quarter to date.")
+        static let yearToDate = NSLocalizedString("Year to date", comment: "The date range option title that shows the statistics for year to date.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Analytics/DateRangeSheet.swift
@@ -4,11 +4,12 @@ import SwiftUI
 //
 struct DateRangeSheet: View {
 
-    // Array with all date range options
+    // Array with all date range options.
     var dateRanges = DateRanges().objectsArray
-
+    // For closing the sheet.
     @Environment(\.presentationMode) var presentationMode
 
+    @State var tempSelectedDateRange: String = "Yesterday"
     @Binding var selectedDateRange: String
 
     var body: some View {
@@ -19,32 +20,36 @@ struct DateRangeSheet: View {
                     Spacer()
                         .frame(height: 8)
                     ForEach(dateRanges, id: \.self) { item in
-                        DateRangeSheetRow(dateRange: item.title, selectedDateRange: $selectedDateRange)
+                        DateRangeSheetRow(dateRange: item.title, selectedDateRange: $tempSelectedDateRange)
                     }
                     Spacer()
                 })
             }
             .toolbar {
                 Button(Localization.apply) {
+                    // After pressing 'Apply' we confirm that the temporary date range is the date range we want to select.
+                    selectedDateRange = tempSelectedDateRange
+                    // Close the sheet.
                     presentationMode.wrappedValue.dismiss()
                 }
                 .foregroundColor(Color(.accent))
-            }
+            }.onAppear(perform: {
+                // Pass the previous selected date range to temporary.
+                self.tempSelectedDateRange = selectedDateRange
+            })
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
         }
+    }
+
+    private enum Localization {
+        static let title = NSLocalizedString("Select a Date Range", comment: "Title of date range sheet.")
+        static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
     }
 }
 
 struct DateRangeSheet_Previews: PreviewProvider {
     static var previews: some View {
         DateRangeSheet(selectedDateRange: .constant("Today"))
-    }
-}
-
-private extension DateRangeSheet {
-    enum Localization {
-        static let title = NSLocalizedString("Select a Date Range", comment: "Title of date range sheet.")
-        static let apply = NSLocalizedString("Apply", comment: "Title for the apply button of date range sheet")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -50,7 +50,7 @@ struct HubMenu: View {
 
             // Go to the Analytics screen
             NavigationLink(destination:
-                            AnalyticsView(),
+                            AnalyticsView(siteID: viewModel.siteID),
                            isActive: $showAnalytics) {
                 EmptyView()
             }.hidden()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -50,7 +50,7 @@ struct HubMenu: View {
 
             // Go to the Analytics screen
             NavigationLink(destination:
-                            EmptyView(),
+                            AnalyticsView(),
                            isActive: $showAnalytics) {
                 EmptyView()
             }.hidden()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndLinkView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndLinkView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct TitleAndLinkView: View {
+    let title: String
+    let link: String
+
+    var body: some View {
+        Link(destination: URL(string: link)!) {
+            VStack(alignment: .center, spacing: 0, content: {
+                Divider()
+                HStack(alignment: .center, spacing: 0, content: {
+                    Text(title)
+                        .font(Font.system(size: Constants.titleFontSize))
+                        .frame(maxHeight: .infinity)
+                        .foregroundColor(Color(.text))
+                    Spacer()
+                    Image(uiImage: .chevronImage)
+                        .flipsForRightToLeftLayoutDirection(true)
+                        .frame(width: Constants.imageSize, height: Constants.imageSize)
+                        .foregroundColor(Color(.text.withAlphaComponent(Constants.chevronImageAlpha)))
+                })
+                .padding(.horizontal, Constants.horizontalPadding)
+                .padding(.vertical, Constants.verticalPadding)
+                Divider()
+            })
+            .background(Color(.listForeground))
+            .frame(height: Constants.cellHeight)
+        }
+        .buttonStyle(PlainButtonStyle()) // Removes the fade hightlight.
+    }
+}
+
+private extension TitleAndLinkView {
+    enum Constants {
+        static let imageSize: CGFloat = 22
+        static let horizontalPadding: CGFloat = 15
+        static let verticalPadding: CGFloat = 13
+        static let titleFontSize: CGFloat = 17
+        static let cellHeight: CGFloat = 44
+        static let chevronImageAlpha: CGFloat = 0.6
+    }
+}
+
+struct TitleAndLinkView_Previews: PreviewProvider {
+    static var previews: some View {
+        TitleAndLinkView(title: "Title", link: "")
+            .preferredColorScheme(.light)
+            .previewLayout(.fixed(width: 375, height: 44))
+        TitleAndLinkView(title: "Title", link: "")
+            .preferredColorScheme(.dark)
+            .previewLayout(.fixed(width: 375, height: 44))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndMoreButtonView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndMoreButtonView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct TitleAndMoreButtonView: View {
+    let title: String
+    let moreButton: (() -> Void)?
+
+    var body: some View {
+        ZStack {
+            HStack(alignment: .center, spacing: 0, content: {
+                Text(title)
+                    .font(Font.system(size: Constants.titleFontSize))
+                    .foregroundColor(Color(.text))
+                Spacer()
+                Button(action: { moreButton!() }) {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .accentColor(Color(.text))
+            })
+            .padding(EdgeInsets(top: Constants.contentInsetTop,
+                                leading: Constants.contentInsetLeading,
+                                bottom: Constants.contentInsetBottom,
+                                trailing: Constants.contentInsetTrailing))
+        }
+        .background(Color(.listForeground))
+    }
+}
+
+struct TitleAndMoreButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+        TitleAndMoreButtonView(title: "Title", moreButton: {})
+            .preferredColorScheme(.light)
+            .previewLayout(.fixed(width: 375, height: 50))
+        TitleAndMoreButtonView(title: "Title", moreButton: {})
+            .preferredColorScheme(.dark)
+            .previewLayout(.fixed(width: 375, height: 50))
+    }
+}
+
+extension TitleAndMoreButtonView {
+    private enum Constants {
+        static let titleFontSize: CGFloat = 13
+        static let contentInsetTop: CGFloat = 16
+        static let contentInsetLeading: CGFloat = 16
+        static let contentInsetBottom: CGFloat = 7
+        static let contentInsetTrailing: CGFloat = 16
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
+		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -1996,6 +1997,7 @@
 		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -4255,6 +4257,14 @@
 			path = inAppFeedback;
 			sourceTree = "<group>";
 		};
+		306F943C277A526E00DC6111 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				306F943A277A526900DC6111 /* DateRangeView.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
 		318853452639FE7F00F66A9C /* CardReadersV2 */ = {
 			isa = PBXGroup;
 			children = (
@@ -5212,6 +5222,7 @@
 		8EEEB78427728F460089BFF3 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				306F943C277A526E00DC6111 /* Cells */,
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
 			);
 			path = Analytics;
@@ -8234,6 +8245,7 @@
 				4590CEE4249BA46700949F05 /* AddProductCategoryViewController.swift in Sources */,
 				CE37C04422984E81008DCB39 /* PickListTableViewCell.swift in Sources */,
 				020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */,
+				306F943B277A526900DC6111 /* DateRangeView.swift in Sources */,
 				B5A56BF5219F5AB20065A902 /* NSNotificationName+Woo.swift in Sources */,
 				D449C51B26DE6B5000D75B02 /* ReportList.swift in Sources */,
 				CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
+		30419930277B9A0F004A317E /* DateRangeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992F277B9A0F004A317E /* DateRangeModel.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
 		306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */; };
@@ -1999,6 +2000,7 @@
 		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		3041992F277B9A0F004A317E /* DateRangeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeModel.swift; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
 		306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheetRow.swift; sourceTree = "<group>"; };
@@ -5230,6 +5232,7 @@
 				306F943C277A526E00DC6111 /* Cells */,
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
 				306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */,
+				3041992F277B9A0F004A317E /* DateRangeModel.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -8004,6 +8007,7 @@
 				D82BB3AA26454F3300A82741 /* CardPresentModalProcessing.swift in Sources */,
 				0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
+				30419930277B9A0F004A317E /* DateRangeModel.swift in Sources */,
 				7E7C5F792719A8F900315B61 /* EditProductCategoryListViewModel.swift in Sources */,
 				DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
+		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -1998,6 +1999,7 @@
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
+		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -5224,6 +5226,7 @@
 			children = (
 				306F943C277A526E00DC6111 /* Cells */,
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
+				306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -8378,6 +8381,7 @@
 				F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */,
 				D8C2A28B231931D100F503E9 /* ReviewViewModel.swift in Sources */,
 				B541B223218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift in Sources */,
+				306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */,
 				E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */,
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
 				D8610CE2257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -891,6 +891,7 @@
 		7E7C5F8F2719BA7300315B61 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F8E2719BA7300315B61 /* ProductCategoryCellViewModel.swift */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
+		8EEEB78627728F5C0089BFF3 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */; };
 		933A27372222354600C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27362222354600C2143A /* Logging.swift */; };
 		934CB123224EAB150005CCB9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934CB122224EAB150005CCB9 /* main.swift */; };
 		9379E1A32255365F006A6BE4 /* TestingMode.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9379E1A22255365F006A6BE4 /* TestingMode.storyboard */; };
@@ -2368,6 +2369,7 @@
 		8CA4F6DE220B257000A47B5D /* WooCommerce.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.release.xcconfig; path = ../config/WooCommerce.release.xcconfig; sourceTree = "<group>"; };
 		8CA4F6E1220B259100A47B5D /* Version.Public.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Version.Public.xcconfig; path = ../config/Version.Public.xcconfig; sourceTree = "<group>"; };
 		8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "RELEASE-NOTES.txt"; path = "../RELEASE-NOTES.txt"; sourceTree = "<group>"; };
+		8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
 		90AC1C0B391E04A837BDC64E /* Pods-WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.debug.xcconfig"; sourceTree = "<group>"; };
 		933A27362222354600C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		934CB122224EAB150005CCB9 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -5207,6 +5209,14 @@
 			path = ../config;
 			sourceTree = "<group>";
 		};
+		8EEEB78427728F460089BFF3 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		AEB73C1525CD8E3100A8454A /* Edit Product Variation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5474,6 +5484,7 @@
 				CE85FD5120F677460080B73E /* Dashboard */,
 				CE1CCB4920570B05000EE3AC /* Orders */,
 				B59C09DA2188D6E800AB41D6 /* Reviews */,
+				8EEEB78427728F460089BFF3 /* Analytics */,
 				45BBFBBF274FD92B00213001 /* Hub Menu */,
 				74EC34A3225FE1F3004BBC2E /* Products */,
 				022BF7FA23B9D681000A1DFB /* Progress */,
@@ -8006,6 +8017,7 @@
 				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,
 				311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */,
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
+				8EEEB78627728F5C0089BFF3 /* AnalyticsView.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
 				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -491,11 +491,15 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
+		300E2E26277DCED30008DDF4 /* TitleAndLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300E2E25277DCED30008DDF4 /* TitleAndLinkView.swift */; };
+		300E2E28277DE4B10008DDF4 /* AnalyticsStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300E2E27277DE4B10008DDF4 /* AnalyticsStatsView.swift */; };
 		30419930277B9A0F004A317E /* DateRangeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992F277B9A0F004A317E /* DateRangeModel.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
 		306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */; };
 		30F5C00A277CB16300025EF9 /* AnalyticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */; };
+		30F5C00C277D2BBB00025EF9 /* AnalyticsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F5C00B277D2BBB00025EF9 /* AnalyticsCardView.swift */; };
+		30F5C010277D433200025EF9 /* TitleAndMoreButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F5C00F277D433200025EF9 /* TitleAndMoreButtonView.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -2001,11 +2005,15 @@
 		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		300E2E25277DCED30008DDF4 /* TitleAndLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndLinkView.swift; sourceTree = "<group>"; };
+		300E2E27277DE4B10008DDF4 /* AnalyticsStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsStatsView.swift; sourceTree = "<group>"; };
 		3041992F277B9A0F004A317E /* DateRangeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeModel.swift; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
 		306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheetRow.swift; sourceTree = "<group>"; };
 		30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModel.swift; sourceTree = "<group>"; };
+		30F5C00B277D2BBB00025EF9 /* AnalyticsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCardView.swift; sourceTree = "<group>"; };
+		30F5C00F277D433200025EF9 /* TitleAndMoreButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndMoreButtonView.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -4270,6 +4278,8 @@
 			children = (
 				306F943A277A526900DC6111 /* DateRangeView.swift */,
 				306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */,
+				30F5C00B277D2BBB00025EF9 /* AnalyticsCardView.swift */,
+				300E2E27277DE4B10008DDF4 /* AnalyticsStatsView.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -4744,6 +4754,8 @@
 				26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */,
 				AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */,
 				26B3EC632745916F0075EAE6 /* BindableTextField.swift */,
+				30F5C00F277D433200025EF9 /* TitleAndMoreButtonView.swift */,
+				300E2E25277DCED30008DDF4 /* TitleAndLinkView.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -7742,6 +7754,7 @@
 				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
 				025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */,
+				30F5C010277D433200025EF9 /* TitleAndMoreButtonView.swift in Sources */,
 				456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
@@ -7830,6 +7843,7 @@
 				022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */,
 				E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */,
 				456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */,
+				300E2E28277DE4B10008DDF4 /* AnalyticsStatsView.swift in Sources */,
 				E15FC74326BC1D2700CF83E6 /* SafariSheet.swift in Sources */,
 				459DB7D52673721300E2CAD2 /* TopLoaderView.swift in Sources */,
 				02BC5AA024D27D8E00C43326 /* ProductVariationFormViewModel.swift in Sources */,
@@ -7839,6 +7853,7 @@
 				024DF32123744798006658FE /* AztecFormatBarCommandCoordinator.swift in Sources */,
 				B5AA7B3F20ED81C2004DA14F /* UserDefaults+Woo.swift in Sources */,
 				DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */,
+				300E2E26277DCED30008DDF4 /* TitleAndLinkView.swift in Sources */,
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
@@ -7954,6 +7969,7 @@
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
 				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift in Sources */,
+				30F5C00C277D2BBB00025EF9 /* AnalyticsCardView.swift in Sources */,
 				2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
 		306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */; };
+		30F5C00A277CB16300025EF9 /* AnalyticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -2004,6 +2005,7 @@
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
 		306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheetRow.swift; sourceTree = "<group>"; };
+		30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModel.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -5233,6 +5235,7 @@
 				8EEEB78527728F5C0089BFF3 /* AnalyticsView.swift */,
 				306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */,
 				3041992F277B9A0F004A317E /* DateRangeModel.swift */,
+				30F5C009277CB16300025EF9 /* AnalyticsViewModel.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -7968,6 +7971,7 @@
 				31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSource.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
+				30F5C00A277CB16300025EF9 /* AnalyticsViewModel.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
 				7E7C5F7A2719A8F900315B61 /* EditProductCategoryListViewController.swift in Sources */,
 				77E53EC82510FE07003D385F /* ProductDownloadsEditableData.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		306F943B277A526900DC6111 /* DateRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943A277A526900DC6111 /* DateRangeView.swift */; };
 		306F943E277A5C7F00DC6111 /* DateRangeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */; };
+		306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -2000,6 +2001,7 @@
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		306F943A277A526900DC6111 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		306F943D277A5C7F00DC6111 /* DateRangeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheet.swift; sourceTree = "<group>"; };
+		306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSheetRow.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -4263,6 +4265,7 @@
 			isa = PBXGroup;
 			children = (
 				306F943A277A526900DC6111 /* DateRangeView.swift */,
+				306F943F277A72DF00DC6111 /* DateRangeSheetRow.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -7683,6 +7686,7 @@
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,
 				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */,
+				306F9440277A72DF00DC6111 /* DateRangeSheetRow.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
 				31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */,
 				025FA38B2522CB4D0054CA57 /* AppCoordinator.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		26E5A08225A66868000DF8F6 /* ProductAttributeTermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */; };
 		26E5A09225A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */; };
 		26FB056A25F6CB7600A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056925F6CB7600A40B26 /* Fakes.framework */; };
+		3041992C277B71D0004A317E /* AnalyticsRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992B277B71D0004A317E /* AnalyticsRange.swift */; };
+		3041992E277B8DA2004A317E /* AnalyticsStatsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */; };
 		312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */; };
 		312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */; };
 		3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */; };
@@ -535,6 +537,8 @@
 		26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStore.swift; sourceTree = "<group>"; };
 		26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStoreTests.swift; sourceTree = "<group>"; };
 		26FB056925F6CB7600A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3041992B277B71D0004A317E /* AnalyticsRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsRange.swift; sourceTree = "<group>"; };
+		3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsStatsAction.swift; sourceTree = "<group>"; };
 		312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGatewayAccount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettingsStoreTests+CardReaderSettings.swift"; sourceTree = "<group>"; };
 		3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountAction.swift; sourceTree = "<group>"; };
@@ -857,6 +861,7 @@
 			children = (
 				0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */,
 				E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */,
+				3041992B277B71D0004A317E /* AnalyticsRange.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1526,6 +1531,7 @@
 				DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */,
 				077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */,
 				FE28F6ED268440B1004465C7 /* UserAction.swift */,
+				3041992D277B8DA2004A317E /* AnalyticsStatsAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -1846,6 +1852,7 @@
 				0271E1662509CF0100633F7A /* AnyError.swift in Sources */,
 				45ED6096257E7472007B4AC6 /* ProductAttributeStore.swift in Sources */,
 				077F39E026A5A6F500ABEADC /* SystemStatusStore.swift in Sources */,
+				3041992E277B8DA2004A317E /* AnalyticsStatsAction.swift in Sources */,
 				02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */,
 				02137901270AB204006430F7 /* MockUserActionHandler.swift in Sources */,
 				B56C1EC220EAE2E500D749F9 /* ReadOnlyConvertible.swift in Sources */,
@@ -1926,6 +1933,7 @@
 				026CF628237D8F30009563D4 /* ProductVariationAction.swift in Sources */,
 				24163B9E257F41A600F94EC3 /* StoresManager.swift in Sources */,
 				247CE8442582F3BB00F9D9D1 /* MockSettingActionHandler.swift in Sources */,
+				3041992C277B71D0004A317E /* AnalyticsRange.swift in Sources */,
 				B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */,
 				5726456F250BD4E4005BBD7C /* OrdersUpsertUseCase.swift in Sources */,
 				3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AnalyticsStatsAction.swift
+++ b/Yosemite/Yosemite/Actions/AnalyticsStatsAction.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Networking
+
+// MARK: - AnalyticsStatsAction: Defines stats operations.
+//
+public enum AnalyticsStatsAction: Action {
+
+    /// Clears all of the stats data.
+    ///
+    case resetStoredStats(onCompletion: () -> Void)
+
+    /// Synchronizes `OrderStats` for the provided siteID, time range, and date.
+    ///
+    case retrieveStats(siteID: Int64,
+        timeRange: AnalyticsRange,
+        earliestDateToInclude: Date,
+        latestDateToInclude: Date,
+        quantity: Int,
+        onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
+    ///
+    case retrieveSiteVisitStats(siteID: Int64,
+        siteTimezone: TimeZone,
+        timeRange: AnalyticsRange,
+        latestDateToInclude: Date,
+        onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Synchronizes `TopEarnerStats` for the provided siteID, time range, and date.
+    ///
+    case retrieveTopEarnerStats(siteID: Int64,
+        timeRange: AnalyticsRange,
+        earliestDateToInclude: Date,
+        latestDateToInclude: Date,
+        onCompletion: (Result<Void, Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -187,6 +187,14 @@ public enum AppSettingsAction: Action {
     ///
     case getTelemetryInfo(siteID: Int64, onCompletion: (Bool, Date?) -> Void)
 
+    /// Sets selected date range value for Analytics.
+    ///
+    case setSelectedDateRange(siteID: Int64, range: String)
+
+    /// Loads selected date range value for Analytics.
+    ///
+    case getSelectedDateRange(siteID: Int64, onCompletion: (String) -> Void)
+
     /// Clears all the products settings
     ///
     case resetGeneralStoreSettings

--- a/Yosemite/Yosemite/Model/Enums/AnalyticsRange.swift
+++ b/Yosemite/Yosemite/Model/Enums/AnalyticsRange.swift
@@ -1,0 +1,25 @@
+/// Represents the date range for Analytics.
+/// This is a local property and not in the remote response.
+///
+/// - today: hourly data starting midnight today until now.
+/// - yesterday: hourly data starting midnight yesterday until 23:59:59 of yesterday.
+/// - lastWeek: daily data starting Sunday of previous week until 23:59:59 of the following Saturday.
+/// - lastMonth: daily data starting 1st of previous month until the last day of previous month.
+/// - lastQuarter: monthly data showing the previous quarter (e.g if right now is December 12, the last quarter will be Jul 1 - Sep 30).
+/// - lastYear: monthly data starting January of the previous year until December of the previous year.
+/// - weekToDate: daily data starting Sunday of this week until now.
+/// - monthToDate: daily data starting 1st of this month until now.
+/// - quarterToDate: monthly data showing the current quarter until now (e.g if right now is December 12, the last quarter will be Oct 1 - December 12).
+/// - yearToDate: monthly data starting January of this year until now.
+public enum AnalyticsRange: String {
+    case today
+    case yesterday
+    case lastWeek
+    case lastMonth
+    case lastQuarter
+    case lastYear
+    case weekToDate
+    case monthToDate
+    case quarterToDate
+    case yearToDate
+}

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -191,6 +191,10 @@ public class AppSettingsStore: Store {
             setTelemetryLastReportedTime(siteID: siteID, time: time)
         case .getTelemetryInfo(siteID: let siteID, onCompletion: let onCompletion):
             getTelemetryInfo(siteID: siteID, onCompletion: onCompletion)
+        case .setSelectedDateRange(siteID: let siteID, range: let range):
+            setSelectedDateRange(siteID: siteID, range: range)
+        case .getSelectedDateRange(siteID: let siteID, onCompletion: let onCompletion):
+            getSelectedDateRange(siteID: siteID, onCompletion: onCompletion)
         case .resetGeneralStoreSettings:
             resetGeneralStoreSettings()
         }
@@ -820,6 +824,19 @@ private extension AppSettingsStore {
     func getTelemetryInfo(siteID: Int64, onCompletion: (Bool, Date?) -> Void) {
         let storeSettings = getStoreSettings(for: siteID)
         onCompletion(storeSettings.isTelemetryAvailable, storeSettings.telemetryLastReportedTime)
+    }
+
+    // Analytics selected date range
+
+    func setSelectedDateRange(siteID: Int64, range: String, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(selectedDateRange: range)
+        setStoreSettings(settings: updatedSettings, for: siteID, onCompletion: onCompletion)
+    }
+
+    func getSelectedDateRange(siteID: Int64, onCompletion: (String) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        onCompletion(storeSettings.selectedDateRange)
     }
 
     func resetGeneralStoreSettings() {


### PR DESCRIPTION
Closes: #5777

### Description
This is a PR draft.
The analytics hub shows a revenue card with stats and graphs and the percentage comparing the current period with the previous one. When you tap on the 'See Report' it redirects you to the wp-admin of the store for more details.

In the first version of this feature, the graphs and the 'more' button action (the button with the three dots) won't be included.

### Screenshots
<img src="https://user-images.githubusercontent.com/11445928/147777528-716af851-9157-45fb-886d-95246e13e983.png" width=350px height=100% >


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.