### PR TITLE
Order Creation: Add product variation list view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -16,7 +16,8 @@ struct AddProductToOrder: View {
             Group {
                 switch viewModel.syncStatus {
                 case .results:
-                    List {
+                    InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
+                                       loadAction: viewModel.syncNextPage) {
                         ForEach(viewModel.productRows) { rowViewModel in
                             ProductRow(viewModel: rowViewModel)
                                 .onTapGesture {
@@ -24,13 +25,7 @@ struct AddProductToOrder: View {
                                     isPresented.toggle()
                                 }
                         }
-
-                        InfiniteScrollIndicator(showContent: viewModel.shouldShowScrollIndicator)
-                            .onAppear {
-                                viewModel.syncNextPage()
-                            }
                     }
-                    .listStyle(PlainListStyle())
                 case .empty:
                     EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
                         .frame(maxHeight: .infinity)
@@ -61,30 +56,6 @@ struct AddProductToOrder: View {
             }
         }
         .wooNavigationBarStyle()
-    }
-}
-
-private struct InfiniteScrollIndicator: View {
-
-    let showContent: Bool
-
-    var body: some View {
-        if #available(iOS 15.0, *) {
-            createProgressView()
-                .listRowSeparator(.hidden, edges: .bottom)
-        } else {
-            createProgressView()
-        }
-    }
-
-    @ViewBuilder func createProgressView() -> some View {
-        ProgressView()
-            .frame(maxWidth: .infinity, alignment: .center)
-            .listRowInsets(EdgeInsets())
-            .listRowBackground(Color(.listBackground))
-            .if(!showContent) { progressView in
-                progressView.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger sync when needed
-            }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -12,43 +12,40 @@ struct AddProductVariationToOrder: View {
     @ObservedObject var viewModel: AddProductVariationToOrderViewModel
 
     var body: some View {
-        NavigationView {
-            Group {
-                switch viewModel.syncStatus {
-                case .results:
-                    InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
-                                       loadAction: viewModel.syncNextPage) {
-                        ForEach(viewModel.productVariationRows) { rowViewModel in
-                            ProductRow(viewModel: rowViewModel)
-                                .onTapGesture {
-                                    viewModel.selectVariation(rowViewModel.productOrVariationID)
-                                    isPresented.toggle()
-                                }
-                        }
-                    }
-                case .empty:
-                    EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
-                        .frame(maxHeight: .infinity)
-                case .firstPageSync:
-                    List(viewModel.ghostRows) { rowViewModel in
+        Group {
+            switch viewModel.syncStatus {
+            case .results:
+                InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
+                                   loadAction: viewModel.syncNextPage) {
+                    ForEach(viewModel.productVariationRows) { rowViewModel in
                         ProductRow(viewModel: rowViewModel)
-                            .redacted(reason: .placeholder)
-                            .shimmering()
+                            .onTapGesture {
+                                viewModel.selectVariation(rowViewModel.productOrVariationID)
+                                isPresented.toggle()
+                            }
                     }
-                    .listStyle(PlainListStyle())
-                default:
-                    EmptyView()
                 }
-            }
-            .background(Color(.listBackground).ignoresSafeArea())
-            .ignoresSafeArea(.container, edges: .horizontal)
-            .navigationTitle(viewModel.productName)
-            .navigationBarTitleDisplayMode(.inline)
-            .onAppear {
-                viewModel.syncFirstPage()
+            case .empty:
+                EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
+                    .frame(maxHeight: .infinity)
+            case .firstPageSync:
+                List(viewModel.ghostRows) { rowViewModel in
+                    ProductRow(viewModel: rowViewModel)
+                        .redacted(reason: .placeholder)
+                        .shimmering()
+                }
+                .listStyle(PlainListStyle())
+            default:
+                EmptyView()
             }
         }
-        .wooNavigationBarStyle()
+        .background(Color(.listBackground).ignoresSafeArea())
+        .ignoresSafeArea(.container, edges: .horizontal)
+        .navigationTitle(viewModel.productName)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            viewModel.syncFirstPage()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// View showing a list of product variations to add to an order.
+///
+struct AddProductVariationToOrder: View {
+    /// Defines whether the view is presented.
+    ///
+    @Binding var isPresented: Bool
+
+    /// View model to drive the view.
+    ///
+    @ObservedObject var viewModel: AddProductVariationToOrderViewModel
+
+    var body: some View {
+        NavigationView {
+            Group {
+                switch viewModel.syncStatus {
+                case .results:
+                    InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
+                                       loadAction: viewModel.syncNextPage) {
+                        ForEach(viewModel.productVariationRows) { rowViewModel in
+                            ProductRow(viewModel: rowViewModel)
+                                .onTapGesture {
+                                    viewModel.selectVariation(rowViewModel.productOrVariationID)
+                                    isPresented.toggle()
+                                }
+                        }
+                    }
+                case .empty:
+                    EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
+                        .frame(maxHeight: .infinity)
+                case .firstPageSync:
+                    List(viewModel.ghostRows) { rowViewModel in
+                        ProductRow(viewModel: rowViewModel)
+                            .redacted(reason: .placeholder)
+                            .shimmering()
+                    }
+                    .listStyle(PlainListStyle())
+                default:
+                    EmptyView()
+                }
+            }
+            .background(Color(.listBackground).ignoresSafeArea())
+            .ignoresSafeArea(.container, edges: .horizontal)
+            .navigationTitle(viewModel.productName)
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                viewModel.syncFirstPage()
+            }
+        }
+        .wooNavigationBarStyle()
+    }
+}
+
+private extension AddProductVariationToOrder {
+    enum Localization {
+        static let emptyStateMessage = NSLocalizedString("No product variations found",
+                                                         comment: "Message displayed if there are no product variations for a product.")
+    }
+}
+
+struct AddProductVariationToOrder_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = AddProductVariationToOrderViewModel(siteID: 1, productID: 2, productName: "Monstera Plant", productAttributes: [])
+
+        AddProductVariationToOrder(isPresented: .constant(true), viewModel: viewModel)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct InfiniteScrollList<Content: View>: View {
+    /// Content to render in the list.
+    ///
+    private let listContent: Content
+
+    /// Whether the list is loading more content. Used to determine whether to show the infinite scroll indicator.
+    ///
+    private let isLoading: Bool
+
+    /// Action to load more content.
+    ///
+    private let loadAction: () -> Void
+
+    /// A list that renders the provided list content with an infinite scroll indicator.
+    ///
+    /// - Parameters:
+    ///   - isLoading: Whether the list is loading more content. Used to determine whether to show the infinite scroll indicator.
+    ///   - loadAction: Action to load more content.
+    ///   - listContent: Content to render in the list.
+    ///
+    init(isLoading: Bool,
+         loadAction: @escaping () -> Void,
+         @ViewBuilder listContent: () -> Content) {
+        self.listContent = listContent()
+        self.isLoading = isLoading
+        self.loadAction = loadAction
+    }
+
+    var body: some View {
+        List {
+            listContent
+
+            InfiniteScrollIndicator(showContent: isLoading)
+                .onAppear {
+                    loadAction()
+                }
+        }
+        .listStyle(PlainListStyle())
+    }
+}
+
+private struct InfiniteScrollIndicator: View {
+
+    let showContent: Bool
+
+    var body: some View {
+        if #available(iOS 15.0, *) {
+            createProgressView()
+                .listRowSeparator(.hidden, edges: .bottom)
+        } else {
+            createProgressView()
+        }
+    }
+
+    @ViewBuilder func createProgressView() -> some View {
+        ProgressView()
+            .frame(maxWidth: .infinity, alignment: .center)
+            .listRowInsets(EdgeInsets())
+            .listRowBackground(Color(.listBackground))
+            .if(!showContent) { progressView in
+                progressView.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger the load action when needed
+            }
+    }
+}
+
+struct InfiniteScrollList_Previews: PreviewProvider {
+    static var previews: some View {
+        InfiniteScrollList(isLoading: true, loadAction: {}) {
+            ForEach((0..<6)) { index in
+                Text("Item \(index)")
+            }
+        }
+        .previewDisplayName("Infinite scroll list: Loading")
+        .previewLayout(.sizeThatFits)
+
+        InfiniteScrollList(isLoading: false, loadAction: {}) {
+            ForEach((0..<6)) { index in
+                Text("Item \(index)")
+            }
+        }
+        .previewDisplayName("Infinite scroll list: Loaded")
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+/// A list that renders the provided list content with an infinite scroll indicator.
+///
 struct InfiniteScrollList<Content: View>: View {
     /// Content to render in the list.
     ///
@@ -13,13 +15,12 @@ struct InfiniteScrollList<Content: View>: View {
     ///
     private let loadAction: () -> Void
 
-    /// A list that renders the provided list content with an infinite scroll indicator.
+    /// Creates a list with the provided content and an infinite scroll indicator.
     ///
     /// - Parameters:
     ///   - isLoading: Whether the list is loading more content. Used to determine whether to show the infinite scroll indicator.
     ///   - loadAction: Action to load more content.
     ///   - listContent: Content to render in the list.
-    ///
     init(isLoading: Bool,
          loadAction: @escaping () -> Void,
          @ViewBuilder listContent: () -> Content) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1181,6 +1181,7 @@
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
 		CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */; };
+		CCF87BC02790582500461C43 /* AddProductVariationToOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBF2790582400461C43 /* AddProductVariationToOrder.swift */; };
 		CCFC00B523E9BD1500157A78 /* ScreenshotCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */; };
 		CCFC00EE23E9BD5500157A78 /* oauth2_token.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00BC23E9BD5500157A78 /* oauth2_token.json */; };
 		CCFC00EF23E9BD5500157A78 /* auth_options.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00BD23E9BD5500157A78 /* auth_options.json */; };
@@ -2774,6 +2775,7 @@
 		CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsTopBanner.swift; sourceTree = "<group>"; };
 		CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollList.swift; sourceTree = "<group>"; };
