### PR TITLE
Show revenue stats without rounding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -155,7 +155,7 @@ private extension StoreStatsPeriodViewModel {
 
     func createRevenueStats(orderStatsData: OrderStatsData, selectedIntervalIndex: Int?) -> String {
         if let revenue = revenue(at: selectedIntervalIndex, orderStats: orderStatsData.stats, orderStatsIntervals: orderStatsData.intervals) {
-            return currencyFormatter.formatHumanReadableAmount(String("\(revenue)"), with: currencyCode) ?? String()
+            return currencyFormatter.formatAmount(revenue, with: currencyCode) ?? String()
         } else {
             return Constants.placeholderText
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -53,13 +53,13 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         // When
         let orderStats = OrderStatsV4(siteID: siteID,
                                       granularity: timeRange.intervalGranularity,
-                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 62.7),
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 6220.7),
                                       intervals: [.fake()])
         insertOrderStats(orderStats, timeRange: timeRange)
 
         // Then
         XCTAssertEqual(orderStatsTextValues, ["-", "3"])
-        XCTAssertEqual(revenueStatsTextValues, ["-", "$62"])
+        XCTAssertEqual(revenueStatsTextValues, ["-", "$6,220.70"])
         XCTAssertEqual(visitorStatsTextValues, ["-"])
         XCTAssertEqual(conversionStatsTextValues, ["-"])
     }
@@ -168,7 +168,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(orderStatsTextValues, ["-", "3", "1"])
-        XCTAssertEqual(revenueStatsTextValues, ["-", "$62", "$25"])
+        XCTAssertEqual(revenueStatsTextValues, ["-", "$62.70", "$25.00"])
         XCTAssertEqual(visitorStatsTextValues, ["-"])
         XCTAssertEqual(conversionStatsTextValues, ["-"])
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5744 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of the Home Screen M2 updates, we are showing the revenue stats with 2 decimal points so that merchants see more accurate revenue that they are earning.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has at least one order with an amount that ideally has some decimal points (e.g. 2.5)

- Launch the app or switch to a different store
- After stats are loaded, check the revenue stats on each time range tab --> it should show the whole revenue stats up to 2 decimal points

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | Today (selected) | This Week | This Month
-- | -- | -- | --
after | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 14 03 20](https://user-images.githubusercontent.com/1945542/148168552-f51e50e5-e7bb-4f93-966f-7dbe9d694619.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 14 03 29](https://user-images.githubusercontent.com/1945542/148168559-1031d057-8e2b-409b-a182-d68dbcfadb6e.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 14 03 32](https://user-images.githubusercontent.com/1945542/148168563-b6ed4e13-a106-4b98-872f-504e2807793f.png)
before | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 14 01 56](https://user-images.githubusercontent.com/1945542/148168593-d5b6f19f-7b53-4fbf-883f-575035ace5d4.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 14 02 14](https://user-images.githubusercontent.com/1945542/148168596-f82bc60b-f4b4-4f66-adbc-ae638bda51b2.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-05 at 14 02 17](https://user-images.githubusercontent.com/1945542/148168600-2d18039e-cdc4-4123-8021-2f94d1fc8421.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
