### PR TITLE
Duplicate `ChartPlaceholderView` for design updates in Home Screen M2

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/LegacyChartPlaceholderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/LegacyChartPlaceholderView.swift
@@ -1,0 +1,53 @@
+import Foundation
+import UIKit
+
+
+// ChartPlaceholderView: Charts Mockup UI!
+//
+class LegacyChartPlaceholderView: UIView {
+
+    /// Top Container View
+    ///
+    @IBOutlet private var topStackView: UIStackView!
+
+    /// Bars Container View
+    ///
+    @IBOutlet private var barsStackView: UIStackView!
+
+    // MARK: - Overridden Methods
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupView()
+        setupSubviews()
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension LegacyChartPlaceholderView {
+    /// Applies color to the view.
+    ///
+    func setupView() {
+        backgroundColor = .listForeground
+        topStackView.backgroundColor = .listForeground
+    }
+
+    /// Applies Rounded Style to the upper views.
+    ///
+    func setupSubviews() {
+        let subviews = barsStackView.subviews + topStackView.subviews.compactMap { $0.subviews.first }
+        for view in subviews {
+            view.layer.cornerRadius = Settings.cornerRadius
+            view.layer.masksToBounds = true
+        }
+    }
+}
+
+
+// MARK: - Private Types
+//
+private enum Settings {
+    static let cornerRadius = CGFloat(6)
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/LegacyChartPlaceholderView.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/LegacyChartPlaceholderView.xib
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="myP-39-aJj" customClass="LegacyChartPlaceholderView" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="290"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="tLL-AN-zl3">
+                    <rect key="frame" x="25" y="0.0" width="270" height="90"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lOK-PB-egW">
+                            <rect key="frame" x="0.0" y="0.0" width="90.5" height="90"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="238-3o-tIA">
+                                    <rect key="frame" x="15.5" y="20" width="60" height="50"/>
+                                    <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="FcV-e0-1Wp"/>
+                                        <constraint firstAttribute="width" constant="60" id="Hcy-Xs-J8v"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstItem="238-3o-tIA" firstAttribute="centerX" secondItem="lOK-PB-egW" secondAttribute="centerX" id="J4g-TI-xGM"/>
+                                <constraint firstItem="238-3o-tIA" firstAttribute="centerY" secondItem="lOK-PB-egW" secondAttribute="centerY" id="gGR-ZG-0jI"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ee5-kF-HK7">
+                            <rect key="frame" x="89.5" y="0.0" width="91" height="90"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lCJ-LD-Hg1">
+                                    <rect key="frame" x="15.5" y="20" width="60" height="50"/>
+                                    <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="60" id="FXL-Ch-Asp"/>
+                                        <constraint firstAttribute="height" constant="50" id="qhB-De-Clq"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstItem="lCJ-LD-Hg1" firstAttribute="centerY" secondItem="ee5-kF-HK7" secondAttribute="centerY" id="GA3-D6-GSA"/>
+                                <constraint firstItem="lCJ-LD-Hg1" firstAttribute="centerX" secondItem="ee5-kF-HK7" secondAttribute="centerX" id="OFz-yr-d7N"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fId-CU-eJU">
+                            <rect key="frame" x="179.5" y="0.0" width="90.5" height="90"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jer-Xj-TlY">
+                                    <rect key="frame" x="15" y="20" width="60" height="50"/>
+                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="60" id="1iZ-qF-fwS"/>
+                                        <constraint firstAttribute="height" constant="50" id="vdi-WG-WZs"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstItem="Jer-Xj-TlY" firstAttribute="centerY" secondItem="fId-CU-eJU" secondAttribute="centerY" id="MlQ-Lj-Cq1"/>
+                                <constraint firstItem="Jer-Xj-TlY" firstAttribute="centerX" secondItem="fId-CU-eJU" secondAttribute="centerX" id="ohb-ql-jEq"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="90" id="tNY-j6-pRB"/>
+                    </constraints>
+                </stackView>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="1eD-TF-3NS">
+                    <rect key="frame" x="32" y="110" width="256" height="120"/>
+                    <subviews>
+                        <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="nwv-3X-yXO">
+                            <rect key="frame" x="0.0" y="60" width="10" height="60"/>
+                            <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="10" id="8pm-un-ftt"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="2vq-Ow-XTA">
+                            <rect key="frame" x="41" y="0.0" width="10" height="120"/>
+                            <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="ezD-Ei-g97">
+                            <rect key="frame" x="82" y="60" width="10" height="60"/>
+                            <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="oHZ-Fw-E7W">
+                            <rect key="frame" x="123" y="100" width="10" height="20"/>
+                            <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="Src-7C-V4i">
+                            <rect key="frame" x="164" y="60" width="10" height="60"/>
+                            <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="RAr-us-CuM">
+                            <rect key="frame" x="205" y="0.0" width="10" height="120"/>
+                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="Gcg-G1-3tN">
+                            <rect key="frame" x="246" y="60" width="10" height="60"/>
+                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="RAr-us-CuM" firstAttribute="height" secondItem="2vq-Ow-XTA" secondAttribute="height" id="0ha-3w-jX0"/>
+                        <constraint firstItem="Src-7C-V4i" firstAttribute="height" secondItem="nwv-3X-yXO" secondAttribute="height" id="5WB-Ht-Do2"/>
+                        <constraint firstItem="oHZ-Fw-E7W" firstAttribute="width" secondItem="nwv-3X-yXO" secondAttribute="width" id="DrR-nA-go4"/>
+                        <constraint firstItem="ezD-Ei-g97" firstAttribute="height" secondItem="nwv-3X-yXO" secondAttribute="height" id="EoO-k5-XEU"/>
+                        <constraint firstItem="2vq-Ow-XTA" firstAttribute="top" secondItem="1eD-TF-3NS" secondAttribute="top" id="H2F-I7-Zpb"/>
+                        <constraint firstItem="Gcg-G1-3tN" firstAttribute="height" secondItem="nwv-3X-yXO" secondAttribute="height" id="IF7-4c-N8t"/>
+                        <constraint firstItem="Gcg-G1-3tN" firstAttribute="width" secondItem="nwv-3X-yXO" secondAttribute="width" id="IZA-dw-Zw5"/>
+                        <constraint firstItem="oHZ-Fw-E7W" firstAttribute="top" secondItem="1eD-TF-3NS" secondAttribute="top" constant="100" id="QfI-dm-9nC"/>
+                        <constraint firstItem="ezD-Ei-g97" firstAttribute="width" secondItem="nwv-3X-yXO" secondAttribute="width" id="lBu-nH-cU1"/>
+                        <constraint firstItem="RAr-us-CuM" firstAttribute="width" secondItem="nwv-3X-yXO" secondAttribute="width" id="nVh-vZ-buX"/>
+                        <constraint firstItem="Src-7C-V4i" firstAttribute="width" secondItem="nwv-3X-yXO" secondAttribute="width" id="ne7-zl-jyQ"/>
+                        <constraint firstItem="nwv-3X-yXO" firstAttribute="top" secondItem="1eD-TF-3NS" secondAttribute="top" constant="60" id="s09-Mt-4Zz"/>
+                        <constraint firstItem="2vq-Ow-XTA" firstAttribute="width" secondItem="nwv-3X-yXO" secondAttribute="width" id="vWi-iL-3fB"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstAttribute="trailingMargin" secondItem="1eD-TF-3NS" secondAttribute="trailing" constant="16" id="0A0-Wc-apU"/>
+                <constraint firstAttribute="trailingMargin" secondItem="tLL-AN-zl3" secondAttribute="trailing" constant="9" id="DmR-KI-vaH"/>
+                <constraint firstItem="tLL-AN-zl3" firstAttribute="leading" secondItem="myP-39-aJj" secondAttribute="leadingMargin" constant="9" id="Ozr-WO-msf"/>
+                <constraint firstItem="tLL-AN-zl3" firstAttribute="top" secondItem="myP-39-aJj" secondAttribute="top" id="PTs-AI-Nzh"/>
+                <constraint firstAttribute="bottom" secondItem="1eD-TF-3NS" secondAttribute="bottom" constant="60" id="SCd-TV-K5s"/>
+                <constraint firstItem="1eD-TF-3NS" firstAttribute="top" secondItem="tLL-AN-zl3" secondAttribute="bottom" constant="20" id="SjD-pr-7cU"/>
+                <constraint firstItem="1eD-TF-3NS" firstAttribute="leading" secondItem="myP-39-aJj" secondAttribute="leadingMargin" constant="16" id="xuD-lZ-hT8"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="barsStackView" destination="1eD-TF-3NS" id="odU-Rg-8kk"/>
+                <outlet property="topStackView" destination="tLL-AN-zl3" id="8UA-4q-cOu"/>
+            </connections>
+            <point key="canvasLocation" x="104" y="107.94602698650675"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.swift
@@ -98,7 +98,7 @@ final class OldStoreStatsV4PeriodViewController: UIViewController {
 
     /// Placeholder: Mockup Charts View
     ///
-    private lazy var placeholderChartsView: ChartPlaceholderView = ChartPlaceholderView.instantiateFromNib()
+    private lazy var placeholderChartsView: LegacyChartPlaceholderView = LegacyChartPlaceholderView.instantiateFromNib()
 
 
     // MARK: - Computed Properties

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -292,6 +292,8 @@
 		02A9BCD42737DE0D00159C79 /* JetpackBenefitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A9BCD32737DE0D00159C79 /* JetpackBenefitsView.swift */; };
 		02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A9BCD52737F73C00159C79 /* JetpackBenefitItem.swift */; };
 		02AAD54525023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AAD54425023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift */; };
