### PR TITLE
Add "View" action to in-app notifications

### DIFF
--- a/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
+++ b/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
@@ -20,7 +20,7 @@ protocol ApplicationAdapter: AnyObject {
 
     /// Presents a given title and optional subtitle and message with an "In App" notification
     ///
-    func presentInAppNotification(title: String, subtitle: String?, message: String?)
+    func presentInAppNotification(title: String, subtitle: String?, message: String?, actionTitle: String, actionHandler: @escaping () -> Void)
 
     /// Presents the Details for the specified Notification.
     ///
@@ -40,8 +40,13 @@ extension UIApplication: ApplicationAdapter {
 
     /// Presents a given Message with an "In App" notification
     ///
-    func presentInAppNotification(title: String, subtitle: String?, message: String?) {
-        let notice = Notice(title: title, subtitle: subtitle, message: message, feedbackType: .success)
+    func presentInAppNotification(title: String, subtitle: String?, message: String?, actionTitle: String, actionHandler: @escaping () -> Void) {
+        let notice = Notice(title: title,
+                            subtitle: subtitle,
+                            message: message,
+                            feedbackType: .success,
+                            actionTitle: actionTitle,
+                            actionHandler: actionHandler)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -356,7 +356,10 @@ private extension PushNotificationsManager {
             configuration.application
                 .presentInAppNotification(title: foregroundNotification.title,
                                           subtitle: foregroundNotification.subtitle,
-                                          message: foregroundNotification.message)
+                                          message: foregroundNotification.message,
+                                          actionTitle: Localization.viewInAppNotification) { [weak self] in
+                    self?.presentDetails(for: foregroundNotification)
+                }
 
             foregroundNotificationsSubject.send(foregroundNotification)
         }
@@ -385,13 +388,7 @@ private extension PushNotificationsManager {
         let pushNotificationsForAllStoresEnabled = featureFlagService.isFeatureFlagEnabled(.pushNotificationsForAllStores)
         if let notification = PushNotification.from(userInfo: userInfo,
                                                     pushNotificationsForAllStoresEnabled: pushNotificationsForAllStoresEnabled) {
-
-            // Handling the product review notifications (`.comment`) has been moved to
-            // `ReviewsCoordinator`. All other push notification handling should be in a coordinator
-            // in the future too.
-            if notification.kind != .comment {
-                configuration.application.presentNotificationDetails(for: Int64(notification.noteID))
-            }
+            presentDetails(for: notification)
 
             inactiveNotificationsSubject.send(notification)
         }
@@ -418,6 +415,17 @@ private extension PushNotificationsManager {
         synchronizeNotifications(completionHandler: completionHandler)
 
         return true
+    }
+}
+
+private extension PushNotificationsManager {
+    func presentDetails(for notification: PushNotification) {
+        // Handling the product review notifications (`.comment`) has been moved to
+        // `ReviewsCoordinator`. All other push notification handling should be in a coordinator
+        // in the future too.
+        if notification.kind != .comment {
+            configuration.application.presentNotificationDetails(for: Int64(notification.noteID))
+        }
     }
 }
 
@@ -589,4 +597,10 @@ private enum AnalyticKey {
 private enum PushType {
     static let badgeReset = "badge-reset"
     static let zendesk = "zendesk"
+}
+
+private extension PushNotificationsManager {
+    enum Localization {
+        static let viewInAppNotification = NSLocalizedString("View", comment: "Action title in an in-app notification to view more details.")
+    }
 }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -10,6 +10,11 @@ protocol PushNotesManager {
     ///
     var foregroundNotifications: AnyPublisher<PushNotification, Never> { get }
 
+    /// An observable that emits values when the user taps to view the in-app notification while the app is
+    /// in the foreground.
+    ///
+    var foregroundNotificationsToView: AnyPublisher<PushNotification, Never> { get }
+
     /// An observable that emits values when a Remote Notification is received while the app is
     /// in inactive.
     ///

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -64,12 +64,12 @@ final class HubMenuCoordinator: Coordinator {
             notificationsSubscription = Publishers
                 .Merge(pushNotificationsManager.inactiveNotifications, pushNotificationsManager.foregroundNotificationsToView)
                 .sink { [weak self] in
-                    self?.handleInactiveNotification($0)
+                    self?.handleNotification($0)
                 }
         }
     }
 
-    private func handleInactiveNotification(_ notification: PushNotification) {
+    private func handleNotification(_ notification: PushNotification) {
         guard notification.kind == .comment else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -18,7 +18,7 @@ final class HubMenuCoordinator: Coordinator {
     private let noticePresenter: NoticePresenter
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
 
-    private var inactiveNotificationsSubscription: AnyCancellable?
+    private var notificationsSubscription: AnyCancellable?
 
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
@@ -46,7 +46,7 @@ final class HubMenuCoordinator: Coordinator {
     }
 
     deinit {
-        inactiveNotificationsSubscription?.cancel()
+        notificationsSubscription?.cancel()
     }
 
     func start() {
@@ -60,10 +60,12 @@ final class HubMenuCoordinator: Coordinator {
             navigationController.viewControllers = [hubMenuController]
         }
 
-        if inactiveNotificationsSubscription == nil {
-            inactiveNotificationsSubscription = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
-                self?.handleInactiveNotification($0)
-            }
+        if notificationsSubscription == nil {
+            notificationsSubscription = Publishers
+                .Merge(pushNotificationsManager.inactiveNotifications, pushNotificationsManager.foregroundNotificationsToView)
+                .sink { [weak self] in
+                    self?.handleInactiveNotification($0)
+                }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -60,8 +60,8 @@ final class ReviewsCoordinator: Coordinator {
             notificationsSubscription = Publishers
                 .Merge(pushNotificationsManager.inactiveNotifications, pushNotificationsManager.foregroundNotificationsToView)
                 .sink { [weak self] in
-                self?.handleNotification($0)
-            }
+                    self?.handleNotification($0)
+                }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -17,7 +17,7 @@ final class ReviewsCoordinator: Coordinator {
     private let noticePresenter: NoticePresenter
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
 
-    private var inactiveNotificationsSubscription: AnyCancellable?
+    private var notificationsSubscription: AnyCancellable?
 
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
@@ -45,7 +45,7 @@ final class ReviewsCoordinator: Coordinator {
     }
 
     deinit {
-        inactiveNotificationsSubscription?.cancel()
+        notificationsSubscription?.cancel()
     }
 
     func start() {
@@ -56,14 +56,16 @@ final class ReviewsCoordinator: Coordinator {
     func activate(siteID: Int64) {
         navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
 
-        if inactiveNotificationsSubscription == nil {
-            inactiveNotificationsSubscription = pushNotificationsManager.inactiveNotifications.sink { [weak self] in
-                self?.handleInactiveNotification($0)
+        if notificationsSubscription == nil {
+            notificationsSubscription = Publishers
+                .Merge(pushNotificationsManager.inactiveNotifications, pushNotificationsManager.foregroundNotificationsToView)
+                .sink { [weak self] in
+                self?.handleNotification($0)
             }
         }
     }
 
-    private func handleInactiveNotification(_ notification: PushNotification) {
+    private func handleNotification(_ notification: PushNotification) {
         guard notification.kind == .comment else {
             return
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockApplicationAdapter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockApplicationAdapter.swift
@@ -37,7 +37,7 @@ final class MockApplicationAdapter: ApplicationAdapter {
 
     /// Innocuous `presentInAppNotification`
     ///
-    func presentInAppNotification(title: String, subtitle: String?, message: String?) {
+    func presentInAppNotification(title: String, subtitle: String?, message: String?, actionTitle: String, actionHandler: @escaping () -> Void) {
         presentInAppMessages.append((title: title, subtitle: subtitle, message: message))
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -12,6 +12,12 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     private let foregroundNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
+    var foregroundNotificationsToView: AnyPublisher<PushNotification, Never> {
+        foregroundNotificationsToViewSubject.eraseToAnyPublisher()
+    }
+
+    private let foregroundNotificationsToViewSubject = PassthroughSubject<PushNotification, Never>()
+
     var inactiveNotifications: AnyPublisher<PushNotification, Never> {
         inactiveNotificationsSubject.eraseToAnyPublisher()
     }
@@ -63,6 +69,13 @@ extension MockPushNotificationsManager {
     ///
     func sendForegroundNotification(_ notification: PushNotification) {
         foregroundNotificationsSubject.send(notification)
+    }
+
+    /// Send a `PushNotification` that will be emitted by the `foregroundNotificationsToView`
+    /// observable.
+    ///
+    func sendForegroundNotificationToView(_ notification: PushNotification) {
+        foregroundNotificationsToViewSubject.send(notification)
     }
 
     /// Send a `PushNotification` that will be emitted by the `inactiveNotifications`


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #5330 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the app receives push notifications while the app is in the foreground, we currently show an in-app notice (snack bar) without any actions. Now that we support push notifications for all stores, there is a higher chance when the app receives a push notification from any connected stores while the user is using it. This PR adds a "View" CTA to the in-app notice that is the same as when the user taps on a push notification from the Notification Center.

A tracking event (`view_in_app_push_notification_pressed`) will be added in a future PR after confirming with the team today.
 
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please test on a device since WP.com push notifications aren't supported in simulators.

#### Order notifications

- Launch the app in the logged-in state
- In web, place an order in any of the connected stores --> there should be an in-app notice in the app about the new order
- Tap "View" in the in-app notice --> the app should navigate to the order details

#### Review notifications

- Launch the app in the logged-in state
- In web, leave a review in any of the connected stores --> there should be an in-app notice in the app about the new review
- Tap "View" in the in-app notice --> the app should navigate to the review details

- [x] @jaclync tests when the `hubMenu` feature flag is disabled

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

new review | new order
-- | --
![IMG_3419](https://user-images.githubusercontent.com/1945542/148870345-9852ba83-dce5-47df-9b55-0aa0bbc5422a.PNG) | ![IMG_3420](https://user-images.githubusercontent.com/1945542/148870351-8e762b90-2d33-4877-9d4f-0f2ecc929d06.PNG)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
