### PR TITLE
Order Creation: Adds SwiftUI notice support

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -1,0 +1,1 @@
+import SwiftUI

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -10,13 +10,9 @@ struct NoticeModifier: ViewModifier {
     let notice: Notice
 
     func body(content: Content) -> some View {
-        // Geometry reader to provide the correct view width.
-        GeometryReader { geometry in
-            ZStack {
-
-                // Main content
-                content
-
+        content.overlay(
+            // Geometry reader to provide the correct view width.
+            GeometryReader { geometry in
                 // VStack with spacer to push content to the bottom
                 VStack {
                     Spacer()
@@ -26,7 +22,7 @@ struct NoticeModifier: ViewModifier {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-        }
+        )
     }
 }
 
@@ -79,7 +75,7 @@ private extension NoticeAlert {
 
         /// Notice view padding.
         ///
-        let defaultInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        let defaultInsets = UIEdgeInsets(top: 16, left: 16, bottom: 28, right: 16)
 
         init(noticeView: NoticeView) {
             self.noticeView = noticeView
@@ -128,7 +124,7 @@ extension View {
 
 struct NoticeModifier_Previews: PreviewProvider {
     static var previews: some View {
-        Text("")
+        Rectangle().foregroundColor(.white)
             .notice(
                 .init(title: "API Error",
                       subtitle: "Restricted Access",

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -28,16 +28,17 @@ struct NoticeModifier: ViewModifier {
 
                     // NoticeView wrapper
                     NoticeAlert(notice: notice, width: geometry.size.width)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .onDismiss {
+                            $notice.wrappedValue = nil
+                        }
                         .onAppear {
                             // TODO: Move this to a proper state management class
                             DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                                $notice.wrappedValue = nil
+                                //$notice.wrappedValue = nil
                             }
                         }
-                        .onTapGesture {
-                            $notice.wrappedValue = nil // TODO: Test the retry button interference
-                        }
+
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
@@ -58,8 +59,14 @@ private struct NoticeAlert: UIViewRepresentable {
     ///
     let width: CGFloat
 
+    /// Action to be invoked when the view is tapped.
+    ///
+    var onDismiss: (() -> Void)?
+
     func makeUIView(context: Context) -> NoticeWrapper {
         let noticeView = NoticeView(notice: notice)
+        noticeView.dismissHandler = onDismiss
+
         let wrapperView = NoticeWrapper(noticeView: noticeView)
         wrapperView.translatesAutoresizingMaskIntoConstraints = false
         return wrapperView
@@ -67,6 +74,14 @@ private struct NoticeAlert: UIViewRepresentable {
 
     func updateUIView(_ uiView: NoticeWrapper, context: Context) {
         uiView.width = width
+    }
+
+    /// Updates the notice dismiss closure.
+    ///
+    func onDismiss(_ onDismiss: @escaping (() -> Void)) -> Self {
+        var copy = self
+        copy.onDismiss = onDismiss
+        return copy
     }
 }
 

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -10,31 +10,36 @@ struct NoticeModifier: ViewModifier {
     @Binding var notice: Notice?
 
     func body(content: Content) -> some View {
-        if let notice = notice {
-            content.overlay(
-                // Geometry reader to provide the correct view width.
-                GeometryReader { geometry in
-                    // VStack with spacer to push content to the bottom
-                    VStack {
-                        Spacer()
+        content
+            .overlay(buildNoticeStack())
+            .animation(.easeInOut, value: notice)
+    }
 
-                        // NoticeView wrapper
-                        NoticeAlert(notice: notice, width: geometry.size.width)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .onAppear {
-                                // TODO: Move this to a proper state management class
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                                    $notice.wrappedValue = nil
-                                }
+    /// Builds a notice view at the bottom of the screen.
+    ///
+    @ViewBuilder private func buildNoticeStack() -> some View {
+        if let notice = notice {
+            // Geometry reader to provide the correct view width.
+            GeometryReader { geometry in
+
+                // VStack with spacer to push content to the bottom
+                VStack {
+                    Spacer()
+
+                    // NoticeView wrapper
+                    NoticeAlert(notice: notice, width: geometry.size.width)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .onAppear {
+                            // TODO: Move this to a proper state management class
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                                $notice.wrappedValue = nil
                             }
-                            .onTapGesture {
-                                $notice.wrappedValue = nil // TODO: Test the retry button interference
-                            }
-                    }
+                        }
+                        .onTapGesture {
+                            $notice.wrappedValue = nil // TODO: Test the retry button interference
+                        }
                 }
-            )
-        } else {
-            content
+            }
         }
     }
 }
@@ -129,7 +134,7 @@ extension View {
     /// Shows the provided notice in front of the view.
     ///
     func notice(_ notice: Binding<Notice?>) -> some View {
-        self.modifier(NoticeModifier(notice: notice))
+        modifier(NoticeModifier(notice: notice))
     }
 }
 

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -39,15 +39,12 @@ struct NoticeModifier: ViewModifier {
                     // NoticeView wrapper
                     NoticeAlert(notice: notice, width: geometry.size.width)
                         .onDismiss {
-                            print("on dismiss")
                             performClearNoticeTask()
                         }
                         .onChange(of: notice) { _ in
-                            print("on change")
                             dispatchClearNoticeTask()
                         }
                         .onAppear {
-                            print("on appear")
                             dispatchClearNoticeTask()
                         }
 
@@ -63,9 +60,7 @@ struct NoticeModifier: ViewModifier {
         clearNoticeTask.cancel()
         clearNoticeTask = .init {
             $notice.wrappedValue = nil
-            print("clear was performed")
         }
-        print("on Dispatch")
         DispatchQueue.main.asyncAfter(deadline: .now() + onScreenNoticeTime, execute: clearNoticeTask)
     }
 

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -7,22 +7,26 @@ struct NoticeModifier: ViewModifier {
 
     /// Notice object to render
     ///
-    let notice: Notice
+    @Binding var notice: Notice?
 
     func body(content: Content) -> some View {
-        content.overlay(
-            // Geometry reader to provide the correct view width.
-            GeometryReader { geometry in
-                // VStack with spacer to push content to the bottom
-                VStack {
-                    Spacer()
+        if let notice = notice {
+            content.overlay(
+                // Geometry reader to provide the correct view width.
+                GeometryReader { geometry in
+                    // VStack with spacer to push content to the bottom
+                    VStack {
+                        Spacer()
 
-                    // NoticeView wrapper
-                    NoticeAlert(notice: notice, width: geometry.size.width)
-                        .fixedSize(horizontal: false, vertical: true)
+                        // NoticeView wrapper
+                        NoticeAlert(notice: notice, width: geometry.size.width)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
-            }
-        )
+            )
+        } else {
+            content
+        }
     }
 }
 
@@ -115,7 +119,7 @@ private extension NoticeAlert {
 extension View {
     /// Shows the provided notice in front of the view.
     ///
-    func notice(_ notice: Notice) -> some View {
+    func notice(_ notice: Binding<Notice?>) -> some View {
         self.modifier(NoticeModifier(notice: notice))
     }
 }
@@ -125,7 +129,7 @@ extension View {
 struct NoticeModifier_Previews: PreviewProvider {
     static var previews: some View {
         Rectangle().foregroundColor(.white)
-            .notice(
+            .notice(.constant(
                 .init(title: "API Error",
                       subtitle: "Restricted Access",
                       message: "Your photos could not be downloaded, please ask for the correct permissions!",
@@ -135,7 +139,7 @@ struct NoticeModifier_Previews: PreviewProvider {
                       actionHandler: {
                           print("Retry")
                       })
-            )
+            ))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
     }

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -21,6 +21,12 @@ struct NoticeModifier: ViewModifier {
                         // NoticeView wrapper
                         NoticeAlert(notice: notice, width: geometry.size.width)
                             .fixedSize(horizontal: false, vertical: true)
+                            .onAppear {
+                                // TODO: Move this to a proper state management class
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                                    $notice.wrappedValue = nil
+                                }
+                            }
                             .onTapGesture {
                                 $notice.wrappedValue = nil // TODO: Test the retry button interference
                             }

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import UIKit
-import Hardware
 
 /// View Modifier that shows a notice in front of a view.
 /// NOTE: This currently does not support.
@@ -15,11 +14,15 @@ struct NoticeModifier: ViewModifier {
 
     /// Cancelable task that clears a notice.
     ///
-    @State var clearNoticeTask = DispatchWorkItem(block: {})
+    @State private var clearNoticeTask = DispatchWorkItem(block: {})
 
     /// Time the notice will remain on screen.
     ///
     private let onScreenNoticeTime = 5.0
+
+    /// Feedback generator.
+    ///
+    private let feedbackGenerator = UINotificationFeedbackGenerator()
 
     func body(content: Content) -> some View {
         content
@@ -44,9 +47,11 @@ struct NoticeModifier: ViewModifier {
                             performClearNoticeTask()
                         }
                         .onChange(of: notice) { _ in
+                            provideHapticFeedbackIfNecessary(notice.feedbackType)
                             dispatchClearNoticeTask()
                         }
                         .onAppear {
+                            provideHapticFeedbackIfNecessary(notice.feedbackType)
                             dispatchClearNoticeTask()
                         }
 
@@ -71,6 +76,14 @@ struct NoticeModifier: ViewModifier {
     private func performClearNoticeTask() {
         clearNoticeTask.perform()
         clearNoticeTask.cancel()
+    }
+
+    /// Sends haptic feedback if required.
+    ///
+    private func provideHapticFeedbackIfNecessary(_ feedbackType: UINotificationFeedbackGenerator.FeedbackType?) {
+        if let feedbackType = feedbackType {
+            feedbackGenerator.notificationOccurred(feedbackType)
+        }
     }
 }
 

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Lottie
 
 /// View Modifier to show a notice in front of a view.
 ///
@@ -22,3 +23,13 @@ extension View {
     }
 }
 
+// MARK: Preview
+
+struct NoticeModifier_Previews: PreviewProvider {
+    static var previews: some View {
+        Text("")
+            .notice()
+            .environment(\.colorScheme, .light)
+            .previewDisplayName("Light Content")
+    }
+}

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -21,6 +21,9 @@ struct NoticeModifier: ViewModifier {
                         // NoticeView wrapper
                         NoticeAlert(notice: notice, width: geometry.size.width)
                             .fixedSize(horizontal: false, vertical: true)
+                            .onTapGesture {
+                                $notice.wrappedValue = nil // TODO: Test the retry button interference
+                            }
                     }
                 }
             )

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -3,7 +3,9 @@ import UIKit
 import Hardware
 
 /// View Modifier that shows a notice in front of a view.
-/// NOTE: This currently does not support enqueuing multiple notices like `DefaultNoticePresenter` does.
+/// NOTE: This currently does not support.
+/// - Enqueuing multiple notices like `DefaultNoticePresenter` does.
+/// - Presenting foreground system notifications.
 ///
 struct NoticeModifier: ViewModifier {
 

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 
 /// View Modifier that shows a notice in front of a view.
+/// NOTE: This currently does not support enqueuing multiple notices like `DefaultNoticePresenter` does.
 ///
 struct NoticeModifier: ViewModifier {
 

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -1,1 +1,24 @@
 import SwiftUI
+
+/// View Modifier to show a notice in front of a view.
+///
+struct NoticeModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+
+            Text("Holi")
+        }
+    }
+}
+
+// MARK: View Extension
+
+extension View {
+    /// Shows a notice in front of the view.
+    ///
+    func notice() -> some View {
+        self.modifier(NoticeModifier())
+    }
+}
+

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -1,14 +1,115 @@
 import SwiftUI
-import Lottie
+import UIKit
 
-/// View Modifier to show a notice in front of a view.
+/// View Modifier that shows a notice in front of a view.
 ///
 struct NoticeModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        ZStack {
-            content
 
-            Text("Holi")
+    /// Notice object to render
+    ///
+    let notice: Notice
+
+    func body(content: Content) -> some View {
+        // Geometry reader to provide the correct view width.
+        GeometryReader { geometry in
+            ZStack {
+
+                // Main content
+                content
+
+                // VStack with spacer to push content to the bottom
+                VStack {
+                    Spacer()
+
+                    // NoticeView wrapper
+                    NoticeAlert(notice: notice, width: geometry.size.width)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+}
+
+// MARK: Custom Views
+
+/// `SwiftUI` representable type for `NoticeView`.
+///
+private struct NoticeAlert: UIViewRepresentable {
+
+    /// Notice object render
+    ///
+    let notice: Notice
+
+    /// Desired width of the view.
+    ///
+    let width: CGFloat
+
+    func makeUIView(context: Context) -> NoticeWrapper {
+        let noticeView = NoticeView(notice: notice)
+        let wrapperView = NoticeWrapper(noticeView: noticeView)
+        wrapperView.translatesAutoresizingMaskIntoConstraints = false
+        return wrapperView
+    }
+
+    func updateUIView(_ uiView: NoticeWrapper, context: Context) {
+        uiView.width = width
+    }
+}
+
+
+private extension NoticeAlert {
+    /// Wrapper type to force the underlying `NoticeView` to fixed width
+    ///
+    class NoticeWrapper: UIView {
+        /// Underlying notice view
+        ///
+        let noticeView: NoticeView
+
+        /// Fixed width constraint.
+        ///
+        var width: CGFloat = 0 {
+            didSet {
+                noticeViewWidthConstraint.constant = width
+            }
+        }
+
+        /// Width constraint for the notice view.
+        ///
+        private var noticeViewWidthConstraint = NSLayoutConstraint()
+
+        /// Notice view padding.
+        ///
+        let defaultInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+
+        init(noticeView: NoticeView) {
+            self.noticeView = noticeView
+            super.init(frame: .zero)
+
+            // Add notice view to edges
+            noticeView.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(noticeView)
+
+            layoutMargins = defaultInsets
+            pinSubviewToAllEdgeMargins(noticeView)
+
+            noticeViewWidthConstraint = widthAnchor.constraint(equalToConstant: width)
+            noticeViewWidthConstraint.isActive = true
+        }
+
+        /// Returns the preferred size of the view using the fixed width.
+        ///
+        override var intrinsicContentSize: CGSize {
+            let targetSize =  CGSize(width: width - defaultInsets.left - defaultInsets.right, height: 0)
+            let noticeHeight = noticeView.systemLayoutSizeFitting(
+                targetSize,
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .defaultLow
+            ).height
+            return CGSize(width: width, height: noticeHeight + defaultInsets.top + defaultInsets.bottom)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
         }
     }
 }
@@ -16,10 +117,10 @@ struct NoticeModifier: ViewModifier {
 // MARK: View Extension
 
 extension View {
-    /// Shows a notice in front of the view.
+    /// Shows the provided notice in front of the view.
     ///
-    func notice() -> some View {
-        self.modifier(NoticeModifier())
+    func notice(_ notice: Notice) -> some View {
+        self.modifier(NoticeModifier(notice: notice))
     }
 }
 
@@ -28,7 +129,17 @@ extension View {
 struct NoticeModifier_Previews: PreviewProvider {
     static var previews: some View {
         Text("")
-            .notice()
+            .notice(
+                .init(title: "API Error",
+                      subtitle: "Restricted Access",
+                      message: "Your photos could not be downloaded, please ask for the correct permissions!",
+                      feedbackType: .error,
+                      notificationInfo: nil,
+                      actionTitle: "Retry",
+                      actionHandler: {
+                          print("Retry")
+                      })
+            )
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 		261AA309275178FA009530FE /* SimplePaymentsMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA308275178FA009530FE /* SimplePaymentsMethod.swift */; };
 		261AA30C2753119E009530FE /* SimplePaymentsMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* SimplePaymentsMethodsViewModel.swift */; };
 		261AA30E275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift */; };
+		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
 		262A09812628A8F40033AD20 /* WooStyleModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09802628A8F40033AD20 /* WooStyleModifiers.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -2012,6 +2013,7 @@
 		261AA308275178FA009530FE /* SimplePaymentsMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethod.swift; sourceTree = "<group>"; };
 		261AA30B2753119E009530FE /* SimplePaymentsMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethodsViewModel.swift; sourceTree = "<group>"; };
 		261AA30D275506DE009530FE /* SimplePaymentsMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsMethodsViewModelTests.swift; sourceTree = "<group>"; };
+		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
 		262A09802628A8F40033AD20 /* WooStyleModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooStyleModifiers.swift; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -4219,6 +4221,7 @@
 				26E0AE12263359F900A5EB3B /* View+Conditionals.swift */,
 				DE4B3B5526A68DD000EEF2D8 /* View+InsetPaddings.swift */,
 				581D5051274AA2480089B6AD /* View+AutofocusTextModifier.swift */,
+				26281775278F0B0100C836D3 /* View+NoticesModifier.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -8187,6 +8190,7 @@
 				7435E58E21C0151B00216F0F /* OrderNote+Woo.swift in Sources */,
 				451A04F42386F7C900E368C9 /* AddProductImageCollectionViewCell.swift in Sources */,
 				D843D5CB22437E59001BFA55 /* TitleAndEditableValueTableViewCell.swift in Sources */,
+				26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */,
 				025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */,
 				CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */,
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,


### PR DESCRIPTION
part of #5842

# Why

Right now, our notices system is meant to be used within `UIKit`. 

As we are building more `SwiftUI` layouts we have made workarounds for our notices to continue to work. The most common workaround is to pass via combine publishers a notice presentation request and enqueue the real notice in the root hosting controller.

https://github.com/woocommerce/woocommerce-ios/blob/ef8776b5aa8944e1808b04b82c442e2ac7d54ae0/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Address%20Edit/EditOrderAddressForm.swift#L56-L83

This initially worked ok but we have found inconveniences when dealing with more complex layouts that do not involve a hosting view controller by default. Like when presenting a modal layout using the `sheet()` modifier.

https://github.com/woocommerce/woocommerce-ios/blob/ef8776b5aa8944e1808b04b82c442e2ac7d54ae0/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/CustomerSection/OrderCustomerSection.swift#L19-L24

This can be worked around by approaches like:
- Injecting a "notice publisher" from the hosting view controller and through all of our `SwiftUI` views.

But recently I hit a strange `UIKit` bug where if I try to dismiss a sheet via an interactive gesture while a notice is being presented, the presenting screen won't go back to its original size.


https://user-images.githubusercontent.com/562080/149450109-3cace191-a822-4537-ae65-8bf21eef4d2a.mov

I this point, I think it's worth having a proper `SwiftUI` notice support rather than hacking our way around `UIKit`.  So this PR introduces a new notice view modifier 

```swift
notice(_ notice: Binding<Notice?>)
```

It receives a `Notice?` type so we can determine when we want one to be presented. And it's `binding` so the modifier can `nill` it when it is dismissed.

I have tried to emulate most of the `DefaultNoticePresenter` functionality but we are still lacking:
- Multiple enqueue support.
- Foreground notification support.

I think both of those can be added as they are needed.

The main thing that is substantially different is the fact that **these notices are visible as long as the current parent view is visible.**  To my limited understanding, the declarative nature of `SwiftUI` prevents us from making these notices work at the parent/main root controller level.

 **I would love to hear if you think this is ok or if you know a way to make them work as the `UIKit` notices.**

# How

- The notice modifier adds a `NoticeView` as an overlay.

- The `NoticeView` has to be used inside a `UIViewRepresentable` type called `NoticeAlert`.

- The `NoticeAlert` uses a `NoticeWrapper` for two things:
    - To force the `NoticeView` to have a maximum width
    - To allow the `NoticeAlert` to be updated when a new notice is set.

- The notice modifier supports:
    - Auto dismiss after 5 seconds
    - Dismiss when tapped
    - Provide haptic feedback
    - Custom width depending on its size class.

# Demo

https://user-images.githubusercontent.com/562080/149452100-1896568f-0fab-426a-af69-a4ef67c45acc.mov

https://user-images.githubusercontent.com/562080/149452105-a23f91d5-6c38-4413-be5c-dac61e6cf006.mov

# Testing step

As this is not yet integrated anywhere, you could test these notices by following these steps:

1. Define the following property in one of your main `SwiftUI` screens
```swift
@State var testNotice: Notice?
```

2. Add the following two modifiers to the screen edited in step `1.`
```swift
    .notice($testNotice)
    .onAppear {
        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
            self.testNotice = Notice(
                title: "API Error",
                subtitle: "Restricted Access",
                message: "Your photos could not be downloaded, please ask for the correct permissions!",
                feedbackType: .error,
                notificationInfo: nil,
                actionTitle: "Retry",
                actionHandler: {
                    print("Retry...")
                }
            )
        }
    }
```

- See that the notice appear after 2 seconds
- See that the notice can be dismissed by tapping on it or by waiting 5 seconds.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
