### PR TITLE
Order Creation: Add basic payment section

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -60,6 +60,13 @@ struct NewOrder: View {
 
                         Spacer(minLength: Layout.sectionSpacing)
 
+                        Group {
+                            OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
+
+                            Spacer(minLength: Layout.sectionSpacing)
+                        }
+                        .renderedIf(viewModel.orderDetails.items.isNotEmpty)
+
                         OrderCustomerSection(geometry: geometry,
                                              viewModel: viewModel.customerDataViewModel,
                                              addressFormViewModel: viewModel.createOrderAddressFormViewModel())

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -65,7 +65,7 @@ struct NewOrder: View {
 
                             Spacer(minLength: Layout.sectionSpacing)
                         }
-                        .renderedIf(viewModel.orderDetails.items.isNotEmpty)
+                        .renderedIf(viewModel.shouldShowPaymentSection)
 
                         OrderCustomerSection(geometry: geometry,
                                              viewModel: viewModel.customerDataViewModel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -60,12 +60,11 @@ struct NewOrder: View {
 
                         Spacer(minLength: Layout.sectionSpacing)
 
-                        Group {
+                        if viewModel.shouldShowPaymentSection {
                             OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
 
                             Spacer(minLength: Layout.sectionSpacing)
                         }
-                        .renderedIf(viewModel.shouldShowPaymentSection)
 
                         OrderCustomerSection(geometry: geometry,
                                              viewModel: viewModel.customerDataViewModel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -98,6 +98,14 @@ final class NewOrderViewModel: ObservableObject {
 
     // MARK: Payment properties
 
+    /// Indicates if the Payment section should be shown
+    ///
+    var shouldShowPaymentSection: Bool {
+        orderDetails.items.isNotEmpty
+    }
+
+    /// Representation of payment data display properties
+    ///
     @Published private(set) var paymentDataViewModel = PaymentDataViewModel()
 
     init(siteID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -8,6 +8,7 @@ final class NewOrderViewModel: ObservableObject {
     let siteID: Int64
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private let currencyFormatter: CurrencyFormatter
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -95,15 +96,24 @@ final class NewOrderViewModel: ObservableObject {
     ///
     @Published var selectedOrderItem: NewOrderItem? = nil
 
-    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, storageManager: StorageManagerType = ServiceLocator.storageManager) {
+    // MARK: Payment properties
+
+    @Published private(set) var paymentDataViewModel = PaymentDataViewModel()
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
 
         configureNavigationTrailingItem()
         configureStatusBadgeViewModel()
         configureProductRowViewModels()
         configureCustomerDataViewModel()
+        configurePaymentDataViewModel()
     }
 
     /// Selects an order item.
@@ -263,6 +273,20 @@ extension NewOrderViewModel {
                       shippingAddressFormatted: shippingAddress?.fullNameWithCompanyAndAddress)
         }
     }
+
+    /// Representation of payment data display properties
+    ///
+    struct PaymentDataViewModel {
+        let itemsTotal: String
+        let orderTotal: String
+
+        init(itemsTotal: String = "",
+             orderTotal: String = "",
+             currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+            self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? ""
+            self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? ""
+        }
+    }
 }
 
 // MARK: - Helpers
@@ -331,5 +355,26 @@ private extension NewOrderViewModel {
                 CustomerDataViewModel(billingAddress: $0.billingAddress, shippingAddress: $0.shippingAddress)
             }
             .assign(to: &$customerDataViewModel)
+    }
+
+    /// Updates payment section view model based on items in the order.
+    ///
+    func configurePaymentDataViewModel() {
+        $orderDetails
+            .map { [weak self] orderDetails in
+                guard let self = self else {
+                    return PaymentDataViewModel()
+                }
+
+                let itemsTotal = orderDetails.items
+                    .map { $0.orderItem.subtotal }
+                    .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
+                    .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
+                    .stringValue
+
+                // For now, the order total is the same as the items total
+                return PaymentDataViewModel(itemsTotal: itemsTotal, orderTotal: itemsTotal, currencyFormatter: self.currencyFormatter)
+            }
+            .assign(to: &$paymentDataViewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -13,7 +13,7 @@ struct OrderPaymentSection: View {
     var body: some View {
         Divider()
 
-        VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+        VStack(alignment: .leading, spacing: .zero) {
             Text(Localization.payment)
                 .headlineStyle()
                 .padding()
@@ -35,9 +35,6 @@ struct OrderPaymentSection: View {
 
 // MARK: Constants
 private extension OrderPaymentSection {
-    enum Layout {
-        static let verticalSpacing: CGFloat = 0.0
-    }
     enum Localization {
         static let payment = NSLocalizedString("Payment", comment: "Title text of the section that shows Payment details when creating a new order")
         static let productsTotal = NSLocalizedString("Products Total", comment: "Label for the row showing the total cost of products in the order")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -21,6 +21,10 @@ struct OrderPaymentSection: View {
             TitleAndValueRow(title: Localization.productsTotal, value: .content(viewModel.itemsTotal), selectable: false) {}
 
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectable: false) {}
+
+            Text(Localization.taxesInfo)
+                .footnoteStyle()
+                .padding([.horizontal, .bottom])
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.listForeground))
@@ -38,6 +42,8 @@ private extension OrderPaymentSection {
         static let payment = NSLocalizedString("Payment", comment: "Title text of the section that shows Payment details when creating a new order")
         static let productsTotal = NSLocalizedString("Products Total", comment: "Label for the row showing the total cost of products in the order")
         static let orderTotal = NSLocalizedString("Order Total", comment: "Label for the the row showing the total cost of the order")
+        static let taxesInfo = NSLocalizedString("Total excluding taxes. Taxes will be automatically calculated based on your store settings.",
+                                                 comment: "Information about taxes and the order total when creating a new order")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Represents the Payment section in an order
+///
+struct OrderPaymentSection: View {
+    /// View model to drive the view content
+    let viewModel: NewOrderViewModel.PaymentDataViewModel
+
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
+    var body: some View {
+        Divider()
+
+        VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+            Text(Localization.payment)
+                .headlineStyle()
+                .padding()
+
+            TitleAndValueRow(title: Localization.productsTotal, value: .content(viewModel.itemsTotal), selectable: false) {}
+
+            TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectable: false) {}
+        }
+        .padding(.horizontal, insets: safeAreaInsets)
+        .background(Color(.listForeground))
+
+        Divider()
+    }
+}
+
+// MARK: Constants
+private extension OrderPaymentSection {
+    enum Layout {
+        static let verticalSpacing: CGFloat = 0.0
+    }
+    enum Localization {
+        static let payment = NSLocalizedString("Payment", comment: "Title text of the section that shows Payment details when creating a new order")
+        static let productsTotal = NSLocalizedString("Products Total", comment: "Label for the row showing the total cost of products in the order")
+        static let orderTotal = NSLocalizedString("Order Total", comment: "Label for the the row showing the total cost of the order")
+    }
+}
+
+struct OrderPaymentSection_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00", orderTotal: "20.00")
+
+        OrderPaymentSection(viewModel: viewModel)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1125,6 +1125,7 @@
 		CC0324A3263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */; };
 		CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */; };
 		CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */; };
+		CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */; };
 		CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */; };
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
 		CC254F3226C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */; };
@@ -2699,6 +2700,7 @@
 		CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
 		CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactory.swift; sourceTree = "<group>"; };
 		CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactoryTests.swift; sourceTree = "<group>"; };
+		CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentSection.swift; sourceTree = "<group>"; };
 		CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackage.swift; sourceTree = "<group>"; };
 		CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModel.swift; sourceTree = "<group>"; };
