### PR TITLE
Update top performers content - cell configuration, section header, and items sorted by items sold

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1543,6 +1543,36 @@ extension SystemPlugin {
     }
 }
 
+extension TopEarnerStatsItem {
+    public func copy(
+        productID: CopiableProp<Int64> = .copy,
+        productName: NullableCopiableProp<String> = .copy,
+        quantity: CopiableProp<Int> = .copy,
+        price: CopiableProp<Double> = .copy,
+        total: CopiableProp<Double> = .copy,
+        currency: CopiableProp<String> = .copy,
+        imageUrl: NullableCopiableProp<String> = .copy
+    ) -> TopEarnerStatsItem {
+        let productID = productID ?? self.productID
+        let productName = productName ?? self.productName
+        let quantity = quantity ?? self.quantity
+        let price = price ?? self.price
+        let total = total ?? self.total
+        let currency = currency ?? self.currency
+        let imageUrl = imageUrl ?? self.imageUrl
+
+        return TopEarnerStatsItem(
+            productID: productID,
+            productName: productName,
+            quantity: quantity,
+            price: price,
+            total: total,
+            currency: currency,
+            imageUrl: imageUrl
+        )
+    }
+}
+
 extension WordPressMedia {
     public func copy(
         mediaID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -67,7 +67,7 @@ private extension TopEarnerStatsItem {
 //
 extension TopEarnerStatsItem: Comparable {
     public static func < (lhs: TopEarnerStatsItem, rhs: TopEarnerStatsItem) -> Bool {
-        return lhs.total < rhs.total ||
-            (lhs.total == rhs.total && lhs.quantity < rhs.quantity)
+        return lhs.quantity < rhs.quantity ||
+            (lhs.quantity == rhs.quantity && lhs.total < rhs.total)
     }
 }

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a single top earner stat for a specific period.
 ///
-public struct TopEarnerStatsItem: Decodable, Equatable, GeneratedFakeable {
+public struct TopEarnerStatsItem: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
 
     /// Product ID
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -103,15 +103,17 @@ extension ProductTableViewCell {
 }
 
 extension ProductTableViewCell.ViewModel {
-    init(statsItem: TopEarnerStatsItem?, isMyStoreTabUpdatesEnabled: Bool) {
+    init(statsItem: TopEarnerStatsItem?,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         isMyStoreTabUpdatesEnabled: Bool) {
         nameText = statsItem?.productName
         imageURL = statsItem?.imageUrl
 
         if isMyStoreTabUpdatesEnabled {
             detailText = String.localizedStringWithFormat(
                 NSLocalizedString("Net sales: %@",
-                                  comment: "Top performers — label for the total number of products ordered"),
-                statsItem?.formattedTotalString ?? ""
+                                  comment: "Top performers — label for the total sales of a product"),
+                statsItem?.totalString(currencyFormatter: currencyFormatter) ?? ""
             )
             accessoryText = "\(statsItem?.quantity ?? 0)"
         } else {
@@ -137,9 +139,8 @@ private extension ProductTableViewCell {
 }
 
 private extension TopEarnerStatsItem {
-    /// Returns a total string including the currency symbol
-    ///
-    var totalString: String {
-        return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatHumanReadableAmount(String(total), with: currency) ?? String()
+    /// Returns a total string without rounding up including the currency symbol.
+    func totalString(currencyFormatter: CurrencyFormatter) -> String? {
+        return currencyFormatter.formatAmount(Decimal(total), with: currency)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -71,17 +71,27 @@ class ProductTableViewCell: UITableViewCell {
 // MARK: - Public Methods
 //
 extension ProductTableViewCell {
-    func configure(_ statsItem: TopEarnerStatsItem?, imageService: ImageService) {
+    func configure(_ statsItem: TopEarnerStatsItem?, isMyStoreTabUpdatesEnabled: Bool, imageService: ImageService) {
         nameText = statsItem?.productName
-        detailText = String.localizedStringWithFormat(
-            NSLocalizedString("Total orders: %ld",
-                              comment: "Top performers — label for the total number of products ordered"),
-            statsItem?.quantity ?? 0
-        )
-        priceText = statsItem?.formattedTotalString
+
+        if isMyStoreTabUpdatesEnabled {
+            detailText = String.localizedStringWithFormat(
+                NSLocalizedString("Net sales: %@",
+                                  comment: "Top performers — label for the total number of products ordered"),
+                statsItem?.formattedTotalString ?? ""
+            )
+            priceText = "\(statsItem?.quantity ?? 0)"
+        } else {
+            detailText = String.localizedStringWithFormat(
+                NSLocalizedString("Total orders: %ld",
+                                  comment: "Top performers — label for the total number of products ordered"),
+                statsItem?.quantity ?? 0
+            )
+            priceText = statsItem?.formattedTotalString
+        }
 
         /// Set `center` contentMode to not distort the placeholder aspect ratio.
-        /// After a sucessfull image download set the contentMode to `scaleAspectFill`
+        /// After a successful image download set the contentMode to `scaleAspectFill`
         productImage.contentMode = .center
         imageService.downloadAndCacheImageForImageView(productImage,
                                                        with: statsItem?.imageUrl,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -10,11 +10,12 @@ class ProductTableViewCell: UITableViewCell {
     @IBOutlet private weak var productImage: UIImageView!
     @IBOutlet private var nameLabel: UILabel!
     @IBOutlet private var detailLabel: UILabel!
-    @IBOutlet private var priceLabel: UILabel!
+    @IBOutlet private var accessoryLabel: UILabel!
 
-    /// We use a custom view isntead of the default separator as it's width varies depending on the image size, which varies depending on the screen size.
+    /// We use a custom view instead of the default separator as it's width varies depending on the image size, which varies depending on the screen size.
     @IBOutlet private var bottomBorderView: UIView!
 
+    /// Shows the name of the product.
     var nameText: String? {
         get {
             return nameLabel.text
@@ -24,6 +25,7 @@ class ProductTableViewCell: UITableViewCell {
         }
     }
 
+    /// Text displayed under the product name.
     var detailText: String? {
         get {
             return detailLabel.text
@@ -33,15 +35,17 @@ class ProductTableViewCell: UITableViewCell {
         }
     }
 
-    var priceText: String? {
+    /// Text displayed at the trailing edge of the cell.
+    var accessoryText: String? {
         get {
-            return priceLabel.text
+            return accessoryLabel.text
         }
         set {
-            priceLabel.text = newValue
+            accessoryLabel.text = newValue
         }
     }
 
+    /// Whether to hide the bottom border.
     var hidesBottomBorder: Bool = false {
         didSet {
             bottomBorderView.isHidden = hidesBottomBorder
@@ -51,7 +55,7 @@ class ProductTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         nameLabel.applyBodyStyle()
-        priceLabel.applyBodyStyle()
+        accessoryLabel.applyBodyStyle()
         detailLabel.applyFootnoteStyle()
         applyProductImageStyle()
         backgroundColor = .listForeground
@@ -80,14 +84,14 @@ extension ProductTableViewCell {
                                   comment: "Top performers — label for the total number of products ordered"),
                 statsItem?.formattedTotalString ?? ""
             )
-            priceText = "\(statsItem?.quantity ?? 0)"
+            accessoryText = "\(statsItem?.quantity ?? 0)"
         } else {
             detailText = String.localizedStringWithFormat(
                 NSLocalizedString("Total orders: %ld",
                                   comment: "Top performers — label for the total number of products ordered"),
                 statsItem?.quantity ?? 0
             )
-            priceText = statsItem?.formattedTotalString
+            accessoryText = statsItem?.formattedTotalString
         }
 
         /// Set `center` contentMode to not distort the placeholder aspect ratio.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -28,16 +28,16 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                                <rect key="frame" x="45" y="0.0" width="145" height="62.5"/>
+                                <rect key="frame" x="45" y="0.0" width="145" height="54.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
-                                        <rect key="frame" x="0.0" y="0.0" width="145" height="42.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="145" height="36"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                        <rect key="frame" x="0.0" y="46.5" width="145" height="16"/>
+                                        <rect key="frame" x="0.0" y="40" width="145" height="14.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -45,16 +45,16 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yc7-gf-KCU">
-                                <rect key="frame" x="206" y="0.0" width="50" height="70.5"/>
+                                <rect key="frame" x="206" y="0.0" width="50" height="67"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="    " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2yh-4i-vuE">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="    " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2yh-4i-vuE" userLabel="Accessory Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="17"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YoE-TO-fIp">
-                                        <rect key="frame" x="0.0" y="20.5" width="50" height="50"/>
+                                        <rect key="frame" x="0.0" y="17" width="50" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     </view>
                                 </subviews>
@@ -85,10 +85,10 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <inset key="separatorInset" minX="82" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
+                <outlet property="accessoryLabel" destination="2yh-4i-vuE" id="Pe0-nm-XVK"/>
                 <outlet property="bottomBorderView" destination="lOL-Ke-vhW" id="k0w-aD-sTk"/>
                 <outlet property="detailLabel" destination="hrx-8V-5Ga" id="tzf-vx-Bs7"/>
                 <outlet property="nameLabel" destination="B98-58-fIv" id="Hh5-mS-u6w"/>
-                <outlet property="priceLabel" destination="2yh-4i-vuE" id="Pe0-nm-XVK"/>
                 <outlet property="productImage" destination="yk6-X3-NSJ" id="Kva-Sx-kub"/>
             </connections>
             <point key="canvasLocation" x="-651.20000000000005" y="-173.61319340329837"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -247,8 +247,8 @@ extension TopPerformerDataViewController: UITableViewDataSource {
             return tableView.dequeueReusableCell(withIdentifier: NoPeriodDataTableViewCell.reuseIdentifier, for: indexPath)
         }
         let cell = tableView.dequeueReusableCell(ProductTableViewCell.self, for: indexPath)
-
-        cell.configure(statsItem, isMyStoreTabUpdatesEnabled: isMyStoreTabUpdatesEnabled, imageService: imageService)
+        let viewModel = ProductTableViewCell.ViewModel(statsItem: statsItem, isMyStoreTabUpdatesEnabled: isMyStoreTabUpdatesEnabled)
+        cell.configure(viewModel: viewModel, imageService: imageService)
         cell.hidesBottomBorder = tableView.lastIndexPathOfTheLastSection() == indexPath ? true : false
         return cell
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 		02AAD54525023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AAD54425023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift */; };
 		02AB407B27827C9100929CF3 /* ChartPlaceholderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02AB407927827C9000929CF3 /* ChartPlaceholderView.xib */; };
 		02AB407C27827C9100929CF3 /* ChartPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AB407A27827C9100929CF3 /* ChartPlaceholderView.swift */; };
+		02AB40822784297C00929CF3 /* ProductTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AB40812784297C00929CF3 /* ProductTableViewCellViewModelTests.swift */; };
 		02AB82EC27069D5D008D7334 /* Experiments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02AB82EB27069D5D008D7334 /* Experiments.framework */; };
 		02AB82ED27069D5D008D7334 /* Experiments.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 02AB82EB27069D5D008D7334 /* Experiments.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		02AC822C2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AC822B2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift */; };
@@ -1876,6 +1877,7 @@
 		02AAD54425023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormRemoteActionUseCase.swift; sourceTree = "<group>"; };
 		02AB407927827C9000929CF3 /* ChartPlaceholderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ChartPlaceholderView.xib; sourceTree = "<group>"; };
 		02AB407A27827C9100929CF3 /* ChartPlaceholderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartPlaceholderView.swift; sourceTree = "<group>"; };
+		02AB40812784297C00929CF3 /* ProductTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		02AB82EB27069D5D008D7334 /* Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		02AC822B2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+UpdatesTests.swift"; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
@@ -4068,6 +4070,7 @@
 				0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */,
 				02404EDF2314FE5900FF1170 /* DashboardUIFactoryTests.swift */,
 				02404EE1231501E000FF1170 /* StatsVersionCoordinatorTests.swift */,
+				02AB40812784297C00929CF3 /* ProductTableViewCellViewModelTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -8169,7 +8172,6 @@
 				DEC51A9D274F8528009F3DF4 /* JetpackInstallStepsViewModel.swift in Sources */,
 				455DC3A327393C7E00D4644C /* OrderDatesFilterViewController.swift in Sources */,
 				45B6F4EF27592A4000C18782 /* ReviewsView.swift in Sources */,
-				028BAC4222F30B05008BB4AF /* OldStoreStatsV4PeriodViewController.swift in Sources */,
 				268FD44727580A81008FDF9B /* CollectOrderPaymentUseCase.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				45F627B6253603AE00894B86 /* Product+DownloadSettingsViewModels.swift in Sources */,
@@ -8877,6 +8879,7 @@
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				FEEB2F6E268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift in Sources */,
 				31E906A326CC91A70099A985 /* CardReaderConnectionControllerTests.swift in Sources */,
+				02AB40822784297C00929CF3 /* ProductTableViewCellViewModelTests.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */,
 				DEC51B04276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductTableViewCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductTableViewCellViewModelTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class ProductTableViewCellViewModelTests: XCTestCase {
+    func test_viewModel_with_TopEarnerStatsItem_sets_properties_correctly() {
+        // Given
+        let statsItem = TopEarnerStatsItem.fake().copy(productName: "Kiwi 🥝",
+                                                       quantity: 5,
+                                                       total: 3888.822,
+                                                       currency: CurrencySettings.CurrencyCode.USD.rawValue,
+                                                       imageUrl: "wp.com/kiwi-image")
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ProductTableViewCell.ViewModel(statsItem: statsItem, currencyFormatter: currencyFormatter, isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        XCTAssertEqual(viewModel.nameText, "Kiwi 🥝")
+        let expectedDetailText = String.localizedStringWithFormat(
+            NSLocalizedString("Net sales: %@",
+                              comment: "Top performers — label for the total sales of a product"),
+            "$3,888.82"
+        )
+        XCTAssertEqual(viewModel.detailText, expectedDetailText)
+        XCTAssertEqual(viewModel.accessoryText, "5")
+        XCTAssertEqual(viewModel.imageURL, "wp.com/kiwi-image")
+    }
+
+    func test_viewModel_with_TopEarnerStatsItem_and_myStoreTabUpdates_feature_disabled_sets_properties_correctly() {
+        // Given
+        let statsItem = TopEarnerStatsItem.fake().copy(productName: "Kiwi 🥝",
+                                                       quantity: 5,
+                                                       total: 3888.822,
+                                                       currency: CurrencySettings.CurrencyCode.USD.rawValue,
+                                                       imageUrl: "wp.com/kiwi-image")
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ProductTableViewCell.ViewModel(statsItem: statsItem, currencyFormatter: currencyFormatter, isMyStoreTabUpdatesEnabled: false)
+
+        // Then
+        XCTAssertEqual(viewModel.nameText, "Kiwi 🥝")
+        let expectedDetailText = String.localizedStringWithFormat(
+            NSLocalizedString("Total orders: %ld",
+                              comment: "Top performers — label for the total number of products ordered"),
+            5
+        )
+        XCTAssertEqual(viewModel.detailText, expectedDetailText)
+        XCTAssertEqual(viewModel.accessoryText, "$3.9k")
+        XCTAssertEqual(viewModel.imageURL, "wp.com/kiwi-image")
+    }
+
+}

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		029BA55B255E0D39006171FD /* ShippingLabelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA55A255E0D39006171FD /* ShippingLabelAction.swift */; };
 		02A098242480D0D8002F8C7A /* MockCrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A098232480D0D8002F8C7A /* MockCrashLogger.swift */; };
 		02A26F1E2744FE97008E4EDB /* MockAccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */; };
+		02AB40802784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AB407F2784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift */; };
 		02BA23C222EEEABC009539E7 /* AvailabilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */; };
 		02BA23C422EEEB3B009539E7 /* AvailabilityAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C322EEEB3B009539E7 /* AvailabilityAction.swift */; };
 		02BA23C622EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C522EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift */; };
@@ -96,12 +97,12 @@
 		02FF056B23DED3670058E6E7 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 02FF056A23DED3670058E6E7 /* Media.xcassets */; };
 		02FF056D23DEDCB90058E6E7 /* MockImageSourceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */; };
 		02FF056F23E04F320058E6E7 /* MockMediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */; };
+		031FD8A026FC970400B315C7 /* RosettaTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */; };
 		03FBDA222631521100ACE257 /* CouponAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA212631521100ACE257 /* CouponAction.swift */; };
 		03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA25263296A100ACE257 /* CouponStore.swift */; };
 		03FBDA2A263296C400ACE257 /* CouponStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA29263296C400ACE257 /* CouponStoreTests.swift */; };
 		03FBDA2E2632A9B400ACE257 /* MockCouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */; };
 		03FBDA3E2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */; };
