### PR TITLE
Implemented tracking events for the Hub Menu

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -550,6 +550,14 @@ public enum WooAnalyticsStat: String {
     case jetpackInstallFailed = "jetpack_install_failed"
     case jetpackInstallInWPAdminButtonTapped = "jetpack_install_in_wpadmin_button_tapped"
     case jetpackInstallContactSupportButtonTapped = "jetpack_install_contact_support_button_tapped"
+
+    // MARK: Hub Menu
+    //
+    case hubMenuTabSelected = "hub_menu_tab_selected"
+    case hubMenuTabReselected = "hub_menu_tab_reselected"
+    case hubMenuSwitchStoreTapped = "hub_menu_switch_store_tapped"
+    case hubMenuOptionTapped = "hub_menu_option_tapped"
+    case hubMenuSettingsTapped = "hub_menu_settings_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -129,6 +129,7 @@ struct HubMenu: View {
                         }
                     }
                     .onTapGesture {
+                        ServiceLocator.analytics.track(.hubMenuSettingsTapped)
                         showSettings = true
                     }
                     Spacer()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -46,8 +46,6 @@ struct HubMenu: View {
                                 showingCoupons = true
                             }
                         })
-                            .frame(width: Constants.itemSize, height: Constants.itemSize)
-                            .contentShape(Rectangle())
                     }
                     .background(Color(.listForeground))
                     .cornerRadius(Constants.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -30,25 +30,24 @@ struct HubMenu: View {
 
                 LazyVGrid(columns: gridItemLayout, spacing: Constants.itemSpacing) {
                     ForEach(viewModel.menuElements, id: \.self) { menu in
-                        HubMenuElement(image: menu.icon, text: menu.title)
+                        HubMenuElement(image: menu.icon, text: menu.title, onTapGesture: {
+                            switch menu {
+                            case .woocommerceAdmin:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "admin_menu"])
+                                showingWooCommerceAdmin = true
+                            case .viewStore:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "view_store"])
+                                showingViewStore = true
+                            case .reviews:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "reviews"])
+                                showingReviews = true
+                            case .coupons:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "coupons"])
+                                showingCoupons = true
+                            }
+                        })
                             .frame(width: Constants.itemSize, height: Constants.itemSize)
                             .contentShape(Rectangle())
-                            .onTapGesture {
-                                switch menu {
-                                case .woocommerceAdmin:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "admin_menu"])
-                                    showingWooCommerceAdmin = true
-                                case .viewStore:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "view_store"])
-                                    showingViewStore = true
-                                case .reviews:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "reviews"])
-                                    showingReviews = true
-                                case .coupons:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "coupons"])
-                                    showingCoupons = true
-                                }
-                            }
                     }
                     .background(Color(.listForeground))
                     .cornerRadius(Constants.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -36,12 +36,16 @@ struct HubMenu: View {
                             .onTapGesture {
                                 switch menu {
                                 case .woocommerceAdmin:
+                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "admin_menu"])
                                     showingWooCommerceAdmin = true
                                 case .viewStore:
+                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "view_store"])
                                     showingViewStore = true
                                 case .reviews:
+                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "reviews"])
                                     showingReviews = true
                                 case .coupons:
+                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "coupons"])
                                     showingCoupons = true
                                 }
                             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -33,16 +33,16 @@ struct HubMenu: View {
                         HubMenuElement(image: menu.icon, text: menu.title, onTapGesture: {
                             switch menu {
                             case .woocommerceAdmin:
-                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "admin_menu"])
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "admin_menu"])
                                 showingWooCommerceAdmin = true
                             case .viewStore:
-                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "view_store"])
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "view_store"])
                                 showingViewStore = true
                             case .reviews:
-                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "reviews"])
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "reviews"])
                                 showingReviews = true
                             case .coupons:
-                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "coupons"])
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "coupons"])
                                 showingCoupons = true
                             }
                         })
