### PR TITLE
My store tab design/technical updates (before design review)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -135,7 +135,8 @@ final class DashboardViewController: UIViewController {
 private extension DashboardViewController {
 
     func configureView() {
-        view.backgroundColor = .listBackground
+        view.backgroundColor = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) ?
+        Constants.backgroundColor: Constants.legacyBackgroundColor
     }
 
     func configureNavigation() {
@@ -479,5 +480,7 @@ private extension DashboardViewController {
         static let animationDuration = 0.2
         static let bannerBottomMargin = CGFloat(8)
         static let horizontalMargin = CGFloat(20)
+        static let backgroundColor: UIColor = .systemBackground
+        static let legacyBackgroundColor: UIColor = .listBackground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/NoPeriodDataTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/NoPeriodDataTableViewCell.swift
@@ -4,7 +4,7 @@ import UIKit
 
 /// Displayed whenever there is no top performer data for a given period (granularity)
 ///
-class NoPeriodDataTableViewCell: UITableViewCell {
+final class NoPeriodDataTableViewCell: UITableViewCell {
     @IBOutlet private weak var mainImageView: UIImageView!
 
     /// LegendLabel: To be displayed below the ImageView.
@@ -21,7 +21,15 @@ class NoPeriodDataTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        contentView.backgroundColor = .listForeground
+        contentView.backgroundColor = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) ?
+        Constants.backgroundColor: Constants.legacyBackgroundColor
         backgroundColor = .listForeground
+    }
+}
+
+private extension NoPeriodDataTableViewCell {
+    enum Constants {
+        static let backgroundColor: UIColor = .systemBackground
+        static let legacyBackgroundColor: UIColor = .listForeground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -58,7 +58,8 @@ final class ProductTableViewCell: UITableViewCell {
         accessoryLabel.applyBodyStyle()
         detailLabel.applyFootnoteStyle()
         applyProductImageStyle()
-        backgroundColor = .listForeground
+        backgroundColor = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) ?
+        Constants.backgroundColor: Constants.legacyBackgroundColor
         bottomBorderView.backgroundColor = .systemColor(.separator)
         selectionStyle = .default
     }
@@ -80,12 +81,14 @@ extension ProductTableViewCell {
         let detailText: String?
         let accessoryText: String?
         let imageURL: String?
+        let backgroundColor: UIColor
     }
 
     func configure(viewModel: ViewModel, imageService: ImageService) {
         nameText = viewModel.nameText
         detailText = viewModel.detailText
         accessoryText = viewModel.accessoryText
+        backgroundColor = viewModel.backgroundColor
 
         /// Set `center` contentMode to not distort the placeholder aspect ratio.
         /// After a successful image download set the contentMode to `scaleAspectFill`
@@ -116,6 +119,7 @@ extension ProductTableViewCell.ViewModel {
                 statsItem?.totalString(currencyFormatter: currencyFormatter) ?? ""
             )
             accessoryText = "\(statsItem?.quantity ?? 0)"
+            backgroundColor = ProductTableViewCell.Constants.backgroundColor
         } else {
             detailText = String.localizedStringWithFormat(
                 NSLocalizedString("Total orders: %ld",
@@ -123,6 +127,7 @@ extension ProductTableViewCell.ViewModel {
                 statsItem?.quantity ?? 0
             )
             accessoryText = statsItem?.formattedTotalString
+            backgroundColor = ProductTableViewCell.Constants.legacyBackgroundColor
         }
     }
 }
@@ -135,6 +140,11 @@ private extension ProductTableViewCell {
         static let borderWidth = CGFloat(0.5)
         static let borderColor = UIColor.border
         static let backgroundColor = UIColor.listForeground
+    }
+
+    enum Constants {
+        static let backgroundColor: UIColor = .systemBackground
+        static let legacyBackgroundColor: UIColor = .listForeground
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -273,6 +273,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
 
     func configureSubviews() {
         view.addSubview(scrollView)
+        view.backgroundColor = Constants.backgroundColor
         view.pinSubviewToSafeArea(scrollView)
 
         scrollView.refreshControl = refreshControl
@@ -356,5 +357,6 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     enum Constants {
         static let storeStatsPeriodViewHeight: CGFloat = 444
         static let ghostStyle: GhostStyle = .wooDefaultGhostStyle
+        static let backgroundColor: UIColor = .systemBackground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -276,7 +276,7 @@ private extension StoreStatsAndTopPerformersViewController {
     }
 
     func configureView() {
-        view.backgroundColor = .listBackground
+        view.backgroundColor = Constants.backgroundColor
         configureButtonBarBottomBorder()
 
         // Disables any content inset adjustment since `XLPagerTabStrip` doesn't seem to support safe area insets.
@@ -477,5 +477,6 @@ private extension StoreStatsAndTopPerformersViewController {
 
     enum Constants {
         static let topEarnerStatsLimit: Int = 5
+        static let backgroundColor: UIColor = .systemBackground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -699,7 +699,7 @@ private extension StoreStatsV4PeriodViewController {
         if hasRevenueData && !hasNegativeRevenueOnly {
             let gradientColors = [Constants.chartGradientBottomColor.cgColor, Constants.chartGradientTopColor.cgColor] as CFArray
             let gradientColorSpace = CGColorSpaceCreateDeviceRGB()
-            let locations: [CGFloat] = hasNegativeRevenueOnly ? [1.0, 0.0]: [0.0, 1.0]
+            let locations: [CGFloat] = [0.0, 1.0]
             if let gradient = CGGradient(colorsSpace: gradientColorSpace, colors: gradientColors, locations: locations) {
                 dataSet.fill = .init(linearGradient: gradient, angle: 90.0)
                 dataSet.fillAlpha = 1.0

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -348,7 +348,8 @@ private extension StoreStatsV4PeriodViewController {
     func configureBarChart() {
         lineChartView.marker = StoreStatsChartCircleMarker()
         lineChartView.chartDescription?.enabled = false
-        lineChartView.dragEnabled = true
+        lineChartView.dragXEnabled = true
+        lineChartView.dragYEnabled = false
         lineChartView.setScaleEnabled(false)
         lineChartView.pinchZoomEnabled = false
         lineChartView.rightAxis.enabled = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #5745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adam just added design for Dark mode, this PR updates some colors based on the new design along with other polishes:

- Disables y-axis dragging on the chart so that scrolling vertically does not unintentionally select a point in the chart https://github.com/woocommerce/woocommerce-ios/commit/0ed2e1c84372a72e2e3c243b1dfe77e3a606cf72
- Fixes the CR feedback from https://github.com/woocommerce/woocommerce-ios/pull/5738#discussion_r776549212

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- While the dashboard is loading, observe the background color behind the spinner, top performers --> the background color should match the design
- After the dashboard is loaded, observe the background color of the empty top performers view or rows --> the background color should match the design
- Scroll up/down for any time range tab --> the chart should not be selected
- Drag horizontally in the chart --> the chart should be selectable
- Feel free to try both dark/light modes

- [ ] @jaclync tests the production version with the `myStoreTabUpdates` feature flag off

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

loading state | no top performers | top performers
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2022-01-13 at 15 42 32](https://user-images.githubusercontent.com/1945542/149293141-d831bcb3-5fd4-4e3b-b443-fc933cd641f5.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-13 at 15 42 42](https://user-images.githubusercontent.com/1945542/149293148-1c5600ec-22c2-4163-8c69-dcfda1aa7449.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-13 at 15 42 47](https://user-images.githubusercontent.com/1945542/149293154-564a4d5b-1a60-4a41-bbeb-ae5b4c8d3391.png)
![Simulator Screen Shot - iPhone 11 - 2022-01-13 at 15 43 06](https://user-images.githubusercontent.com/1945542/149293193-49d2c0b2-0953-4468-9981-3a878c57bbb0.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-13 at 15 44 05](https://user-images.githubusercontent.com/1945542/149293198-5d07e355-4395-46fa-bda9-f3010da08652.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-13 at 15 44 09](https://user-images.githubusercontent.com/1945542/149293202-49ec0895-09ac-405f-bd6f-e13898cf4dc0.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
