### PR TITLE
Products List: Replace the word "variant" with "variation"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -92,18 +92,34 @@ private extension EditableProductModel {
             return nil
         }
         let numberOfVariations = product.variations.count
-        let singularFormat = NSLocalizedString("%ld variant", comment: "Label about one product variation shown on Products tab")
-        let pluralFormat = NSLocalizedString("%ld variants", comment: "Label about number of variations shown on Products tab")
-        let format = String.pluralize(numberOfVariations, singular: singularFormat, plural: pluralFormat)
+        let format = String.pluralize(numberOfVariations,
+                                      singular: Localization.VariationCount.singular,
+                                      plural: Localization.VariationCount.plural)
         return String.localizedStringWithFormat(format, numberOfVariations)
+    }
+}
+
+// MARK: Localization
+//
+private extension EditableProductModel {
+    enum Localization {
+        enum VariationCount {
+            static let singular = NSLocalizedString("%1$ld variation",
+                                                    comment: "Label about one product variation shown on Products tab. Reads, `1 variation`")
+            static let plural = NSLocalizedString("%1$ld variations",
+                                                  comment: "Label about number of variations shown on Products tab. Reads, `2 variations`")
+        }
     }
 }
 
 private extension ProductsTabProductViewModel {
     enum Localization {
-        static let noTitle = NSLocalizedString("(No Title)", comment: "Product title in Products list when there is no title")
+        static let noTitle = NSLocalizedString("(No Title)",
+                                               comment: "Product title in Products list when there is no title")
+
         static func variationID(variationID: String) -> String {
-            let titleFormat = NSLocalizedString("#%1$@", comment: "Variation ID. Parameters: %1$@ - Product variation ID")
+            let titleFormat = NSLocalizedString("#%1$@",
+                                                comment: "Variation ID. Parameters: %1$@ - Product variation ID")
             return String.localizedStringWithFormat(titleFormat, variationID)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -73,7 +73,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         let detailsText = viewModel.detailsAttributedString.string
 
         // Assert
-        let singularFormat = NSLocalizedString("%ld variant", comment: "Label about one product variation shown on Products tab")
+        let singularFormat = NSLocalizedString("%ld variation", comment: "Label about one product variation shown on Products tab")
         let expectedStockDetail = String.localizedStringWithFormat(singularFormat, variations.count)
         XCTAssertTrue(detailsText.contains(expectedStockDetail))
     }
@@ -88,7 +88,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         let detailsText = viewModel.detailsAttributedString.string
 
         // Assert
-        let pluralFormat = NSLocalizedString("%ld variants", comment: "Label about number of variations shown on Products tab")
+        let pluralFormat = NSLocalizedString("%ld variations", comment: "Label about number of variations shown on Products tab")
         let expectedStockDetail = String.localizedStringWithFormat(pluralFormat, variations.count)
         XCTAssertTrue(detailsText.contains(expectedStockDetail))
     }


### PR DESCRIPTION
Closes: #5644

### Description
This PR replaces the usage of the word "variant" with "variation" by making the following changes.

- Replace word "variant" with "variation" in view model.
- Move these `NSLocalizedString`s to private enum.
- Update tests to expect the word "variation".

### Testing instructions
1. Ensure that you have two products X and Y. 
1. Product X should have exactly 1 variation. This helps us to test the singular version of the word "variant".
1. Product Y should have more than 1 variation. This helps us to test the plural version of the word "variant" which is "variations".
1. Navigate to the Products tab to view the list of products.
1. Observe that the label in product X reads as "variation"
1. Observe that the label in product Y reads as "variations"


### Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/524475/148504707-caa27d83-c18d-4c6e-bdf1-1c876e09d95d.png" width="350"> | <img src="https://user-images.githubusercontent.com/524475/148504836-dd84659d-54f2-4c41-a947-3761bc1464e3.png"  width="350"> |


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.