### PR TITLE
Simple Payments: Support any currency on amount screen.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -121,7 +121,7 @@ struct SimplePaymentsAmount: View {
                     .opacity(0)
 
                 // Visible & formatted label
-                Text(viewModel.formattedAmmount)
+                Text(viewModel.formattedAmount)
                     .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold))
                     .foregroundColor(Color(viewModel.amountTextColor))
                     .onTapGesture {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -97,6 +97,10 @@ struct SimplePaymentsAmount: View {
     ///
     @ScaledMetric private var scale: CGFloat = 1.0
 
+    /// Defines if the amount input  text field should be focused. Defaults to `true`
+    ///
+    @State private var focusAmountInput: Bool = true
+
     /// ViewModel to drive the view content
     ///
     @ObservedObject private(set) var viewModel: SimplePaymentsAmountViewModel
@@ -112,15 +116,17 @@ struct SimplePaymentsAmount: View {
 
             ZStack(alignment: .center) {
                 // Hidden input text field
-                BindableTextfield("", text: $viewModel.amount)
+                BindableTextfield("", text: $viewModel.amount, focus: $focusAmountInput)
                     .keyboardType(.decimalPad)
-                    .focused()
                     .opacity(0)
 
                 // Visible & formatted label
                 Text(viewModel.formattedAmmount)
                     .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold))
                     .foregroundColor(Color(viewModel.amountTextColor))
+                    .onTapGesture {
+                        focusAmountInput = true
+                    }
             }
             .fixedSize()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -110,14 +110,19 @@ struct SimplePaymentsAmount: View {
             Text(Localization.instructions)
                 .secondaryBodyStyle()
 
-            // Amount Textfield
-            BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount)
-                .font(.systemFont(ofSize: Layout.amountFontSize(scale: scale), weight: .bold))
-                .foregroundColor(.text)
-                .textAlignment(.center)
-                .keyboardType(.decimalPad)
-                .focused()
-                .fixedSize()
+            ZStack(alignment: .center) {
+                // Hidden input text field
+                BindableTextfield("", text: $viewModel.amount)
+                    .keyboardType(.decimalPad)
+                    .focused()
+                    .opacity(0)
+
+                // Visible & formatted label
+                Text(viewModel.formattedAmmount)
+                    .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold))
+                    .foregroundColor(Color(viewModel.amountTextColor))
+            }
+            .fixedSize()
 
             Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -34,7 +34,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
 
     /// Formatted amount to display. When empty displays a placeholder value.
     ///
