### PR TITLE
Hub Menu: Update tint colors of menu items when switching between light mode and dark mode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -30,7 +30,7 @@ struct HubMenu: View {
 
                 LazyVGrid(columns: gridItemLayout, spacing: Constants.itemSpacing) {
                     ForEach(viewModel.menuElements, id: \.self) { menu in
-                        HubMenuElement(image: menu.icon, text: menu.title, onTapGesture: {
+                        HubMenuElement(image: menu.icon, imageColor: menu.iconColor, text: menu.title, onTapGesture: {
                             switch menu {
                             case .woocommerceAdmin:
                                 ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: ["option": "admin_menu"])

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -4,6 +4,7 @@ import SwiftUI
 ///
 struct HubMenuElement: View {
     let image: UIImage
+    let imageColor: UIColor
     let text: String
     let onTapGesture: (() -> Void)
 
@@ -19,8 +20,10 @@ struct HubMenuElement: View {
                     Color(UIColor(light: .listBackground,
                                   dark: .secondaryButtonBackground))
                     Image(uiImage: image)
+                        .renderingMode(.template)
                         .resizable()
                         .scaledToFit()
+                        .foregroundColor(Color(imageColor))
                         .frame(width: iconSize, height: iconSize)
                 }
                 .frame(width: imageSize, height: imageSize, alignment: .center)
@@ -42,7 +45,9 @@ struct HubMenuElement: View {
 struct HubMenuElement_Previews: PreviewProvider {
     static var previews: some View {
         HubMenuElement(image: .starOutlineImage(),
-                       text: "Menu", onTapGesture: { })
+                       imageColor: .blue, 
+                       text: "Menu", 
+                       onTapGesture: { })
             .previewLayout(.fixed(width: 160, height: 160))
             .previewDisplayName("Hub Menu Element")
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -45,9 +45,9 @@ struct HubMenuElement: View {
 struct HubMenuElement_Previews: PreviewProvider {
     static var previews: some View {
         HubMenuElement(image: .starOutlineImage(),
-                       imageColor: .blue, 
-                       text: "Menu", 
-                       onTapGesture: { })
+                       imageColor: .blue,
+                       text: "Menu",
+                       onTapGesture: {})
             .previewLayout(.fixed(width: 160, height: 160))
             .previewDisplayName("Hub Menu Element")
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -112,13 +112,27 @@ extension HubMenuViewModel {
         var icon: UIImage {
             switch self {
             case .woocommerceAdmin:
-                return .wordPressLogoImage.imageWithTintColor(.blue) ?? .wordPressLogoImage
+                return .wordPressLogoImage
             case .viewStore:
-                return .storeImage.imageWithTintColor(.accent) ?? .storeImage
+                return .storeImage
             case .coupons:
                 return .couponImage
             case .reviews:
-                return .starImage(size: 24.0).imageWithTintColor(.primary) ?? .starImage(size: 24.0)
+                return .starImage(size: 24.0)
+            }
+        }
+
+        var iconColor: UIColor {
+            switch self {
+            case .woocommerceAdmin:
+                return .blue
+            case .viewStore:
+                return .accent
+            case .coupons:
+                return UIColor(light: .withColorStudio(.green, shade: .shade30),
+                               dark: .withColorStudio(.green, shade: .shade50))
+            case .reviews:
+                return .primary
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5880 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, the menu items on the Hub Menu are configured with different colors for light mode and dark mode. However, these colors are not updated correctly when switching between these modes.

This PR fixes that by making the menu icons render as template images and applying a foreground color for each of them.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build the app to your device or simulator, make sure that the `.hubMenu` feature flag is enabled.
- Select the Menu tab, if your device is in light mode, notice that the icons' colors are bold.
- Switch the device to dark mode, notice that the icons' colors are lighter.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Light mode | Dark mode | 
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/149265051-2ec033ad-25e2-4e96-87c3-6b73ec66335b.png" width=320 /> |  <img src="https://user-images.githubusercontent.com/5533851/149265074-9aa7973f-1989-4ffb-8310-9f20a65af85b.png" width=320 /> |

Video:
https://user-images.githubusercontent.com/5533851/149264986-3551288d-c480-4514-b059-b9f50976a889.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
