### PR TITLE
Integrate CollectOrderPaymentUseCase on Order Details

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -504,7 +504,7 @@ extension OrderDetailsViewModel {
     }
 
     /// Collects payments for the current order.
-    /// Tries to connect to a reader if necesary.
+    /// Tries to connect to a reader if necessary.
     /// Handles receipt sharing.
     ///
     func collectPayment(rootViewController: UIViewController, backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -11,7 +11,6 @@ final class OrderDetailsViewModel {
     ///
     private var collectPaymentsUseCase: CollectOrderPaymentUseCase?
 
-    private let paymentOrchestrator = PaymentCaptureOrchestrator()
     private let stores: StoresManager
 
     private(set) var order: Order
@@ -89,16 +88,6 @@ final class OrderDetailsViewModel {
         }
     }
 
-    /// Name of the user we will be collecting car present payments from
-    ///
-    var collectPaymentFrom: String {
-        guard let name = order.billingAddress?.firstName else {
-            return "Collect payment"
-        }
-
-        return "Collect payment from \(name)"
-    }
-
     /// Closure to be executed when the UI needs to be reloaded.
     /// That could happen, for example, when new incoming data is detected
     ///
@@ -138,15 +127,6 @@ final class OrderDetailsViewModel {
         order.billingAddress?.email
     }
 
-    /// Subject for the email containing a receipt generated after a card present payment has been captured
-    ///
-    var paymentReceiptEmailSubject: String {
-        guard let storeName = stores.sessionManager.defaultSite?.name else {
-            return Localization.emailSubjectWithoutStoreName
-        }
-
-        return String.localizedStringWithFormat(Localization.emailSubjectWithStoreName, storeName)
-    }
 
     private var cardPresentPaymentGatewayAccounts: [PaymentGatewayAccount] {
         return dataSource.cardPresentPaymentGatewayAccounts()
@@ -523,20 +503,6 @@ extension OrderDetailsViewModel {
         stores.dispatch(deleteTrackingAction)
     }
 
-    /// Returns a publisher that emits an initial value if there is no reader connected and completes as soon as a
-    /// reader connects.
-    func cardReaderAvailable() -> AnyPublisher<[CardReader], Never> {
-        Future<AnyPublisher<[CardReader], Never>, Never> { [stores] promise in
-            let action = CardPresentPaymentAction.checkCardReaderConnected(onCompletion: { publisher in
-                promise(.success(publisher))
-            })
-
-            stores.dispatch(action)
-        }
-        .switchToLatest()
-        .eraseToAnyPublisher()
-    }
-
     /// Collects payments for the current order.
     /// Tries to connect to a reader if necesary.
     /// Handles receipt sharing.
@@ -562,54 +528,5 @@ extension OrderDetailsViewModel {
             // Make sure we free all the resources
             self?.collectPaymentsUseCase = nil
         })
-    }
-
-    /// We are passing the ReceiptParameters as part of the completon block
-    /// We do so at this point for testing purposes.
-    /// When we implement persistance, the receipt metadata would be persisted
-    /// to Storage, associated to an order. We would not need to propagate
-    /// that object outside of Yosemite.
-    func collectPayment(onWaitingForInput: @escaping () -> Void, // i.e. waiting for buyer to swipe/insert/tap card
-                        onProcessingMessage: @escaping () -> Void, // i.e. payment is processing
-                        onDisplayMessage: @escaping (String) -> Void, // e.g. "Remove Card"
-                        onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) { // used to tell user payment completed (or not)
-        /// We don't have a concept of priority yet, so use the first paymentGatewayAccount for now
-        /// since we can't yet have multiple accounts
-        ///
-        if self.cardPresentPaymentGatewayAccounts.count != 1 {
-            DDLogWarn("Expected one card present gateway account. Got something else.")
-        }
-
-        let statementDescriptor = cardPresentPaymentGatewayAccounts.first?.statementDescriptor
-
-        paymentOrchestrator.collectPayment(for: self.order,
-                                           statementDescriptor: statementDescriptor,
-                                           onWaitingForInput: onWaitingForInput,
-                                           onProcessingMessage: onProcessingMessage,
-                                           onDisplayMessage: onDisplayMessage,
-                                           onCompletion: onCompletion)
-
-    }
-
-    func cancelPayment(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        paymentOrchestrator.cancelPayment(onCompletion: onCompletion)
-    }
-
-    func printReceipt(params: CardPresentReceiptParameters) {
-        ReceiptActionCoordinator.printReceipt(for: order, params: params)
-    }
-
-    func emailReceipt(params: CardPresentReceiptParameters, onContent: @escaping (String) -> Void) {
-        ServiceLocator.analytics.track(.receiptEmailTapped)
-        paymentOrchestrator.emailReceipt(for: order, params: params, onContent: onContent)
-    }
-}
-
-private extension OrderDetailsViewModel {
-    enum Localization {
-        static let emailSubjectWithStoreName = NSLocalizedString("Your receipt from %1$@",
-                                                                 comment: "Subject of email sent with a card present payment receipt")
-        static let emailSubjectWithoutStoreName = NSLocalizedString("Your receipt",
-                                                                    comment: "Subject of email sent with a card present payment receipt")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -711,6 +711,17 @@ private extension OrderDetailsViewController {
     }
 
     @objc private func collectPayment(at: IndexPath) {
+        viewModel.collectPayment(rootViewController: self, backButtonTitle: Localization.Payments.backToOrder) { [weak self] result in
+            guard let self = self else { return }
+            // Refresh date & view once payment has been collected.
+            if result.isSuccess {
+                self.syncOrderAfterPaymentCollection {
+                    self.refreshCardPresentPaymentEligibility()
+                }
+            }
+        }
+        return
+
         cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
             .sink(
                 receiveCompletion: { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -56,31 +56,6 @@ final class OrderDetailsViewController: UIViewController {
 
     private let notices = OrderDetailsNotices()
 
-    /// Orchestrates what needs to be presented in the modal views
-    /// that provide user-facing feedback about the card present payment process.
-    private lazy var paymentAlerts: OrderDetailsPaymentAlerts = {
-        OrderDetailsPaymentAlerts(presentingController: self)
-    }()
-
-    /// Subscription that listens for connected readers while we are trying to connect to one to capture payment
-    /// We need to cancel that subscription if the process is canceled by the user or when we connect to a reader.
-    ///
-    private var cardReaderAvailableSubscription: Combine.Cancellable? = nil
-
-    /// Connection Controller (helps connect readers)
-    ///
-    private lazy var connectionController: CardReaderConnectionController? = {
-        guard let siteID = viewModel?.order.siteID else {
-            return nil
-        }
-
-        return CardReaderConnectionController(
-            forSiteID: siteID,
-            knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
-            alertsProvider: CardReaderSettingsAlerts()
-        )
-    }()
-
     // MARK: - View Lifecycle
 
     /// Create an instance of `Self` from its corresponding storyboard.
@@ -513,10 +488,10 @@ private extension OrderDetailsViewController {
         case .issueRefund:
             issueRefundWasPressed()
         case .collectPayment:
-            guard let indexPath = indexPath else {
+            guard indexPath != nil else {
                 break
             }
-            collectPayment(at: indexPath)
+            collectPayment()
         case .reprintShippingLabel(let shippingLabel):
             guard let navigationController = navigationController else {
                 assertionFailure("Cannot reprint a shipping label because `navigationController` is nil")
@@ -710,7 +685,7 @@ private extension OrderDetailsViewController {
         present(navigationController, animated: true, completion: nil)
     }
 
-    @objc private func collectPayment(at: IndexPath) {
+    @objc private func collectPayment() {
         viewModel.collectPayment(rootViewController: self, backButtonTitle: Localization.Payments.backToOrder) { [weak self] result in
             guard let self = self else { return }
             // Refresh date & view once payment has been collected.
@@ -720,97 +695,6 @@ private extension OrderDetailsViewController {
                 }
             }
         }
-        return
-
-        cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
-            .sink(
-                receiveCompletion: { [weak self] result in
-                    self?.dismiss(animated: false, completion: {
-                        self?.collectPaymentForCurrentOrder()
-                    })
-                    self?.cardReaderAvailableSubscription = nil
-                },
-                receiveValue: { [weak self] _ in
-                    self?.connectToCardReader()
-                })
-    }
-
-    private func collectPaymentForCurrentOrder() {
-        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        let currencyCode = ServiceLocator.currencySettings.currencyCode
-        let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let value = currencyFormatter.formatAmount(viewModel.order.total, with: unit) ?? ""
-
-        paymentAlerts.readerIsReady(title: viewModel.collectPaymentFrom,
-                                    amount: value)
-
-        ServiceLocator.analytics.track(.collectPaymentTapped)
-        viewModel.collectPayment(
-            onWaitingForInput: { [weak self] in
-                self?.paymentAlerts.tapOrInsertCard(onCancel: {
-                	self?.viewModel.cancelPayment(onCompletion: { _ in
-                	    ServiceLocator.analytics.track(.collectPaymentCanceled)
-                	})
-		})
-            },
-            onProcessingMessage: { [weak self] in
-                self?.paymentAlerts.processingPayment()
-            },
-            onDisplayMessage: { [weak self] message in // display a message from the reader, e.g. "Remove Card"
-                self?.paymentAlerts.displayReaderMessage(message: message)
-            },
-            onCompletion: { [weak self] result in
-                guard let self = self else {
-                    return
-                }
-
-                switch result {
-                case .failure(let error):
-                    ServiceLocator.analytics.track(.collectPaymentFailed, withError: error)
-                    DDLogError("Failed to collect payment: \(error.localizedDescription)")
-                    self.paymentAlerts.error(error: error, tryAgain: {
-                        self.retryCollectPayment()
-                    })
-                case .success(let receiptParameters):
-                    ServiceLocator.analytics.track(.collectPaymentSuccess)
-                    self.syncOrderAfterPaymentCollection {
-                        self.refreshCardPresentPaymentEligibility()
-                    }
-
-                    self.paymentAlerts.success(printReceipt: {
-                        self.viewModel.printReceipt(params: receiptParameters)
-                    }, emailReceipt: {
-                        self.viewModel.emailReceipt(params: receiptParameters, onContent: { emailContent in
-                            self.emailReceipt(emailContent)
-                        })
-                    }, noReceiptTitle: Localization.Payments.backToOrder,
-                       noReceiptAction: {})
-                }
-            }
-        )
-    }
-
-    private func retryCollectPayment() {
-        viewModel.cancelPayment { [weak self] result in
-            switch result {
-            case .failure(let error):
-                self?.paymentAlerts.nonRetryableError(from: self, error: error)
-            case .success:
-                self?.collectPaymentForCurrentOrder()
-            }
-        }
-    }
-
-    private func connectToCardReader() {
-        connectionController?.searchAndConnect(from: self) { _ in
-            /// No need for logic here. Once connected, the connected reader will publish
-            /// through the `cardReaderAvailableSubscription`
-        }
-    }
-
-    private func cancelObservingCardReader() {
-        cardReaderAvailableSubscription?.cancel()
-        cardReaderAvailableSubscription = nil
     }
 
     private func itemAddOnsButtonTapped(addOns: [OrderItemAttribute]) {
@@ -818,41 +702,6 @@ private extension OrderDetailsViewController {
         let addOnsController = OrderAddOnsListViewController(viewModel: addOnsViewModel)
         let navigationController = WooNavigationController(rootViewController: addOnsController)
         present(navigationController, animated: true, completion: nil)
-    }
-
-    private func emailReceipt(_ content: String) {
-        guard MFMailComposeViewController.canSendMail() else {
-            DDLogError("⛔️ Failed to submit email receipt for order: \(viewModel.order.orderID). Email is not configured")
-            return
-        }
-
-        let mail = MFMailComposeViewController()
-        mail.mailComposeDelegate = self
-
-        mail.setSubject(viewModel.paymentReceiptEmailSubject)
-        mail.setMessageBody(content, isHTML: true)
-
-        if let customerEmail = viewModel.order.billingAddress?.email {
-            mail.setToRecipients([customerEmail])
-        }
-
-        present(mail, animated: true)
-    }
-}
-
-extension OrderDetailsViewController: MFMailComposeViewControllerDelegate {
-    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        switch result {
-        case .cancelled:
-            ServiceLocator.analytics.track(.receiptEmailCanceled)
-        case .sent, .saved:
-            ServiceLocator.analytics.track(.receiptEmailSuccess)
-        case .failed:
-            ServiceLocator.analytics.track(.receiptEmailFailed, withError: error ?? UnknownEmailError())
-        @unknown default:
-            assertionFailure("MFMailComposeViewController finished with an unknown result type")
-        }
-        controller.dismiss(animated: true)
     }
 }
 
@@ -917,12 +766,6 @@ extension OrderDetailsViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return viewModel.dataSource.viewForHeaderInSection(section, tableView: tableView)
-    }
-}
-
-extension OrderDetailsViewController: UIAdaptivePresentationControllerDelegate {
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        cancelObservingCardReader()
     }
 }
 


### PR DESCRIPTION
Part of #5655 

# Why

`CollectOrderPaymentUseCase` was created by abstracting the payments code from `OrderDetailsViewModel` and `OrderDetailsViewController` into a single place with the intention that it could be reused for both flows.

`CollectOrderPaymentUseCase` was integrated on Simple Payments on https://github.com/woocommerce/woocommerce-ios/pull/5581 but it wasn't integrated on `Order Details` in order to not include any regression and be able to test "Order Details" in isolation.

This PR integrates `CollectOrderPaymentUseCase` on `Order Details` and removes the unnecessary code.

# Demo

https://user-images.githubusercontent.com/562080/147793987-dcb2f469-619c-4c0b-ab1d-031706da4929.MP4


https://user-images.githubusercontent.com/562080/147794002-e4218c75-247c-4500-841b-d3298096deb6.MP4

# Testing Instructions

- Test the order details collect payment flow & edge cases

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