+		CCF87BBF2790582400461C43 /* AddProductVariationToOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductVariationToOrder.swift; sourceTree = "<group>"; };
 		CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotCredentials.swift; sourceTree = "<group>"; };
 		CCFC00BC23E9BD5500157A78 /* oauth2_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = oauth2_token.json; sourceTree = "<group>"; };
 		CCFC00BD23E9BD5500157A78 /* auth_options.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = auth_options.json; sourceTree = "<group>"; };
@@ -6139,6 +6141,7 @@
 			children = (
 				CC53FB372755213900C4CA4F /* AddProductToOrder.swift */,
 				CC53FB3B2757EC7200C4CA4F /* AddProductToOrderViewModel.swift */,
+				CCF87BBF2790582400461C43 /* AddProductVariationToOrder.swift */,
 				CC13C0CA278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
 				CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */,
@@ -8600,6 +8603,7 @@
 				0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */,
 				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
+				CCF87BC02790582500461C43 /* AddProductVariationToOrder.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */,
 				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1180,6 +1180,7 @@
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
+		CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */; };
 		CCFC00B523E9BD1500157A78 /* ScreenshotCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */; };
 		CCFC00EE23E9BD5500157A78 /* oauth2_token.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00BC23E9BD5500157A78 /* oauth2_token.json */; };
 		CCFC00EF23E9BD5500157A78 /* auth_options.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00BD23E9BD5500157A78 /* auth_options.json */; };
