### PR TITLE
Coupons: Add option to delete coupons to Yosemite

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -9,6 +9,10 @@ public protocol CouponsRemoteProtocol {
                         pageNumber: Int,
                         pageSize: Int,
                         completion: @escaping (Result<[Coupon], Error>) -> ())
+
+    func deleteCoupon(for siteID: Int64,
+                      couponID: Int64,
+                      completion: @escaping (Result<Coupon, Error>) -> Void)
 }
 
 

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -24,10 +24,10 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     /// Retrieves all of the `Coupon`s from the API.
     ///
     /// - Parameters:
-    ///     - siteID
-    ///     - pageNumber:
-    ///     - pageSize:
-    ///     - completion:
+    ///     - siteID: The site for which we'll fetch coupons.
+    ///     - pageNumber: The page number of the coupon list to be fetched.
+    ///     - pageSize: The maximum number of coupons to be fetched for the current page.
+    ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllCoupons(for siteID: Int64,
                                pageNumber: Int = Default.pageNumber,

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -121,6 +121,14 @@ public extension StorageType {
         }
     }
 
+    /// Delete the stored Coupon with the given couponID for the provided siteID.
+    ///
+    func deleteCoupon(siteID: Int64, couponID: Int64) {
+        if let coupon = loadCoupon(siteID: siteID, couponID: couponID) {
+            deleteObject(coupon)
+        }
+    }
+
     /// Deletes all of the stored `AddOnGroups` for a `siteID` that are not included in the provided `activeGroupIDs` array.
     ///
     func deleteStaleAddOnGroups(siteID: Int64, activeGroupIDs: [Int64]) {

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -121,7 +121,7 @@ public extension StorageType {
         }
     }
 
