### PR TITLE
Simple Payments: Enable sharing payment links

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -37,8 +37,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .couponManagement:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .simplePaymentsLink:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productSKUInputScanner:
             return true
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -70,10 +70,6 @@ public enum FeatureFlag: Int {
     ///
     case myStoreTabUpdates
 
-    /// Allow merchants to share a payment link when creating a simple payments order.
-    ///
-    case simplePaymentsLink
-
     /// Displays the option to manage coupons
     ///
     case couponManagement

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [***] All merchants can create Simple Payments orders. [https://github.com/woocommerce/woocommerce-ios/pull/5684]
 - [**] System status report can now be viewed and copied directly from within the app. [https://github.com/woocommerce/woocommerce-ios/pull/5702]
 - [**] Product SKU input scanner is now available as a beta feature. To try it, enable it from settings and you can scan a barcode to use as the product SKU in product inventory settings! [https://github.com/woocommerce/woocommerce-ios/pull/5695]
+- [**] Now you chan share a payment link when creating a Simple Payments order [https://github.com/woocommerce/woocommerce-ios/pull/5819]
 
 8.2
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -382,6 +382,7 @@ extension WooAnalyticsEvent {
         enum PaymentMethod: String {
             case card
             case cash
+            case paymentLink = "payment_link"
         }
 
         /// Possible view sources

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -58,7 +58,7 @@ struct SimplePaymentsMethod: View {
 
                     MethodRow(icon: .linkImage, title: Localization.link) {
                         sharingPaymentLink = true
-                        // TODO: Analytics
+                        viewModel.trackCollectByPaymentLink()
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -161,7 +161,7 @@ private extension SimplePaymentsMethod {
         static let header = NSLocalizedString("Choose your payment method", comment: "Heading text on the select payment method screen for simple payments")
         static let cash = NSLocalizedString("Cash", comment: "Cash method title on the select payment method screen for simple payments")
         static let card = NSLocalizedString("Card", comment: "Card method title on the select payment method screen for simple payments")
-        static let link = NSLocalizedString("Payment Link", comment: "Payment Link method title on the select payment method screen for simple payments")
+        static let link = NSLocalizedString("Share Payment Link", comment: "Payment Link method title on the select payment method screen for simple payments")
         static let markAsPaidTitle = NSLocalizedString("Mark as Paid?", comment: "Alert title when selecting the cash payment method for simple payments")
         static let markAsPaidButton = NSLocalizedString("Mark as Paid", comment: "Alert button when selecting the cash payment method for simple payments")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -37,7 +37,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
     /// Defines if the view should show a payment link payment method.
     ///
     var showPaymentLinkRow: Bool {
-        enablePaymentLink && paymentLink != nil
+        paymentLink != nil
     }
 
     /// Store's ID.
@@ -72,10 +72,6 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
     ///
     private let analytics: Analytics
 
-    /// Defines if sharing a payment link should be enabled or not.
-    ///
-    private let enablePaymentLink: Bool
-
     /// Stored payment gateways accounts.
     /// We will care about the first one because only one is supported right now.
     ///
@@ -109,8 +105,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
          cppStoreStateObserver: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
-         analytics: Analytics = ServiceLocator.analytics,
-         enablePaymentLink: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.simplePaymentsLink)) {
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.orderID = orderID
         self.formattedTotal = formattedTotal
@@ -119,7 +114,6 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
         self.stores = stores
         self.storage = storage
         self.analytics = analytics
-        self.enablePaymentLink = enablePaymentLink
         self.title = Localization.title(total: formattedTotal)
 
         bindStoreCPPState()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -203,11 +203,15 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
         trackCollectIntention(method: .cash)
     }
 
+    func trackCollectByPaymentLink() {
+        trackCollectIntention(method: .paymentLink)
+    }
+
     /// Perform the necesary tasks after a link is shared.
     ///
     func performLinkSharedTasks() {
-        self.presentNoticeSubject.send(.created)
-        // TODO: Analytics
+        presentNoticeSubject.send(.created)
+        trackFlowCompleted(method: .paymentLink)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -177,6 +177,20 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         assertEqual(analytics.receivedProperties.first?["amount"] as? String, "$12.00")
     }
 
+    func test_completed_event_is_tracked_after_sharing_a_link() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.performLinkSharedTasks()
+
+        // Then
+        assertEqual(analytics.receivedEvents.first, WooAnalyticsStat.simplePaymentsFlowCompleted.rawValue)
+        assertEqual(analytics.receivedProperties.first?["payment_method"] as? String, "payment_link")
+        assertEqual(analytics.receivedProperties.first?["amount"] as? String, "$12.00")
+    }
+
     func test_failed_event_is_tracked_after_failing_to_mark_order_as_paid() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -200,7 +214,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         assertEqual(analytics.receivedProperties.first?["source"] as? String, "payment_method")
     }
 
-    func test_collect_event_is_tracked_when_required() {
+    func test_collect_event_is_tracked_when_paying_by_cash() {
         // Given
         let analytics = MockAnalyticsProvider()
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -212,6 +226,19 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         // Then
         assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowCollect.rawValue])
         assertEqual(analytics.receivedProperties.first?["payment_method"] as? String, "cash")
+    }
+
+    func test_collect_event_is_tracked_when_sharing_payment_links() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackCollectByPaymentLink()
+
+        // Then
+        assertEqual(analytics.receivedEvents, [WooAnalyticsStat.simplePaymentsFlowCollect.rawValue])
+        assertEqual(analytics.receivedProperties.first?["payment_method"] as? String, "payment_link")
     }
 
     func test_collect_event_is_tracked_when_collecting_payment() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -300,7 +300,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores, enablePaymentLink: true)
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores)
 
         // Then
         XCTAssertFalse(viewModel.showPaymentLinkRow)
@@ -323,7 +323,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores, enablePaymentLink: true)
+        let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", stores: stores)
 
         // Then
         XCTAssertTrue(viewModel.showPaymentLinkRow)


### PR DESCRIPTION
# Why

As discussed in p91TBi-72H-p2, we are releasing the ability to share a payment link as part of the simple payments feature.

Changes are:

- Change copy of the "Payment Link" row to "Share Payment Link"
- Add analytics & tests
- Remove `simplePaymentsLink` feature flag.

# Demo

https://user-images.githubusercontent.com/562080/148281500-348ac931-41d3-4d8d-a6e4-6c9407a36336.mov

# Testing Steps

- Launch the app, start the simple payments flow & and go all the way to the payment method screen
- Tap on the "Share Payment Link" row and see the collect analytic event being fired
- Choose any share option and see the completed analytic event being fired.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
