### PR TITLE
Order Creation: Include variable products in product list on Add Product screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -19,11 +19,7 @@ struct AddProductToOrder: View {
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
                                        loadAction: viewModel.syncNextPage) {
                         ForEach(viewModel.productRows) { rowViewModel in
-                            ProductRow(viewModel: rowViewModel)
-                                .onTapGesture {
-                                    viewModel.selectProduct(rowViewModel.productOrVariationID)
-                                    isPresented.toggle()
-                                }
+                            createProductRow(rowViewModel: rowViewModel)
                         }
                     }
                 case .empty:
@@ -56,6 +52,22 @@ struct AddProductToOrder: View {
             }
         }
         .wooNavigationBarStyle()
+    }
+
+    @ViewBuilder private func createProductRow(rowViewModel: ProductRowViewModel) -> some View {
+        if rowViewModel.numberOfVariations > 0 {
+            NavigationLink {
+                // TODO: Navigate to variation list
+            } label: {
+                ProductRow(viewModel: rowViewModel)
+            }
+        } else {
+            ProductRow(viewModel: rowViewModel)
+                .onTapGesture {
+                    viewModel.selectProduct(rowViewModel.productOrVariationID)
+                    isPresented.toggle()
+                }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -57,7 +57,9 @@ struct AddProductToOrder: View {
     @ViewBuilder private func createProductRow(rowViewModel: ProductRowViewModel) -> some View {
         if rowViewModel.numberOfVariations > 0 {
             NavigationLink {
-                // TODO: Navigate to variation list
+                if let addVariationToOrderVM = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
+                    AddProductVariationToOrder(isPresented: $isPresented, viewModel: addVariationToOrderVM)
+                }
             } label: {
                 ProductRow(viewModel: rowViewModel)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -54,13 +54,12 @@ struct AddProductToOrder: View {
         .wooNavigationBarStyle()
     }
 
+    /// Creates the `ProductRow` for a product, depending on whether the product is variable.
+    ///
     @ViewBuilder private func createProductRow(rowViewModel: ProductRowViewModel) -> some View {
-        if rowViewModel.numberOfVariations > 0 {
-            NavigationLink {
-                if let addVariationToOrderVM = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
-                    AddProductVariationToOrder(isPresented: $isPresented, viewModel: addVariationToOrderVM)
-                }
-            } label: {
+        if rowViewModel.numberOfVariations > 0,
+           let addVariationToOrderVM = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
+            LazyNavigationLink(destination: AddProductVariationToOrder(isPresented: $isPresented, viewModel: addVariationToOrderVM)) {
                 ProductRow(viewModel: rowViewModel)
             }
         } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -82,6 +82,15 @@ final class AddProductToOrderViewModel: ObservableObject {
         }
         onProductSelected?(selectedProduct)
     }
+
+    /// Get the view model for a list of product variations to add to the order
+    ///
+    func getVariationsViewModel(for productID: Int64) -> AddProductVariationToOrderViewModel? {
+        guard let variableProduct = products.first(where: { $0.productID == productID }) else {
+            return nil
+        }
+        return AddProductVariationToOrderViewModel(siteID: siteID, product: variableProduct)
+    }
 }
 
 // MARK: - SyncingCoordinatorDelegate & Sync Methods

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -14,11 +14,6 @@ final class AddProductToOrderViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
-    /// Product types excluded from the product list.
-    /// For now, only non-variable product types are supported.
-    ///
-    private let excludedProductTypes: [ProductType] = [ProductType.variable]
-
     /// Product statuses included in the product list.
     /// Only published or private products can be added to an order.
     ///
@@ -28,9 +23,7 @@ final class AddProductToOrderViewModel: ObservableObject {
     ///
     private var products: [Product] {
         return productsResultsController.fetchedObjects.filter {
-            let hasValidProductType = !excludedProductTypes.contains( $0.productType )
-            let hasValidProductStatus = includedProductStatuses.contains( $0.productStatus )
-            return hasValidProductType && hasValidProductStatus
+            includedProductStatuses.contains( $0.productStatus )
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -14,17 +14,10 @@ final class AddProductToOrderViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
-    /// Product statuses included in the product list.
-    /// Only published or private products can be added to an order.
-    ///
-    private let includedProductStatuses: [ProductStatus] = [ProductStatus.publish, ProductStatus.privateStatus]
-
     /// All products that can be added to an order.
     ///
     private var products: [Product] {
-        return productsResultsController.fetchedObjects.filter {
-            includedProductStatuses.contains( $0.productStatus )
-        }
+        productsResultsController.fetchedObjects.filter { $0.purchasable }
     }
 
     /// View models for each product row

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// View showing a list of product variations to add to an order.
 ///
 struct AddProductVariationToOrder: View {
+    @Environment(\.presentationMode) private var presentation
+
     /// Defines whether the view is presented.
     ///
     @Binding var isPresented: Bool
@@ -43,6 +45,17 @@ struct AddProductVariationToOrder: View {
         .ignoresSafeArea(.container, edges: .horizontal)
         .navigationTitle(viewModel.productName)
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            // Minimal back button
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    presentation.wrappedValue.dismiss()
+                } label: {
+                    Image(uiImage: .chevronLeftImage.imageFlippedForRightToLeftLayoutDirection())
+                }
+            }
+        }
         .onAppear {
             viewModel.syncFirstPage()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -116,7 +116,6 @@ private enum Layout {
     static let stepperButtonSize: CGFloat = 22.0
     static let stepperPadding: CGFloat = 11.0
     static let stepperWidth: CGFloat = 112.0
-    static let chevronImageSize: CGFloat = 22.0
 }
 
 private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -42,12 +42,6 @@ struct ProductRow: View {
 
                 ProductStepper(viewModel: viewModel)
                     .renderedIf(viewModel.canChangeQuantity)
-
-                Image(uiImage: .chevronImage)
-                    .renderedIf(viewModel.isSelectable)
-                    .flipsForRightToLeftLayoutDirection(true)
-                    .frame(width: Layout.chevronImageSize, height: Layout.chevronImageSize)
-                    .foregroundColor(Color(UIColor.gray(.shade30)))
             }
         }
     }
@@ -149,17 +143,6 @@ struct ProductRow_Previews: PreviewProvider {
                                                           manageStock: true,
                                                           canChangeQuantity: false,
                                                           imageURL: nil)
-        let viewModelSelectable = ProductRowViewModel(productOrVariationID: 1,
-                                                      name: "Love Ficus",
-                                                      sku: "123456",
-                                                      price: "",
-                                                      stockStatusKey: "instock",
-                                                      stockQuantity: 7,
-                                                      manageStock: true,
-                                                      canChangeQuantity: false,
-                                                      imageURL: nil,
-                                                      isSelectable: true,
-                                                      numberOfVariations: 3)
 
         ProductRow(viewModel: viewModel)
             .previewDisplayName("ProductRow with stepper")
@@ -167,10 +150,6 @@ struct ProductRow_Previews: PreviewProvider {
 
         ProductRow(viewModel: viewModelWithoutStepper)
             .previewDisplayName("ProductRow without stepper")
-            .previewLayout(.sizeThatFits)
-
-        ProductRow(viewModel: viewModelSelectable)
-            .previewDisplayName("Selectable ProductRow")
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -30,7 +30,7 @@ struct ProductRow: View {
                     // Product details
                     VStack(alignment: .leading) {
                         Text(viewModel.name)
-                        Text(viewModel.stockAndPriceLabel)
+                        Text(viewModel.productDetailsLabel)
                             .subheadlineStyle()
                         Text(viewModel.skuLabel)
                             .subheadlineStyle()
@@ -42,6 +42,12 @@ struct ProductRow: View {
 
                 ProductStepper(viewModel: viewModel)
                     .renderedIf(viewModel.canChangeQuantity)
+
+                Image(uiImage: .chevronImage)
+                    .renderedIf(viewModel.isSelectable)
+                    .flipsForRightToLeftLayoutDirection(true)
+                    .frame(width: Layout.chevronImageSize, height: Layout.chevronImageSize)
+                    .foregroundColor(Color(UIColor.gray(.shade30)))
             }
         }
     }
@@ -116,6 +122,7 @@ private enum Layout {
     static let stepperButtonSize: CGFloat = 22.0
     static let stepperPadding: CGFloat = 11.0
     static let stepperWidth: CGFloat = 112.0
+    static let chevronImageSize: CGFloat = 22.0
 }
 
 private enum Localization {
@@ -142,6 +149,17 @@ struct ProductRow_Previews: PreviewProvider {
                                                           manageStock: true,
                                                           canChangeQuantity: false,
                                                           imageURL: nil)
+        let viewModelSelectable = ProductRowViewModel(productOrVariationID: 1,
+                                                      name: "Love Ficus",
+                                                      sku: "123456",
+                                                      price: "",
+                                                      stockStatusKey: "instock",
+                                                      stockQuantity: 7,
+                                                      manageStock: true,
+                                                      canChangeQuantity: false,
+                                                      imageURL: nil,
+                                                      isSelectable: true,
+                                                      numberOfVariations: 3)
 
         ProductRow(viewModel: viewModel)
             .previewDisplayName("ProductRow with stepper")
@@ -149,6 +167,10 @@ struct ProductRow_Previews: PreviewProvider {
 
         ProductRow(viewModel: viewModelWithoutStepper)
             .previewDisplayName("ProductRow without stepper")
+            .previewLayout(.sizeThatFits)
+
+        ProductRow(viewModel: viewModelSelectable)
+            .previewDisplayName("Selectable ProductRow")
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -84,14 +84,9 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         quantity <= minimumQuantity
     }
 
-    /// Whether the product row is selectable
-    /// Used to add a disclosure indicator for variable products
-    ///
-    let isSelectable: Bool
-
     /// Number of variations in a variable product
     ///
-    private let numberOfVariations: Int
+    let numberOfVariations: Int
 
     init(id: String? = nil,
          productOrVariationID: Int64,
@@ -104,7 +99,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          quantity: Decimal = 1,
          canChangeQuantity: Bool,
          imageURL: URL?,
-         isSelectable: Bool = false,
          numberOfVariations: Int = 0,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.id = id ?? productOrVariationID.description
@@ -119,7 +113,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.canChangeQuantity = canChangeQuantity
         self.imageURL = imageURL
         self.currencyFormatter = currencyFormatter
-        self.isSelectable = isSelectable
         self.numberOfVariations = numberOfVariations
     }
 
@@ -149,7 +142,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   quantity: quantity,
                   canChangeQuantity: canChangeQuantity,
                   imageURL: product.imageURL,
-                  isSelectable: product.productType == .variable,
                   numberOfVariations: product.variations.count,
                   currencyFormatter: currencyFormatter)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -35,7 +35,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Product price
     ///
-    private let price: String
+    private let price: String?
 
     /// Product stock status
     ///
@@ -49,13 +49,14 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     private let manageStock: Bool
 
-    /// Label showing product stock status and price.
+    /// Label showing product details: stock status, price, and variations (if any).
     ///
-    lazy var stockAndPriceLabel: String = {
+    lazy var productDetailsLabel: String = {
         let stockLabel = createStockText()
         let priceLabel = createPriceText()
+        let variationsLabel = createVariationsText()
 
-        return [stockLabel, priceLabel]
+        return [stockLabel, priceLabel, variationsLabel]
             .compactMap({ $0 })
             .joined(separator: " • ")
     }()
@@ -83,17 +84,28 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         quantity <= minimumQuantity
     }
 
+    /// Whether the product row is selectable
+    /// Used to add a disclosure indicator for variable products
+    ///
+    let isSelectable: Bool
+
+    /// Number of variations in a variable product
+    ///
+    private let numberOfVariations: Int
+
     init(id: String? = nil,
          productOrVariationID: Int64,
          name: String,
          sku: String?,
-         price: String,
+         price: String?,
          stockStatusKey: String,
          stockQuantity: Decimal?,
          manageStock: Bool,
          quantity: Decimal = 1,
          canChangeQuantity: Bool,
          imageURL: URL?,
+         isSelectable: Bool = false,
+         numberOfVariations: Int = 0,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.id = id ?? productOrVariationID.description
         self.productOrVariationID = productOrVariationID
@@ -107,6 +119,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.canChangeQuantity = canChangeQuantity
         self.imageURL = imageURL
         self.currencyFormatter = currencyFormatter
+        self.isSelectable = isSelectable
+        self.numberOfVariations = numberOfVariations
     }
 
     /// Initialize `ProductRowViewModel` with a `Product`
@@ -116,17 +130,27 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      quantity: Decimal = 1,
                      canChangeQuantity: Bool,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        // Don't show any price for variable products; price will be shown for each product variation.
+        let price: String?
+        if product.productType == .variable {
+            price = nil
+        } else {
+            price = product.price
+        }
+
         self.init(id: id,
                   productOrVariationID: product.productID,
                   name: product.name,
                   sku: product.sku,
-                  price: product.price,
+                  price: price,
                   stockStatusKey: product.stockStatusKey,
                   stockQuantity: product.stockQuantity,
                   manageStock: product.manageStock,
                   quantity: quantity,
                   canChangeQuantity: canChangeQuantity,
                   imageURL: product.imageURL,
+                  isSelectable: product.productType == .variable,
+                  numberOfVariations: product.variations.count,
                   currencyFormatter: currencyFormatter)
     }
 
@@ -186,8 +210,21 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Create the price text based on a product's price.
     ///
     private func createPriceText() -> String? {
+        guard let price = price else {
+            return nil
+        }
         let unformattedPrice = price.isNotEmpty ? price : "0"
         return currencyFormatter.formatAmount(unformattedPrice)
+    }
+
+    /// Create the variations text for a variable product.
+    ///
+    private func createVariationsText() -> String? {
+        guard numberOfVariations > 0 else {
+            return nil
+        }
+        let format = String.pluralize(numberOfVariations, singular: Localization.singleVariation, plural: Localization.pluralVariations)
+        return String.localizedStringWithFormat(format, numberOfVariations)
     }
 
     /// Increment the product quantity.
@@ -210,5 +247,9 @@ private extension ProductRowViewModel {
     enum Localization {
         static let stockFormat = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown during order creation")
         static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
+        static let singleVariation = NSLocalizedString("%ld variation",
+                                                       comment: "Label for one product variation when showing details about a variable product")
+        static let pluralVariations = NSLocalizedString("%ld variations",
+                                                        comment: "Label for multiple product variations when showing details about a variable product")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyNavigationLink.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyNavigationLink.swift
@@ -10,7 +10,7 @@ struct LazyNavigationLink<Destination: View, Label: View>: View {
 
     /// Set it to `true` to proceed with the desired navigation. Set it to `false` to remove the view from the navigation context.
     ///
-    @Binding var isActive: Bool
+    var isActive: Binding<Bool>?
 
     /// `NavigationLink` label
     ///
@@ -19,15 +19,19 @@ struct LazyNavigationLink<Destination: View, Label: View>: View {
     /// Creates a navigation link that creates and presents the destination view when active.
     /// - Parameters:
     ///   - destination: A view for the navigation link to present.
-    ///   - isActive: A binding to a Boolean value that indicates whether `destination` is currently presented.
+    ///   - isActive: An optional binding to a Boolean value that indicates whether `destination` is currently presented.
     ///   - label: A view builder to produce a label describing the `destination` to present.
-    init(destination: @autoclosure @escaping () -> Destination, isActive: Binding<Bool>, label: @escaping () -> Label) {
+    init(destination: @autoclosure @escaping () -> Destination, isActive: Binding<Bool>? = nil, label: @escaping () -> Label) {
         self.destination = destination
-        self._isActive = isActive
+        self.isActive = isActive
         self.label = label
     }
 
     var body: some View {
-        NavigationLink(destination: LazyView(destination), isActive: $isActive, label: label)
+        if let isActive = isActive {
+            NavigationLink(destination: LazyView(destination), isActive: isActive, label: label)
+        } else {
+            NavigationLink(destination: LazyView(destination), label: label)
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -25,7 +25,7 @@ class AddProductToOrderViewModelTests: XCTestCase {
 
     func test_view_model_adds_product_rows_with_unchangeable_quantity() {
         // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, statusKey: "publish")
+        let product = Product.fake().copy(siteID: sampleSiteID, purchasable: true)
         insert(product)
 
         // When
@@ -36,24 +36,6 @@ class AddProductToOrderViewModelTests: XCTestCase {
 
         let productRow = viewModel.productRows[0]
         XCTAssertFalse(productRow.canChangeQuantity, "Product row canChangeQuantity property should be false but is true instead")
-    }
-
-    func test_product_rows_only_contain_products_with_published_and_private_statuses() {
-        // Given
-        let publishedProduct = Product.fake().copy(siteID: sampleSiteID, productID: 1, statusKey: "publish")
-        let draftProduct = Product.fake().copy(siteID: sampleSiteID, productID: 2, statusKey: "draft")
-        let pendingProduct = Product.fake().copy(siteID: sampleSiteID, productID: 3, statusKey: "pending")
-        let privateProduct = Product.fake().copy(siteID: sampleSiteID, productID: 4, statusKey: "private")
-        insert([publishedProduct, draftProduct, pendingProduct, privateProduct])
-
-        // When
-        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
-
-        // Then
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 1 }), "Product rows do not include published product")
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == 2 }), "Product rows include draft product")
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == 3 }), "Product rows include pending product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 4 }), "Product rows do not include private product")
     }
 
     func test_scrolling_indicator_appears_only_during_sync() {
@@ -104,7 +86,7 @@ class AddProductToOrderViewModelTests: XCTestCase {
             switch action {
             case let .synchronizeProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
-                let product = Product.fake().copy(siteID: self.sampleSiteID, statusKey: "publish")
+                let product = Product.fake().copy(siteID: self.sampleSiteID, purchasable: true)
                 self.insert(product)
                 onCompletion(.success(true))
             default:
@@ -121,7 +103,7 @@ class AddProductToOrderViewModelTests: XCTestCase {
 
     func test_sync_status_does_not_change_while_syncing_when_storage_contains_products() {
         // Given
-        let product = Product.fake().copy(siteID: self.sampleSiteID, statusKey: "publish")
+        let product = Product.fake().copy(siteID: self.sampleSiteID, purchasable: true)
         insert(product)
 
         let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, stores: stores)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -38,26 +38,6 @@ class AddProductToOrderViewModelTests: XCTestCase {
         XCTAssertFalse(productRow.canChangeQuantity, "Product row canChangeQuantity property should be false but is true instead")
     }
 
-    func test_products_include_all_product_types_except_variable() {
-        // Given
-        let simpleProduct = Product.fake().copy(siteID: sampleSiteID, productID: 1, productTypeKey: "simple", statusKey: "publish")
-        let groupedProduct = Product.fake().copy(siteID: sampleSiteID, productID: 2, productTypeKey: "grouped", statusKey: "publish")
-        let affiliateProduct = Product.fake().copy(siteID: sampleSiteID, productID: 3, productTypeKey: "external", statusKey: "publish")
-        let variableProduct = Product.fake().copy(siteID: sampleSiteID, productID: 4, productTypeKey: "variable", statusKey: "publish")
-        let subscriptionProduct = Product.fake().copy(siteID: sampleSiteID, productID: 5, productTypeKey: "subscription", statusKey: "publish")
-        insert([simpleProduct, groupedProduct, affiliateProduct, variableProduct, subscriptionProduct])
-
-        // When
-        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
-
-        // Then
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 1 }), "Products do not include simple product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 2 }), "Products do not include grouped product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 3 }), "Products do not include affiliate product")
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == 4 }), "Products include variable product")
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == 5 }), "Products do not include subscription product")
-    }
-
     func test_product_rows_only_contain_products_with_published_and_private_statuses() {
         // Given
         let publishedProduct = Product.fake().copy(siteID: sampleSiteID, productID: 1, statusKey: "publish")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -130,7 +130,7 @@ class NewOrderViewModelTests: XCTestCase {
 
     func test_view_model_is_updated_when_product_is_added_to_order() {
         // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish")
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
@@ -146,7 +146,7 @@ class NewOrderViewModelTests: XCTestCase {
 
     func test_order_details_are_updated_when_product_quantity_changes() {
         // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish")
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
@@ -166,7 +166,7 @@ class NewOrderViewModelTests: XCTestCase {
 
     func test_selectOrderItem_selects_expected_order_item() {
         // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish")
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
@@ -182,8 +182,8 @@ class NewOrderViewModelTests: XCTestCase {
 
     func test_view_model_is_updated_when_product_is_removed_from_order() {
         // Given
-        let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, statusKey: "publish")
-        let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, statusKey: "publish")
+        let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
+        let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         let storageManager = MockStorageManager()
         storageManager.insertProducts([product0, product1])
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
@@ -249,7 +249,7 @@ class NewOrderViewModelTests: XCTestCase {
 
     func test_payment_section_only_displayed_when_order_has_products() {
         // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish")
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
@@ -266,7 +266,7 @@ class NewOrderViewModelTests: XCTestCase {
     func test_payment_section_is_updated_when_products_update() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, statusKey: "publish", price: "8.50")
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
         let storageManager = MockStorageManager()
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, currencySettings: currencySettings)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -22,6 +22,18 @@ class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.imageURL, URL(string: imageURLString))
         XCTAssertFalse(viewModel.canChangeQuantity)
         XCTAssertEqual(viewModel.quantity, 1)
+        XCTAssertFalse(viewModel.isSelectable)
+    }
+
+    func test_viewModel_is_created_with_correct_initial_values_from_variable_product() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "variable")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        XCTAssertTrue(viewModel.isSelectable)
     }
 
     func test_viewModel_is_created_with_correct_initial_values_from_product_variation() {
@@ -58,8 +70,8 @@ class ProductRowViewModelTests: XCTestCase {
         let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
         let format = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown during order creation")
         let expectedStockLabel = String.localizedStringWithFormat(format, localizedStockQuantity)
-        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedStockLabel),
-                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockLabel),
+                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
     func test_view_model_creates_expected_label_for_product_with_unmanaged_stock() {
@@ -71,8 +83,8 @@ class ProductRowViewModelTests: XCTestCase {
 
         // Then
         let expectedStockLabel = NSLocalizedString("In stock", comment: "Display label for the product's inventory stock status")
-        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedStockLabel),
-                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockLabel),
+                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
     func test_view_model_creates_expected_label_for_out_of_stock_product() {
@@ -84,8 +96,8 @@ class ProductRowViewModelTests: XCTestCase {
 
         // Then
         let expectedStockLabel = NSLocalizedString("Out of stock", comment: "Display label for the product's inventory stock status")
-        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedStockLabel),
-                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockLabel),
+                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
     func test_view_model_creates_expected_label_for_product_with_price() {
@@ -99,8 +111,8 @@ class ProductRowViewModelTests: XCTestCase {
 
         // Then
         let expectedPriceLabel = "2.50"
-        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedPriceLabel),
-                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedPriceLabel),
+                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
     func test_view_model_creates_expected_label_for_product_with_no_price() {
@@ -114,8 +126,20 @@ class ProductRowViewModelTests: XCTestCase {
 
         // Then
         let expectedPriceLabel = "$0.00"
-        XCTAssertTrue(viewModel.stockAndPriceLabel.contains(expectedPriceLabel),
-                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.stockAndPriceLabel)\"")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedPriceLabel),
+                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
+    }
+
+    func test_view_model_creates_expected_product_details_label_for_variable_product() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "variable", stockStatusKey: "instock", variations: [0, 1])
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let expectedProductDetailsLabel = "In stock • 2 variations"
+        XCTAssertEqual(viewModel.productDetailsLabel, expectedProductDetailsLabel)
     }
 
     func test_sku_label_is_formatted_correctly_for_product_with_sku() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -22,18 +22,18 @@ class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.imageURL, URL(string: imageURLString))
         XCTAssertFalse(viewModel.canChangeQuantity)
         XCTAssertEqual(viewModel.quantity, 1)