@@ -6054,6 +6056,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		CC200BAF27847D9300EC5884 /* PaymentSection */ = {
+			isa = PBXGroup;
+			children = (
+				CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */,
+			);
+			path = PaymentSection;
+			sourceTree = "<group>";
+		};
 		CC254F2E26C2A4E6005F3C82 /* Package Creation */ = {
 			isa = PBXGroup;
 			children = (
@@ -6332,6 +6342,7 @@
 				CCFC50542743BC0D001E505F /* NewOrder.swift */,
 				CCFC50582743E021001E505F /* NewOrderViewModel.swift */,
 				AE264C05275A495E00B52996 /* FlowCoordinator */,
+				CC200BAF27847D9300EC5884 /* PaymentSection */,
 				CC53FB3627551A8700C4CA4F /* ProductsSection */,
 				AE9E04732776034B003FA09E /* CustomerSection */,
 				AE264C04275A493800B52996 /* StatusSection */,
@@ -8803,6 +8814,7 @@
 				CE8CCD43239AC06E009DBD22 /* RefundDetailsViewController.swift in Sources */,
 				B560D68C2195BD1E0027BB7E /* NoteDetailsCommentTableViewCell.swift in Sources */,
 				451C77712404518600413F73 /* ProductSettingsRows.swift in Sources */,
+				CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */,
 				743E272021AEF20100D6DC82 /* FancyAlertViewController+Upgrade.swift in Sources */,
 				CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */,
 				023053492374528A00487A64 /* AztecBlockquoteFormatBarCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -18,6 +18,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.navigationTrailingItem, .none)
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "pending")
         XCTAssertEqual(viewModel.productRows.count, 0)
+        XCTAssertFalse(viewModel.shouldShowPaymentSection)
     }
 
     func test_create_button_is_enabled_when_order_detail_changes_from_default_value() {
@@ -247,7 +248,23 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
     }
 
-    func test_payment_data_is_updated_when_products_update() {
+    func test_payment_section_only_displayed_when_order_has_products() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish")
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // When & Then
+        viewModel.addProductViewModel.selectProduct(product.productID)
+        XCTAssertTrue(viewModel.shouldShowPaymentSection)
+
+        // When & Then
+        viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
+        XCTAssertFalse(viewModel.shouldShowPaymentSection)
+    }
+
+    func test_payment_section_is_updated_when_products_update() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish", price: "8.50")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -230,6 +230,41 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertNotNil(customerDataViewModel.billingAddressFormatted)
         XCTAssertNil(customerDataViewModel.shippingAddressFormatted)
     }
+
+    func test_payment_data_view_model_is_initialized_with_expected_values() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+        let itemsTotal = "20.00"
+        let orderTotal = "30.00"
+
+        // When
+        let paymentDataViewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: itemsTotal,
+                                                                          orderTotal: orderTotal,
+                                                                          currencyFormatter: CurrencyFormatter(currencySettings: currencySettings))
+
+        // Then
+        XCTAssertEqual(paymentDataViewModel.itemsTotal, "£20.00")
+        XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
+    }
+
+    func test_payment_data_is_updated_when_products_update() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish", price: "8.50")
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, currencySettings: currencySettings)
+
+        // When & Then
+        viewModel.addProductViewModel.selectProduct(product.productID)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
+
+        // When & Then
+        viewModel.productRows[0].incrementQuantity()
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£17.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£17.00")
+    }
 }
 
 private extension MockStorageManager {


### PR DESCRIPTION
Closes: #5411

## Description

This adds a basic Payment section to the new order screen, in the order creation flow.

The Payment section appears when there is at least one product in the order. For now, it is a read-only summary showing the total cost of the products in the order.

**Question:** Should we show some kind of info text about the "Order Total" to explain that taxes may be calculated automatically and added to this total? (Also raised in Slack: p1641317781008900-slack-C02KUCFCSFP)

## Changes

* New `OrderPaymentSection` view that displays the Products Total and Order Total with formatted amounts.
* Adds `OrderPaymentSection` to `NewOrder` view.
* `NewOrderViewModel` manages the Payment section properties:
   * `shouldShowPaymentSection` indicates if the Payment section should be shown, depending on whether there are items in the order.
   * `PaymentDataViewModel` is a new struct that represents the payment data. It takes unformatted totals and formats them according to the provided currency formatter.
   * `configurePaymentDataViewModel()` updates the payment data based on the total price of the items in the order.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. Confirm there is no Payment section visible on the New Order screen.
5. Add a product to the order.
6. Confirm a Payment section now appears with the correct product total.
7. Change the products in the order (multiple products, different quantities) and confirm the Payment section updates accordingly.

## Screenshots

<img src="https://user-images.githubusercontent.com/8658164/148113260-62ae224f-0c6c-4f62-8adf-fde73d8ef487.png" width="300px">

https://user-images.githubusercontent.com/8658164/148113270-0245b762-65a0-4085-b7c2-a03f874719f2.mp4

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.