### PR TITLE
Hub Menu: highlighted state of the settings button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -116,22 +116,23 @@ struct HubMenu: View {
                 }
                 Spacer()
                 VStack {
-                    ZStack {
-                        Circle()
-                            .fill(Color(UIColor(light: .white,
-                                                dark: .secondaryButtonBackground)))
-                            .frame(width: settingsSize,
-                                   height: settingsSize)
-                        if let cogImage = UIImage.cogImage.imageWithTintColor(.accent) {
-                            Image(uiImage: cogImage)
-                                .resizable()
-                                .frame(width: settingsIconSize,
-                                       height: settingsIconSize)
-                        }
-                    }
-                    .onTapGesture {
+                    Button {
                         ServiceLocator.analytics.track(.hubMenuSettingsTapped)
                         showSettings = true
+                    } label: {
+                        ZStack {
+                            Circle()
+                                .fill(Color(UIColor(light: .white,
+                                                    dark: .secondaryButtonBackground)))
+                                .frame(width: settingsSize,
+                                       height: settingsSize)
+                            if let cogImage = UIImage.cogImage.imageWithTintColor(.accent) {
+                                Image(uiImage: cogImage)
+                                    .resizable()
+                                    .frame(width: settingsIconSize,
+                                           height: settingsIconSize)
+                            }
+                        }
                     }
                     Spacer()
                 }


### PR DESCRIPTION
Closes: #5887 

### Description
Previously the settings button on the top bar doesn't have a highlighted state. Now it was converted to a Button, and when pressed it will be highlighted.

### Testing instructions
Please make sure the hubMenu feature flag is enabled.

1. Tap the Menu tab
2. Tap on the navbar item for opening the Settings
3. You should be able to notice the highlighted state when pressed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
