### PR TITLE
Fix crash when tapping on Menu tab in iOS 14

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -52,7 +52,7 @@ final class HubMenuViewModel: ObservableObject {
             menuElements.append(.coupons)
         }
         menuElements.append(.reviews)
-       observeSiteForUIUpdates()
+        observeSiteForUIUpdates()
     }
 
     /// Present the `StorePickerViewController` using the `StorePickerCoordinator`, passing the navigation controller from the entry point.

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -47,7 +47,7 @@ final class HubMenuViewModel: ObservableObject {
     init(siteID: Int64, navigationController: UINavigationController? = nil, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
         self.navigationController = navigationController
-        menuElements = [.woocommerceAdmin, .viewStore, .reviews]
+        menuElements = [.woocommerceAdmin, .viewStore]
         if featureFlagService.isFeatureFlagEnabled(.couponManagement) {
             menuElements.append(.coupons)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fix iOS 14 crash in `trunk`

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While testing other changes on an iOS 14.5.1 device, I noticed that the app crashed consistently when tapping on the new Menu tab for the following reason:

```
SwiftUI:0: Fatal error: each layout item may only occur once
```

After looking into the crash message, it looks like it's from elements with non-unique IDs inside `ForEach` in a lazy stack/grid view. At first, I thought it's because the `Menu` elements not having a unique ID. But it turns out that it's from duplicated `Menu.reviews` elements in `viewModel.menuElements`.

The app does not crash in iOS 15, and the duplicated element is removed behind the scene.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please test this on an iOS 14 simulator or device (I reproduced the crash and tested the fix with iOS 14.5 simulator and iOS 14.5.1 device).

- Launch the app
- Tap the "Menu" tab in the bottom tab bar --> the app should not crash, and the menu is shown as expected

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
