### PR TITLE
Coupons: Fix mapping for coupons to filter non-default discount types

### DIFF
--- a/Networking/Networking/Mapper/CouponListMapper.swift
+++ b/Networking/Networking/Mapper/CouponListMapper.swift
@@ -14,7 +14,7 @@ struct CouponListMapper: Mapper {
         let coupons = try Coupon.decoder.decode(CouponListEnvelope.self, from: response).coupons
         return coupons
             .map { $0.copy(siteID: siteID) }
-            .filter { $0.mappedDiscountType != nil }
+            .filter { $0.discountType != .other }
     }
 }
 

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -26,22 +26,7 @@ public struct Coupon {
     public let dateModified: Date
 
     /// Determines the type of discount that will be applied. Options: `.percent` `.fixedCart` and `.fixedProduct`
-    public var discountType: DiscountType {
-        if let type = mappedDiscountType {
-            return type
-        } else {
-            // Returns default value for fallback case to avoid working with optionals.
-            // Since `CouponListMapper` filters out nil `mappedDiscountType`,
-            // this case is unlikely to happen.
-            return .fixedCart
-        }
-    }
-
-    /// Discount type if matched with any of the ones supported by Core.
-    /// Returns nil if other types are found.
-    /// Used to filter only coupons with default types, so internal to this module only.
-    ///
-    internal let mappedDiscountType: DiscountType?
+    public let discountType: DiscountType
 
     public let description: String
 
@@ -97,9 +82,10 @@ public struct Coupon {
     /// There are other types supported by other plugins, but those are not supported for now.
     ///
     public enum DiscountType: String {
-        case percent = "percent"
+        case percent
         case fixedCart = "fixed_cart"
         case fixedProduct = "fixed_product"
+        case other
     }
 
     public init(siteID: Int64 = 0,
@@ -132,7 +118,7 @@ public struct Coupon {
         self.amount = amount
         self.dateCreated = dateCreated
         self.dateModified = dateModified
-        self.mappedDiscountType = discountType
+        self.discountType = discountType
         self.description = description
         self.dateExpires = dateExpires
         self.usageCount = usageCount
@@ -166,7 +152,7 @@ extension Coupon: Codable {
         case amount
         case dateCreated = "dateCreatedGmt"
         case dateModified = "dateModifiedGmt"
-        case mappedDiscountType
+        case discountType
         case description
         case dateExpires = "dateExpiresGmt"
         case usageCount
@@ -187,7 +173,12 @@ extension Coupon: Codable {
     }
 }
 
-extension Coupon.DiscountType: Codable {}
+extension Coupon.DiscountType: Codable {
+    public init(from decoder: Decoder) throws {
+        let rawValue = try decoder.singleValueContainer().decode(String.self)
+        self = Coupon.DiscountType(rawValue: rawValue) ?? .other
+    }
+}
 
 
 // MARK: - Other Conformances

--- a/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
@@ -7,7 +7,7 @@ class CouponListMapperTests: XCTestCase {
     ///
     private let dummySiteID: Int64 = 12983476
 
-    /// Verifies that the whole list is parsed.
+    /// Verifies that the whole list is parsed, minus the items with non-default discount type.
     ///
     func test_CouponsList_map_parses_all_coupons_in_response() throws {
         let coupons = try mapLoadAllCouponsResponse()
@@ -73,7 +73,7 @@ class CouponListMapperTests: XCTestCase {
             amount: "0.00",
             dateCreated: dateFormatter.date(from: "2021-04-13T08:26:25")!,
             dateModified: dateFormatter.date(from: "2021-04-13T08:26:25")!,
-            discountType: .fixedCart,
+            discountType: .percent,
             description: "",
             dateExpires: nil,
             usageCount: 0,

--- a/Networking/NetworkingTests/Responses/coupons-all.json
+++ b/Networking/NetworkingTests/Responses/coupons-all.json
@@ -49,7 +49,7 @@
             "date_created_gmt": "2017-03-21T18:23:00",
             "date_modified": "2017-03-21T15:23:00",
             "date_modified_gmt": "2017-03-21T18:23:00",
-            "discount_type": "percent",
+            "discount_type": "fixed_cart",
             "description": "",
             "date_expires": null,
             "date_expires_gmt": null,
@@ -90,7 +90,7 @@
             "date_created_gmt": "2021-04-13T08:26:25",
             "date_modified": "2021-04-13T08:26:25",
             "date_modified_gmt": "2021-04-13T08:26:25",
-            "discount_type": "fixed_cart",
+            "discount_type": "percent",
             "description": "",
             "date_expires": null,
             "date_expires_gmt": null,
@@ -119,6 +119,47 @@
                 "collection": [
                     {
                         "href": "https://example.com/wp-json/wc/v3/coupons"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 581,
+            "code": "usrufb6q",
+            "amount": "30.00",
+            "date_created": "2022-01-07T10:59:47",
+            "date_created_gmt": "2022-01-07T03:59:47",
+            "date_modified": "2022-01-07T10:59:56",
+            "date_modified_gmt": "2022-01-07T03:59:56",
+            "discount_type": "sign_up_fee_percent",
+            "description": "",
+            "date_expires": null,
+            "date_expires_gmt": null,
+            "usage_count": 0,
+            "individual_use": false,
+            "product_ids": [],
+            "excluded_product_ids": [],
+            "usage_limit": null,
+            "usage_limit_per_user": null,
+            "limit_usage_to_x_items": null,
+            "free_shipping": false,
+            "product_categories": [],
+            "excluded_product_categories": [],
+            "exclude_sale_items": false,
+            "minimum_amount": "0.00",
+            "maximum_amount": "0.00",
+            "email_restrictions": [],
+            "used_by": [],
+            "meta_data": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://huongdotests1.blog/wp-json/wc/v3/coupons/581"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://huongdotests1.blog/wp-json/wc/v3/coupons"
                     }
                 ]
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5896
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, I added an internal property `mappedDiscountType` to filter only coupons with discount types that are supported by Core. This solution didn't quite work:
- I forgot to explicitly set the value for `mappedDiscountType` in the coding key list.
- Even when the coding key is set to `discountType`, the decoding will always throw an error when catching an undefined value for enum `DiscountType`. Which leads to the case that `mappedDiscountType` is always nil and `discountType` always returns the fallback case: `.fixedCart`.
- Using the internal property causes CodeGen to fail.

Unfortunately, the unit test for the coupon mapper didn't catch the parsing failure because the test data is a coupon with discount type `.fixedCart`!

Here's the solution:
- Remove `mappedDiscountType`
- Add a new case `.other` for `DiscountType`.
- Add a custom implementation for Decodable conformance.
- Filter the coupon list to exclude items with discount type `.other`.
- Update test data in the json file.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that CI passes ✅ 
- On the app:
  - Prequisite: make sure that you have access to a store with at least one coupon set up, with at least one with non-default discount type. To add a non-default discount type, install and activate WCPay plugin for your store.
  - On the app, navigate to the Menu tab and select Coupons.
  - Notice that the coupon list is loaded successfully.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