-    var formattedAmmount: String {
+    var formattedAmount: String {
         guard amount.isNotEmpty else {
             return amountPlaceholder
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -7,12 +7,13 @@ import Experiments
 ///
 final class SimplePaymentsAmountViewModel: ObservableObject {
 
-    /// Stores the amount(formatted) entered by the merchant.
+    /// Stores the amount(unformatted) entered by the merchant.
     ///
     @Published var amount: String = "" {
         didSet {
             guard amount != oldValue else { return }
-            amount = formatAmount(amount)
+            amount = sanitizeAmount(amount)
+            amountWithSymbol = setCurrencySymbol(to: amount)
         }
     }
 
@@ -31,6 +32,21 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
         }
     }
 
+    /// Formatted amount to display. When empty displays a placeholder value.
+    ///
+    var formattedAmmount: String {
+        guard amount.isNotEmpty else {
+            return amountPlaceholder
+        }
+        return amountWithSymbol
+    }
+
+    /// Defines the amount text color.
+    ///
+    var amountTextColor: UIColor {
+        amount.isEmpty ? .textSubtle : .text
+    }
+
     /// Returns true when the amount is not a positive number.
     ///
     var shouldDisableDoneButton: Bool {
@@ -45,11 +61,14 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
         loading
     }
 
+    /// Stores the formatted amount with the store currency symbol.
+    ///
+    private var amountWithSymbol: String = ""
+
     /// Dynamically builds the amount placeholder based on the store decimal separator.
     ///
-    private(set) lazy var amountPlaceholder: String = {
-        // TODO: We are appending the currency symbol always to the left, we should use `CurrencyFormatter` when releasing to more countries.
-        storeCurrencySymbol + "0" + storeCurrencySettings.decimalSeparator + "00"
+    private lazy var amountPlaceholder: String = {
+        currencyFormatter.formatAmount("0.00") ?? "$0.00"
     }()
 
     /// Retains the SummaryViewModel.
@@ -146,30 +165,23 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
 // MARK: Helpers
 private extension SimplePaymentsAmountViewModel {
 
-    /// Formats a received value by making sure the `$` symbol is present and trimming content to two decimal places.
-    /// TODO: Update to support multiple currencies
+    /// Formats a received value by sanitizing the input and trimming content to two decimal places.
     ///
-    func formatAmount(_ amount: String) -> String {
+    func sanitizeAmount(_ amount: String) -> String {
         guard amount.isNotEmpty else { return amount }
 
         let deviceDecimalSeparator = userLocale.decimalSeparator ?? "."
         let storeDecimalSeparator = storeCurrencySettings.decimalSeparator
 
         // Removes any unwanted character & makes sure to use the store decimal separator
-        var formattedAmount = amount
+        let sanitized = amount
             .replacingOccurrences(of: deviceDecimalSeparator, with: storeDecimalSeparator)
-            .filter { $0.isNumber || $0.isCurrencySymbol || "\($0)" == storeDecimalSeparator }
-
-        // Prepend the store currency symbol if needed.
-        // TODO: We are appending the currency symbol always to the left, we should use `CurrencyFormatter` when releasing to more countries.
-        if !formattedAmount.hasPrefix(storeCurrencySymbol) {
-            formattedAmount.insert(contentsOf: storeCurrencySymbol, at: formattedAmount.startIndex)
-        }
+            .filter { $0.isNumber || "\($0)" == storeDecimalSeparator }
 
         // Trim to two decimals & remove any extra "."
-        let components = formattedAmount.components(separatedBy: storeDecimalSeparator)
+        let components = sanitized.components(separatedBy: storeDecimalSeparator)
         switch components.count {
-        case 1 where formattedAmount.contains(storeDecimalSeparator):
+        case 1 where sanitized.contains(storeDecimalSeparator):
             return components[0] + storeDecimalSeparator
         case 1:
             return components[0]
@@ -181,6 +193,15 @@ private extension SimplePaymentsAmountViewModel {
         default:
             fatalError("Should not happen, components can't be 0 or negative")
         }
+    }
+
+    /// Formats a received value by adding the store currency symbol to it's correct position.
+    ///
+    func setCurrencySymbol(to amount: String) -> String {
+        currencyFormatter.formatCurrency(using: amount,
+                                         at: storeCurrencySettings.currencyPosition,
+                                         with: storeCurrencySymbol,
+                                         isNegative: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -172,6 +172,7 @@ private extension SimplePaymentsAmountViewModel {
 
         let deviceDecimalSeparator = userLocale.decimalSeparator ?? "."
         let storeDecimalSeparator = storeCurrencySettings.decimalSeparator
+        let storeNumberOfDecimals = storeCurrencySettings.numberOfDecimals
 
         // Removes any unwanted character & makes sure to use the store decimal separator
         let sanitized = amount
@@ -188,7 +189,7 @@ private extension SimplePaymentsAmountViewModel {
         case 2...Int.max:
             let number = components[0]
             let decimals = components[1]
-            let trimmedDecimals = decimals.count > 2 ? "\(decimals.prefix(2))" : decimals
+            let trimmedDecimals = decimals.count > storeNumberOfDecimals ? "\(decimals.prefix(storeNumberOfDecimals))" : decimals
             return number + storeDecimalSeparator + trimmedDecimals
         default:
             fatalError("Should not happen, components can't be 0 or negative")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
@@ -15,6 +15,10 @@ struct BindableTextfield: UIViewRepresentable {
     ///
     @Binding var text: String
 
+    /// Binding to focus or unfocus the text field.
+    ///
+    @Binding var focus: Bool
+
     /// Textfield font.
     ///
     var font = UIFont.body
@@ -31,9 +35,10 @@ struct BindableTextfield: UIViewRepresentable {
     ///
     var textAlignment = NSTextAlignment.left
 
-    init(_ placeholder: String?, text: Binding<String>) {
+    init(_ placeholder: String?, text: Binding<String>, focus: Binding<Bool>) {
         self.placeHolder = placeholder
         self._text = text
+        self._focus = focus
     }
 
     /// Creates view with the initial configuration.
@@ -47,7 +52,7 @@ struct BindableTextfield: UIViewRepresentable {
     /// Creates coordinator.
     ///
     func makeCoordinator() -> Coordinator {
-        Coordinator(_text)
+        Coordinator(_text, focus: _focus)
     }
 
     /// Updates underlying view.
@@ -59,6 +64,15 @@ struct BindableTextfield: UIViewRepresentable {
         uiView.textColor = foregroundColor
         uiView.textAlignment = textAlignment
         uiView.keyboardType = keyboardType
+
+        switch focus {
+        case true:
+            if !uiView.isFirstResponder {
+                uiView.becomeFirstResponder()
+            }
+        case false:
+            uiView.resignFirstResponder()
+        }
     }
 }
 
@@ -73,8 +87,13 @@ extension BindableTextfield {
         ///
         @Binding var text: String
 
-        init(_ text: Binding<String>) {
+        /// Binding to focus or unfocus the text field.
+        ///
+        @Binding var focus: Bool
+
+        init(_ text: Binding<String>, focus: Binding<Bool>) {
             self._text = text
+            self._focus = focus
         }
 
         /// Relays the input value to the binding variable.
@@ -86,6 +105,22 @@ extension BindableTextfield {
                 text = string
             }
             return false
+        }
+
+        /// Binds focus value when text field starts editing.
+        ///
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            DispatchQueue.main.async {
+                self.focus = true
+            }
+        }
+
+        /// Binds focus value when text field ends editing.
+        ///
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            DispatchQueue.main.async {
+                self.focus = false
+            }
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -31,14 +31,14 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
                                               currencyPosition: .rightSpace,
                                               thousandSeparator: ",",
                                               decimalSeparator: ".",
-                                              numberOfDecimals: 2)
+                                              numberOfDecimals: 3)
         let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: customSettings)
 
         // When
         viewModel.amount = "12.203"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "12.20 £")
+        XCTAssertEqual(viewModel.formattedAmmount, "12.203 £")
     }
 
     func test_view_model_removes_non_digit_characters() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -22,7 +22,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "12"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "$12")
+        XCTAssertEqual(viewModel.formattedAmount, "$12")
     }
 
     func test_view_model_formats_amount_with_custom_currency_settings() {
@@ -38,7 +38,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "12.203"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "12.203 £")
+        XCTAssertEqual(viewModel.formattedAmount, "12.203 £")
     }
 
     func test_view_model_removes_non_digit_characters() {
@@ -49,7 +49,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "hi:11.30-"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "$11.30")
+        XCTAssertEqual(viewModel.formattedAmount, "$11.30")
     }
 
     func test_view_model_trims_more_than_two_decimal_numbers() {
@@ -60,7 +60,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "$67.321432432"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "$67.32")
+        XCTAssertEqual(viewModel.formattedAmount, "$67.32")
     }
 
     func test_view_model_removes_duplicated_decimal_separators() {
@@ -71,7 +71,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "$6.7.3"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "$6.7")
+        XCTAssertEqual(viewModel.formattedAmount, "$6.7")
     }
 
     func test_view_model_removes_consecutive_decimal_separators() {
@@ -82,7 +82,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "$6..."
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "$6.")
+        XCTAssertEqual(viewModel.formattedAmount, "$6.")
     }
 
     func test_view_model_disables_next_button_when_there_is_no_amount() {
@@ -138,7 +138,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "10,25"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "$10.25")
+        XCTAssertEqual(viewModel.formattedAmount, "$10.25")
     }
 
     func test_view_model_uses_the_store_currency_symbol() {
@@ -150,7 +150,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "10.25"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmmount, "€10.25")
+        XCTAssertEqual(viewModel.formattedAmount, "€10.25")
     }
 
     func test_amount_placeholder_is_formatted_with_store_currency_settings() {
@@ -159,7 +159,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
 
         // When & Then
-        XCTAssertEqual(viewModel.formattedAmmount, "€0,00")
+        XCTAssertEqual(viewModel.formattedAmount, "€0,00")
     }
 
     func test_view_model_enables_loading_state_while_performing_network_operations() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -22,7 +22,23 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "12"
 
         // Then
