### PR TITLE
Coupons: Add pull-to-refresh to coupon list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -10,6 +10,14 @@ final class CouponListViewController: UIViewController {
     ///
     private var emptyStateViewController: UIViewController?
 
+    /// Pull To Refresh Support.
+    ///
+    private lazy var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(refreshCouponList), for: .valueChanged)
+        return refreshControl
+    }()
+
     private var subscriptions: Set<AnyCancellable> = []
 
     init(siteID: Int64) {
@@ -53,6 +61,13 @@ final class CouponListViewController: UIViewController {
     }
 }
 
+// MARK: - Actions
+private extension CouponListViewController {
+    @objc func refreshCouponList() {
+        viewModel.refreshCoupons()
+    }
+}
+
 
 // MARK: - View Configuration
 //
@@ -66,6 +81,7 @@ private extension CouponListViewController {
         tableView.dataSource = self
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.addSubview(refreshControl)
     }
 
     func registerTableViewCells() {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -41,8 +41,7 @@ final class CouponListViewController: UIViewController {
             .removeDuplicates()
             .sink { [weak self] state in
                 guard let self = self else { return }
-                self.removeNoResultsOverlay()
-                self.removePlaceholderCoupons()
+                self.resetViews()
                 switch state {
                 case .empty:
                     self.displayNoResultsOverlay()
@@ -50,6 +49,8 @@ final class CouponListViewController: UIViewController {
                     self.displayPlaceholderCoupons()
                 case .coupons:
                     self.tableView.reloadData()
+                case .refreshing:
+                    self.refreshControl.beginRefreshing()
                 case .initialized:
                     break
                 }
@@ -63,8 +64,20 @@ final class CouponListViewController: UIViewController {
 
 // MARK: - Actions
 private extension CouponListViewController {
+    /// Triggers a refresh for the coupon list
+    ///
     @objc func refreshCouponList() {
         viewModel.refreshCoupons()
+    }
+
+    /// Removes overlays and loading indicators if present.
+    ///
+    func resetViews() {
+        removeNoResultsOverlay()
+        removePlaceholderCoupons()
+        if refreshControl.isRefreshing {
+            refreshControl.endRefreshing()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
@@ -116,6 +116,12 @@ final class CouponListViewModel {
     func coupon(at indexPath: IndexPath) -> Coupon? {
         return resultsController.safeObject(at: indexPath)
     }
+
+    /// Triggers a refresh of loaded coupons
+    ///
+    func refreshCoupons() {
+        syncingCoordinator.resynchronize(reason: nil, onCompletion: nil)
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
@@ -15,6 +15,7 @@ enum CouponListState {
     case loading // View should show ghost cells
     case empty // View should display the empty state
     case coupons // View should display the contents of `couponViewModels`
+    case refreshing // View should display the refresh control
 }
 
 final class CouponListViewModel {
@@ -139,7 +140,7 @@ extension CouponListViewModel: SyncingCoordinatorDelegate {
               pageSize: Int,
               reason: String?,
               onCompletion: ((Bool) -> Void)?) {
-        transitionToSyncingState(pageNumber: pageNumber)
+        transitionToSyncingState(pageNumber: pageNumber, hasData: couponViewModels.isNotEmpty)
         let action = CouponAction
             .synchronizeCoupons(siteID: siteID,
                                 pageNumber: pageNumber,
@@ -168,9 +169,9 @@ extension CouponListViewModel: SyncingCoordinatorDelegate {
 // MARK: - Pagination
 //
 private extension CouponListViewModel {
-    func transitionToSyncingState(pageNumber: Int) {
+    func transitionToSyncingState(pageNumber: Int, hasData: Bool) {
         if pageNumber == 1 {
-            state = .loading
+            state = hasData ? .refreshing : .loading
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
@@ -111,4 +111,38 @@ final class CouponListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.state, .empty)
     }
+
+    func test_refreshCoupon_updates_state_to_refreshing() {
+        // Given
+        setUpWithCouponFetched() // we need to have existing data to enter refreshing state
+
+        // When
+        sut.refreshCoupons()
+
+        // Then
+        XCTAssertEqual(sut.state, .refreshing)
+    }
+
+    func test_refreshCoupons_calls_resynchronize_on_syncCoordinator() {
+        // Given
+        sut = CouponListViewModel(siteID: 123, syncingCoordinator: mockSyncingCoordinator)
+
+        // When
+        sut.refreshCoupons()
+
+        // Then
+        XCTAssert(mockSyncingCoordinator.spyDidCallResynchronize)
+    }
+
+    func test_handleCouponSyncResult_removes_refreshing_when_refresh_completes() {
+        // Given
+        setUpWithCouponFetched()
+        sut.refreshCoupons()
+
+        // When
+        sut.handleCouponSyncResult(result: .success(false))
+
+        // Then
+        XCTAssertEqual(sut.state, .coupons)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5767 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the pull-to-refresh feature to the coupon list. The actual implementation of the refresh has already been handled in the view model's syncing coordinator, so the changes are pretty lightweight:
- Add new state `refreshing` to the state enum.
- Add a refresh control to the coupon list view.
- Update the coupon list UI for the refreshing state.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a valid account.
- Switch to a store that has at least one coupon if needed.
- Navigate to the hub menu and select Coupons.
- Notice that the coupon list is loaded successfully. No refresh control should be shown when the list is first loaded.
- Try pulling the list down and release. Notice that the list is then refreshed (there should be a message in the console saying "Synchronized coupons").

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/148370777-9ff02460-9800-4ec4-bd80-9ead5e0dddba.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