-        XCTAssertFalse(viewModel.isSelectable)
+        XCTAssertEqual(viewModel.numberOfVariations, 0)
     }
 
     func test_viewModel_is_created_with_correct_initial_values_from_variable_product() {
         // Given
-        let product = Product.fake().copy(productTypeKey: "variable")
+        let product = Product.fake().copy(productTypeKey: "variable", variations: [0, 1, 2])
 
         // When
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
 
         // Then
-        XCTAssertTrue(viewModel.isSelectable)
+        XCTAssertEqual(viewModel.numberOfVariations, 3)
     }
 
     func test_viewModel_is_created_with_correct_initial_values_from_product_variation() {


### PR DESCRIPTION
Closes: #5846
⚠️ Depends on #5893 ⚠️ 

## Description

For Order Creation, we are adding support for variable products (adding a product variation to an order).

This PR adds variable products to the product list on the Add Product screenWhen a variable product is selected, it opens a list of the purchasable variations for that product.

Note that you can select a variation, but it won't yet add the selected variation to the order (this will be added in #5848).

## Changes

* Adds support for showing a variable product in `ProductRow`:
   * Changes `stockAndPriceLabel` to `productDetailsLabel`, which now shows a product's stock status, price, and the number of variations (if any).
   * If a product row is initialized with a variable product, the `price` is set to `nil` so no price is shown (since prices are set on the variations).
* `AddProductToOrder`:
   *  Now uses a `createProductRow()` method to generate each product row in the product list. Non-variable products are created the same as before, but variable products (a row that has variations) will show the row in a `LazyNavigationLink` that leads to the `AddProductVariationToOrder` view for that product.
* `AddProductToOrderViewModel`:
   * Removes the `products` filter that excludes variable products from the product list.
   * Updates the `products` filter to use the product's `purchasable` property instead of including specific product statuses, which is a more reliable way to determine if a product can be added to an order (purchased).
   * Adds a method to generate the view model for a product's `AddProductVariationToOrder` view.
* `LazyNavigationLink` now works without passing an `$isActive` binding. This simplifies its use in a `ForEach` loop like in this view (so a separate binding doesn't need to be created for each instance).
* Updates unit tests.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, confirm the product list includes all purchasable products, including variable products. 
6. Confirm that non-variable products include a price, and variable products have no price but do show the number of variations for that product.
7. Select a non-variable product and confirm it is added to the order (same behavior as before).
8. Tap the "Add product" button again and select a variable product.
9. Confirm you are taken to a list of the purchasable variations for that product, with the available details appearing for each variation (image, name, stock status, price, SKU).
10. Confirm you can tap the back button to navigate back to the product list, or tap a variation to close the modal view. (The selected variation is not yet added to the order.)

## Screenshots

Product list|Variation list
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-01-13 at 17 48 18](https://user-images.githubusercontent.com/8658164/149384611-006a98c6-c711-48d8-9f0a-b9cc9394ab3b.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-01-13 at 17 59 01](https://user-images.githubusercontent.com/8658164/149384617-f711eb81-53d8-47c4-8257-c199750d9caf.png)


https://user-images.githubusercontent.com/8658164/149384290-3307d520-c3cb-4aef-a3f2-3ca89fcdc50a.mp4


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
