### PR TITLE
Coupons: Update Networking and Yosemite with option to create coupon

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -15,6 +15,8 @@ public protocol CouponsRemoteProtocol {
                       completion: @escaping (Result<Coupon, Error>) -> Void)
 
     func updateCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void)
+
+    func createCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void)
 }
 
 
@@ -89,6 +91,28 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
             let siteID = coupon.siteID
             let path = Path.coupons + "/\(couponID)"
             let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+            let mapper = CouponMapper(siteID: siteID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    // MARK: - Create coupon
+
+    /// Create a `Coupon`.
+    ///
+    /// - Parameters:
+    ///     - coupon: The coupon to be created remotely.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void) {
+        do {
+            let parameters = try coupon.toDictionary()
+            let siteID = coupon.siteID
+            let path = Path.coupons
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
             let mapper = CouponMapper(siteID: siteID)
 
             enqueue(request, mapper: mapper, completion: completion)

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -31,8 +31,16 @@ public enum CouponAction: Action {
     /// Updates a coupon for a site given its ID and returns the updated coupon if the request succeeds.
     ///
     /// - `coupon`: the coupon to be updated.
-    /// - `onCompletion`: invoked when the deletion finishes.
+    /// - `onCompletion`: invoked when the update finishes.
     ///
     case updateCoupon(_ coupon: Coupon,
+                      onCompletion: (Result<Coupon, Error>) -> Void)
+
+    /// Creates a coupon for a site given its ID and returns the created coupon if the request succeeds.
+    ///
+    /// - `coupon`: the coupon to be created.
+    /// - `onCompletion`: invoked when the creation finishes.
+    ///
+    case createCoupon(_ coupon: Coupon,
                       onCompletion: (Result<Coupon, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -170,9 +170,9 @@ private extension CouponStore {
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
-            case .success(let updatedCoupon):
-                self.upsertStoredCouponsInBackground(readOnlyCoupons: [updatedCoupon], siteID: updatedCoupon.siteID) {
-                    onCompletion(.success(updatedCoupon))
+            case .success(let createdCoupon):
+                self.upsertStoredCouponsInBackground(readOnlyCoupons: [createdCoupon], siteID: createdCoupon.siteID) {
+                    onCompletion(.success(createdCoupon))
                 }
             }
         }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -159,7 +159,7 @@ private extension CouponStore {
     }
 
     /// Creates a coupon given its details.
-    /// After the API request succeeds, the a new stored coupon should be inserted to the local storage.
+    /// After the API request succeeds, a new stored coupon should be inserted into the local storage.
     /// - Parameters:
     ///   - coupon: The coupon to be created
     ///   - onCompletion: Closure to call after creation is complete. Called on the main thread.

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -15,6 +15,9 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     var didCallUpdateCoupon = false
     var spyUpdateCoupon: Coupon?
 
+    var didCallCreateCoupon = false
+    var spyCreateCoupon: Coupon?
+
     // MARK: - Stub responses
     var resultForLoadAllCoupons: Result<[Coupon], Error>?
 
@@ -42,5 +45,10 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     func updateCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallUpdateCoupon = true
         spyUpdateCoupon = coupon
+    }
+
+    func createCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void) {
+        didCallCreateCoupon = true
+        spyCreateCoupon = coupon
     }
 }

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -393,7 +393,7 @@ final class CouponStoreTests: XCTestCase {
         // this is not really important because we'll test the parsed coupon from the json file
         let sampleCoupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10.00", discountType: .percent)
 
-        network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupon")
 
         // When
         let result: Result<Networking.Coupon, Error> = waitFor { promise in

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -350,6 +350,67 @@ final class CouponStoreTests: XCTestCase {
         XCTAssertEqual(storedCoupon?.amount, "10.00")
         XCTAssertEqual(storedCoupon?.discountType, Coupon.DiscountType.fixedCart.rawValue)
     }
+
+    func test_createCoupon_calls_remote_using_correct_request_parameters() {
+        setUpUsingSpyRemote()
+        // Given
+        let sampleCouponID: Int64 = 720
+        let coupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10", discountType: .percent)
+        let action = CouponAction.createCoupon(coupon) { _ in }
+
+        // When
+        store.onAction(action)
+
+        // Then
+        XCTAssertTrue(remote.didCallCreateCoupon)
+        XCTAssertEqual(remote.spyCreateCoupon, coupon)
+    }
+
+    func test_createCoupon_returns_network_error_on_failure() {
+        // Given
+        let sampleCouponID: Int64 = 720
+        let sampleCoupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10.00")
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "coupons", error: expectedError)
+
+        // When
+        let result: Result<Networking.Coupon, Error> = waitFor { promise in
+            let action = CouponAction.createCoupon(sampleCoupon) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(result.failure as? NetworkError, expectedError)
+        XCTAssertEqual(storedCouponsCount, 0)
+    }
+
+    func test_createCoupon_insert_stored_coupon_upon_success() throws {
+        // Given
+        let sampleCouponID: Int64 = 720
+        // this is not really important because we'll test the parsed coupon from the json file
+        let sampleCoupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10.00", discountType: .percent)
+
+        network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
+
+        // When
+        let result: Result<Networking.Coupon, Error> = waitFor { promise in
+            let action: CouponAction
+            action = .createCoupon(sampleCoupon) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let storedCoupon = viewStorage.loadCoupon(siteID: sampleSiteID, couponID: sampleCouponID)
+        XCTAssertNotNil(storedCoupon)
+        XCTAssertEqual(storedCoupon?.amount, "10.00")
+        XCTAssertEqual(storedCoupon?.discountType, Coupon.DiscountType.fixedCart.rawValue)
+    }
 }
 
 private extension CouponStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5792 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As the title suggests, this PR updates lower layers for coupon creation. Changes include:
- Updates Networking to add a new endpoint for creating coupons.
- Updates `CouponAction` and `CouponStore` for creating coupons.
- Also removes the private method `updateStoredCoupon` in `CouponStore` and use `upsertStoredCouponsInBackground` with a single coupon in the input list to avoid duplicating code when updating and creating coupons.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Coupon creation hasn't been integrated yet so it's good to just have CI passing.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
