### PR TITLE
Coupons: Add loading next page functionality to coupon list

### DIFF
--- a/Networking/Networking/Mapper/CouponListMapper.swift
+++ b/Networking/Networking/Mapper/CouponListMapper.swift
@@ -12,7 +12,9 @@ struct CouponListMapper: Mapper {
     ///
     func map(response: Data) throws -> [Coupon] {
         let coupons = try Coupon.decoder.decode(CouponListEnvelope.self, from: response).coupons
-        return coupons.map { $0.copy(siteID: siteID) }
+        return coupons
+            .map { $0.copy(siteID: siteID) }
+            .filter { $0.mappedDiscountType != nil }
     }
 }
 

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -26,7 +26,22 @@ public struct Coupon {
     public let dateModified: Date
 
     /// Determines the type of discount that will be applied. Options: `.percent` `.fixedCart` and `.fixedProduct`
-    public let discountType: DiscountType
+    public var discountType: DiscountType {
+        if let type = mappedDiscountType {
+            return type
+        } else {
+            // Returns default value for fallback case to avoid working with optionals.
+            // Since `CouponListMapper` filters out nil `mappedDiscountType`,
+            // this case is unlikely to happen.
+            return .fixedCart
+        }
+    }
+
+    /// Discount type if matched with any of the ones supported by Core.
+    /// Returns nil if other types are found.
+    /// Used to filter only coupons with default types, so internal to this module only.
+    ///
+    internal let mappedDiscountType: DiscountType?
 
     public let description: String
 
@@ -78,6 +93,9 @@ public struct Coupon {
     /// Email addresses of customers who have used this coupon
     public let usedBy: [String]
 
+    /// Discount types supported by Core.
+    /// There are other types supported by other plugins, but those are not supported for now.
+    ///
     public enum DiscountType: String {
         case percent = "percent"
         case fixedCart = "fixed_cart"
@@ -114,7 +132,7 @@ public struct Coupon {
         self.amount = amount
         self.dateCreated = dateCreated
         self.dateModified = dateModified
-        self.discountType = discountType
+        self.mappedDiscountType = discountType
         self.description = description
         self.dateExpires = dateExpires
         self.usageCount = usageCount
@@ -148,7 +166,7 @@ extension Coupon: Codable {
         case amount
         case dateCreated = "dateCreatedGmt"
         case dateModified = "dateModifiedGmt"
-        case discountType
+        case mappedDiscountType
         case description
         case dateExpires = "dateExpiresGmt"
         case usageCount

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -87,6 +87,20 @@ private extension CouponListViewController {
             refreshControl.endRefreshing()
         }
     }
+
+    /// Starts the loading indicator in the footer, to show that another page is being fetched
+    ///
+    func startFooterLoadingIndicator() {
+        tableView?.tableFooterView = footerSpinnerView
+        footerSpinnerView.startAnimating()
+    }
+
+    /// Stops the loading indicator in the footer
+    ///
+    func stopFooterLoadingIndicator() {
+        footerSpinnerView.stopAnimating()
+        tableView?.tableFooterView = footerEmptyView
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -59,6 +59,8 @@ final class CouponListViewController: UIViewController {
                     self.tableView.reloadData()
                 case .refreshing:
                     self.refreshControl.beginRefreshing()
+                case .loadingNextPage:
+                    self.startFooterLoadingIndicator()
                 case .initialized:
                     break
                 }
@@ -83,6 +85,7 @@ private extension CouponListViewController {
     func resetViews() {
         removeNoResultsOverlay()
         removePlaceholderCoupons()
+        stopFooterLoadingIndicator()
         if refreshControl.isRefreshing {
             refreshControl.endRefreshing()
         }
@@ -103,6 +106,14 @@ private extension CouponListViewController {
     }
 }
 
+// MARK: - TableView Delegate
+//
+extension CouponListViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        viewModel.tableWillDisplayCell(at: indexPath)
+    }
+}
+
 
 // MARK: - View Configuration
 //
@@ -117,6 +128,7 @@ private extension CouponListViewController {
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.addSubview(refreshControl)
+        tableView.delegate = self
     }
 
     func registerTableViewCells() {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -18,6 +18,14 @@ final class CouponListViewController: UIViewController {
         return refreshControl
     }()
 
+    /// Footer "Loading More" Spinner.
+    ///
+    private lazy var footerSpinnerView = FooterSpinnerView()
+
+    /// Empty Footer Placeholder. Replaces spinner view and allows footer to collapse and be completely hidden.
+    ///
+    private lazy var footerEmptyView = UIView(frame: .zero)
+
     private var subscriptions: Set<AnyCancellable> = []
 
     init(siteID: Int64) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
@@ -70,7 +70,7 @@ final class CouponListViewModel {
                                                 storageManager: StorageManagerType) -> ResultsController<StorageCoupon> {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
-                                          ascending: true)
+                                          ascending: false)
 
         return ResultsController<StorageCoupon>(storageManager: storageManager,
                                                 matching: predicate,

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementListViewModel.swift
@@ -16,6 +16,7 @@ enum CouponListState {
     case empty // View should display the empty state
     case coupons // View should display the contents of `couponViewModels`
     case refreshing // View should display the refresh control
+    case loadingNextPage // View should display a bottom loading indicator and contents of `couponViewModels`
 }
 
 final class CouponListViewModel {
@@ -123,6 +124,12 @@ final class CouponListViewModel {
     func refreshCoupons() {
         syncingCoordinator.resynchronize(reason: nil, onCompletion: nil)
     }
+
+    /// The ViewController can trigger loading of the next page when the user scrolls to the bottom
+    ///
+    func tableWillDisplayCell(at indexPath: IndexPath) {
+        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: indexPath.row)
+    }
 }
 
 
@@ -172,6 +179,8 @@ private extension CouponListViewModel {
     func transitionToSyncingState(pageNumber: Int, hasData: Bool) {
         if pageNumber == 1 {
             state = hasData ? .refreshing : .loading
+        } else {
+            state = .loadingNextPage
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
@@ -145,4 +145,24 @@ final class CouponListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.state, .coupons)
     }
+
+    func test_tableWillDisplayCellAtIndexPath_calls_ensureNextPageIsSynchronized_on_syncCoordinator() {
+        // Given
+        sut = CouponListViewModel(siteID: 123, syncingCoordinator: mockSyncingCoordinator)
+        
+        // When
+        sut.tableWillDisplayCell(at: IndexPath(row: 3, section: 0))
+
+        // Then
+        XCTAssertTrue(mockSyncingCoordinator.spyDidCallEnsureNextPageIsSynchronized)
+        XCTAssertEqual(mockSyncingCoordinator.spyEnsureNextPageIsSynchronizedLastVisibleIndex, 3)
+    }
+
+    func test_sync_updates_state_correctly_when_syncing_next_page() {
+        // When
+        sut.sync(pageNumber: 2, pageSize: 10, reason: nil, onCompletion: nil)
+
+        // Then
+        XCTAssertEqual(sut.state, .loadingNextPage)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
@@ -149,7 +149,7 @@ final class CouponListViewModelTests: XCTestCase {
     func test_tableWillDisplayCellAtIndexPath_calls_ensureNextPageIsSynchronized_on_syncCoordinator() {
         // Given
         sut = CouponListViewModel(siteID: 123, syncingCoordinator: mockSyncingCoordinator)
-        
+
         // When
         sut.tableWillDisplayCell(at: IndexPath(row: 3, section: 0))
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5767 
⚠️ Please make sure that #5827 is reviewed and merged first since this PR depends on that one ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the loading next page feature to the coupon list. The actual implementation of the refresh has already been handled in the view model's syncing coordinator, so the changes are pretty lightweight:
- Add new state `loadingNextPage` to the state enum.
- Set up 2 different footer views to the coupon list view.
- Update the coupon list UI for the `loadingNextPage` state.
- Additionally: update the coupon results controller to sort result by created date DESC.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a valid account.
- Switch to a store that has at least 26 coupons if needed.
- Navigate to the hub menu and select Coupons.
- Scroll down the list; notice that after the first 25 coupons, there's a footer view displayed indicating that the next page is being loaded.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/148375436-ed532847-95a1-46f7-8d6d-655096cde0dd.mp4

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
