### PR TITLE
Fix: removed Ghost "Hub Menu" label that appears in the tab bar after navigating back to the Menu tab

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -7,7 +7,6 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
 
     init(siteID: Int64, navigationController: UINavigationController?) {
         super.init(rootView: HubMenu(siteID: siteID, navigationController: navigationController))
-        configureNavigationBar()
         configureTabBarItem()
     }
 
@@ -23,10 +22,6 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
 }
 
 private extension HubMenuViewController {
-    func configureNavigationBar() {
-        navigationItem.title = Localization.navigationBarTitle
-    }
-
     func configureTabBarItem() {
         tabBarItem.title = Localization.tabTitle
         tabBarItem.image = .hubMenu
@@ -37,8 +32,5 @@ private extension HubMenuViewController {
 private extension HubMenuViewController {
     enum Localization {
         static let tabTitle = NSLocalizedString("Menu", comment: "Title of the Menu tab")
-        static let navigationBarTitle =
-            NSLocalizedString("Hub Menu",
-                              comment: "Navigation bar title of hub menu view")
     }
 }


### PR DESCRIPTION
Fixes #5860 

### Description
When the hubMenu feature flag is on and the Menu tab replaces the previous Reviews tab, a "Hub Menu" appears in the tab bar after navigating to a screen from the Menu tab and then back to the root view. This only happens in iOS 14 simulators/devices. With the fix proposed by @jaclync [here](https://github.com/woocommerce/woocommerce-ios/issues/5860#issuecomment-1010754472), everything works like a charm.

### Testing instructions
Please make sure the hubMenu feature flag is enabled.

1. Tap the Menu tab
2. Tap the Reviews or Coupons item
3. Tap the Menu tab again to go back to the root view --> the “Hub Menu” label shouldn't appear in the bottom left of the tab bar.

### Screenshots
| Before            |  After |
:-------------------------:|:-------------------------:
![148896479-7973a702-35e6-4b18-9175-76e6c66172c1](https://user-images.githubusercontent.com/495617/149150292-23ac3e9d-889d-4ebe-88a9-6422edb8f20d.PNG) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-01-12 at 14 35 00](https://user-images.githubusercontent.com/495617/149150302-3c27e66d-530b-41dc-a733-5d4297de5070.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