+		02AB407B27827C9100929CF3 /* ChartPlaceholderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02AB407927827C9000929CF3 /* ChartPlaceholderView.xib */; };
+		02AB407C27827C9100929CF3 /* ChartPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AB407A27827C9100929CF3 /* ChartPlaceholderView.swift */; };
 		02AB82EC27069D5D008D7334 /* Experiments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02AB82EB27069D5D008D7334 /* Experiments.framework */; };
 		02AB82ED27069D5D008D7334 /* Experiments.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 02AB82EB27069D5D008D7334 /* Experiments.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		02AC822C2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AC822B2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift */; };
@@ -1002,8 +1004,8 @@
 		B541B223218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B541B222218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift */; };
 		B541B226218A412C008FE7C1 /* UIFont+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B541B225218A412C008FE7C1 /* UIFont+Woo.swift */; };
 		B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FBE542111F70700390F57 /* ResultsController+UIKit.swift */; };
-		B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55401682170D5E10067DC90 /* ChartPlaceholderView.swift */; };
-		B554016B2170D6010067DC90 /* ChartPlaceholderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B554016A2170D6010067DC90 /* ChartPlaceholderView.xib */; };
+		B55401692170D5E10067DC90 /* LegacyChartPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55401682170D5E10067DC90 /* LegacyChartPlaceholderView.swift */; };
+		B554016B2170D6010067DC90 /* LegacyChartPlaceholderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B554016A2170D6010067DC90 /* LegacyChartPlaceholderView.xib */; };
 		B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B554E1782152F20000F31188 /* UINavigationBar+Appearance.swift */; };
 		B554E17B2152F27200F31188 /* UILabel+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B554E17A2152F27200F31188 /* UILabel+Appearance.swift */; };
 		B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B555530C21B57DC300449E71 /* UserNotificationsCenterAdapter.swift */; };