-    /// Delete the stored Coupon with the given couponID for the provided siteID.
+    /// Deletes the stored Coupon with the given couponID for the provided siteID.
     ///
     func deleteCoupon(siteID: Int64, couponID: Int64) {
         if let coupon = loadCoupon(siteID: siteID, couponID: couponID) {

--- a/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Storage
 
-class StorageTypeDeletionsTests: XCTestCase {
+final class StorageTypeDeletionsTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 98765
     private var storageManager: StorageManagerType!
@@ -57,6 +57,45 @@ class StorageTypeDeletionsTests: XCTestCase {
         // Then
         let storedCoupons = try XCTUnwrap(storage.loadAllCoupons(siteID: 12345))
         XCTAssertEqual(storedCoupons, [otherSiteCoupon])
+    }
+
+    func test_deleteCoupon_by_siteID_and_couponID_only_deletes_coupon_with_the_given_IDs() throws {
+        // Given
+        let sampleCouponID: Int64 = 13435
+        let coupon = storage.insertNewObject(ofType: Coupon.self)
+        coupon.siteID = sampleSiteID
+        coupon.couponID = sampleCouponID
+
+        let otherCoupon = storage.insertNewObject(ofType: Coupon.self)
+        otherCoupon.siteID = sampleSiteID
+        otherCoupon.couponID = 2
+
+        // When
+        storage.deleteCoupon(siteID: sampleSiteID, couponID: sampleCouponID)
+
+        // Then
+        let storedCoupons = try XCTUnwrap(storage.loadAllCoupons(siteID: sampleSiteID))
+        XCTAssertEqual(storedCoupons, [otherCoupon])
+    }
+
+    func test_deleteCoupon_by_siteID_and_couponID_only_deletes_coupon_for_the_given_site() throws {
+        // Given
+        let sampleCouponID: Int64 = 13435
+        let coupon = storage.insertNewObject(ofType: Coupon.self)
+        coupon.siteID = sampleSiteID
+        coupon.couponID = sampleCouponID
+
+        let otherSiteID: Int64 = 333
+        let otherCoupon = storage.insertNewObject(ofType: Coupon.self)
+        otherCoupon.siteID = otherSiteID
+        otherCoupon.couponID = sampleCouponID
+
+        // When
+        storage.deleteCoupon(siteID: sampleSiteID, couponID: sampleCouponID)
+
+        // Then
+        let storedCoupons = try XCTUnwrap(storage.loadAllCoupons(siteID: otherSiteID))
+        XCTAssertEqual(storedCoupons, [otherCoupon])
     }
 
     func test_deleteStaleAddOnGroups_does_not_delete_active_addOns() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
@@ -99,6 +99,8 @@ final class CouponListViewModelTests: XCTestCase {
             XCTAssertEqual(siteID, 123)
             XCTAssertEqual(pageNumber, 4)
             XCTAssertEqual(pageSize, 8)
+        default:
+            break
         }
     }
 

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -20,7 +20,7 @@ public enum CouponAction: Action {
 
     /// Deletes a coupon for a site given its ID
     ///
-    /// - `siteID`: ID of the site that the coupon belong to.
+    /// - `siteID`: ID of the site that the coupon belongs to.
     /// - `couponID`: ID of the coupon to be deleted.
     /// - `onCompletion`: invoked when the deletion finishes.
     ///

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -17,4 +17,14 @@ public enum CouponAction: Action {
                             pageNumber: Int,
                             pageSize: Int,
                             onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Delete a coupon for a site given its ID
+    ///
+    /// - `siteID`: ID of the site that the coupon belong to.
+    /// - `couponID`: ID of the coupon to be deleted.
+    /// - `onCompletion`: invoked when the deletion finishes.
+    ///
+    case deleteCoupon(siteID: Int64,
+                      couponID: Int64,
+                      onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -18,7 +18,7 @@ public enum CouponAction: Action {
                             pageSize: Int,
                             onCompletion: (Result<Bool, Error>) -> Void)
 
-    /// Delete a coupon for a site given its ID
+    /// Deletes a coupon for a site given its ID
     ///
     /// - `siteID`: ID of the site that the coupon belong to.
     /// - `couponID`: ID of the coupon to be deleted.

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -106,6 +106,13 @@ private extension CouponStore {
         }
     }
 
+    /// Deletes a coupon from a Site with what is persisted in the storage layer.
+    /// After API request succeeds, the stored coupon should be removed from the local storage.
+    /// - Parameters:
+    ///   - siteID: The site that the deleted coupon belongs to.
+    ///   - couponID: The ID of the coupon to be deleted.
+    ///   - onCompletion: Closure to call after deletion is complete. Called on the main thread.
+    ///
     func deleteCoupon(siteID: Int64, couponID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         remote.deleteCoupon(for: siteID, couponID: couponID) { [weak self] result in
             guard let self = self else { return }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -113,7 +113,9 @@ private extension CouponStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success:
-                self.deleteCoupon(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
+                self.deleteStoredCoupon(siteID: siteID, couponID: couponID) {
+                    onCompletion(.success(()))
+                }
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -119,7 +119,14 @@ private extension CouponStore {
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
-            case .success:
+            case .success(let coupon):
+                // This is unlikely to happen, but worth checking
+                guard coupon.siteID == siteID, coupon.couponID == couponID else {
+                    onCompletion(.failure(CouponError.unexpectedCouponDeleted))
+                    DDLogError("⛔️ Unexpected coupon: Deleted couponID \(coupon.couponID) for site \(coupon.siteID) " +
+                               "while expecting couponID \(couponID) and site \(siteID)")
+                    return
+                }
                 self.deleteStoredCoupon(siteID: siteID, couponID: couponID) {
                     onCompletion(.success(()))
                 }
@@ -190,4 +197,8 @@ private extension CouponStore {
             DispatchQueue.main.async(execute: onCompletion)
         }
     }
+}
+
+public enum CouponError: Error {
+    case unexpectedCouponDeleted
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -8,6 +8,10 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     var spyLoadAllCouponsPageNumber: Int?
     var spyLoadAllCouponsPageSize: Int?
 
+    var didCallDeleteCoupon = false
+    var spyDeleteCouponSiteID: Int64?
+    var spyDeleteCouponWithID: Int64?
+
     // MARK: - Stub responses
     var resultForLoadAllCoupons: Result<[Coupon], Error>?
 
@@ -22,5 +26,13 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
         spyLoadAllCouponsPageSize = pageSize
         guard let result = resultForLoadAllCoupons else { return }
         completion(result)
+    }
+
+    func deleteCoupon(for siteID: Int64,
+                      couponID: Int64,
+                      completion: @escaping (Result<Coupon, Error>) -> Void) {
+        didCallDeleteCoupon = true
+        spyDeleteCouponSiteID = couponID
+        spyDeleteCouponWithID = couponID
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -32,7 +32,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
                       couponID: Int64,
                       completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallDeleteCoupon = true
-        spyDeleteCouponSiteID = couponID
+        spyDeleteCouponSiteID = siteID
         spyDeleteCouponWithID = couponID
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5790
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously there was an implementation in Networking for deleting a coupon, but this hasn't been added to CouponRemote and Yosemite layer.

This PR adds the following changes:
- Updates `CouponRemote` to make coupon deletion accessible
- Updates `StorageType+Deletion` to support deleting a coupon given its site ID and coupon ID.
- Updates `CouponAction` and `CouponStore` to support coupon deletion.
- Updates unit tests

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Coupon deletion hasn't been integrated, so CI passing is enough.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
