### PR TITLE
Remove unused identifier in project.pbxproj

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -9216,7 +9216,6 @@
 				7E7C5F8B2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift in Sources */,
 				020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */,
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,
-				573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */,
 				579CDF01274D811D00E8903D /* StoreStatsUsageTracksEventEmitterTests.swift in Sources */,
 				262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */,
 				027F240C258371150021DB06 /* RefundShippingLabelViewModelTests.swift in Sources */,


### PR DESCRIPTION
## Description

When running `bundle exec pod install` I've noticed a warning:

```
[!] `<PBXSourcesBuildPhase UUID=`B56DB3D92049BFAA00D4AA8E`>` attempted to initialize an object with an unknown UUID. `573D0ACF2458665C004DE614` for attribute: `files`. This can be the result of a merge and the unknown UUID is being discarded.
```

Looking into project.pbxproj file I see a single reference to `OrderSearchStarterViewModelTests.swift`. It doesn't show up in the codebase, so likely a leftover from earlier merge. The change is removing this single reference.

## Testing

1. Run `bundle exec pod install` in `trunk`, notice a warning.
2. Run `bundle exec pod install` in this branch, notice no warning.
3. Open project and confirm it builds.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
