### PR TITLE
Order Creation: Add support for showing a product variation in ProductRow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -20,7 +20,7 @@ struct AddProductToOrder: View {
                         ForEach(viewModel.productRows) { rowViewModel in
                             ProductRow(viewModel: rowViewModel)
                                 .onTapGesture {
-                                    viewModel.selectProduct(rowViewModel.productID)
+                                    viewModel.selectProduct(rowViewModel.productOrVariationID)
                                     isPresented.toggle()
                                 }
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -72,7 +72,7 @@ private extension ProductInOrder {
 
 struct ProductInOrder_Previews: PreviewProvider {
     static var previews: some View {
-        let productRowVM = ProductRowViewModel(productID: 1,
+        let productRowVM = ProductRowViewModel(productOrVariationID: 1,
                                             name: "Love Ficus",
                                             sku: "123456",
                                             price: "20",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Kingfisher
 
-/// Represent a single product row in the Product section of a New Order
+/// Represent a single product or variation row in the Product section of a New Order
 ///
 struct ProductRow: View {
     /// View model to drive the view.
@@ -124,7 +124,7 @@ private enum Localization {
 
 struct ProductRow_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ProductRowViewModel(productID: 1,
+        let viewModel = ProductRowViewModel(productOrVariationID: 1,
                                             name: "Love Ficus",
                                             sku: "123456",
                                             price: "20",
@@ -133,7 +133,7 @@ struct ProductRow_Previews: PreviewProvider {
                                             manageStock: true,
                                             canChangeQuantity: true,
                                             imageURL: nil)
-        let viewModelWithoutStepper = ProductRowViewModel(productID: 1,
+        let viewModelWithoutStepper = ProductRowViewModel(productOrVariationID: 1,
                                                           name: "Love Ficus",
                                                           sku: "123456",
                                                           price: "20",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -51,11 +51,11 @@ class AddProductToOrderViewModelTests: XCTestCase {
         let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // Then
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == 1 }), "Products do not include simple product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == 2 }), "Products do not include grouped product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == 3 }), "Products do not include affiliate product")
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productID == 4 }), "Products include variable product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == 5 }), "Products do not include subscription product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 1 }), "Products do not include simple product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 2 }), "Products do not include grouped product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 3 }), "Products do not include affiliate product")
+        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == 4 }), "Products include variable product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 5 }), "Products do not include subscription product")
     }
 
     func test_product_rows_only_contain_products_with_published_and_private_statuses() {
@@ -70,10 +70,10 @@ class AddProductToOrderViewModelTests: XCTestCase {
         let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // Then
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == 1 }), "Product rows do not include published product")
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productID == 2 }), "Product rows include draft product")
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productID == 3 }), "Product rows include pending product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == 4 }), "Product rows do not include private product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 1 }), "Product rows do not include published product")
+        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == 2 }), "Product rows include draft product")
+        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == 3 }), "Product rows include pending product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 4 }), "Product rows do not include private product")
     }
 
     func test_scrolling_indicator_appears_only_during_sync() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -140,7 +140,7 @@ class NewOrderViewModelTests: XCTestCase {
 
         // Then
         let expectedOrderItem = product.toOrderItem(quantity: 1)
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productID == sampleProductID }), "Product rows do not contain expected product")
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
         XCTAssertTrue(viewModel.orderDetails.items.contains(where: { $0.orderItem == expectedOrderItem }), "Order details do not contain expected order item")
     }
 
@@ -197,7 +197,7 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
 
         // Then
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productID == product0.productID }))
+        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product0.productID }))
         XCTAssertEqual(viewModel.orderDetails.items, [expectedRemainingItem])
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 class ProductRowViewModelTests: XCTestCase {
 
-    func test_viewModel_is_created_with_correct_initial_values() {
+    func test_viewModel_is_created_with_correct_initial_values_from_product() {
         // Given
         let rowID = "0"
         let imageURLString = "https://woo.com/woo.jpg"
@@ -17,8 +17,30 @@ class ProductRowViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.id, rowID)
-        XCTAssertEqual(viewModel.productID, product.productID)
+        XCTAssertEqual(viewModel.productOrVariationID, product.productID)
         XCTAssertEqual(viewModel.name, product.name)
+        XCTAssertEqual(viewModel.imageURL, URL(string: imageURLString))
+        XCTAssertFalse(viewModel.canChangeQuantity)
+        XCTAssertEqual(viewModel.quantity, 1)
+    }
+
+    func test_viewModel_is_created_with_correct_initial_values_from_product_variation() {
+        // Given
+        let rowID = "0"
+        let imageURLString = "https://woo.com/woo.jpg"
+        let allAttributes = [ProductAttribute.fake().copy(attributeID: 1, name: "Color"),
+                             ProductAttribute.fake().copy(attributeID: 2, name: "Size")]
+        let productVariation = ProductVariation.fake().copy(productVariationID: 12,
+                                                            attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")],
+                                                            image: ProductImage.fake().copy(src: imageURLString))
+
+        // When
+        let viewModel = ProductRowViewModel(id: rowID, productVariation: productVariation, allAttributes: allAttributes, canChangeQuantity: false)
+
+        // Then
+        XCTAssertEqual(viewModel.id, rowID)
+        XCTAssertEqual(viewModel.productOrVariationID, productVariation.productVariationID)
+        XCTAssertEqual(viewModel.name, "Blue - Any Size")
         XCTAssertEqual(viewModel.imageURL, URL(string: imageURLString))
         XCTAssertFalse(viewModel.canChangeQuantity)
         XCTAssertEqual(viewModel.quantity, 1)


### PR DESCRIPTION
Part of: #5847

## Description

As part of Order Creation, we need the ability to select a product variation to add to the new order. This updates `ProductRow` so it can display a product variation as well as a product.

## Changes

* Adds a convenience init to `ProductRowViewModel` so the view model can be initialized with a product variation. The same details (image, name, stock, price, and SKU) are displayed for the variation as for a product.
* Updates the `ProductRowViewModel` to have a `productOrVariationID` (instead of `productID`) for clarity.
* Adds a unit test for initializing the view model with a product variation.

## Testing

Product variations aren't yet displayed anywhere in Order Creation, so the only test for this change is to confirm that products continue to be displayed in the UI as expected:

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, confirm the product list loads with all the expected details for each product.
6. Tap to select a product.
7. Confirm the Products section of the new order shows the selected product with all the expected details and quantity stepper.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
