### PR TITLE
Design updates for top performers section header

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartPlaceholderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartPlaceholderView.swift
@@ -30,15 +30,22 @@ private extension ChartPlaceholderView {
     /// Applies color to the view.
     ///
     func configureView() {
-        backgroundColor = .listForeground
-        topStackView.backgroundColor = .listForeground
+        backgroundColor = Constants.backgroundColor
+        topStackView.backgroundColor = Constants.backgroundColor
     }
 
     /// Chart lines always show the same color without ghost animation.
     func configureLinesStackView() {
         linesStackView.isGhostableDisabled = true
         linesStackView.arrangedSubviews.forEach { chartLineView in
-            chartLineView.backgroundColor = .init(light: .gray(.shade5), dark: .systemGray5)
+            chartLineView.backgroundColor = Constants.chartLineBackgroundColor
         }
+    }
+}
+
+private extension ChartPlaceholderView {
+    enum Constants {
+        static let backgroundColor: UIColor = .systemBackground
+        static let chartLineBackgroundColor: UIColor = .init(light: .gray(.shade5), dark: .systemGray5)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -270,38 +270,12 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         // Top performers header.
         let topPerformersHeaderView = TopPerformersSectionHeaderView(title:
             NSLocalizedString("Top Performers",
-                              comment: "Header label for Top Performers section of My Store tab.")
-                .uppercased())
+                              comment: "Header label for Top Performers section of My Store tab."))
         stackView.addArrangedSubview(topPerformersHeaderView)
-        let headerTopBorderView = createBorderView()
-        let headerBottomBorderView = createBorderView()
-        topPerformersHeaderView.addSubview(headerTopBorderView)
-        topPerformersHeaderView.addSubview(headerBottomBorderView)
-        NSLayoutConstraint.activate([
-            topPerformersHeaderView.heightAnchor.constraint(equalToConstant: 44),
-            // Top border view
-            headerTopBorderView.topAnchor.constraint(equalTo: topPerformersHeaderView.topAnchor),
-            headerTopBorderView.leadingAnchor.constraint(equalTo: topPerformersHeaderView.leadingAnchor),
-            headerTopBorderView.trailingAnchor.constraint(equalTo: topPerformersHeaderView.trailingAnchor),
-            // Bottom border view
-            headerBottomBorderView.bottomAnchor.constraint(equalTo: topPerformersHeaderView.bottomAnchor),
-            headerBottomBorderView.leadingAnchor.constraint(equalTo: topPerformersHeaderView.leadingAnchor),
-            headerBottomBorderView.trailingAnchor.constraint(equalTo: topPerformersHeaderView.trailingAnchor),
-            ])
 
         // Top performers.
         let topPerformersPeriodView = topPerformersPeriodViewController.view!
         stackView.addArrangedSubview(topPerformersPeriodView)
-        stackView.addArrangedSubview(createBorderView())
-
-        // Empty padding view at the bottom.
-        let emptyView = UIView(frame: .zero)
-        emptyView.translatesAutoresizingMaskIntoConstraints = false
-        emptyView.backgroundColor = .clear
-        NSLayoutConstraint.activate([
-            emptyView.heightAnchor.constraint(equalToConstant: 44),
-            ])
-        stackView.addArrangedSubview(emptyView)
 
         childViewContrllers.forEach { childViewController in
             childViewController.didMove(toParent: self)
@@ -331,16 +305,6 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         }()
 
         return [emptySpaceView, cardView]
-    }
-
-    func createBorderView() -> UIView {
-        let view = UIView(frame: .zero)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .systemColor(.separator)
-        NSLayoutConstraint.activate([
-            view.heightAnchor.constraint(equalToConstant: 0.5)
-            ])
-        return view
     }
 
     func configureInAppFeedbackViewControllerAction() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Experiments
 
 /// Section header view shown above the top performers data view.
 ///
@@ -7,10 +8,13 @@ class TopPerformersSectionHeaderView: UIView {
         return UILabel(frame: .zero)
     }()
 
-    init(title: String) {
+    init(title: String, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
-        configureLabel(title: title)
+
+        let isMyStoreTabUpdatesEnabled = featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates)
+        configureView(isMyStoreTabUpdatesEnabled: isMyStoreTabUpdatesEnabled)
+        configureLabel(title: title, isMyStoreTabUpdatesEnabled: isMyStoreTabUpdatesEnabled)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -19,20 +23,33 @@ class TopPerformersSectionHeaderView: UIView {
 }
 
 private extension TopPerformersSectionHeaderView {
-    func configureLabel(title: String) {
+    func configureView(isMyStoreTabUpdatesEnabled: Bool) {
+        guard isMyStoreTabUpdatesEnabled else {
+            return
+        }
+        backgroundColor = Constants.backgroundColor
+    }
+
+    func configureLabel(title: String, isMyStoreTabUpdatesEnabled: Bool) {
         addSubview(label)
 
         label.text = title
 
-        label.applyFootnoteStyle()
-        label.textColor = .listIcon
+        if isMyStoreTabUpdatesEnabled {
+            label.applyHeadlineStyle()
+            label.textColor = .systemColor(.label)
+        } else {
+            label.applyFootnoteStyle()
+            label.textColor = .listIcon
+        }
 
         label.translatesAutoresizingMaskIntoConstraints = false
+        let labelInsets = isMyStoreTabUpdatesEnabled ? Constants.labelInsets: Constants.legacyLabelInsets
         NSLayoutConstraint.activate([
             label.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.labelInsets.left),
-            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.labelInsets.right),
-            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.labelInsets.bottom)
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: labelInsets.left),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -labelInsets.right),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -labelInsets.bottom)
             ])
     }
 }
