### PR TITLE
Orders tab: fix sample data shown in placeholder view after switching tabs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -158,6 +158,8 @@ final class OrderListViewController: UIViewController {
         //
         // We can remove this once we've replaced XLPagerTabStrip.
         tableView.reloadData()
+
+        restartPlaceholderAnimation()
     }
 
     /// Returns a function that creates cells for `dataSource`.
@@ -423,6 +425,14 @@ private extension OrderListViewController {
         ghostableTableView.removeGhostContent()
     }
 
+    /// After returning to the screen, `restartGhostAnimation` is required to resume ghost animation.
+    func restartPlaceholderAnimation() {
+        guard ghostableTableView.isHidden == false else {
+            return
+        }
+        ghostableTableView.restartGhostAnimation(style: Constants.ghostStyle)
+    }
+
     /// Shows the EmptyStateViewController
     ///
     func displayEmptyViewController() {
@@ -674,5 +684,9 @@ private extension OrderListViewController {
         case syncing
         case results
         case empty
+    }
+
+    enum Constants {
+        static let ghostStyle: GhostStyle = .wooDefaultGhostStyle
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -412,7 +412,7 @@ private extension OrderListViewController {
         // let's reset the state before using it again
         ghostableTableView.removeGhostContent()
         ghostableTableView.displayGhostContent(options: options,
-                                               style: .wooDefaultGhostStyle)
+                                               style: Constants.ghostStyle)
         ghostableTableView.startGhostAnimation()
         ghostableTableView.isHidden = false
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3821
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While fixing a similar issue for the dashboard tab, I remembered the same issue in the orders tab ([Jayson's screencast](https://user-images.githubusercontent.com/198826/110989517-43418100-832f-11eb-9afc-bfb07e161bfc.mp4)). This PR fixes the issue by calling `restartGhostAnimation` with the same style in view controller's `viewWillAppear`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app, then quickly go to the orders tab, switch to any other tab, and go back to the orders tab --> the ghost placeholder view should be shown without the sample data like below. If the data are already loaded, you can switch to a different store and then repeat the same step

<img src="https://user-images.githubusercontent.com/1945542/148349580-633fe0a0-64c8-401b-9f59-505c5ab84114.png" width="300" />

These sample data are from `OrderTableViewCell.xib`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1945542/148349718-f8a777a0-f7b7-4c9c-8e37-196c1e2d6fda.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
