### PR TITLE
Simple Payments: Prevent amount overflowing the screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -124,11 +124,13 @@ struct SimplePaymentsAmount: View {
                 Text(viewModel.formattedAmmount)
                     .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold))
                     .foregroundColor(Color(viewModel.amountTextColor))
+                    .minimumScaleFactor(0.1)
+                    .lineLimit(1)
                     .onTapGesture {
                         focusAmountInput = true
                     }
             }
-            .fixedSize()
+            .fixedSize(horizontal: false, vertical: true)
 
             Spacer()
 


### PR DESCRIPTION
closes #5783 

# Why

Currently, the merchant can enter such an amount that overflows the screen. This PR shrinks the amount font size to make the content fit the screen. The bug was more noticeable when using big fonts.

# Demo

https://user-images.githubusercontent.com/562080/148127559-94d70ab6-8913-4c7e-93ee-f4630ec72c3a.mov

# Testing Steps

- Launch the app and start the simple payments flow
- Enter a big amount eg: 10000000000000000
- See that the app properly reduces de font size to keep the amount within the screen bounds

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