-		031FD8A026FC970400B315C7 /* RosettaTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */; };
 		077F39DE26A5A1CB00ABEADC /* SystemStatusAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */; };
 		077F39E026A5A6F500ABEADC /* SystemStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */; };
 		077F39E226A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */; };
@@ -451,6 +452,7 @@
 		029BA55A255E0D39006171FD /* ShippingLabelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAction.swift; sourceTree = "<group>"; };
 		02A098232480D0D8002F8C7A /* MockCrashLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCrashLogger.swift; sourceTree = "<group>"; };
 		02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAccountRemote.swift; sourceTree = "<group>"; };
+		02AB407F2784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopEarnerStatsItem+ComparableTests.swift"; sourceTree = "<group>"; };
 		02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityStore.swift; sourceTree = "<group>"; };
 		02BA23C322EEEB3B009539E7 /* AvailabilityAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityAction.swift; sourceTree = "<group>"; };
 		02BA23C522EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV4AvailabilityStoreTests.swift; sourceTree = "<group>"; };
@@ -487,12 +489,12 @@
 		02FF056A23DED3670058E6E7 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageSourceWriter.swift; sourceTree = "<group>"; };
 		02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaExportService.swift; sourceTree = "<group>"; };
+		031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosettaTestingHelper.swift; sourceTree = "<group>"; };
 		03FBDA212631521100ACE257 /* CouponAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAction.swift; sourceTree = "<group>"; };
 		03FBDA25263296A100ACE257 /* CouponStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStore.swift; sourceTree = "<group>"; };
 		03FBDA29263296C400ACE257 /* CouponStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreTests.swift; sourceTree = "<group>"; };
 		03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponsRemote.swift; sourceTree = "<group>"; };
 		03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
-		031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosettaTestingHelper.swift; sourceTree = "<group>"; };
 		077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusAction.swift; sourceTree = "<group>"; };
 		077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStore.swift; sourceTree = "<group>"; };
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -856,6 +858,7 @@
 				0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */,
 				D8652E312630741000350F37 /* PaymentIntent+ReceiptParametersTests.swift */,
 				FEEB2F5E268A1C5E0075A6E0 /* User+RolesTests.swift */,
