### PR TITLE
Coupons: Simplify state management on coupon list using Combine

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -29,7 +29,6 @@ final class CouponListViewController: UIViewController {
     }
 
     private func configureViewModel() {
-        viewModel.viewDidLoad()
         viewModel.$state
             .removeDuplicates()
             .sink { [weak self] state in
@@ -48,6 +47,9 @@ final class CouponListViewController: UIViewController {
                 }
             }
             .store(in: &subscriptions)
+
+        // Call this after the state subscription for extra safety
+        viewModel.viewDidLoad()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
@@ -1,4 +1,4 @@
-import Foundation
+import Combine
 import Yosemite
 import protocol Storage.StorageManagerType
 import class AutomatticTracks.CrashLogging
@@ -18,26 +18,10 @@ enum CouponListState {
 }
 
 final class CouponListViewModel {
-    /// onListStateChange
-    ///
-    private var didLeaveState: (CouponListState) -> ()
-
-    /// onListStateChange
-    ///
-    private var didEnterState: (CouponListState) -> ()
 
     /// Active state
     ///
-    private var state: CouponListState = .initialized {
-        didSet {
-            guard oldValue != state else {
-                return
-            }
-
-            didLeaveState(oldValue)
-            didEnterState(state)
-        }
-    }
+    @Published private(set) var state: CouponListState = .initialized
 
     /// couponViewModels: ViewModels for the cells representing Coupons
     ///
@@ -69,15 +53,11 @@ final class CouponListViewModel {
     init(siteID: Int64,
          syncingCoordinator: SyncingCoordinatorProtocol = SyncingCoordinator(),
          storesManager: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager,
-         didLeaveState: @escaping (CouponListState) -> (),
-         didEnterState: @escaping (CouponListState) -> ()) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
         self.syncingCoordinator = syncingCoordinator
         self.storesManager = storesManager
         self.storageManager = storageManager
-        self.didLeaveState = didLeaveState
-        self.didEnterState = didEnterState
         self.resultsController = Self.createResultsController(siteID: siteID,
                                                               storageManager: storageManager)
         configureSyncingCoordinator()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5767 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before adding more features to the coupon list, I think it's necessary to simplify things a little especially the state management in the controller. Changes include:
- Get rid of the closure-based style and convert the state to a read-only `@Published` variable to make it simple to work with states. This also avoids having to force unwrap the view model in the view controller since it can be initialized separately.
- Make the view controller observe the state to update UI accordingly. A simple solution is to always remove current overlays first (if they exist) and add appropriate updates based on the current state of the screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure feature flag `couponManagement` is enabled before building the app.
- Log in to a valid account.
- Navigate to the hub menu and select Coupons.
- If your store has at least one coupon, you should see the coupon list transition from the loading state to a list view. Otherwise, you should see the empty state view when loading finishes.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
(Please ignore the empty CTA on the empty view, it will be updated in a separate PR later.)

https://user-images.githubusercontent.com/5533851/148199064-67fc3a7a-9fd0-4a7f-8201-47768bdc03f8.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