@@ -154,6 +154,7 @@ struct HubMenu: View {
         static let padding: CGFloat = 16
         static let topBarSpacing: CGFloat = 2
         static let avatarSize: CGFloat = 40
+        static let option = "option"
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -29,11 +29,13 @@ struct HubMenuElement: View {
                 Text(text)
                     .bodyStyle()
             }
+            .frame(width: Constants.itemSize, height: Constants.itemSize)
         }
     }
 
     enum Constants {
         static let paddingBetweenElements: CGFloat = 8
+        static let itemSize: CGFloat = 160
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -5,25 +5,30 @@ import SwiftUI
 struct HubMenuElement: View {
     let image: UIImage
     let text: String
+    let onTapGesture: (() -> Void)
 
     @ScaledMetric var imageSize: CGFloat = 58
     @ScaledMetric var iconSize: CGFloat = 34
 
     var body: some View {
-        VStack {
-            ZStack {
-                Color(UIColor(light: .listBackground,
-                              dark: .secondaryButtonBackground))
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: iconSize, height: iconSize)
+        Button {
+            onTapGesture()
+        } label: {
+            VStack {
+                ZStack {
+                    Color(UIColor(light: .listBackground,
+                                  dark: .secondaryButtonBackground))
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: iconSize, height: iconSize)
+                }
+                .frame(width: imageSize, height: imageSize, alignment: .center)
+                .cornerRadius(imageSize/2)
+                .padding(.bottom, Constants.paddingBetweenElements)
+                Text(text)
+                    .bodyStyle()
             }
-            .frame(width: imageSize, height: imageSize, alignment: .center)
-            .cornerRadius(imageSize/2)
-            .padding(.bottom, Constants.paddingBetweenElements)
-            Text(text)
-                .bodyStyle()
         }
     }
 
@@ -34,9 +39,8 @@ struct HubMenuElement: View {
 
 struct HubMenuElement_Previews: PreviewProvider {
     static var previews: some View {
-
         HubMenuElement(image: .starOutlineImage(),
-                       text: "Menu")
+                       text: "Menu", onTapGesture: { })
             .previewLayout(.fixed(width: 160, height: 160))
             .previewDisplayName("Hub Menu Element")
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -62,7 +62,7 @@ final class HubMenuViewModel: ObservableObject {
     /// Present the `StorePickerViewController` using the `StorePickerCoordinator`, passing the navigation controller from the entry point.
     ///
     func presentSwitchStore() {
-        //TODO-5509: add analytics events
+        ServiceLocator.analytics.track(.hubMenuSwitchStoreTapped)
         if let navigationController = navigationController {
             storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
             storePickerCoordinator?.start()

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -244,7 +244,7 @@ private extension MainTabBarController {
         case .reviews:
             ServiceLocator.analytics.track(.notificationsReselected)
         case .hubMenu:
-            //TODO-5509: implement tracking
+            ServiceLocator.analytics.track(.hubMenuTabReselected)
             break
         }
     }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -226,7 +226,7 @@ private extension MainTabBarController {
         case .reviews:
             ServiceLocator.analytics.track(.notificationsSelected)
         case .hubMenu:
-            //TODO-5509: implement tracking
+            ServiceLocator.analytics.track(.hubMenuTabSelected)
             break
         }
     }


### PR DESCRIPTION
Closes: #5798

### Description
As part of the new Hub Menu, I implemented the new tracking events discussed here `p91TBi-7aB`.


### Testing instructions
- `hub_menu_tab_selected`- When the hub menu will be selected, this event should appear in the console.
- `hub_menu_tab_reselected` - When the hub menu will be re-selected, this event should appear in the console.
- `hub_menu_switch_store_tapped` - When the user press the "Switch Store" button under the hub menu, this event should appear in the console.
- ` hub_menu_option_tapped` -  When the user press one of the options in the hub menu, this event should appear in the console with one of these properties: `view_store`, `admin_menu`, `reviews`, `coupons`.
- `hub_menu_settings_tapped` When the user presses the Settings button in the hub menu, the event should appear in the console.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
