### PR TITLE
Fix ghost "Reviews" label in the tab bar when `hubMenu` feature flag is off

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -229,7 +229,11 @@ private extension ReviewsViewController {
     }
 
     func refreshTitle() {
-        title = Localization.title
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.hubMenu) {
+            title = Localization.title
+        } else {
+            navigationItem.title = Localization.title
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

- [x] ⚠️ Confirm target branch ⚠️ 

Closes: #5855 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While testing in-app notifications when the `hubMenu` feature flag is off, I noticed that I wasn't able to clear the Reviews tab badge (the purple dot on the Reviews tab like in [this screenshot](https://user-images.githubusercontent.com/1945542/148886583-c48d8c17-e901-471f-b9b8-46540b9c4b04.PNG)). In the meantime, there is a ghost "Reviews" label in the bottom left corner of the tab bar. After some debugging by checking out recent related changes, it was from [this change](https://github.com/woocommerce/woocommerce-ios/commit/d05da62e44deb73729e33ec4395eddc3ebe42f37#diff-b763a8bda6b8fde2f84744a3c13b9819168dcfc0b6c653bba6f3edda1220971a) in December that updates setting the reviews tab (`ReviewsViewController`)'s navigation bar title from `navigationItem.title` to `title` to work with SwiftUI.

⚠️ I'm considering targeting this fix for release 8.3, since we received a number of user reports on not being able to clear the app icon badge for a recent release (something that merchants could care about a lot). I was hoping to verify that it's an issue in release 8.3 build first, but the TestFlight build isn't available yet. It'd be great if you can help verify that you can reproduce #5855!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Hub menu feature flag on

- Launch the app
- Tap on the Menu tab
- Tap on the Reviews item --> the navigation bar should still show "Reviews" and the tab bar "Menu"
- Navigation back to the root of Menu tab --> the tab bar should still show "Menu"

#### Hub menu feature flag off

Please test on a device to receive remote push notifications for new reviews.

- In code, return `false` for `DefaultFeatureFlagService`'s `hubMenu` feature flag
- Launch the app
- Tap on the Reviews tab --> there should not be any ghost label in the tab bar (before this PR, there is a ghost "Reviews" label in the tab bar)
- Tap on any other tab
- In web, leave a review in the connected store --> a purple dot/badge should show up on the Reviews tab
- Tap on the reviews tab --> the purple dot/badge should be cleared (before this PR, it cannot be cleared)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
