### PR TITLE
Update time range date text

### DIFF
--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -10,17 +10,25 @@ extension DateFormatter {
 
         // MARK: - Chark axis formatters
 
-        /// Date formatter used for creating the date displayed on a chart axis for **hour** granularity.
+        /// Date formatter used for creating the date for a selected date displayed on the time range bar for **hour** granularity.
         ///
-        public static let chartAxisHourFormatter: DateFormatter = {
+        public static let chartSelectedDateHourFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d, h:mm a")
             return formatter
         }()
 
+        /// Date formatter used for creating the date for a selected date displayed on the time range bar for **hour** granularity.
+        ///
+        public static let legacyChartSelectedDateHourFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("ha")
+            return formatter
+        }()
+
         /// Date formatter used for creating the date displayed on a chart axis for **hour** granularity.
         ///
-        public static let legacyChartAxisHourFormatter: DateFormatter = {
+        public static let chartAxisHourFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("ha")
             return formatter

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -14,6 +14,14 @@ extension DateFormatter {
         ///
         public static let chartAxisHourFormatter: DateFormatter = {
             let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d, h:mm a")
+            return formatter
+        }()
+
+        /// Date formatter used for creating the date displayed on a chart axis for **hour** granularity.
+        ///
+        public static let legacyChartAxisHourFormatter: DateFormatter = {
+            let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("ha")
             return formatter
         }()
@@ -53,6 +61,14 @@ extension DateFormatter {
         /// Date formatter used for displaying the full month on a chart axis.
         ///
         public static let chartAxisFullMonthFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("MMMM yyyy")
+            return formatter
+        }()
+
+        /// Date formatter used for displaying the full month on a chart axis.
+        ///
+        public static let legacyChartAxisFullMonthFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("MMMM")
             return formatter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -49,7 +49,9 @@ private extension StatsTimeRangeV4 {
         case .thisWeek:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
         case .thisMonth:
-            dateFormatter = isMyStoreTabUpdatesEnabled ? DateFormatter.Charts.chartAxisFullMonthFormatter: DateFormatter.Charts.legacyChartAxisFullMonthFormatter
+            dateFormatter = isMyStoreTabUpdatesEnabled ?
+            DateFormatter.Charts.chartAxisFullMonthFormatter:
+            DateFormatter.Charts.legacyChartAxisFullMonthFormatter
         case .thisYear:
             dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -1,3 +1,4 @@
+import Experiments
 import Yosemite
 
 private extension StatsTimeRangeV4 {
@@ -67,7 +68,8 @@ struct StatsTimeRangeBarViewModel: Equatable {
     init(startDate: Date,
          endDate: Date,
          timeRange: StatsTimeRangeV4,
-         timezone: TimeZone) {
+         timezone: TimeZone,
+         isMyStoreTabUpdatesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates)) {
         timeRangeText = timeRange.timeRangeText(startDate: startDate,
                                                 endDate: endDate,
                                                 timezone: timezone)
@@ -77,7 +79,8 @@ struct StatsTimeRangeBarViewModel: Equatable {
          endDate: Date,
          selectedDate: Date,
          timeRange: StatsTimeRangeV4,
-         timezone: TimeZone) {
+         timezone: TimeZone,
+         isMyStoreTabUpdatesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates)) {
         timeRangeText = timeRange.timeRangeText(startDate: startDate,
                                                 endDate: endDate,
                                                 selectedDate: selectedDate,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -64,7 +64,9 @@ private extension StatsTimeRangeV4 {
         let dateFormatter: DateFormatter
         switch self {
         case .today:
-            dateFormatter = isMyStoreTabUpdatesEnabled ? DateFormatter.Charts.chartAxisHourFormatter: DateFormatter.Charts.legacyChartAxisHourFormatter
+            dateFormatter = isMyStoreTabUpdatesEnabled ?
+            DateFormatter.Charts.chartSelectedDateHourFormatter:
+            DateFormatter.Charts.legacyChartSelectedDateHourFormatter
         case .thisWeek, .thisMonth:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
         case .thisYear:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -1,18 +1,26 @@
 import XCTest
 @testable import WooCommerce
 
-class StatsTimeRangeBarViewModelTests: XCTestCase {
+final class StatsTimeRangeBarViewModelTests: XCTestCase {
 
-    func testTodayText() {
+    // MARK: - Legacy (`myStoreTabUpdates` feature flag disabled)
+
+    func test_today_text_with_myStoreTabUpdates_feature_disabled() {
+        // Given
         // GMT: Thursday, August 15, 2019 6:14:35 PM
         let startDate = Date(timeIntervalSince1970: 1565892875)
         // GMT: Friday, August 16, 2019 2:14:35 AM
         let endDate = Date(timeIntervalSince1970: 1565921675)
         let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
         let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
                                                    endDate: endDate,
                                                    timeRange: .today,
-                                                   timezone: timezone)
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
         formatter.timeZone = timezone
@@ -20,16 +28,54 @@ class StatsTimeRangeBarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.timeRangeText, expectedText)
     }
 
-    func testThisWeekText() {
+    func test_today_text_with_selected_date_and_myStoreTabUpdates_feature_disabled() {
+        // Given
+        // GMT: Thursday, August 15, 2019 6:14:35 PM
+        let startDate = Date(timeIntervalSince1970: 1565892875)
+        // GMT: Friday, August 16, 2019 2:14:35 AM
+        let endDate = Date(timeIntervalSince1970: 1565921675)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .today,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
+        formatter.timeZone = timezone
+        let timeRangeString = formatter.string(from: startDate)
+
+        let selectedDateFormatter = DateFormatter()
+        selectedDateFormatter.setLocalizedDateFormatFromTemplate("ha")
+        selectedDateFormatter.timeZone = timezone
+        let selectedDateString = selectedDateFormatter.string(from: startDate)
+
+        let dateBreadcrumbFormat = NSLocalizedString("%1$@ › %2$@", comment: "Displays a time range followed by a specific date/time")
+        let expectedText = String.localizedStringWithFormat(dateBreadcrumbFormat, timeRangeString, selectedDateString)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisWeek_text_with_myStoreTabUpdates_feature_disabled() {
+        // Given
         // GMT: Sunday, July 28, 2019 12:00:00 AM
         let startDate = Date(timeIntervalSince1970: 1564272000)
         // GMT: Saturday, August 3, 2019 11:59:59 PM
         let endDate = Date(timeIntervalSince1970: 1564876799)
         let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
         let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
                                                    endDate: endDate,
                                                    timeRange: .thisWeek,
-                                                   timezone: timezone)
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
         formatter.timeZone = timezone
@@ -39,16 +85,46 @@ class StatsTimeRangeBarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.timeRangeText, expectedText)
     }
 
-    func testThisMonthText() {
+    func test_thisWeek_text_with_selected_date_and_myStoreTabUpdates_feature_disabled() {
+        // Given
         // GMT: Sunday, July 28, 2019 12:00:00 AM
         let startDate = Date(timeIntervalSince1970: 1564272000)
         // GMT: Saturday, August 3, 2019 11:59:59 PM
         let endDate = Date(timeIntervalSince1970: 1564876799)
         let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .thisWeek,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate) // "Jul 28" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisMonth_text_with_myStoreTabUpdates_feature_disabled() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
         let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
                                                    endDate: endDate,
                                                    timeRange: .thisMonth,
-                                                   timezone: timezone)
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("MMMM")
         formatter.timeZone = timezone
@@ -56,20 +132,83 @@ class StatsTimeRangeBarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.timeRangeText, expectedText)
     }
 
-    func testThisYearText() {
+    func test_thisMonth_text_with_selected_date_and_myStoreTabUpdates_feature_disabled() {
+        // Given
         // GMT: Sunday, July 28, 2019 12:00:00 AM
         let startDate = Date(timeIntervalSince1970: 1564272000)
         // GMT: Saturday, August 3, 2019 11:59:59 PM
         let endDate = Date(timeIntervalSince1970: 1564876799)
         let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .thisMonth,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate) // "Jul 28" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisYear_text_with_myStoreTabUpdates_feature_disabled() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
         let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
                                                    endDate: endDate,
                                                    timeRange: .thisYear,
-                                                   timezone: timezone)
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("yyyy")
         formatter.timeZone = timezone
         let expectedText = formatter.string(from: startDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisYear_text_with_selected_date_and_myStoreTabUpdates_feature_disabled() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .thisYear,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: false)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("yyyy")
+        formatter.timeZone = timezone
+        let timeRangeString = formatter.string(from: startDate)
+
+        let selectedDateFormatter = DateFormatter()
+        selectedDateFormatter.setLocalizedDateFormatFromTemplate("MMMM")
+        selectedDateFormatter.timeZone = timezone
+        let selectedDateString = selectedDateFormatter.string(from: startDate)
+
+        let dateBreadcrumbFormat = NSLocalizedString("%1$@ › %2$@", comment: "Displays a time range followed by a specific date/time")
+        // "2019 › July" in en-US locale.
+        let expectedText = String.localizedStringWithFormat(dateBreadcrumbFormat, timeRangeString, selectedDateString)
         XCTAssertEqual(viewModel.timeRangeText, expectedText)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -2,6 +2,196 @@ import XCTest
 @testable import WooCommerce
 
 final class StatsTimeRangeBarViewModelTests: XCTestCase {
+    func test_today_text() {
+        // Given
+        // GMT: Thursday, August 15, 2019 6:14:35 PM
+        let startDate = Date(timeIntervalSince1970: 1565892875)
+        // GMT: Friday, August 16, 2019 2:14:35 AM
+        let endDate = Date(timeIntervalSince1970: 1565921675)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .today,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_today_text_with_selected_date() {
+        // Given
+        // GMT: Thursday, August 15, 2019 6:14:35 PM
+        let startDate = Date(timeIntervalSince1970: 1565892875)
+        // GMT: Friday, August 16, 2019 2:14:35 AM
+        let endDate = Date(timeIntervalSince1970: 1565921675)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .today,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d, h:mm a")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate) // "Thursday, Aug 15, 6:14 PM" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisWeek_text() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .thisWeek,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        // "Jul 28 - Aug 3" in en-US locale.
+        let expectedText = String.localizedStringWithFormat(NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a stats interval"),
+                                                            formatter.string(from: startDate),
+                                                            formatter.string(from: endDate))
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisWeek_text_with_selected_date() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .thisWeek,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate) // "Jul 28" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisMonth_text() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .thisMonth,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMMM yyyy")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate) // "July 2019" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisMonth_text_with_selected_date() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .thisMonth,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate) // "Jul 28" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisYear_text() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .thisYear,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("yyyy")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_thisYear_text_with_selected_date() {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: startDate,
+                                                   timeRange: .thisYear,
+                                                   timezone: timezone,
+                                                   isMyStoreTabUpdatesEnabled: true)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMMM yyyy")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate) // "July 2019" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
 
     // MARK: - Legacy (`myStoreTabUpdates` feature flag disabled)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStatsV4ChartAxisHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStatsV4ChartAxisHelperTests.swift
@@ -1,10 +1,34 @@
 import XCTest
 @testable import WooCommerce
 
-class StoreStatsV4ChartAxisHelperTests: XCTestCase {
+final class StoreStatsV4ChartAxisHelperTests: XCTestCase {
     private let helper = StoreStatsV4ChartAxisHelper()
 
-    func testDatesAcrossTwoMonths() {
+    // MARK: - Today
+
+    func test_generateLabelText_for_today_contains_hour_text() throws {
+        // Given
+        // GMT: Wednesday, January 5, 2022 12:50:05 AM
+        let dateAt12AM = Date(timeIntervalSince1970: 1641343805)
+        // GMT: Wednesday, January 5, 2022 5:50:05 PM
+        let dateAt5PM = Date(timeIntervalSince1970: 1641405005)
+        let dates = [dateAt12AM, dateAt5PM]
+        let timezone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+
+        // When
+        let text = helper.generateLabelText(for: dates, timeRange: .today, siteTimezone: timezone)
+
+        // Then
+        // "12 AM" in en-US locale.
+        XCTAssertEqual(text[0], todayXAxisFormatter(timezone: timezone).string(from: dateAt12AM))
+        // "5 PM" in en-US locale.
+        XCTAssertEqual(text[1], todayXAxisFormatter(timezone: timezone).string(from: dateAt5PM))
+    }
+
+    // MARK: - This Week
+
+    func test_generateLabelText_for_thisWeek_with_dates_across_two_months_contains_month_text_for_first_different_month() {
+        // Given
         // GMT: Saturday, June 1, 2019 12:29:29 AM
         let dateInJune = Date(timeIntervalSince1970: 1559348969)
         // GMT: Monday, June 10, 2019 12:29:29 AM
@@ -13,7 +37,11 @@ class StoreStatsV4ChartAxisHelperTests: XCTestCase {
         let dateInAugust = Date(timeIntervalSince1970: 1564619369)
         let dates = [dateInAugust, dateInJune, secondDateInJune]
         let timezone = TimeZone(identifier: "GMT")!
+
+        // When
         let text = helper.generateLabelText(for: dates, timeRange: .thisWeek, siteTimezone: timezone)
+
+        // Then
         let textOfDateInAugust = text[0]
         let textOfFirstDateInJune = text[1]
         let textOfSecondDateInJune = text[2]
@@ -22,16 +50,93 @@ class StoreStatsV4ChartAxisHelperTests: XCTestCase {
         XCTAssertEqual(textOfSecondDateInJune, dayOfMonthFormatter(timezone: timezone).string(from: secondDateInJune))
     }
 
-    private func dayOfMonthFormatter(timezone: TimeZone) -> DateFormatter {
+    func test_generateLabelText_for_thisWeek_with_dates_in_the_same_month_only_contains_month_text_for_the_first_date() throws {
+        // Given
+        // GMT: Wednesday, January 5, 2022 12:50:05 AM
+        let dateOnJan5 = Date(timeIntervalSince1970: 1641343805)
+        // GMT: Wednesday, January 12, 2022 5:50:05 PM
+        let dateOnJan12 = Date(timeIntervalSince1970: 1642009805)
+        let dates = [dateOnJan12, dateOnJan5]
+        let timezone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+
+        // When
+        let text = helper.generateLabelText(for: dates, timeRange: .thisWeek, siteTimezone: timezone)
+
+        // Then
+        // "Jan 12" in en-US locale.
+        XCTAssertEqual(text[0], dayMonthFormatter(timezone: timezone).string(from: dateOnJan12))
+        // "5" in en-US locale (no month text).
+        XCTAssertEqual(text[1], dayOfMonthFormatter(timezone: timezone).string(from: dateOnJan5))
+    }
+
+    // MARK: - This Month
+
+    func test_generateLabelText_for_thisMonth_only_contains_month_text_for_the_first_date() throws {
+        // Given
+        // GMT: Wednesday, January 5, 2022 12:50:05 AM
+        let dateOnJan5 = Date(timeIntervalSince1970: 1641343805)
+        // GMT: Wednesday, January 12, 2022 5:50:05 PM
+        let dateOnJan12 = Date(timeIntervalSince1970: 1642009805)
+        let dates = [dateOnJan12, dateOnJan5]
+        let timezone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+
+        // When
+        let text = helper.generateLabelText(for: dates, timeRange: .thisMonth, siteTimezone: timezone)
+
+        // Then
+        // "Jan 12" in en-US locale.
+        XCTAssertEqual(text[0], dayMonthFormatter(timezone: timezone).string(from: dateOnJan12))
+        // "5" in en-US locale (no month text).
+        XCTAssertEqual(text[1], dayOfMonthFormatter(timezone: timezone).string(from: dateOnJan5))
+    }
+
+    // MARK: - This Year
+
+    func test_generateLabelText_for_thisYear_has_month_text_for_all_dates() throws {
+        // Given
+        // GMT: Friday, March 11, 2022 5:50:05 PM
+        let dateInMarch = Date(timeIntervalSince1970: 1647021005)
+        // GMT: Wednesday, January 12, 2022 5:50:05 PM
+        let dateInJan = Date(timeIntervalSince1970: 1642009805)
+        let dates = [dateInMarch, dateInJan]
+        let timezone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+
+        // When
+        let text = helper.generateLabelText(for: dates, timeRange: .thisYear, siteTimezone: timezone)
+
+        // Then
+        // "Mar" in en-US locale.
+        XCTAssertEqual(text[0], monthFormatter(timezone: timezone).string(from: dateInMarch))
+        // "Jan" in en-US locale (no month text).
+        XCTAssertEqual(text[1], monthFormatter(timezone: timezone).string(from: dateInJan))
+    }
+}
+
+private extension StoreStatsV4ChartAxisHelperTests {
+    func dayOfMonthFormatter(timezone: TimeZone) -> DateFormatter {
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("d")
         formatter.timeZone = timezone
         return formatter
     }
 
-    private func dayMonthFormatter(timezone: TimeZone) -> DateFormatter {
+    func dayMonthFormatter(timezone: TimeZone) -> DateFormatter {
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        return formatter
+    }
+
+    func monthFormatter(timezone: TimeZone) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM")
+        formatter.timeZone = timezone
+        return formatter
+    }
+
+    func todayXAxisFormatter(timezone: TimeZone) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("ha")
         formatter.timeZone = timezone
         return formatter
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5743 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For Home Screen M2, we are also updating the text that displays the time range under the tab selector (see screenshots). Sorry about the 500+ diffs in this PR, about 2/3 of the changes are on unit tests for both feature flag states to prevent regression. Most of the time range text stays the same, with the following changes:

- `Today`: when selecting an interval, the time range text changes from "Wednesday, Jan 5 > 1AM" to "Wednesday, Jan 5, 1:00 AM" (in the design, it uses lowercase `am`/`pm` but this is not feasible in iOS without breaking localization)
- `This Week`: the time range text changes from "Sep 6-Sep 12" to "Sep 6 - Sep 12" (extra space around the hyphen)
- `This Month`: the time range text changes from "March" to "March 2021" (adding the year)
- `This Year`: when selecting an interval, the time range text changes from "2022 > March" to "March 2022"

It's a bit challenging to make changes while maintaining both feature flag states, so I added/updated unit tests for each time range and each feature flag state. There are date formatters reused for the x-axis labels, and some test cases were added for x-axis labels as well.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Let's focus on testing the feature flag enabled state, and the screenshots for the feature flag disabled state are shown below.

Prerequisite: the store has at least one order for today so that the chart for each time range is interactive.

- Launch the app
- After stats are loaded, check the time range text below the time range tab selector --> the time range text should follow the design
- For each time range tab, select an interval in the chart --> the time range text should follow design (the design doesn't have the selected state for all time ranges, so I assume it's using the non-selected state for the same granularity)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | Today | This Week | This Month | This Year
-- | -- | -- | -- | --
new design (selected) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 26](https://user-images.githubusercontent.com/1945542/148166817-de486c31-834a-491b-a947-af129fb3b0e4.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 41](https://user-images.githubusercontent.com/1945542/148166820-d0f8bb89-2bab-45b7-9cd8-e9f5b9134084.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 46](https://user-images.githubusercontent.com/1945542/148166823-a43adbad-df2e-48b9-9281-a6cdd21be1ad.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 53](https://user-images.githubusercontent.com/1945542/148166827-fae52b59-8e07-4249-bb72-8283db7dc96f.png)
new design (default) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 37](https://user-images.githubusercontent.com/1945542/148166890-3c93cf59-f31f-43fa-95c9-19861592217c.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 43](https://user-images.githubusercontent.com/1945542/148166900-7b060fbb-7f5d-4a43-8f7b-641d6f23ee72.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 49](https://user-images.githubusercontent.com/1945542/148166901-96f16c0d-4837-41d7-81a2-752dc37042fc.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 31 56](https://user-images.githubusercontent.com/1945542/148166905-ab5925e0-7082-400a-b738-07db68eeb7ff.png)
before (selected) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 06](https://user-images.githubusercontent.com/1945542/148166976-d857be20-c4b5-4720-830d-b65c1e46194c.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 12](https://user-images.githubusercontent.com/1945542/148166974-f7d68d72-6163-4c26-a0d1-6a5cfeae1620.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 16](https://user-images.githubusercontent.com/1945542/148166970-2d838c46-e7c9-41a8-a965-2bba9ea99269.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 20](https://user-images.githubusercontent.com/1945542/148166966-8744ff52-3f3c-466d-81fd-0b1b1172a7bf.png)
before (default) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 08](https://user-images.githubusercontent.com/1945542/148167012-628388ed-d5f1-4c22-9628-b18b9fbe5862.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 13](https://user-images.githubusercontent.com/1945542/148167017-a32a3159-0a5b-4056-9203-60f4ec360a0c.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 18](https://user-images.githubusercontent.com/1945542/148167019-fd584010-a523-4531-8c51-deb43f5804a6.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 13 48 22](https://user-images.githubusercontent.com/1945542/148167022-dad1d2db-8fbd-4be1-abd6-7168f8a0bb45.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