-        XCTAssertEqual(viewModel.amount, "$12")
+        XCTAssertEqual(viewModel.formattedAmmount, "$12")
+    }
+
+    func test_view_model_formats_amount_with_custom_currency_settings() {
+        // Given
+        let customSettings = CurrencySettings(currencyCode: .GBP,
+                                              currencyPosition: .rightSpace,
+                                              thousandSeparator: ",",
+                                              decimalSeparator: ".",
+                                              numberOfDecimals: 2)
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: customSettings)
+
+        // When
+        viewModel.amount = "12.203"
+
+        // Then
+        XCTAssertEqual(viewModel.formattedAmmount, "12.20 £")
     }
 
     func test_view_model_removes_non_digit_characters() {
@@ -33,7 +49,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "hi:11.30-"
 
         // Then
-        XCTAssertEqual(viewModel.amount, "$11.30")
+        XCTAssertEqual(viewModel.formattedAmmount, "$11.30")
     }
 
     func test_view_model_trims_more_than_two_decimal_numbers() {
@@ -44,7 +60,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "$67.321432432"
 
         // Then
-        XCTAssertEqual(viewModel.amount, "$67.32")
+        XCTAssertEqual(viewModel.formattedAmmount, "$67.32")
     }
 
     func test_view_model_removes_duplicated_decimal_separators() {
@@ -55,7 +71,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "$6.7.3"
 
         // Then
-        XCTAssertEqual(viewModel.amount, "$6.7")
+        XCTAssertEqual(viewModel.formattedAmmount, "$6.7")
     }
 
     func test_view_model_removes_consecutive_decimal_separators() {
@@ -66,7 +82,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "$6..."
 
         // Then
-        XCTAssertEqual(viewModel.amount, "$6.")
+        XCTAssertEqual(viewModel.formattedAmmount, "$6.")
     }
 
     func test_view_model_disables_next_button_when_there_is_no_amount() {
@@ -122,7 +138,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "10,25"
 
         // Then
-        XCTAssertEqual(viewModel.amount, "$10.25")
+        XCTAssertEqual(viewModel.formattedAmmount, "$10.25")
     }
 
     func test_view_model_uses_the_store_currency_symbol() {
@@ -134,7 +150,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         viewModel.amount = "10.25"
 
         // Then
-        XCTAssertEqual(viewModel.amount, "€10.25")
+        XCTAssertEqual(viewModel.formattedAmmount, "€10.25")
     }
 
     func test_amount_placeholder_is_formatted_with_store_currency_settings() {
@@ -143,7 +159,7 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
 
         // When & Then
-        XCTAssertEqual(viewModel.amountPlaceholder, "€0,00")
+        XCTAssertEqual(viewModel.formattedAmmount, "€0,00")
     }
 
     func test_view_model_enables_loading_state_while_performing_network_operations() {


### PR DESCRIPTION
close #5784 

# Why

As "Simple Payments" is now available for all stores, it is fair to support all currencies with propper formatting following the store currency settings.

# How

First, we now use `CurrencyFormatter` to add the currency symbol in the correct position, which could be (left, left with space, right, right with space)

Second, as symbols can be placed on the right(with or without space), we have to decouple input from content rendered to prevent merchants from deleting the symbol when they are trying to remove a number.

In order to do that, I have hidden the input field and added a new label that renders the content entered in the input field + the store symbol.

This caused another problem which is that the keyboard could be dismissed when attempting an interactive dismissal, so in order to bring the keyboard back, we had to implement a keyboard focus that worked in all iOS versions.

# Demo

https://user-images.githubusercontent.com/562080/148083921-b3a38c4b-5b8b-49c6-82b4-a77978d4c9ee.mov

# Testing Steps

- Go to your store settings and change the currency symbol settings.
- Launch the app, wait for it to sync, and start the simple payments flow.
- See that the amount you entered is formatted with the new store currency settings.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
