### PR TITLE
Hub Menu: handled highlighted state when tapping on items

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -46,8 +46,6 @@ struct HubMenu: View {
                                 showingCoupons = true
                             }
                         })
-                            .frame(width: Constants.itemSize, height: Constants.itemSize)
-                            .contentShape(Rectangle())
                     }
                     .background(Color(.listForeground))
                     .cornerRadius(Constants.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -30,25 +30,24 @@ struct HubMenu: View {
 
                 LazyVGrid(columns: gridItemLayout, spacing: Constants.itemSpacing) {
                     ForEach(viewModel.menuElements, id: \.self) { menu in
-                        HubMenuElement(image: menu.icon, text: menu.title)
+                        HubMenuElement(image: menu.icon, text: menu.title, onTapGesture: {
+                            switch menu {
+                            case .woocommerceAdmin:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "admin_menu"])
+                                showingWooCommerceAdmin = true
+                            case .viewStore:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "view_store"])
+                                showingViewStore = true
+                            case .reviews:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "reviews"])
+                                showingReviews = true
+                            case .coupons:
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "coupons"])
+                                showingCoupons = true
+                            }
+                        })
                             .frame(width: Constants.itemSize, height: Constants.itemSize)
                             .contentShape(Rectangle())
-                            .onTapGesture {
-                                switch menu {
-                                case .woocommerceAdmin:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "admin_menu"])
-                                    showingWooCommerceAdmin = true
-                                case .viewStore:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "view_store"])
-                                    showingViewStore = true
-                                case .reviews:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "reviews"])
-                                    showingReviews = true
-                                case .coupons:
-                                    ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "coupons"])
-                                    showingCoupons = true
-                                }
-                            }
                     }
                     .background(Color(.listForeground))
                     .cornerRadius(Constants.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -29,11 +29,13 @@ struct HubMenuElement: View {
                 Text(text)
                     .bodyStyle()
             }
+            .frame(width: Constants.itemSize, height: Constants.itemSize)
         }
     }
 
     enum Constants {
         static let paddingBetweenElements: CGFloat = 8
+        static let itemSize: CGFloat = 160
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -5,25 +5,30 @@ import SwiftUI
 struct HubMenuElement: View {
     let image: UIImage
     let text: String
+    let onTapGesture: (() -> Void)
 
     @ScaledMetric var imageSize: CGFloat = 58
     @ScaledMetric var iconSize: CGFloat = 34
 
     var body: some View {
-        VStack {
-            ZStack {
-                Color(UIColor(light: .listBackground,
-                              dark: .secondaryButtonBackground))
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: iconSize, height: iconSize)
+        Button {
+            onTapGesture()
+        } label: {
+            VStack {
+                ZStack {
+                    Color(UIColor(light: .listBackground,
+                                  dark: .secondaryButtonBackground))
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: iconSize, height: iconSize)
+                }
+                .frame(width: imageSize, height: imageSize, alignment: .center)
+                .cornerRadius(imageSize/2)
+                .padding(.bottom, Constants.paddingBetweenElements)
+                Text(text)
+                    .bodyStyle()
             }
-            .frame(width: imageSize, height: imageSize, alignment: .center)
-            .cornerRadius(imageSize/2)
-            .padding(.bottom, Constants.paddingBetweenElements)
-            Text(text)
-                .bodyStyle()
         }
     }
 
@@ -34,9 +39,8 @@ struct HubMenuElement: View {
 
 struct HubMenuElement_Previews: PreviewProvider {
     static var previews: some View {
-
         HubMenuElement(image: .starOutlineImage(),
-                       text: "Menu")
+                       text: "Menu", onTapGesture: { })
             .previewLayout(.fixed(width: 160, height: 160))
             .previewDisplayName("Hub Menu Element")
     }


### PR DESCRIPTION
Fixes #5814 

### Description
Added the highlighted state when tapping on elements of the hub menu, embedding the content under `Button`.

### Testing instructions
Please make sure the hubMenu feature flag is enabled.

1. Tap the Menu tab
2. Tap on one of the items.
3. You should notice the highlighted state and should work like before.

### Video
https://user-images.githubusercontent.com/495617/149179847-89e081e3-ea1f-400d-9da1-febc0d24eec1.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
