### PR TITLE
Migrate Observables to Combine: `PushNotesManager` and its dependencies

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -1,9 +1,9 @@
+import Combine
 import Experiments
 import Foundation
 import UserNotifications
 import AutomatticTracks
 import Yosemite
-import Observables
 
 
 
@@ -18,22 +18,22 @@ final class PushNotificationsManager: PushNotesManager {
     /// An observable that emits values when the Remote Notifications are received while the app is
     /// in the foreground.
     ///
-    var foregroundNotifications: Observable<PushNotification> {
-        foregroundNotificationsSubject
+    var foregroundNotifications: AnyPublisher<PushNotification, Never> {
+        foregroundNotificationsSubject.eraseToAnyPublisher()
     }
 
     /// Mutable reference to `foregroundNotifications`.
-    private let foregroundNotificationsSubject = PublishSubject<PushNotification>()
+    private let foregroundNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
     /// An observable that emits values when a Remote Notification is received while the app is
     /// in inactive.
     ///
-    var inactiveNotifications: Observable<PushNotification> {
-        inactiveNotificationsSubject
+    var inactiveNotifications: AnyPublisher<PushNotification, Never> {
+        inactiveNotificationsSubject.eraseToAnyPublisher()
     }
 
     /// Mutable reference to `inactiveNotifications`
-    private let inactiveNotificationsSubject = PublishSubject<PushNotification>()
+    private let inactiveNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
     /// Returns the current Application's State
     ///

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -1,19 +1,19 @@
+import Combine
 import Foundation
 import UIKit
 import Yosemite
-import Observables
 
 protocol PushNotesManager {
 
     /// An observable that emits values when the Remote Notifications are received while the app is
     /// in the foreground.
     ///
-    var foregroundNotifications: Observable<PushNotification> { get }
+    var foregroundNotifications: AnyPublisher<PushNotification, Never> { get }
 
     /// An observable that emits values when a Remote Notification is received while the app is
     /// in inactive.
     ///
-    var inactiveNotifications: Observable<PushNotification> { get }
+    var inactiveNotifications: AnyPublisher<PushNotification, Never> { get }
 
     /// Resets the Badge Count.
     ///

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -1,6 +1,6 @@
+import Combine
 import Foundation
 import UIKit
-import Observables
 
 import enum Yosemite.ProductReviewAction
 import enum Yosemite.NotificationAction
@@ -17,7 +17,7 @@ final class HubMenuCoordinator: Coordinator {
     private let noticePresenter: NoticePresenter
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
 
-    private var observationToken: ObservationToken?
+    private var observationToken: AnyCancellable?
 
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
@@ -57,7 +57,7 @@ final class HubMenuCoordinator: Coordinator {
         navigationController.viewControllers = [HubMenuViewController(siteID: siteID, navigationController: navigationController)]
 
         if observationToken == nil {
-            observationToken = pushNotificationsManager.inactiveNotifications.subscribe { [weak self] in
+            observationToken = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
                 self?.handleInactiveNotification($0)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -17,7 +17,7 @@ final class HubMenuCoordinator: Coordinator {
     private let noticePresenter: NoticePresenter
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
 
-    private var observationToken: AnyCancellable?
+    private var inactiveNotificationsSubscription: AnyCancellable?
 
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
@@ -45,7 +45,7 @@ final class HubMenuCoordinator: Coordinator {
     }
 
     deinit {
-        observationToken?.cancel()
+        inactiveNotificationsSubscription?.cancel()
     }
 
     func start() {
@@ -56,8 +56,8 @@ final class HubMenuCoordinator: Coordinator {
     func activate(siteID: Int64) {
         navigationController.viewControllers = [HubMenuViewController(siteID: siteID, navigationController: navigationController)]
 
-        if observationToken == nil {
-            observationToken = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
+        if inactiveNotificationsSubscription == nil {
+            inactiveNotificationsSubscription = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
                 self?.handleInactiveNotification($0)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -26,7 +26,7 @@ final class OrderListViewModel {
 
     /// Used for cancelling the observer for Remote Notifications when `self` is deallocated.
     ///
-    private var cancellable: AnyCancellable?
+    private var foregroundNotificationsSubscription: AnyCancellable?
 
     /// The block called if self requests a resynchronization of the first page. The
     /// resynchronization should only be done if the view is visible.
@@ -224,7 +224,7 @@ private extension OrderListViewModel {
     /// A refresh will be requested when receiving them.
     ///
     func observeForegroundRemoteNotifications() {
-        cancellable = pushNotificationsManager.foregroundNotifications.sink { [weak self] notification in
+        foregroundNotificationsSubscription = pushNotificationsManager.foregroundNotifications.sink { [weak self] notification in
             guard notification.kind == .storeOrder else {
                 return
             }
@@ -234,7 +234,7 @@ private extension OrderListViewModel {
     }
 
     func stopObservingForegroundRemoteNotifications() {
-        cancellable?.cancel()
+        foregroundNotificationsSubscription?.cancel()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -2,8 +2,6 @@ import Combine
 import Yosemite
 import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
-import Observables
-import Combine
 
 /// ViewModel for `OrderListViewController`.
 ///
@@ -28,7 +26,7 @@ final class OrderListViewModel {
 
     /// Used for cancelling the observer for Remote Notifications when `self` is deallocated.
     ///
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     /// The block called if self requests a resynchronization of the first page. The
     /// resynchronization should only be done if the view is visible.
@@ -226,7 +224,7 @@ private extension OrderListViewModel {
     /// A refresh will be requested when receiving them.
     ///
     func observeForegroundRemoteNotifications() {
-        cancellable = pushNotificationsManager.foregroundNotifications.subscribe { [weak self] notification in
+        cancellable = pushNotificationsManager.foregroundNotifications.sink { [weak self] notification in
             guard notification.kind == .storeOrder else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -17,7 +17,7 @@ final class ReviewsCoordinator: Coordinator {
     private let noticePresenter: NoticePresenter
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
 
-    private var cancellable: AnyCancellable?
+    private var inactiveNotificationsSubscription: AnyCancellable?
 
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
@@ -45,7 +45,7 @@ final class ReviewsCoordinator: Coordinator {
     }
 
     deinit {
-        cancellable?.cancel()
+        inactiveNotificationsSubscription?.cancel()
     }
 
     func start() {
@@ -56,8 +56,8 @@ final class ReviewsCoordinator: Coordinator {
     func activate(siteID: Int64) {
         navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
 
-        if cancellable == nil {
-            cancellable = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
+        if inactiveNotificationsSubscription == nil {
+            inactiveNotificationsSubscription = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
                 self?.handleInactiveNotification($0)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -1,6 +1,6 @@
+import Combine
 import Foundation
 import UIKit
-import Observables
 
 import enum Yosemite.ProductReviewAction
 import enum Yosemite.NotificationAction
@@ -17,7 +17,7 @@ final class ReviewsCoordinator: Coordinator {
     private let noticePresenter: NoticePresenter
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
 
-    private var observationToken: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
@@ -45,7 +45,7 @@ final class ReviewsCoordinator: Coordinator {
     }
 
     deinit {
-        observationToken?.cancel()
+        cancellable?.cancel()
     }
 
     func start() {
@@ -56,8 +56,8 @@ final class ReviewsCoordinator: Coordinator {
     func activate(siteID: Int64) {
         navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
 
-        if observationToken == nil {
-            observationToken = pushNotificationsManager.inactiveNotifications.subscribe { [weak self] in
+        if cancellable == nil {
+            cancellable = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
                 self?.handleInactiveNotification($0)
             }
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -1,23 +1,22 @@
-
+import Combine
 import Foundation
 import UIKit
 @testable import WooCommerce
 import Yosemite
-import Observables
 
 final class MockPushNotificationsManager: PushNotesManager {
 
-    var foregroundNotifications: Observable<PushNotification> {
-        foregroundNotificationsSubject
+    var foregroundNotifications: AnyPublisher<PushNotification, Never> {
+        foregroundNotificationsSubject.eraseToAnyPublisher()
     }
 
-    private let foregroundNotificationsSubject = PublishSubject<PushNotification>()
+    private let foregroundNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
-    var inactiveNotifications: Observable<PushNotification> {
-        inactiveNotificationsSubject
+    var inactiveNotifications: AnyPublisher<PushNotification, Never> {
+        inactiveNotificationsSubject.eraseToAnyPublisher()
     }
 
-    private let inactiveNotificationsSubject = PublishSubject<PushNotification>()
+    private let inactiveNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
     func resetBadgeCount(type: Note.Kind) {
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -458,7 +458,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         }()
 
         var emittedNotifications = [PushNotification]()
-        _ = manager.foregroundNotifications.subscribe { notification in
+        _ = manager.foregroundNotifications.sink { notification in
             emittedNotifications.append(notification)
         }
 
@@ -496,7 +496,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         }()
 
         var emittedNotifications = [PushNotification]()
-        _ = manager.foregroundNotifications.subscribe { notification in
+        _ = manager.foregroundNotifications.sink { notification in
             emittedNotifications.append(notification)
         }
 
@@ -528,7 +528,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         application.applicationState = .background
 
         var emittedNotifications = [PushNotification]()
-        _ = manager.foregroundNotifications.subscribe { notification in
+        _ = manager.foregroundNotifications.sink { notification in
             emittedNotifications.append(notification)
         }
 
@@ -558,7 +558,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         }()
 
         var emittedNotifications = [PushNotification]()
-        _ = manager.inactiveNotifications.subscribe { notification in
+        _ = manager.inactiveNotifications.sink { notification in
             emittedNotifications.append(notification)
         }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Experiments
 import XCTest
 import UserNotifications
@@ -33,10 +34,14 @@ final class PushNotificationsManagerTests: XCTestCase {
     ///
     private var userNotificationCenter: MockUserNotificationsCenterAdapter!
 
+    private var subscriptions = Set<AnyCancellable>()
+
     // MARK: - Overridden Methods
 
     override func setUp() {
         super.setUp()
+
+        subscriptions = []
 
         application = MockApplicationAdapter()
 
@@ -458,9 +463,9 @@ final class PushNotificationsManagerTests: XCTestCase {
         }()
 
         var emittedNotifications = [PushNotification]()
-        _ = manager.foregroundNotifications.sink { notification in
+        manager.foregroundNotifications.sink { notification in
             emittedNotifications.append(notification)
-        }
+        }.store(in: &subscriptions)
 
         let userinfo = notificationPayload(noteID: 9_981, type: .storeOrder, featureFlagService: featureFlagService)
 
@@ -472,7 +477,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then
         XCTAssertEqual(emittedNotifications.count, 1)
 
-        let emittedNotification = emittedNotifications.first!
+        let emittedNotification = try XCTUnwrap(emittedNotifications.first)
         XCTAssertEqual(emittedNotification.kind, .storeOrder)
         XCTAssertEqual(emittedNotification.noteID, 9_981)
         XCTAssertEqual(emittedNotification.title, Sample.defaultMessage)
@@ -496,9 +501,9 @@ final class PushNotificationsManagerTests: XCTestCase {
         }()
 
         var emittedNotifications = [PushNotification]()
-        _ = manager.foregroundNotifications.sink { notification in
+        manager.foregroundNotifications.sink { notification in
             emittedNotifications.append(notification)
-        }
+        }.store(in: &subscriptions)
 
         let userinfo = notificationPayload(noteID: 9_981,
                                            type: .storeOrder,
@@ -558,9 +563,9 @@ final class PushNotificationsManagerTests: XCTestCase {
         }()
 
         var emittedNotifications = [PushNotification]()
-        _ = manager.inactiveNotifications.sink { notification in
+        manager.inactiveNotifications.sink { notification in
             emittedNotifications.append(notification)
-        }
+        }.store(in: &subscriptions)
 
         let userinfo = notificationPayload(noteID: 9_981, type: .storeOrder, title: Sample.defaultTitle, featureFlagService: featureFlagService)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Prep for #5330 
Part of #4379 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We used to have our own implementation of observables before we can use Combine in iOS 13, and now we're ready to migrate to Combine in the codebase. This PR only contains the changes for `PushNotesManager` and its dependencies in preparation for #5330. The implementation is `PushNotificationsManager` and its dependencies include: 

- `HubMenuCoordinator`
- `OrderListViewModel`
- `ReviewsCoordinator`

And unit tests are updated to fix the issues where `AnyCancellable` is not being held and thus the subscription gets canceled right away.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to smoke test on push notifications on a device to make sure there is no regression:

- Launch the app
- Put the app to the background
- In web, place an order or leave a review on a product in one of the connected stores --> the app should receive a push notification
- Tap on the push notification --> it should open the order or review details

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
