### PR TITLE
Hide settings button in home screen and switch store action under settings if hub menu feature flag is enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -189,18 +189,20 @@ private extension DashboardViewController {
     }
 
     private func configureNavigationItem() {
-        let rightBarButton = UIBarButtonItem(image: .gearBarButtonItemImage,
-                                             style: .plain,
-                                             target: self,
-                                             action: #selector(settingsTapped))
-        rightBarButton.accessibilityLabel = NSLocalizedString("Settings", comment: "Accessibility label for the Settings button.")
-        rightBarButton.accessibilityTraits = .button
-        rightBarButton.accessibilityHint = NSLocalizedString(
-            "Navigates to Settings.",
-            comment: "VoiceOver accessibility hint, informing the user the button can be used to navigate to the Settings screen."
-        )
-        rightBarButton.accessibilityIdentifier = "dashboard-settings-button"
-        navigationItem.setRightBarButton(rightBarButton, animated: false)
+        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.hubMenu) {
+            let rightBarButton = UIBarButtonItem(image: .gearBarButtonItemImage,
+                                                 style: .plain,
+                                                 target: self,
+                                                 action: #selector(settingsTapped))
+            rightBarButton.accessibilityLabel = NSLocalizedString("Settings", comment: "Accessibility label for the Settings button.")
+            rightBarButton.accessibilityTraits = .button
+            rightBarButton.accessibilityHint = NSLocalizedString(
+                "Navigates to Settings.",
+                comment: "VoiceOver accessibility hint, informing the user the button can be used to navigate to the Settings screen."
+            )
+            rightBarButton.accessibilityIdentifier = "dashboard-settings-button"
+            navigationItem.setRightBarButton(rightBarButton, animated: false)
+        }
     }
 
     func configureDashboardUIContainer() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -170,7 +170,7 @@ private extension SettingsViewModel {
     func configureSections() {
         // Selected Store
         let selectedStoreSection: Section? = {
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.hubMenu) {
+            if featureFlagService.isFeatureFlagEnabled(.hubMenu) {
                 return nil
             }
             else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -169,12 +169,17 @@ private extension SettingsViewModel {
 
     func configureSections() {
         // Selected Store
-        let selectedStoreSection: Section = {
-            let storeRows: [Row] = sites.count > 1 ?
+        let selectedStoreSection: Section? = {
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.hubMenu) {
+                return nil
+            }
+            else {
+                let storeRows: [Row] = sites.count > 1 ?
                 [.selectedStore, .switchStore] : [.selectedStore]
-            return Section(title: Localization.selectedStoreTitle,
-                           rows: storeRows,
-                           footerHeight: UITableView.automaticDimension)
+                return Section(title: Localization.selectedStoreTitle,
+                               rows: storeRows,
+                               footerHeight: UITableView.automaticDimension)
+            }
         }()
 
         // Plugins

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -44,6 +44,30 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.sections.count > 0)
     }
 
+    func test_selectedStoreSection_is_hidden_if_hub_menu_feature_flag_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isHubMenuOn: true)
+        let viewModel = SettingsViewModel(stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.selectedStore) })
+    }
+
+    func test_selectedStoreSection_is_showed_if_hub_menu_feature_flag_is_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isHubMenuOn: false)
+        let viewModel = SettingsViewModel(stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(.selectedStore) })
+    }
+
     func test_sections_contain_install_jetpack_row_when_JCP_support_feature_flag_is_on_and_default_site_is_jcp() {
         // Given
         let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -56,7 +56,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.selectedStore) })
     }
 
-    func test_selectedStoreSection_is_showed_if_hub_menu_feature_flag_is_off() {
+    func test_selectedStoreSection_is_shown_if_hub_menu_feature_flag_is_off() {
         // Given
         let featureFlagService = MockFeatureFlagService(isHubMenuOn: false)
         let viewModel = SettingsViewModel(stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)


### PR DESCRIPTION
Closes: #5862 

### Description
Since we are near releasing the new Hub Menu, we should remove the Settings button in the current Home Screen and remove also the selected store and the switch store button under Settings, because they will be redundant.

### Testing instructions
#### Case 1
1. Launch the app with the hub menu feature flag enabled (enabled by default in `debug`).
2. You should not be able to see the Settings button on the home screen.
3. Go to the hub menu. Open Settings.
4. You should not be able to see the selected store in settings and the switch store button.

#### Case 2
1. Launch the app with the hub menu feature flag disabled.
2. You should be able to see the Settings button on the home screen.
3. Go to the hub menu. Open Settings.
4. You should be able to see the selected store in settings and the switch store button.

### Screenshots
| Home Screen before             |  Home Screen After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-01-11 at 12 28 18](https://user-images.githubusercontent.com/495617/148951303-23b4d216-e6b3-491f-8e58-11b4bfff2ead.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-01-11 at 14 29 02](https://user-images.githubusercontent.com/495617/148951313-5d5691c5-4e4b-43be-944a-b131f3a59e74.png)



| Settings before            |  Settings after |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-01-11 at 12 28 31](https://user-images.githubusercontent.com/495617/148952136-6b31623f-12fa-4a79-b753-5e953c6365cd.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-01-11 at 14 29 16](https://user-images.githubusercontent.com/495617/148952145-951537ee-ec75-4f82-8c32-1431b362e068.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
