### PR TITLE
Order Creation: Add support for displaying a list of variations to select for a new order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -34,7 +34,7 @@ final class AddProductVariationToOrderViewModel: AddProductToOrderViewModelProto
 
     /// Current sync status; used to determine what list view to display.
     ///
-    @Published private(set) var syncStatus: SyncStatus?
+    @Published private(set) var syncStatus: AddProductToOrderSyncStatus?
 
     /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -46,13 +46,7 @@ final class AddProductVariationToOrderViewModel: AddProductToOrderViewModelProto
 
     /// Product Variations Results Controller.
     ///
-//    private lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
-//        let predicate = NSPredicate(format: "product.siteID == %lld AND product.productID == %lld", siteID, product.productID)
-//        let descriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
-//        let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
-//        return resultsController
-//    }()
-    lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
+    private lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
         let predicate = NSPredicate(format: "siteID == %lld AND productID == %lld", siteID, product.productID)
         let descriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
         let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -1,0 +1,163 @@
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// View model for `AddProductToOrder` with a list of product variations for a product.
+///
+final class AddProductVariationToOrderViewModel: AddProductToOrderViewModelProtocol {
+    private let siteID: Int64
+
+    /// Storage to fetch product variation list
+    ///
+    private let storageManager: StorageManagerType
+
+    /// Stores to sync product variation list
+    ///
+    private let stores: StoresManager
+
+    /// The product whose variations are listed
+    ///
+    private var product: Product
+
+    /// All purchasable product variations for the product.
+    ///
+    private var productVariations: [ProductVariation] {
+        productVariationsResultsController.fetchedObjects.filter { $0.purchasable }
+    }
+
+    /// View models for each product row
+    ///
+    var productRows: [ProductRowViewModel] {
+        productVariations.map { .init(productVariation: $0, allAttributes: product.attributesForVariations, canChangeQuantity: false) }
+    }
+
+    // MARK: Sync & Storage properties
+
+    /// Current sync status; used to determine what list view to display.
+    ///
+    @Published private(set) var syncStatus: SyncStatus?
+
+    /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
+    ///
+    private let syncingCoordinator = SyncingCoordinator()
+
+    /// Tracks if the infinite scroll indicator should be displayed
+    ///
+    @Published private(set) var shouldShowScrollIndicator = false
+
+    /// Product Variations Results Controller.
+    ///
+//    private lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
+//        let predicate = NSPredicate(format: "product.siteID == %lld AND product.productID == %lld", siteID, product.productID)
+//        let descriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
+//        let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+//        return resultsController
+//    }()
+    lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
+        let predicate = NSPredicate(format: "siteID == %lld AND productID == %lld", siteID, product.productID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
+        let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        return resultsController
+    }()
+
+    init(siteID: Int64,
+         product: Product,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.product = product
+        self.storageManager = storageManager
+        self.stores = stores
+
+        configureSyncingCoordinator()
+        configureProductVariationsResultsController()
+    }
+
+    /// Select a product variation to add to the order
+    ///
+    func selectProductOrVariation(_ productID: Int64) {
+        // TODO: Add the selected product variation to the order
+    }
+}
+
+// MARK: - SyncingCoordinatorDelegate & Sync Methods
+extension AddProductVariationToOrderViewModel: SyncingCoordinatorDelegate {
+    /// Sync product variations from remote.
+    ///
+    func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)?) {
+        transitionToSyncingState()
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: siteID,
+                                                                         productID: product.productID,
+                                                                         pageNumber: pageNumber,
+                                                                         pageSize: pageSize) { [weak self] error in
+            guard let self = self else { return }
+
+            if let error = error {
+                DDLogError("⛔️ Error synchronizing product variations during order creation: \(error)")
+            } else {
+                self.updateProductVariationsResultsController()
+            }
+
+            self.transitionToResultsUpdatedState()
+            onCompletion?(error == nil)
+        }
+        stores.dispatch(action)
+    }
+
+    /// Sync first page of product variations from remote if needed.
+    ///
+    func syncFirstPage() {
+        syncingCoordinator.synchronizeFirstPage()
+    }
+
+    /// Sync next page of product variations from remote.
+    ///
+    func syncNextPage() {
+        let lastIndex = productVariationsResultsController.numberOfObjects - 1
+        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: lastIndex)
+    }
+}
+
+// MARK: - Finite State Machine Management
+private extension AddProductVariationToOrderViewModel {
+    /// Update state for sync from remote.
+    ///
+    func transitionToSyncingState() {
+        shouldShowScrollIndicator = true
+        if productVariations.isEmpty {
+            syncStatus = .firstPageSync
+        }
+    }
+
+    /// Update state after sync is complete.
+    ///
+    func transitionToResultsUpdatedState() {
+        shouldShowScrollIndicator = false
+        syncStatus = productVariations.isNotEmpty ? .results: .empty
+    }
+}
+
+// MARK: - Configuration
+private extension AddProductVariationToOrderViewModel {
+    /// Performs initial fetch from storage and updates sync status accordingly.
+    ///
+    func configureProductVariationsResultsController() {
+        updateProductVariationsResultsController()
+        transitionToResultsUpdatedState()
+    }
+
+    /// Fetches product variations from storage.
+    ///
+    func updateProductVariationsResultsController() {
+        do {
+            try productVariationsResultsController.performFetch()
+        } catch {
+            DDLogError("⛔️ Error fetching product variations for new order: \(error)")
+        }
+    }
+
+    /// Setup: Syncing Coordinator
+    ///
+    func configureSyncingCoordinator() {
+        syncingCoordinator.delegate = self
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1135,6 +1135,8 @@
 		CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */; };
 		CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */; };
 		CC13C0C9278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0C8278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift */; };