+				02AB407F2784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2037,6 +2040,7 @@
 				029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */,
 				0248B36924590FC300A271A4 /* ProductStore+FilterProductsTests.swift in Sources */,
 				AEFB3DC4272AA2FF00550F93 /* TelemetryStoreTests.swift in Sources */,
+				02AB40802784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift in Sources */,
 				02A098242480D0D8002F8C7A /* MockCrashLogger.swift in Sources */,
 				02FF055F23D985710058E6E7 /* URL+MediaTests.swift in Sources */,
 				D87F27DB25E7E8EA006EC8C9 /* MockCardReader.swift in Sources */,

--- a/Yosemite/YosemiteTests/Model/Extensions/TopEarnerStatsItem+ComparableTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/TopEarnerStatsItem+ComparableTests.swift
@@ -1,0 +1,23 @@
+import Codegen
+import XCTest
+@testable import Yosemite
+
+final class TopEarnerStatsItem_ComparableTests: XCTestCase {
+    func test_comparing_TopEarnerStatsItem_with_equal_quantity_is_by_total_amount() {
+        // When
+        let statsItemWithLowerTotal = TopEarnerStatsItem.fake().copy(quantity: 2, total: 3.5)
+        let statsItemWithHigherTotal = TopEarnerStatsItem.fake().copy(quantity: 2, total: 3.6)
+
+        // Then
+        XCTAssertGreaterThan(statsItemWithHigherTotal, statsItemWithLowerTotal)
+    }
+
+    func test_comparing_TopEarnerStatsItem_with_different_quantity_is_by_quantity() {
+        // When
+        let statsItemWithLowerQuantity = TopEarnerStatsItem.fake().copy(quantity: 1, total: 3.7)
+        let statsItemWithHigherQuantity = TopEarnerStatsItem.fake().copy(quantity: 2, total: 3.6)
+
+        // Then
+        XCTAssertGreaterThan(statsItemWithHigherQuantity, statsItemWithLowerQuantity)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5793 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the content of the top performers section in the My Store tab. Previously (production version), the top-performing products are sorted by "total amount" in a hacky way due to API limitation (p91TBi-716-p2). With the new design  to better match core, the products are now sorted by "items sold" as returned in the Leaderboards API. The section header labels and cell configuration are also updated based on the latest design.

Major changes include:

- Updated `ProductTableViewCell` for new cell configuration and refactored with a view model for unit testing
  - The view model can be initialized with a `TopEarnerStatsItem` and the feature flag value
  - Its `priceLabel` property is renamed to `accessoryLabel` for flexibility
  - Added unit tests for the view model when the feature flag is on/off
- Updated the top performers section labels in `TopPerformerDataViewController`
- Updated how top-performing products are sorted by updating its `Comparable` implementation (unfortunately we can't feature flag this, we will manually test the production version)
  - Added unit tests for comparing `TopEarnerStatsItem`
  - Implemented `Copiable` for `TopEarnerStatsItem` for easier unit testing

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has at least two orders in any of the time range (today/this week/this month/this year)

- Launch the app
- After the stats are synced, tap each time range tab --> if the time range has any orders, the top performers section should show the updated header labels ("Products" and "Items Sold") and cell content. The products should be ordered by quantity instead of total amount like before

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="826" alt="Screen Shot 2022-01-04 at 3 02 26 PM" src="https://user-images.githubusercontent.com/1945542/148025378-cd706e3c-bfb1-4c6c-bda5-aef7b3c72f1a.png">

\ | before | after
-- | -- | --
dark | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 15 43 15](https://user-images.githubusercontent.com/1945542/148025667-c17624db-4dfb-4813-8e2b-ae5ab26c0251.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 15 04 19](https://user-images.githubusercontent.com/1945542/148025418-3d9ceb0e-24c0-48c1-8ade-89415fee2c1f.png)
light | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 15 42 53](https://user-images.githubusercontent.com/1945542/148025657-e67fceef-78b3-4b14-9eff-a607e391d661.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-04 at 15 04 34](https://user-images.githubusercontent.com/1945542/148025422-eca14a69-93f9-4a9f-a9ca-c25cee54a19b.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->