### PR TITLE
Reviews: Update right bar button item when embedded in hosting controller

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsView.swift
@@ -29,7 +29,7 @@ struct ReviewsView: UIViewControllerRepresentable {
         // This fixes the issue when `rightBarButtonItem` is updated in `ReviewsViewController`,
         // the hosting controller should be updated to reflect the change.
         context.coordinator.rightBarButtonItemObserver = viewController.observe(\.navigationItem.rightBarButtonItem, changeHandler: { vc, _ in
-            vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
+            vc.parent?.navigationItem.rightBarButtonItem = vc.navigationItem.rightBarButtonItem
         })
         return viewController
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsView.swift
@@ -19,6 +19,8 @@ struct ReviewsView: UIViewControllerRepresentable {
     ///
     func makeUIViewController(context: Self.Context) -> ReviewsViewController {
         let viewController = ReviewsViewController(siteID: siteID)
+        // This makes sure that the navigation item of the hosting controller
+        // is in sync with that of the wrapped controller.
         context.coordinator.parentObserver = viewController.observe(\.parent, changeHandler: { vc, _ in
             vc.parent?.navigationItem.title = vc.title
             vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsView.swift
@@ -9,6 +9,7 @@ struct ReviewsView: UIViewControllerRepresentable {
 
     class Coordinator {
         var parentObserver: NSKeyValueObservation?
+        var rightBarButtonItemObserver: NSKeyValueObservation?
     }
 
     /// This is a UIKit solution for fixing Navigation Title and Bar Button Items ignored in NavigationView.
@@ -20,6 +21,12 @@ struct ReviewsView: UIViewControllerRepresentable {
         let viewController = ReviewsViewController(siteID: siteID)
         context.coordinator.parentObserver = viewController.observe(\.parent, changeHandler: { vc, _ in
             vc.parent?.navigationItem.title = vc.title
+            vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
+        })
+
+        // This fixes the issue when `rightBarButtonItem` is updated in `ReviewsViewController`,
+        // the hosting controller should be updated to reflect the change.
+        context.coordinator.rightBarButtonItemObserver = viewController.observe(\.navigationItem.rightBarButtonItem, changeHandler: { vc, _ in
             vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
         })
         return viewController


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5830 & #5872.
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When embedded in a hosting controller, UIKit view controllers cannot update their navigation items properly. There has been a solution to remedy that by observing a view controller's parent (the hosting controller) and updating the navigation item of the parent to match with the child's.

The issue in #5830 is that the navigation item on the hosting controller is not updated when the hosted controller updates its navigation item. Hence this PR fixes that by observing changes in the child controller and updating the parent accordingly.

Since the `ReviewsViewController` updates its `rightBarButtonItem` when there are changes to the number of unread reviews, the solution here is to observe changes to its `rightBarButtonItem` property specifically. I'm not quite happy with the solution because it might need to be updated if we change the way we update the navigation item (e.g using `rightBarButtonItems` instead). It's up to the reviewers to decide whether this solution is acceptable 😅 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Add a new review to your test store.
- Build the app to your device or simulator, make sure that the `.hubMenu` feature flag is on.
- Navigate to the Menu tab, select Reviews.
- Notice that if there haven't been any unread reviews earlier, when the Reviews screen doesn't have any button item on the right of the navigation bar.
- When the review list is loaded successfully, notice that there's an ellipsis button on the right of the navigation bar.
- Tap to select the unread review(s) and navigate back to the list.
- Pull to refresh the review list, notice that the right bar button item is not longer present.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/149261124-5ce97942-ca54-4603-a693-aea8368e3bb4.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
