### PR TITLE
Coupons: Update Networking and Yosemite with option to update coupon

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -13,6 +13,8 @@ public protocol CouponsRemoteProtocol {
     func deleteCoupon(for siteID: Int64,
                       couponID: Int64,
                       completion: @escaping (Result<Coupon, Error>) -> Void)
+
+    func updateCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void)
 }
 
 
@@ -70,6 +72,29 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
         let mapper = CouponMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    // MARK: - Update Coupon
+
+    /// Update a `Coupon`.
+    ///
+    /// - Parameters:
+    ///     - coupon: The coupon to be updated remotely.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void) {
+        do {
+            let parameters = try coupon.toDictionary()
+            let couponID = coupon.couponID
+            let siteID = coupon.siteID
+            let path = Path.coupons + "/\(couponID)"
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+            let mapper = CouponMapper(siteID: siteID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -27,4 +27,12 @@ public enum CouponAction: Action {
     case deleteCoupon(siteID: Int64,
                       couponID: Int64,
                       onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Updates a coupon for a site given its ID
+    ///
+    /// - `coupon`: the coupon to be updated.
+    /// - `onCompletion`: invoked when the deletion finishes.
+    ///
+    case updateCoupon(_ coupon: Coupon,
+                      onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -28,11 +28,11 @@ public enum CouponAction: Action {
                       couponID: Int64,
                       onCompletion: (Result<Void, Error>) -> Void)
 
-    /// Updates a coupon for a site given its ID
+    /// Updates a coupon for a site given its ID and returns the updated coupon if the request succeeds.
     ///
     /// - `coupon`: the coupon to be updated.
     /// - `onCompletion`: invoked when the deletion finishes.
     ///
     case updateCoupon(_ coupon: Coupon,
-                      onCompletion: (Result<Void, Error>) -> Void)
+                      onCompletion: (Result<Coupon, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -142,7 +142,7 @@ private extension CouponStore {
     ///   - coupon: The coupon to be updated
     ///   - onCompletion: Closure to call after deletion is complete. Called on the main thread.
     ///
-    func updateCoupon(_ coupon: Coupon, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func updateCoupon(_ coupon: Coupon, onCompletion: @escaping (Result<Coupon, Error>) -> Void) {
         remote.updateCoupon(coupon) { [weak self] result in
             guard let self = self else { return }
             switch result {
@@ -150,7 +150,7 @@ private extension CouponStore {
                 onCompletion(.failure(error))
             case .success(let updatedCoupon):
                 self.updateStoredCoupon(readOnlyCoupon: updatedCoupon) {
-                    onCompletion(.success(()))
+                    onCompletion(.success(updatedCoupon))
                 }
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -12,6 +12,9 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     var spyDeleteCouponSiteID: Int64?
     var spyDeleteCouponWithID: Int64?
 
+    var didCallUpdateCoupon = false
+    var spyUpdateCoupon: Coupon?
+
     // MARK: - Stub responses
     var resultForLoadAllCoupons: Result<[Coupon], Error>?
 
@@ -34,5 +37,10 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
         didCallDeleteCoupon = true
         spyDeleteCouponSiteID = siteID
         spyDeleteCouponWithID = couponID
+    }
+
+    func updateCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void) {
+        didCallUpdateCoupon = true
+        spyUpdateCoupon = coupon
     }
 }

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -282,6 +282,74 @@ final class CouponStoreTests: XCTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(storedCouponsCount, 0)
     }
+
+    func test_updateCoupon_calls_remote_using_correct_request_parameters() {
+        setUpUsingSpyRemote()
+        // Given
+        let sampleCouponID: Int64 = 720
+        let coupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10", discountType: .percent)
+        let action = CouponAction.updateCoupon(coupon) { _ in }
+
+        // When
+        store.onAction(action)
+
+        // Then
+        XCTAssertTrue(remote.didCallUpdateCoupon)
+        XCTAssertEqual(remote.spyUpdateCoupon, coupon)
+    }
+
+    func test_updateCoupon_returns_network_error_on_failure() {
+        // Given
+        let sampleCouponID: Int64 = 720
+        let sampleCoupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10")
+        storeCoupon(sampleCoupon, for: sampleSiteID)
+        XCTAssertEqual(storedCouponsCount, 1)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "coupons/\(sampleCouponID)", error: expectedError)
+
+        // When
+        let updatedCoupon = sampleCoupon.copy(amount: "9")
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = CouponAction.updateCoupon(updatedCoupon) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(result.failure as? NetworkError, expectedError)
+        XCTAssertEqual(storedCouponsCount, 1)
+        XCTAssertEqual(viewStorage.loadCoupon(siteID: sampleSiteID, couponID: sampleCouponID)?.amount, "10")
+    }
+
+    func test_updateCoupon_updates_stored_coupon_upon_success() throws {
+        // Given
+        let sampleCouponID: Int64 = 720
+        let sampleCoupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "11", discountType: .percent)
+        storeCoupon(sampleCoupon, for: sampleSiteID)
+        XCTAssertEqual(storedCouponsCount, 1)
+
+        network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
+
+        // When
+        // this is not really important because we'll test the parsed coupon from the json file
+        let updatedCoupon = sampleCoupon.copy(amount: "10.00", discountType: .fixedCart)
+        let result: Result<Void, Error> = waitFor { promise in
+            let action: CouponAction
+            action = .updateCoupon(updatedCoupon) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let storedCoupon = viewStorage.loadCoupon(siteID: sampleSiteID, couponID: sampleCouponID)
+        XCTAssertNotNil(storedCoupon)
+        XCTAssertEqual(storedCoupon?.amount, "10.00")
+        XCTAssertEqual(storedCoupon?.discountType, Coupon.DiscountType.fixedCart.rawValue)
+    }
 }
 
 private extension CouponStoreTests {

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -310,7 +310,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let updatedCoupon = sampleCoupon.copy(amount: "9")
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Networking.Coupon, Error> = waitFor { promise in
             let action = CouponAction.updateCoupon(updatedCoupon) { result in
                 promise(result)
             }
@@ -335,7 +335,7 @@ final class CouponStoreTests: XCTestCase {
         // When
         // this is not really important because we'll test the parsed coupon from the json file
         let updatedCoupon = sampleCoupon.copy(amount: "10.00", discountType: .fixedCart)
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Networking.Coupon, Error> = waitFor { promise in
             let action: CouponAction
             action = .updateCoupon(updatedCoupon) { result in
                 promise(result)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5791 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As the title suggests, this PR update lower layers for coupon update. Changes include:
- Updates Networking to add a new endpoint for updating coupons.
- Updates `CouponAction` and `CouponStore` for updating coupons.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Coupon update hasn't been integrated yet so it's good to just have CI passing.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
