### PR TITLE
Reviews screen - Mark all as read bar button: Replace checkmark button with menu button and action sheet.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [**] System status report can now be viewed and copied directly from within the app. [https://github.com/woocommerce/woocommerce-ios/pull/5702]
 - [**] Product SKU input scanner is now available as a beta feature. To try it, enable it from settings and you can scan a barcode to use as the product SKU in product inventory settings! [https://github.com/woocommerce/woocommerce-ios/pull/5695]
 - [**] Now you chan share a payment link when creating a Simple Payments order [https://github.com/woocommerce/woocommerce-ios/pull/5819]
+- [**] Reviews: "Mark all as read" checkmark bar button item button replaced with menu button which launches an action sheet. Menu button is displayed only if there are unread reviews available.[https://github.com/woocommerce/woocommerce-ios/pull/5833]
 
 8.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [**] System status report can now be viewed and copied directly from within the app. [https://github.com/woocommerce/woocommerce-ios/pull/5702]
 - [**] Product SKU input scanner is now available as a beta feature. To try it, enable it from settings and you can scan a barcode to use as the product SKU in product inventory settings! [https://github.com/woocommerce/woocommerce-ios/pull/5695]
 - [**] Now you chan share a payment link when creating a Simple Payments order [https://github.com/woocommerce/woocommerce-ios/pull/5819]
-- [**] Reviews: "Mark all as read" checkmark bar button item button replaced with menu button which launches an action sheet. Menu button is displayed only if there are unread reviews available.[https://github.com/woocommerce/woocommerce-ios/pull/5833]
+- [*] Reviews: "Mark all as read" checkmark bar button item button replaced with menu button which launches an action sheet. Menu button is displayed only if there are unread reviews available.[https://github.com/woocommerce/woocommerce-ios/pull/5833]
 
 8.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -276,7 +276,7 @@ private extension ReviewsViewController {
                 tracks.track(.reviewsMarkAllReadSuccess)
             }
 
-            self.updateMenuButtonState()
+            self.updateRightBarButtonItem()
             self.tableView.reloadData()
         }
     }
@@ -414,7 +414,7 @@ private extension ReviewsViewController {
     /// Note: Just because this func runs does not guarantee `didEnter()` or `didLeave()` will run as well.
     ///
     func willEnter(state: State) {
-        updateNavBarButtonsState()
+        updateRightBarButtonItem()
     }
 
     /// Runs whenever the FSM enters a State.
@@ -480,13 +480,9 @@ private extension ReviewsViewController {
 //
 private extension ReviewsViewController {
 
-    func updateNavBarButtonsState() {
-        updateMenuButtonState()
-    }
-
     /// Show the rightBarButtonItem only if there are unread reviews available.
     ///
-    func updateMenuButtonState() {
+    func updateRightBarButtonItem() {
         navigationItem.rightBarButtonItem = viewModel.hasUnreadNotifications ? rightBarButton : nil
     }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -499,8 +499,7 @@ private extension ReviewsViewController {
         }
 
         markAsReadCount += 1
-        let notice = Notice(title: Localization.Notice.allReviewsMarkedAsRead,
-                            feedbackType: .success)
+        let notice = Notice(title: Localization.Notice.allReviewsMarkedAsRead, feedbackType: .success)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -19,7 +19,7 @@ final class ReviewsViewController: UIViewController {
                                    style: .plain,
                                    target: self,
                                    action: #selector(presentActionSheet))
-        item.accessibilityIdentifier = "reviews-mark-all-as-read-button" // TODO: Change the identifier and check UI tests
+        item.accessibilityIdentifier = "reviews-open-menu-button"
         item.accessibilityTraits = .button
         item.accessibilityLabel = Localization.MenuButton.accessibilityLabel
         item.accessibilityHint = Localization.MenuButton.accessibilityHint

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -478,14 +478,12 @@ private extension ReviewsViewController {
 //
 private extension ReviewsViewController {
 
-    /// Enables/disables the navbar buttons if needed
-    ///
-    /// - Parameter filterEnabled: If true, the filter navbar buttons is enabled; if false, it's disabled
-    ///
     func updateNavBarButtonsState() {
         updateMenuButtonState()
     }
 
+    /// Show the rightBarButtonItem only if there are unread reviews available.
+    ///
     func updateMenuButtonState() {
         navigationItem.rightBarButtonItem = viewModel.hasUnreadNotifications ? rightBarButton : nil
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -21,10 +21,8 @@ final class ReviewsViewController: UIViewController {
                                    action: #selector(presentActionSheet))
         item.accessibilityIdentifier = "reviews-mark-all-as-read-button" // TODO: Change the identifier and check UI tests
         item.accessibilityTraits = .button
-        item.accessibilityLabel = NSLocalizedString("Open menu",
-                                                    comment: "Accessibility label for the Menu button")
-        item.accessibilityHint = NSLocalizedString("Menu button which opens an action sheet with option to mark all reviews as read.",
-                                                   comment: "VoiceOver accessibility hint for the Menu button action")
+        item.accessibilityLabel = Localization.MenuButton.accessibilityLabel
+        item.accessibilityHint = Localization.MenuButton.accessibilityHint
         return item
     }()
 
@@ -186,7 +184,7 @@ private extension ReviewsViewController {
     /// Setup: TabBar
     ///
     func configureTabBarItem() {
-        tabBarItem.title = NSLocalizedString("Reviews", comment: "Title of the Reviews tab — plural form of Review")
+        tabBarItem.title = Localization.tabBarItemTitle
         tabBarItem.image = .starOutlineImage()
         tabBarItem.accessibilityIdentifier = "tab-bar-reviews-item"
     }
@@ -225,10 +223,7 @@ private extension ReviewsViewController {
     }
 
     func refreshTitle() {
-        title = NSLocalizedString(
-            "Reviews",
-            comment: "Title that appears on top of the main Reviews screen (plural form of the word Review)."
-        )
+        title = Localization.title
     }
 }
 
@@ -341,11 +336,11 @@ private extension ReviewsViewController {
     ///
     func displayEmptyViewController() {
         let childController = emptyStateViewController
-        let emptyStateConfig = EmptyStateViewController.Config.withLink(message: NSAttributedString(string: Localization.emptyStateMessage),
-                                                              image: .emptyReviewsImage,
-                                                              details: Localization.emptyStateDetail,
-                                                              linkTitle: Localization.emptyStateAction,
-                                                              linkURL: WooConstants.URLs.productReviewInfo.asURL())
+        let emptyStateConfig = EmptyStateViewController.Config.withLink(message: NSAttributedString(string: Localization.EmptyState.message),
+                                                                        image: .emptyReviewsImage,
+                                                                        details: Localization.EmptyState.detail,
+                                                                        linkTitle: Localization.EmptyState.action,
+                                                                        linkURL: WooConstants.URLs.productReviewInfo.asURL())
 
         // Abort if we are already displaying this childController
         guard childController.parent == nil,
@@ -504,8 +499,8 @@ private extension ReviewsViewController {
         }
 
         markAsReadCount += 1
-        let message = NSLocalizedString("All reviews marked as read", comment: "Mark all reviews as read notice")
-        let notice = Notice(title: message, feedbackType: .success)
+        let notice = Notice(title: Localization.Notice.allReviewsMarkedAsRead,
+                            feedbackType: .success)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
@@ -624,6 +619,19 @@ private extension ReviewsViewController {
 //
 private extension ReviewsViewController {
     enum Localization {
+        static let title = NSLocalizedString("Reviews",
+                                             comment: "Title that appears on top of the main Reviews screen (plural form of the word Review).")
+
+        static let tabBarItemTitle = NSLocalizedString("Reviews",
+                                                       comment: "Title of the Reviews tab — plural form of Review")
+
+        enum MenuButton {
+            static let accessibilityLabel = NSLocalizedString("Open menu",
+                                                        comment: "Accessibility label for the Menu button")
+            static let accessibilityHint = NSLocalizedString("Menu button which opens an action sheet with option to mark all reviews as read.",
+                                                       comment: "VoiceOver accessibility hint for the Menu button action")
+        }
+
         enum ActionSheet {
             static let markAsReadAction = NSLocalizedString("Mark all reviews as read",
                                                             comment: "Option to mark all reviews as read from the action sheet in Reviews screen.")
@@ -646,9 +654,18 @@ private extension ReviewsViewController {
                                                               comment: "Alert button title - confirms and marks all reviews as read")
         }
 
-        static let emptyStateMessage = NSLocalizedString("Get your first reviews", comment: "Message shown in the Reviews tab if the list is empty")
-        static let emptyStateDetail = NSLocalizedString("Capture high-quality product reviews for your store.",
-                                                        comment: "Detailed message shown in the Reviews tab if the list is empty")
-        static let emptyStateAction = NSLocalizedString("Learn more", comment: "Title of button shown in the Reviews tab if the list is empty")
+        enum Notice {
+            static let allReviewsMarkedAsRead = NSLocalizedString("All reviews marked as read",
+                                                                  comment: "Mark all reviews as read notice")
+        }
+
+        enum EmptyState {
+            static let message = NSLocalizedString("Get your first reviews",
+                                                             comment: "Message shown in the Reviews tab if the list is empty")
+            static let detail = NSLocalizedString("Capture high-quality product reviews for your store.",
+                                                            comment: "Detailed message shown in the Reviews tab if the list is empty")
+            static let action = NSLocalizedString("Learn more",
+                                                            comment: "Title of button shown in the Reviews tab if the list is empty")
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -18,7 +18,7 @@ final class ReviewsViewController: UIViewController {
         let item = UIBarButtonItem(image: .ellipsisImage,
                                    style: .plain,
                                    target: self,
-                                   action: #selector(presentActionSheet))
+                                   action: #selector(presentMoreActions))
         item.accessibilityIdentifier = "reviews-open-menu-button"
         item.accessibilityTraits = .button
         item.accessibilityLabel = Localization.MenuButton.accessibilityLabel
@@ -241,7 +241,7 @@ private extension ReviewsViewController {
 
     /// Presents an action sheet on tapping the menu right bar button item.
     ///
-    @IBAction func presentActionSheet() {
+    @IBAction func presentMoreActions() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -239,6 +239,8 @@ private extension ReviewsViewController {
         }
     }
 
+    /// Presents an action sheet on tapping the menu right bar button item.
+    ///
     @IBAction func presentActionSheet() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -12,7 +12,7 @@ public final class ReviewsScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ { $0.buttons["reviews-mark-all-as-read-button"] } ],
+            expectedElementGetters: [ { $0.buttons["reviews-open-menu-button"] } ],
             app: app
         )
     }


### PR DESCRIPTION
Closes #4295

### Description

This PR replaces the  "Mark all as read" bar button item in `ReviewsViewController` with a menu button. Refer [design at].(https://github.com/woocommerce/woocommerce-ios/issues/4295#issuecomment-888041823) 
- The menu button will be displayed only when there are unread notifications/reviews available. 
- Tapping on the menu button opens an action sheet which has an option to "Mark all reviews as read"
- Tapping on the "Mark all reviews as read" action from the action sheet will present an alert to confirm before marking all reviews as read.

### Changes
- Replace mark all as read checkmark button with menu button.
- Use action sheet to present `Mark all reviews as read` option.
- Use alert to get confirmation from the user.
- Show menu button only when there are unread reviews present. (I will be adding unit tests while fixing #5829)
- Move existing localization strings to private enum. 
- Change `rightBarButtonItem` 's `accessibilityIdentifier` to match the menu button behaviour. 
- Update comments.

### Testing instructions
1. Switch to a store with no reviews and navigate to the Review screen.
1. Observe that there is no right bar button item present.
1. Switch to a store with reviews and navigate to the Review screen.
1. Observe that the right bar button item is displayed when there are unread notifications present.
1. If there are no unread notifications present, please add a review to any of the products.
1. Refresh the Reviews screen and observe that the right bar button item is displayed.
1. Mark all unread notifications as read by tapping on the right bar button item which opens an action sheet.
1. Tap on "Mark all reviews as read" action and confirm in the following alert. This should mark all the reviews as read.
1. You can also mark the review as read by tapping on the cell and reading the review.
1. Refresh the Reviews screen and observe that the right bar button is not displayed.

### Points to be noted
1. The bar button item doesn't get refreshed properly due to another issue discussed in p91TBi-74J-p2. (Issue created #5830 ) You have to switch to a different tab and navigate back to the Reviews screen to see the bar button item update. 
1. UI tests aren't running successfully unless we disable the `hubMenu` feature. I had to disable the `hubMenu` feature to ensure that my changes related to `accessibilityIdentifier` are working as expected. I checked with the team and ensured that it is a [work in progress](https://github.com/woocommerce/woocommerce-ios/projects/43). 

### Screenshots

| Review Screen state | Description | Light | Dark|
| -------------  | ------------- | ------------- | ------------- |
| No reviews | Menu bar button item not displayed as there are no reviews available.  |<img src="https://user-images.githubusercontent.com/524475/148303103-f6bfd46f-4ca9-4c05-be15-91dd064e0452.png" width="250"> | <img src="https://user-images.githubusercontent.com/524475/148303111-e4f0958e-3792-486d-b9f9-43a632b8f0e8.png" width="250">  | 
| Unread notifications available | Menu bar button item displayed. |<img src="https://user-images.githubusercontent.com/524475/148472808-2ba3b297-cbff-4809-bb4c-9f2eb184bb5f.png" width="250"> | <img src="https://user-images.githubusercontent.com/524475/148472795-46bd788a-8fca-4161-9cb6-db6a627ec2ed.png" width="250">  | 
| Action sheet | Action sheet with mark all reviews as read and cancel options. | <img src="https://user-images.githubusercontent.com/524475/148473268-fe6b85ab-9d9b-4576-babb-3dd11317c604.png" width="250">  | <img src="https://user-images.githubusercontent.com/524475/148473279-47b82e36-398f-415c-816b-7e1872888232.png" width="250">  | 
| Alert | Alert controller to get confirmation from user before marking all reviews as read. | <img src="https://user-images.githubusercontent.com/524475/148473055-5397871c-0cf2-40f3-a935-62338dc673ce.png" width="250">  | <img src="https://user-images.githubusercontent.com/524475/148473048-cc1d8b29-9774-4c52-a360-d0a04ddcdb1c.png" width="250">  | 
| No unread notifications available | Menu bar button item is not displayed as there are no unread notifications. | <img src="https://user-images.githubusercontent.com/524475/148472600-85646d65-b3e5-4a8e-b377-af315e96d303.png" width="250">  | <img src="https://user-images.githubusercontent.com/524475/148472606-dbaf5b86-ca39-4e3f-b626-92b1c244fc34.png" width="250">  | 

### Screen recording
![MenuActionSheet](https://user-images.githubusercontent.com/524475/148473952-ba3e567d-d781-4bde-b713-71cc55c0de48.gif)


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