@@ -41,6 +58,8 @@ private extension TopPerformersSectionHeaderView {
 //
 private extension TopPerformersSectionHeaderView {
     enum Constants {
-        static let labelInsets = UIEdgeInsets(top: 0, left: 14, bottom: 6, right: 14)
+        static let labelInsets = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
+        static let legacyLabelInsets = UIEdgeInsets(top: 0, left: 14, bottom: 6, right: 14)
+        static let backgroundColor: UIColor = .systemBackground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// Renders a Section Header/Footer with two labels [Left / Right].
 ///
-class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
+final class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
 
     /// Left Label
     ///
@@ -13,6 +13,20 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
     ///
     @IBOutlet private weak var rightColumn: UILabel!
 
+    /// Constraint of the top of left/right labels to the view's top margin.
+    @IBOutlet private weak var topMarginSpacingConstraint: NSLayoutConstraint!
+
+    /// The spacing from the top of left/right labels to the view's top margin. The default value matches the value in its xib
+    /// There is an additional 8px top margin by default in iOS.
+    var topMarginSpacing: CGFloat = 14 {
+        didSet {
+            topMarginSpacingConstraint.constant = topMarginSpacing
+        }
+    }
+
+    /// Whether the label text is converted to uppercase.
+    var shouldShowUppercase: Bool = true
+
     /// Left Label's Text
     ///
     var leftText: String? {
@@ -20,7 +34,7 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
             return leftColumn.text
         }
         set {
-            leftColumn.text = newValue?.uppercased()
+            leftColumn.text = shouldShowUppercase ? newValue?.uppercased(): newValue
             leftColumn.isHidden = newValue == nil || newValue?.isEmpty == true
         }
     }
@@ -32,7 +46,7 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
             return rightColumn.text
         }
         set {
-            rightColumn.text = newValue?.uppercased()
+            rightColumn.text = shouldShowUppercase ? newValue?.uppercased(): newValue
             rightColumn.isHidden = newValue == nil || newValue?.isEmpty == true
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,13 +18,13 @@
                     <rect key="frame" x="16" y="14" width="343" height="28"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Fd-ta-Azy">
-                            <rect key="frame" x="0.0" y="0.0" width="33" height="28"/>
+                            <rect key="frame" x="0.0" y="0.0" width="31" height="28"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nAe-82-c1s">
-                            <rect key="frame" x="310" y="0.0" width="33" height="28"/>
+                            <rect key="frame" x="312" y="0.0" width="31" height="28"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -42,6 +42,7 @@
             <connections>
                 <outlet property="leftColumn" destination="4Fd-ta-Azy" id="RMc-vo-ssc"/>
                 <outlet property="rightColumn" destination="nAe-82-c1s" id="kEj-jV-tZ2"/>
+                <outlet property="topMarginSpacingConstraint" destination="eD3-Jv-3jx" id="217-ao-B6Q"/>
             </connections>
             <point key="canvasLocation" x="34.5" y="89.5"/>
         </view>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5793 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR includes just design updates for the top performers section header. Updates on the data to sort by items sold will be implemented separately. Major changes include:

- In `StoreStatsAndTopPerformersPeriodViewController`, removed the borders around the "Top Performers" header view and the empty view att the bottom
- In `TopPerformerDataViewController` (shared by both feature flag states), updated design based on the feature flag. It shows `TwoColumnSectionHeaderView` as the table view section header instead of `TopPerformersHeaderView` to remove the extra detail text ("Gain insights...") since it's not easy to hide it in `TopPerformersHeaderView`
  - Using `TwoColumnSectionHeaderView` requires adding support to not always uppercase the left/right text, and a constraint for the top spacing
- In `TopPerformersSectionHeaderView` that shows the "Top Performers" header (shared by both feature flag states), updated design based on the feature flag
- Store stats skeleton/placeholder (`ChartPlaceholderView`) background color was updated to match the chart in Dark mode
- Fixed an iOS 15+ table view top spacing issue by setting `tableView.sectionHeaderTopPadding = 0` (took me a while to realize it's an issue in production and only iOS 15+)

<img src="https://user-images.githubusercontent.com/1945542/148002650-b2431065-222a-43fb-91fa-803c53e2f2b4.png" width="200" />


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app or switch to another store --> the order stats skeleton/ghost/placeholder should look good (screenshots below)
- After data are loaded, tap each time range tab --> the top performers section header should follow design

- [x] @jaclync tests the production version (feature flag disabled)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | no top performers | 1+ top performers | skeleton/ghost/placeholder
-- | -- | -- | --
dark | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 10 21 53](https://user-images.githubusercontent.com/1945542/148002236-3595787a-a958-437f-a625-1f34dbc97e5c.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 10 21 58](https://user-images.githubusercontent.com/1945542/148002240-a03aeb9f-ad94-451c-baf8-a7b42cd026d3.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 10 24 23](https://user-images.githubusercontent.com/1945542/148002244-c19b0851-cc1b-4aaa-8140-aa3efabc9036.png)
light | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 10 22 48](https://user-images.githubusercontent.com/1945542/148002275-a29c5f92-e2b5-453c-acc5-52f4928019a2.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 10 23 09](https://user-images.githubusercontent.com/1945542/148002280-0e86f252-1cbd-451d-8375-bb784199c877.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 10 25 01](https://user-images.githubusercontent.com/1945542/148002282-b0aa2194-c8fb-4090-bb2e-c3b58321da0d.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
