### PR TITLE
My store tab: fix glitch when scrolling up the dashboard with certain content height

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -88,7 +88,7 @@ final class DashboardViewController: UIViewController {
         return view
     }()
 
-    private var cancellables = Set<AnyCancellable>()
+    private var subscriptions = Set<AnyCancellable>()
 
     // MARK: View Lifecycle
 
@@ -423,7 +423,7 @@ private extension DashboardViewController {
             guard let self = self else { return }
             self.updateUI(site: site)
             self.reloadData(forced: true)
-        }.store(in: &cancellables)
+        }.store(in: &subscriptions)
     }
 
     func observeBottomJetpackBenefitsBannerVisibilityUpdates() {
@@ -447,7 +447,7 @@ private extension DashboardViewController {
                     self.updateJetpackBenefitsBannerVisibility(isBannerVisible: shouldShowJetpackBenefitsBanner, contentView: contentView)
                 }
                 ServiceLocator.stores.dispatch(action)
-            }.store(in: &cancellables)
+            }.store(in: &subscriptions)
     }
 
     func observeNavigationBarHeightForStoreNameLabelVisibility() {
@@ -462,7 +462,7 @@ private extension DashboardViewController {
                 }
                 self.storeNameLabel.isHidden = navigationBarHeight <= Constants.collapsedNavigationBarHeight
             })
-            .store(in: &cancellables)
+            .store(in: &subscriptions)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5843 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Due to the limited API for iOS large titles when the view has multiple scroll views, we had to make a workaround for the large title to work in the My store tab in the first place. More details about the workaround are in Issue 3 in p91TBi-45c-p2, basically we had to add a "hidden scroll view" in `DashboardViewController`'s `view` to simulate the scrolling gestures in any of the time range tabs (Today/This Week/This Month/This Year) to "trick" the navigation controller to expand the navigation bar to show large title or collapse the navigation bar to show the small title. We simulate the scrolling gestures by implementing `UIScrollViewDelegate.scrollViewDidScroll` from the visible `UIScrollView` and setting the hidden scroll view's content offset and content size to match the visible scroll view.

The glitch happens when we're showing/hiding the store name label in the same `UIScrollViewDelegate.scrollViewDidScroll` where we adjust the hidden scroll view's properties. We don't know all the implementation details of iOS large titles, how it detects to show the large title or shrink to the small title. My guess is that the change of the store name label's height might mess with the visible `UIScrollView`'s content offset/size while we update the hidden scroll view. The content offset thus jumps around and creates a glitch.

To fix the glitch, I was hoping to show/hide the store name label based on whether the large title is shown or not instead of checking the header view height. Unfortunately, I couldn't find an official API for the navigation bar title display mode and I had to compare the navigation bar height against 44.0px 😟 Please feel free to share any nicer solutions/ideas! I tried with many different things from `UIScrollViewDelegate.scrollViewDidScroll` and they didn't work.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The glitch happens most often when there is one top performers item on iPhone 11 size and the 5th font size in Accessibility > Display & Text Size > Larger Text:

<img width="265" alt="Screen Shot 2022-01-13 at 11 27 44 AM" src="https://user-images.githubusercontent.com/1945542/149260794-a0172eac-8307-495b-9046-e91d481a587b.png">

Feel free to reproduce the glitch first in `trunk` then test this PR.

- Launch the app
- In the My store tab, tap on a time range tab that has 1 top performers item (or some other number of items that you can reproduce the glitch in `trunk)
- Scroll up --> there should not be a glitch, and the store name label should only be shown with a large title

- [x] @jaclync tests when `myStoreTabUpdate` feature flag is off

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before:
https://user-images.githubusercontent.com/1945542/149261445-663bee15-7b1a-4850-83e8-b64ead3d59a3.mov | 

After:
https://user-images.githubusercontent.com/1945542/149261075-3477a10d-a396-4190-bfb3-aac77902f4dc.mov

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->