### PR TITLE
Order Creation: Add protocol for AddProductToOrder view models to make it reusable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -20,7 +20,7 @@ struct AddProductToOrder<ViewModel: AddProductToOrderViewModelProtocol>: View {
                         ForEach(viewModel.productRows) { rowViewModel in
                             ProductRow(viewModel: rowViewModel)
                                 .onTapGesture {
-                                    viewModel.selectProduct(rowViewModel.productOrVariationID)
+                                    viewModel.selectProductOrVariation(rowViewModel.productOrVariationID)
                                     isPresented.toggle()
                                 }
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 
-/// View showing a list of products to add to an order.
+/// View showing a list of products or product variations to add to an order.
 ///
-struct AddProductToOrder: View {
+struct AddProductToOrder<ViewModel: AddProductToOrderViewModelProtocol>: View {
     /// Defines whether the view is presented.
     ///
     @Binding var isPresented: Bool
 
     /// View model to drive the view.
     ///
-    @ObservedObject var viewModel: AddProductToOrderViewModel
+    @ObservedObject var viewModel: ViewModel
 
     var body: some View {
         NavigationView {
@@ -88,13 +88,11 @@ private struct InfiniteScrollIndicator: View {
     }
 }
 
-private extension AddProductToOrder {
-    enum Localization {
-        static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
-        static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
-        static let emptyStateMessage = NSLocalizedString("No products found",
-                                                         comment: "Message displayed if there are no products to display in the Add Product screen")
-    }
+private enum Localization {
+    static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
+    static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
+    static let emptyStateMessage = NSLocalizedString("No products found",
+                                                     comment: "Message displayed if there are no products to display in the Add Product screen")
 }
 
 struct AddProduct_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -82,7 +82,7 @@ final class AddProductToOrderViewModel: AddProductToOrderViewModelProtocol {
 
     /// Select a product to add to the order
     ///
-    func selectProduct(_ productID: Int64) {
+    func selectProductOrVariation(_ productID: Int64) {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -1,9 +1,9 @@
 import Yosemite
 import protocol Storage.StorageManagerType
 
-/// View model for `AddProductToOrder`.
+/// View model for `AddProductToOrder` with a list of products.
 ///
-final class AddProductToOrderViewModel: ObservableObject {
+final class AddProductToOrderViewModel: AddProductToOrderViewModelProtocol {
     private let siteID: Int64
 
     /// Storage to fetch product list
@@ -57,14 +57,6 @@ final class AddProductToOrderViewModel: ObservableObject {
     /// Tracks if the infinite scroll indicator should be displayed
     ///
     @Published private(set) var shouldShowScrollIndicator = false
-
-    /// View models of the ghost rows used during the loading process.
-    ///
-    var ghostRows: [ProductRowViewModel] {
-        return Array(0..<6).map { index in
-            ProductRowViewModel(product: sampleGhostProduct(id: index), canChangeQuantity: false)
-        }
-    }
 
     /// Products Results Controller.
     ///
@@ -184,84 +176,5 @@ private extension AddProductToOrderViewModel {
     ///
     func configureSyncingCoordinator() {
         syncingCoordinator.delegate = self
-    }
-}
-
-// MARK: - Utils
-extension AddProductToOrderViewModel {
-    /// Represents possible statuses for syncing products
-    ///
-    enum SyncStatus {
-        case firstPageSync
-        case results
-        case empty
-    }
-
-    /// Used for ghost list view while syncing
-    ///
-    private func sampleGhostProduct(id: Int64) -> Product {
-        Product(siteID: 1,
-                productID: id,
-                name: "Love Ficus",
-                slug: "",
-                permalink: "",
-                date: Date(),
-                dateCreated: Date(),
-                dateModified: nil,
-                dateOnSaleStart: nil,
-                dateOnSaleEnd: nil,
-                productTypeKey: ProductType.simple.rawValue,
-                statusKey: ProductStatus.draft.rawValue,
-                featured: false,
-                catalogVisibilityKey: ProductCatalogVisibility.hidden.rawValue,
-                fullDescription: nil,
-                shortDescription: nil,
-                sku: "123456",
-                price: "20",
-                regularPrice: nil,
-                salePrice: nil,
-                onSale: false,
-                purchasable: true,
-                totalSales: 0,
-                virtual: false,
-                downloadable: false,
-                downloads: [],
-                downloadLimit: -1,
-                downloadExpiry: -1,
-                buttonText: "",
-                externalURL: nil,
-                taxStatusKey: ProductTaxStatus.taxable.rawValue,
-                taxClass: nil,
-                manageStock: false,
-                stockQuantity: 7,
-                stockStatusKey: ProductStockStatus.inStock.rawValue,
-                backordersKey: ProductBackordersSetting.notAllowed.rawValue,
-                backordersAllowed: false,
-                backordered: false,
-                soldIndividually: true,
-                weight: nil,
-                dimensions: ProductDimensions(length: "1", width: "1", height: "1"),
-                shippingRequired: false,
-                shippingTaxable: false,
-                shippingClass: nil,
-                shippingClassID: 0,
-                productShippingClass: nil,
-                reviewsAllowed: false,
-                averageRating: "5",
-                ratingCount: 0,
-                relatedIDs: [],
-                upsellIDs: [],
-                crossSellIDs: [],
-                parentID: 0,
-                purchaseNote: nil,
-                categories: [],
-                tags: [],
-                images: [],
-                attributes: [],
-                defaultAttributes: [],
-                variations: [],
-                groupedProducts: [],
-                menuOrder: 0,
-                addOns: [])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -48,7 +48,7 @@ final class AddProductToOrderViewModel: AddProductToOrderViewModelProtocol {
 
     /// Current sync status; used to determine what list view to display.
     ///
-    @Published private(set) var syncStatus: SyncStatus?
+    @Published private(set) var syncStatus: AddProductToOrderSyncStatus?
 
     /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
@@ -26,7 +26,7 @@ protocol AddProductToOrderViewModelProtocol: ObservableObject {
 
     /// Select a product or product variation to add to the order
     ///
-    func selectProduct(_ productID: Int64)
+    func selectProductOrVariation(_ productID: Int64)
 
     /// Sync first page of products from remote if needed.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
@@ -1,0 +1,117 @@
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// Represents possible statuses for syncing products
+///
+enum SyncStatus {
+    case firstPageSync
+    case results
+    case empty
+}
+
+/// Protocol for view models for `AddProductToOrder`, to add a product or product variation to an order.
+///
+protocol AddProductToOrderViewModelProtocol: ObservableObject {
+    /// View models for each product row
+    ///
+    var productRows: [ProductRowViewModel] { get }
+
+    /// Current sync status; used to determine what list view to display.
+    ///
+    var syncStatus: SyncStatus? { get }
+
+    /// Tracks if the infinite scroll indicator should be displayed
+    ///
+    var shouldShowScrollIndicator: Bool { get }
+
+    /// Select a product or product variation to add to the order
+    ///
+    func selectProduct(_ productID: Int64)
+
+    /// Sync first page of products from remote if needed.
+    ///
+    func syncFirstPage()
+
+    /// Sync next page of products from remote.
+    ///
+    func syncNextPage()
+}
+
+// MARK: - Utils
+extension AddProductToOrderViewModelProtocol {
+    /// View models of the ghost rows used during the loading process.
+    ///
+    var ghostRows: [ProductRowViewModel] {
+        return Array(0..<6).map { index in
+            ProductRowViewModel(product: sampleGhostProduct(id: index), canChangeQuantity: false)
+        }
+    }
+
+    /// Used for ghost list view while syncing
+    ///
+    private func sampleGhostProduct(id: Int64) -> Product {
+        Product(siteID: 1,
+                productID: id,
+                name: "Love Ficus",
+                slug: "",
+                permalink: "",
+                date: Date(),
+                dateCreated: Date(),
+                dateModified: nil,
+                dateOnSaleStart: nil,
+                dateOnSaleEnd: nil,
+                productTypeKey: ProductType.simple.rawValue,
+                statusKey: ProductStatus.draft.rawValue,
+                featured: false,
+                catalogVisibilityKey: ProductCatalogVisibility.hidden.rawValue,
+                fullDescription: nil,
+                shortDescription: nil,
+                sku: "123456",
+                price: "20",
+                regularPrice: nil,
+                salePrice: nil,
+                onSale: false,
+                purchasable: true,
+                totalSales: 0,
+                virtual: false,
+                downloadable: false,
+                downloads: [],
+                downloadLimit: -1,
+                downloadExpiry: -1,
+                buttonText: "",
+                externalURL: nil,
+                taxStatusKey: ProductTaxStatus.taxable.rawValue,
+                taxClass: nil,
+                manageStock: false,
+                stockQuantity: 7,
+                stockStatusKey: ProductStockStatus.inStock.rawValue,
+                backordersKey: ProductBackordersSetting.notAllowed.rawValue,
+                backordersAllowed: false,
+                backordered: false,
+                soldIndividually: true,
+                weight: nil,
+                dimensions: ProductDimensions(length: "1", width: "1", height: "1"),
+                shippingRequired: false,
+                shippingTaxable: false,
+                shippingClass: nil,
+                shippingClassID: 0,
+                productShippingClass: nil,
+                reviewsAllowed: false,
+                averageRating: "5",
+                ratingCount: 0,
+                relatedIDs: [],
+                upsellIDs: [],
+                crossSellIDs: [],
+                parentID: 0,
+                purchaseNote: nil,
+                categories: [],
+                tags: [],
+                images: [],
+                attributes: [],
+                defaultAttributes: [],
+                variations: [],
+                groupedProducts: [],
+                menuOrder: 0,
+                addOns: [])
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
@@ -1,5 +1,4 @@
 import Yosemite
-import protocol Storage.StorageManagerType
 
 /// Represents possible statuses for syncing products
 ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModelProtocol.swift
@@ -1,8 +1,8 @@
 import Yosemite
 
-/// Represents possible statuses for syncing products
+/// Represents possible statuses for syncing a list of products or product variations
 ///
-enum SyncStatus {
+enum AddProductToOrderSyncStatus {
     case firstPageSync
     case results
     case empty
@@ -17,7 +17,7 @@ protocol AddProductToOrderViewModelProtocol: ObservableObject {
 
     /// Current sync status; used to determine what list view to display.
     ///
-    var syncStatus: SyncStatus? { get }
+    var syncStatus: AddProductToOrderSyncStatus? { get }
 
     /// Tracks if the infinite scroll indicator should be displayed
     ///

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1134,6 +1134,7 @@
 		CC0324A3263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */; };
 		CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */; };
 		CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */; };
+		CC13C0C9278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0C8278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift */; };
 		CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */; };
 		CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */; };
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
@@ -2718,6 +2719,7 @@
 		CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
 		CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactory.swift; sourceTree = "<group>"; };
 		CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactoryTests.swift; sourceTree = "<group>"; };
+		CC13C0C8278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductToOrderViewModelProtocol.swift; sourceTree = "<group>"; };
 		CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentSection.swift; sourceTree = "<group>"; };
 		CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackage.swift; sourceTree = "<group>"; };
@@ -6124,6 +6126,7 @@
 			children = (
 				CC53FB372755213900C4CA4F /* AddProductToOrder.swift */,
 				CC53FB3B2757EC7200C4CA4F /* AddProductToOrderViewModel.swift */,
+				CC13C0C8278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
 				CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */,
 				CCC284102768C18500F6CC8B /* ProductInOrder.swift */,
@@ -8149,6 +8152,7 @@
 				029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */,
 				B5A8F8AD20B88D9900D211DE /* LoginPrologueViewController.swift in Sources */,
 				B5D1AFC620BC7B7300DB0E8C /* StorePickerViewController.swift in Sources */,
+				CC13C0C9278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift in Sources */,
 				02DD81FB242CAA400060E50B /* WordPressMediaLibraryPickerDataSource.swift in Sources */,
 				0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */,
 				31579028273EE2B1008CA3AF /* VersionHelpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -136,7 +136,7 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // When
-        viewModel.addProductViewModel.selectProduct(product.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product.productID)
 
         // Then
         let expectedOrderItem = product.toOrderItem(quantity: 1)
@@ -152,11 +152,11 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // When
-        viewModel.addProductViewModel.selectProduct(product.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product.productID)
         viewModel.productRows[0].incrementQuantity()
 
         // And when another product is added to the order (to confirm the first product's quantity change is retained)
-        viewModel.addProductViewModel.selectProduct(product.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product.productID)
 
         // Then
         let expectedOrderItem = product.toOrderItem(quantity: 2)
@@ -170,7 +170,7 @@ class NewOrderViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
-        viewModel.addProductViewModel.selectProduct(product.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product.productID)
 
         // When
         let expectedOrderItem = viewModel.orderDetails.items[0]
@@ -189,8 +189,8 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // Given products are added to order
-        viewModel.addProductViewModel.selectProduct(product0.productID)
-        viewModel.addProductViewModel.selectProduct(product1.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product0.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product1.productID)
 
         // When
         let expectedRemainingItem = viewModel.orderDetails.items[1]
@@ -255,7 +255,7 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // When & Then
-        viewModel.addProductViewModel.selectProduct(product.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product.productID)
         XCTAssertTrue(viewModel.shouldShowPaymentSection)
 
         // When & Then
@@ -272,7 +272,7 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, currencySettings: currencySettings)
 
         // When & Then
-        viewModel.addProductViewModel.selectProduct(product.productID)
+        viewModel.addProductViewModel.selectProductOrVariation(product.productID)
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
 


### PR DESCRIPTION
Part of: #5847
⚠️ Depends on #5869 ⚠️ 

## Description

As part of Order Creation, we need the ability to display a list of product variations to add a variation to a new order. This prepares the Add Product view to be reusable, so it can display either a list of products or a list of product variations, which can be added to a new order.

(The changes that add the new view model for a list of variations will come in a separate PR, to avoid having a single huge PR.)

## Changes

* Adds `AddProductToOrderViewModelProtocol` with the necessary properties for the `AddProductToOrder` view.
* Updates `AddProductToOrder` to use the new protocol for its view model.

## Testing

Product variations aren't yet displayed anywhere in Order Creation, so the only test for this change is to confirm that products continue to be displayed in the UI as expected:

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, confirm the product list loads with all the expected details for each product.
6. Tap to select a product.
7. Confirm the Products section of the new order shows the selected product with all the expected details and quantity stepper.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