@@ -2772,6 +2773,7 @@
 		CCDC49F224006130003166BA /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UITests.xctestplan; path = WooCommerceUITests/UITests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsTopBanner.swift; sourceTree = "<group>"; };
+		CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollList.swift; sourceTree = "<group>"; };
 		CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotCredentials.swift; sourceTree = "<group>"; };
 		CCFC00BC23E9BD5500157A78 /* oauth2_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = oauth2_token.json; sourceTree = "<group>"; };
 		CCFC00BD23E9BD5500157A78 /* auth_options.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = auth_options.json; sourceTree = "<group>"; };
@@ -4957,6 +4959,7 @@
 				AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */,
 				26B3EC632745916F0075EAE6 /* BindableTextField.swift */,
 				AEACCB6C2785FF4A000D01F0 /* NavigationRow.swift */,
+				CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -8146,6 +8149,7 @@
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,
 				E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */,
+				CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */,
 				D85A3C5226C15DE200C0E026 /* InPersonPaymentsPluginNotSupportedVersionView.swift in Sources */,
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */,


### PR DESCRIPTION
Closes: #5847
⚠️ Depends on #5889 ⚠️ 

## Description

This adds a view for showing a list of product variations that can be added to a new order during Order Creation.

It also adds a reusable component for creating an infinite scroll list (a list with an infinite scroll indicator that appears while more list content is loading).

## Changes

* Extracts the infinite scroll list from `AddProductToOrder` and makes it a reusable SwiftUI component `InfiniteScrollList`.
* Adds a new view `AddProductVariationToOrder`, which creates the list of product variations that can be added to a new order.
* Updates the view model `AddProductVariationToOrderViewModel` so it can be initialized with just the required properties (to avoid using the `Product` type from the Yosemite layer in SwiftUI previews) or the convenience init.

## Testing

The product variations list isn't yet used in Order Creation, so for the variation list view and view model changes make sure that the changes make sense and unit tests pass.

To test the infinite scroll component, confirm that the Add Product screen continues to load the product list with infinite scroll as before:

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, confirm the product list loads with infinite scroll as expected (the infinite scroll indicator appears when there is more content to sync, and newly synced content loads).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