@@ -1865,6 +1867,8 @@
 		02A9BCD32737DE0D00159C79 /* JetpackBenefitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsView.swift; sourceTree = "<group>"; };
 		02A9BCD52737F73C00159C79 /* JetpackBenefitItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitItem.swift; sourceTree = "<group>"; };
 		02AAD54425023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormRemoteActionUseCase.swift; sourceTree = "<group>"; };
+		02AB407927827C9000929CF3 /* ChartPlaceholderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ChartPlaceholderView.xib; sourceTree = "<group>"; };
+		02AB407A27827C9100929CF3 /* ChartPlaceholderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartPlaceholderView.swift; sourceTree = "<group>"; };
 		02AB82EB27069D5D008D7334 /* Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		02AC822B2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+UpdatesTests.swift"; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
@@ -2546,8 +2550,8 @@
 		B541B222218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSParagraphStyle+Woo.swift"; sourceTree = "<group>"; };
 		B541B225218A412C008FE7C1 /* UIFont+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Woo.swift"; sourceTree = "<group>"; };
 		B54FBE542111F70700390F57 /* ResultsController+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResultsController+UIKit.swift"; sourceTree = "<group>"; };
-		B55401682170D5E10067DC90 /* ChartPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPlaceholderView.swift; sourceTree = "<group>"; };
-		B554016A2170D6010067DC90 /* ChartPlaceholderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ChartPlaceholderView.xib; sourceTree = "<group>"; };
+		B55401682170D5E10067DC90 /* LegacyChartPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyChartPlaceholderView.swift; sourceTree = "<group>"; };
+		B554016A2170D6010067DC90 /* LegacyChartPlaceholderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LegacyChartPlaceholderView.xib; sourceTree = "<group>"; };
 		B554E1782152F20000F31188 /* UINavigationBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+Appearance.swift"; sourceTree = "<group>"; };
 		B554E17A2152F27200F31188 /* UILabel+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Appearance.swift"; sourceTree = "<group>"; };
 		B555530C21B57DC300449E71 /* UserNotificationsCenterAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationsCenterAdapter.swift; sourceTree = "<group>"; };
@@ -5153,8 +5157,10 @@
 			children = (
 				74F9E9CA214C034A00A3F2D2 /* Cells */,
 				74AAF6A4212A04A900C612B0 /* ChartMarker.swift */,
