### PR TITLE
Update top performers placeholder

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -223,16 +223,7 @@ extension TopPerformerDataViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         if isMyStoreTabUpdatesEnabled {
-            guard let cell =
-                    tableView.dequeueReusableHeaderFooterView(withIdentifier: TwoColumnSectionHeaderView.reuseIdentifier) as? TwoColumnSectionHeaderView else {
-                        fatalError()
-                    }
-
-            cell.topMarginSpacing = Constants.sectionHeaderTopSpacing
-            cell.shouldShowUppercase = false
-            cell.leftText = Text.sectionLeftColumn
-            cell.rightText = Text.sectionRightColumn
-            return cell
+            return nil
         } else {
             guard let cell =
                     tableView.dequeueReusableHeaderFooterView(withIdentifier: TopPerformersHeaderView.reuseIdentifier) as? TopPerformersHeaderView else {
@@ -274,11 +265,11 @@ extension TopPerformerDataViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return Constants.estimatedSectionHeight
+        return isMyStoreTabUpdatesEnabled ? 0: Constants.estimatedSectionHeight
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        return isMyStoreTabUpdatesEnabled ? 0: UITableView.automaticDimension
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/LegacyTopPerformersSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/LegacyTopPerformersSectionHeaderView.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+/// Section header view shown above the top performers data view.
+///
+class LegacyTopPerformersSectionHeaderView: UIView {
+    private lazy var label: UILabel = {
+        return UILabel(frame: .zero)
+    }()
+
+    init(title: String) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        configureLabel(title: title)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension LegacyTopPerformersSectionHeaderView {
+    func configureLabel(title: String) {
+        addSubview(label)
+
+        label.text = title
+
+        label.applyFootnoteStyle()
+        label.textColor = .listIcon
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.labelInsets.left),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.labelInsets.right),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.labelInsets.bottom)
+            ])
+    }
+}
+
+// MARK: - Constants!
+//
+private extension LegacyTopPerformersSectionHeaderView {
+    enum Constants {
+        static let labelInsets = UIEdgeInsets(top: 0, left: 14, bottom: 6, right: 14)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersPeriodViewController.swift
@@ -5,7 +5,7 @@ import Observables
 
 /// Container view controller for a stats v4 time range that consists of a scrollable stack view of:
 /// - Store stats data view (managed by child view controller `OldStoreStatsV4PeriodViewController`)
-/// - Top performers header view (`TopPerformersSectionHeaderView`)
+/// - Top performers header view (`LegacyTopPerformersSectionHeaderView`)
 /// - Top performers data view (managed by child view controller `TopPerformerDataViewController`)
 ///
 final class OldStoreStatsAndTopPerformersPeriodViewController: UIViewController {
@@ -287,7 +287,7 @@ private extension OldStoreStatsAndTopPerformersPeriodViewController {
         stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)
 
         // Top performers header.
-        let topPerformersHeaderView = TopPerformersSectionHeaderView(title:
+        let topPerformersHeaderView = LegacyTopPerformersSectionHeaderView(title:
             NSLocalizedString("Top Performers",
                               comment: "Header label for Top Performers section of My Store tab.")
                 .uppercased())

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import struct WordPressUI.GhostStyle
 import XLPagerTabStrip
 import Yosemite
 import Observables
@@ -73,6 +74,10 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         stackView.axis = .vertical
         return stackView
     }()
+
+    private lazy var topPerformersHeaderView =
+    TopPerformersSectionHeaderView(title: NSLocalizedString("Top Performers",
+                                                            comment: "Header label for Top Performers section of My Store tab."))
 
     // MARK: Child View Controllers
 
@@ -156,6 +161,9 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         // Fix any incomplete animation of the refresh control
         // when switching tabs mid-animation
         refreshControl.resetAnimation(in: scrollView)
+
+        // After returning to the My Store tab, `restartGhostAnimation` is required to resume ghost animation.
+        restartGhostAnimationIfNeeded()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -186,6 +194,7 @@ extension StoreStatsAndTopPerformersPeriodViewController {
 
     func displayGhostContent() {
         storeStatsPeriodViewController.displayGhostContent()
+        topPerformersHeaderView.startGhostAnimation(style: Constants.ghostStyle)
         topPerformersPeriodViewController.displayGhostContent()
     }
 
@@ -193,6 +202,7 @@ extension StoreStatsAndTopPerformersPeriodViewController {
     ///
     func removeStoreStatsGhostContent() {
         storeStatsPeriodViewController.removeGhostContent()
+        topPerformersHeaderView.stopGhostAnimation()
     }
 
     /// Removes the placeholder content for top performers.
@@ -205,6 +215,13 @@ extension StoreStatsAndTopPerformersPeriodViewController {
     ///
     var shouldDisplayStoreStatsGhostContent: Bool {
         return storeStatsPeriodViewController.shouldDisplayGhostContent
+    }
+
+    func restartGhostAnimationIfNeeded() {
+        guard topPerformersHeaderView.superview != nil else {
+            return
+        }
+        topPerformersHeaderView.restartGhostAnimation(style: Constants.ghostStyle)
     }
 }
 
@@ -286,9 +303,6 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)
 
         // Top performers header.
-        let topPerformersHeaderView = TopPerformersSectionHeaderView(title:
-            NSLocalizedString("Top Performers",
-                              comment: "Header label for Top Performers section of My Store tab."))
         stackView.addArrangedSubview(topPerformersHeaderView)
 
         // Top performers.
@@ -343,5 +357,6 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
 private extension StoreStatsAndTopPerformersPeriodViewController {
     enum Constants {
         static let storeStatsPeriodViewHeight: CGFloat = 444
+        static let ghostStyle: GhostStyle = .wooDefaultGhostStyle
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -75,9 +75,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         return stackView
     }()
 
-    private lazy var topPerformersHeaderView =
-    TopPerformersSectionHeaderView(title: NSLocalizedString("Top Performers",
-                                                            comment: "Header label for Top Performers section of My Store tab."))
+    private lazy var topPerformersHeaderView = TopPerformersSectionHeaderView()
 
     // MARK: Child View Controllers
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
@@ -5,12 +5,12 @@ import Experiments
 /// This contains a vertical stack view of a title label and a two-column view of labels for top performers data (products and items sold).
 ///
 final class TopPerformersSectionHeaderView: UIView {
-    init(title: String) {
+    init() {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
 
         configureView()
-        configureStackView(title: title)
+        configureStackView()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -23,8 +23,8 @@ private extension TopPerformersSectionHeaderView {
         backgroundColor = Constants.backgroundColor
     }
 
-    func configureStackView(title: String) {
-        let titleView = createTitleLabelContainerView(title: title)
+    func configureStackView() {
+        let titleView = createTitleLabelContainerView(title: Localization.title)
         let twoColumnStackView: UIStackView = {
             let leftLabelContainer = createColumnLabelContainerView(labelText: Localization.leftColumn, columnPosition: .left)
             let rightLabelContainer = createColumnLabelContainerView(labelText: Localization.rightColumn, columnPosition: .right)
@@ -127,6 +127,8 @@ private extension TopPerformersSectionHeaderView {
 //
 private extension TopPerformersSectionHeaderView {
     enum Localization {
+        static let title = NSLocalizedString("Top Performers",
+                                             comment: "Header label for Top Performers section of My Store tab.")
         static let leftColumn = NSLocalizedString("Products", comment: "Description for Top Performers left column header")
         static let rightColumn = NSLocalizedString("Items Sold", comment: "Description for Top Performers right column header")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
@@ -2,19 +2,15 @@ import UIKit
 import Experiments
 
 /// Section header view shown above the top performers data view.
+/// This contains a vertical stack view of a title label and a two-column view of labels for top performers data (products and items sold).
 ///
-class TopPerformersSectionHeaderView: UIView {
-    private lazy var label: UILabel = {
-        return UILabel(frame: .zero)
-    }()
-
-    init(title: String, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+final class TopPerformersSectionHeaderView: UIView {
+    init(title: String) {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
 
-        let isMyStoreTabUpdatesEnabled = featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates)
-        configureView(isMyStoreTabUpdatesEnabled: isMyStoreTabUpdatesEnabled)
-        configureLabel(title: title, isMyStoreTabUpdatesEnabled: isMyStoreTabUpdatesEnabled)
+        configureView()
+        configureStackView(title: title)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -23,43 +19,127 @@ class TopPerformersSectionHeaderView: UIView {
 }
 
 private extension TopPerformersSectionHeaderView {
-    func configureView(isMyStoreTabUpdatesEnabled: Bool) {
-        guard isMyStoreTabUpdatesEnabled else {
-            return
-        }
+    func configureView() {
         backgroundColor = Constants.backgroundColor
     }
 
-    func configureLabel(title: String, isMyStoreTabUpdatesEnabled: Bool) {
-        addSubview(label)
+    func configureStackView(title: String) {
+        let titleView = createTitleLabelContainerView(title: title)
+        let twoColumnStackView: UIStackView = {
+            let leftLabelContainer = createColumnLabelContainerView(labelText: Localization.leftColumn, columnPosition: .left)
+            let rightLabelContainer = createColumnLabelContainerView(labelText: Localization.rightColumn, columnPosition: .right)
+            let stackView = UIStackView(arrangedSubviews: [leftLabelContainer, rightLabelContainer])
+            stackView.axis = .horizontal
+            stackView.distribution = .fillEqually
+            stackView.spacing = Constants.columnHorizontalSpacing
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+            return stackView
+        }()
 
-        label.text = title
+        let contentStackView: UIStackView = {
+            let stackView = UIStackView(arrangedSubviews: [titleView, twoColumnStackView])
+            stackView.axis = .vertical
+            stackView.alignment = .fill
+            stackView.spacing = Constants.titleAndColumnSpacing
+            return stackView
+        }()
 
-        if isMyStoreTabUpdatesEnabled {
+        addSubview(contentStackView)
+
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        let labelInsets = Constants.labelInsets
+        NSLayoutConstraint.activate([
+            contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: labelInsets.top),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: labelInsets.left),
+            contentStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -labelInsets.right),
+            contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -labelInsets.bottom)
+            ])
+    }
+
+    func createTitleLabelContainerView(title: String) -> UIView {
+        let label: UILabel = {
+            let label = UILabel(frame: .zero)
+            label.text = title
             label.applyHeadlineStyle()
             label.textColor = .systemColor(.label)
-        } else {
-            label.applyFootnoteStyle()
-            label.textColor = .listIcon
-        }
+            return label
+        }()
 
-        label.translatesAutoresizingMaskIntoConstraints = false
-        let labelInsets = isMyStoreTabUpdatesEnabled ? Constants.labelInsets: Constants.legacyLabelInsets
-        NSLayoutConstraint.activate([
-            label.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: labelInsets.left),
-            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -labelInsets.right),
-            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -labelInsets.bottom)
+        let containerView: UIView = {
+            let view = UIView()
+            view.addSubview(label)
+
+            label.translatesAutoresizingMaskIntoConstraints = false
+            view.translatesAutoresizingMaskIntoConstraints = false
+
+            NSLayoutConstraint.activate([
+                label.topAnchor.constraint(equalTo: view.topAnchor),
+                label.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor)
             ])
+            return view
+        }()
+        return containerView
+    }
+
+    func createColumnLabelContainerView(labelText: String?, columnPosition: ColumnPosition) -> UIView {
+        let label: UILabel = {
+            let label = UILabel(frame: .zero)
+            label.text = labelText
+            label.applyFootnoteStyle()
+            label.numberOfLines = 0
+            label.textColor = .listIcon
+            return label
+        }()
+
+        let containerView: UIView = {
+            let view = UIView()
+            view.addSubview(label)
+
+            label.translatesAutoresizingMaskIntoConstraints = false
+            view.translatesAutoresizingMaskIntoConstraints = false
+
+            NSLayoutConstraint.activate([
+                label.topAnchor.constraint(equalTo: view.topAnchor),
+                label.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
+
+            switch columnPosition {
+            case .left:
+                NSLayoutConstraint.activate([
+                    label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                    label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor)
+                ])
+            case .right:
+                NSLayoutConstraint.activate([
+                    label.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
+                    label.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+                ])
+            }
+            return view
+        }()
+        return containerView
     }
 }
 
 // MARK: - Constants!
 //
 private extension TopPerformersSectionHeaderView {
+    enum Localization {
+        static let leftColumn = NSLocalizedString("Products", comment: "Description for Top Performers left column header")
+        static let rightColumn = NSLocalizedString("Items Sold", comment: "Description for Top Performers right column header")
+    }
+
     enum Constants {
         static let labelInsets = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
-        static let legacyLabelInsets = UIEdgeInsets(top: 0, left: 14, bottom: 6, right: 14)
         static let backgroundColor: UIColor = .systemBackground
+        static let columnHorizontalSpacing: CGFloat = 30
+        static let titleAndColumnSpacing: CGFloat = 16
+    }
+
+    enum ColumnPosition {
+        case left
+        case right
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
 		021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */; };
 		0222729227746D8B007D3851 /* OldStoreStatsV4PeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0222729127746D8B007D3851 /* OldStoreStatsV4PeriodViewController.swift */; };
+		0224B1C82786E69B008F536D /* LegacyTopPerformersSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0224B1C72786E69B008F536D /* LegacyTopPerformersSectionHeaderView.swift */; };
 		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
 		0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */; };
 		0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */; };
@@ -1679,6 +1680,7 @@
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
 		021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommand.swift; sourceTree = "<group>"; };
 		0222729127746D8B007D3851 /* OldStoreStatsV4PeriodViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldStoreStatsV4PeriodViewController.swift; sourceTree = "<group>"; };
+		0224B1C72786E69B008F536D /* LegacyTopPerformersSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTopPerformersSectionHeaderView.swift; sourceTree = "<group>"; };
 		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
 		0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelProductListFilterTests.swift; sourceTree = "<group>"; };
 		0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModel.swift; sourceTree = "<group>"; };
@@ -3856,6 +3858,7 @@
 				028BAC3F22F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift */,
 				0222729127746D8B007D3851 /* OldStoreStatsV4PeriodViewController.swift */,
 				028BAC4422F3AE5C008BB4AF /* OldStoreStatsV4PeriodViewController.xib */,
+				0224B1C72786E69B008F536D /* LegacyTopPerformersSectionHeaderView.swift */,
 				028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */,
 				0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */,
 				02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */,
@@ -8591,6 +8594,7 @@
 				45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorCommand.swift in Sources */,
 				453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */,
 				024DF30E23742A70006658FE /* AztecBoldFormatBarCommand.swift in Sources */,
+				0224B1C82786E69B008F536D /* LegacyTopPerformersSectionHeaderView.swift in Sources */,
 				02396251239948470096F34C /* UIImage+TintColor.swift in Sources */,
 				DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */,
 				0290E275238E4F8100B5C466 /* PaginatedListSelectorViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5742 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of Home Screen M2 updates, we are showing ghost/placeholder content for the top performers header UI (a title and a two-column view) as well. Previously, the two-column view is implemented by the section header view of `TopPerformerDataViewController`'s table view. However, the ghost animation for a table view's section header [sets the section header title to an empty string](https://github.com/wordpress-mobile/WordPressUI-iOS/blob/ed207232e4318d16b838b54433f604bb968334a0/WordPressUI/Ghosts/Internal/GhostTableViewHandler.swift#L31-L33) and does not match the design.

Eventually, I decided to create a new version for `TopPerformersSectionHeaderView` and include the two-column view there. Using a feature flag would make the implementation very complicated, so I moved the legacy implementation to `LegacyTopPerformersSectionHeaderView` without using a feature flag.

`TopPerformersSectionHeaderView` was implemented by Auto Layout in code, so I followed it to add the two-column view. I thought about implementing it with SwiftUI, but I don't think the ghost animation works with SwiftUI. The labels in the two-column view are in a container view to support the new ghost animation.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app or switching to a different store to see the ghost animation
- Tap another tab on the bottom tab bar, or another time range tab, then back --> the ghost animation looks good in the top performers section. If the data are fetched too soon (good performance site), you can switch to a different store (easier with a slower site 😆 ) to see the loading state again

- [ ] @jaclync tests the production version when the feature flag is off

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 11 - 2022-01-07 at 13 49 23](https://user-images.githubusercontent.com/1945542/148500103-22fe1052-0cc2-4153-9bc9-f41498a759e5.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-07 at 14 09 47](https://user-images.githubusercontent.com/1945542/148500106-f9357d40-1798-4c81-b49d-d6cf857bbd7f.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