+		CC13C0CB278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CA278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift */; };
+		CC13C0CD278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */; };
 		CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */; };
 		CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */; };
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
@@ -2720,6 +2722,8 @@
 		CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactory.swift; sourceTree = "<group>"; };
 		CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		CC13C0C8278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductToOrderViewModelProtocol.swift; sourceTree = "<group>"; };
+		CC13C0CA278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductVariationToOrderViewModel.swift; sourceTree = "<group>"; };
+		CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductVariationToOrderViewModelTests.swift; sourceTree = "<group>"; };
 		CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentSection.swift; sourceTree = "<group>"; };
 		CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackage.swift; sourceTree = "<group>"; };
@@ -6126,6 +6130,7 @@
 			children = (
 				CC53FB372755213900C4CA4F /* AddProductToOrder.swift */,
 				CC53FB3B2757EC7200C4CA4F /* AddProductToOrderViewModel.swift */,
+				CC13C0CA278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift */,
 				CC13C0C8278DE76A00C0B5B5 /* AddProductToOrderViewModelProtocol.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
 				CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */,
@@ -6142,6 +6147,7 @@
 				AEA622B627468790002A9B57 /* AddOrderCoordinatorTests.swift */,
 				CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */,
 				CC53FB3F2759042600C4CA4F /* AddProductToOrderViewModelTests.swift */,
+				CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -8105,6 +8111,7 @@
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
 				E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */,
+				CC13C0CB278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				0217399E2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
@@ -9128,6 +9135,7 @@
 				A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */,
 				029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */,
 				0236BCA425087B660043EB43 /* ProductFormRemoteActionUseCaseTests.swift in Sources */,
+				CC13C0CD278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift in Sources */,
 				DE26B5292775C76C00A2EA0A /* MockSyncingCoordinator.swift in Sources */,
 				DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */,
 				0277AE9B256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -151,20 +151,6 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
 
 // MARK: - Utils
 private extension AddProductVariationToOrderViewModelTests {
-    /// Insert a `Product` into storage
-    func insert(_ readOnlyProduct: Yosemite.Product) {
-        let product = storage.insertNewObject(ofType: StorageProduct.self)
-        product.update(with: readOnlyProduct)
-    }
-
-    /// Insert an array of `Product`s into storage
-    func insert(_ readOnlyProducts: [Yosemite.Product]) {
-        for readOnlyProduct in readOnlyProducts {
-            let product = storage.insertNewObject(ofType: StorageProduct.self)
-            product.update(with: readOnlyProduct)
-        }
-    }
-
     /// Insert a `ProductVariation` into storage
     func insert(_ readOnlyProduct: Yosemite.ProductVariation) {
         let product = storage.insertNewObject(ofType: StorageProductVariation.self)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+@testable import Storage
+
+class AddProductVariationToOrderViewModelTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 123
+    private let sampleProductID: Int64 = 12
+    private var storageManager: StorageManagerType!
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+    private let stores = MockStoresManager(sessionManager: .testingInstance)
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+        stores.reset()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_view_model_adds_product_rows_with_unchangeable_quantity() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        insert(productVariation)
+
+        // When
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.productRows.count, 1)
+
+        let productRow = viewModel.productRows[0]
+        XCTAssertFalse(productRow.canChangeQuantity, "Product row canChangeQuantity property should be false but is true instead")
+    }
+
+    func test_product_rows_only_include_purchasable_product_variations() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let purchasableProductVariation = ProductVariation.fake().copy(siteID: sampleSiteID,
+                                                                       productID: sampleProductID,
+                                                                       productVariationID: 1,
+                                                                       purchasable: true)
+        let nonPurchasableProductVariation = ProductVariation.fake().copy(siteID: sampleSiteID, productVariationID: 2, purchasable: false)
+        insert([purchasableProductVariation, nonPurchasableProductVariation])
+
+        // When
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager)
+
+        // Then
+        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 1 }), "Product rows do not include purchasable product variation")
+        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == 2 }), "Product rows include non-purchasable product variation")
+    }
+
+    func test_scrolling_indicator_appears_only_during_sync() {
+        // Given
+        let product = Product.fake()
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
+        XCTAssertFalse(viewModel.shouldShowScrollIndicator, "Scroll indicator is not disabled at start")
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+                XCTAssertTrue(viewModel.shouldShowScrollIndicator, "Scroll indicator is not enabled during sync")
+                onCompletion(nil)
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowScrollIndicator, "Scroll indicator is not disabled after sync ends")
+    }
+
+    func test_sync_status_updates_as_expected_for_empty_product_variation_list() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+                XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
+                onCompletion(nil)
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.syncStatus, .empty)
+    }
+
+    func test_sync_status_updates_as_expected_when_product_variations_are_synced() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+                XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
+                let productVariation = ProductVariation.fake().copy(siteID: self.sampleSiteID, productID: self.sampleProductID, purchasable: true)
+                self.insert(productVariation)
+                onCompletion(nil)
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.syncStatus, .results)
+    }
+
+    func test_sync_status_does_not_change_while_syncing_when_storage_contains_product_variations() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        insert(productVariation)
+
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+                XCTAssertEqual(viewModel.syncStatus, .results)
+                onCompletion(nil)
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.syncStatus, .results)
+    }
+}
+
+// MARK: - Utils
+private extension AddProductVariationToOrderViewModelTests {
+    /// Insert a `Product` into storage
+    func insert(_ readOnlyProduct: Yosemite.Product) {
+        let product = storage.insertNewObject(ofType: StorageProduct.self)
+        product.update(with: readOnlyProduct)
+    }
+
+    /// Insert an array of `Product`s into storage
+    func insert(_ readOnlyProducts: [Yosemite.Product]) {
+        for readOnlyProduct in readOnlyProducts {
+            let product = storage.insertNewObject(ofType: StorageProduct.self)
+            product.update(with: readOnlyProduct)
+        }
+    }
+
+    /// Insert a `ProductVariation` into storage
+    func insert(_ readOnlyProduct: Yosemite.ProductVariation) {
+        let product = storage.insertNewObject(ofType: StorageProductVariation.self)
+        product.update(with: readOnlyProduct)
+    }
+
+    /// Insert an array of `ProductVariation`s into storage
+    func insert(_ readOnlyProducts: [Yosemite.ProductVariation]) {
+        for readOnlyProduct in readOnlyProducts {
+            let product = storage.insertNewObject(ofType: StorageProductVariation.self)
+            product.update(with: readOnlyProduct)
+        }
+    }
+}


### PR DESCRIPTION
Closes: #5847 
⚠️ Depends on #5870

## Description

As part of Order Creation, we need the ability to display a list of product variations to add a variation to a new order. This adds a new view model so the `AddProductToOrder` view can be used to display that list of variations.

## Changes

* Adds `AddProductVariationToOrderViewModel`, which follows the protocol from `AddProductToOrderViewModelProtocol`. This is very similar to the existing view model used to display a list of products that can be added to an order (`AddProductToOrderViewModel`), with a few key differences:
   * The view model contains `product` (the parent variable product) and `productVariations` (all variations associated with the parent product).
   * The `sync()` method syncs the variations from remote.
   * `productVariationsResultsController` retrieves all the variations from Core Data.
   * The product rows are initialized using each purchasable product variation.
   * The `selectProductOrVariation()` method is still TODO. This will be finished once there is support for adding the selected variation to a new order.
* Adds unit tests for the new view model.

## Testing

The product variations list isn't yet used in Order Creation, so for now make sure that the changes make sense and unit tests pass.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