-				B55401682170D5E10067DC90 /* ChartPlaceholderView.swift */,
-				B554016A2170D6010067DC90 /* ChartPlaceholderView.xib */,
+				02AB407A27827C9100929CF3 /* ChartPlaceholderView.swift */,
+				02AB407927827C9000929CF3 /* ChartPlaceholderView.xib */,
+				B55401682170D5E10067DC90 /* LegacyChartPlaceholderView.swift */,
+				B554016A2170D6010067DC90 /* LegacyChartPlaceholderView.xib */,
 				748D34E02148291E00E21A2F /* TopPerformerDataViewController.swift */,
 				748D34DC214828DC00E21A2F /* TopPerformerDataViewController.xib */,
 			);
@@ -7688,6 +7694,7 @@
 				CE27258021925AE8002B22EB /* ValueOneTableViewCell.xib in Resources */,
 				451A04F12386F7B500E368C9 /* ProductImageCollectionViewCell.xib in Resources */,
 				45C8B26223155CBC0002FA77 /* BillingInformationViewController.xib in Resources */,
+				02AB407B27827C9100929CF3 /* ChartPlaceholderView.xib in Resources */,
 				02482A8C237BE8C7007E73ED /* LinkSettingsViewController.xib in Resources */,
 				7E7C5F842719A93C00315B61 /* ProductCategoryListViewController.xib in Resources */,
 				740ADFE521C33688009EE5A9 /* licenses.html in Resources */,
@@ -7698,7 +7705,7 @@
 				0286B27C23C7051F003D784B /* ProductImagesViewController.xib in Resources */,
 				02F49ADE23BF3A4100FA0BFA /* ErrorSectionHeaderView.xib in Resources */,
 				6832C7CC26DA5FDF00BA4088 /* LabeledTextViewTableViewCell.xib in Resources */,
-				B554016B2170D6010067DC90 /* ChartPlaceholderView.xib in Resources */,
+				B554016B2170D6010067DC90 /* LegacyChartPlaceholderView.xib in Resources */,
 				26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */,
 				CE32B11620BF8779006FBCF4 /* ButtonTableViewCell.xib in Resources */,
 				45381B4627341B8A003FEC5F /* DateRangeFilterViewController.xib in Resources */,
@@ -8249,6 +8256,7 @@
 				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift in Sources */,
 				2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
+				02AB407C27827C9100929CF3 /* ChartPlaceholderView.swift in Sources */,
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,
 				314265AC26459F7300500598 /* CardReaderSettingsSearchingViewController.swift in Sources */,
 				CC254F3226C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift in Sources */,
@@ -8620,7 +8628,7 @@
 				262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */,
 				4515262E2577D56C0076B03C /* AddAttributeViewController.swift in Sources */,
 				57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */,
-				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
+				B55401692170D5E10067DC90 /* LegacyChartPlaceholderView.swift in Sources */,
 				57CDABB9252E9BEB00BED88C /* ButtonTableFooterView.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Prep for #5742 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To implement the new ghost UI for My Store tab (p91TBi-6Of-p2), we need to update the placeholder view in the store stats header view which is in `ChartPlaceholderView` using a nib. In order to make design updates without affecting production version, the only option I can think of is to duplicate the view and xib like some of the view controllers before. I don't think there is an easy way to use a feature flag in a nib 😞 This PR simply duplicated the original `ChartPlaceholderView` view and xib and rename the production version to `LegacyChartPlaceholderView`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please just make sure the placeholder/ghost view looks the same as before:
- Launch the app --> the placeholder/ghost view should look the same as before (like in screenshot)

- [x] @jaclync tests the production version when the feature flag is off

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1945542/147893583-187512d0-c172-4f08-b91a-f9d38772a3e9.png" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
