### PR TITLE
Jetpack CP: Reload Settings sections when dismissing Install Jetpack screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -307,6 +307,7 @@ private extension SettingsViewController {
         let installJetpackController = JetpackInstallHostingController(siteID: site.siteID, siteURL: site.url, siteAdminURL: site.adminURL)
         installJetpackController.setDismissAction { [weak self] in
             self?.dismiss(animated: true, completion: nil)
+            self?.viewModel.onJetpackInstallDismiss()
         }
         present(installJetpackController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -38,6 +38,10 @@ protocol SettingsViewModelActionsHandler {
     /// Presenter (SettingsViewController in this case) is responsible for calling this method when store picker is dismissed.
     ///
     func onStorePickerDismiss()
+
+    /// Reloads settings if the site is no longer Jetpack CP.
+    ///
+    func onJetpackInstallDismiss()
 }
 
 protocol SettingsViewModelInput: AnyObject {
@@ -138,6 +142,15 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     ///
     func onStorePickerDismiss() {
         loadSites()
+        reloadSettings()
+    }
+
+    /// Reloads settings if the site is no longer Jetpack CP.
+    ///
+    func onJetpackInstallDismiss() {
+        guard stores.sessionManager.defaultSite?.isJetpackCPConnected == false else {
+            return
+        }
         reloadSettings()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -151,6 +151,28 @@ final class SettingsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(presenter.refreshViewContentCalled)
     }
+
+    func test_onJetpackInstallDismiss_updates_sections_correctly() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isJetpackConnectionPackageSupportOn: true)
+        let site = Site.fake().copy(isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        sessionManager.defaultSite = site
+        let viewModel = SettingsViewModel(
+            stores: stores,
+            storageManager: storageManager,
+            featureFlagService: featureFlagService)
+
+        viewModel.onViewDidLoad()
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.installJetpack) })
+
+        // When
+        let updatedSite = site.copy(isJetpackThePluginInstalled: true, isJetpackConnected: false)
+        sessionManager.defaultSite = updatedSite
+        viewModel.onJetpackInstallDismiss()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.installJetpack) })
+    }
 }
 
 private final class MockSettingsPresenter: SettingsViewPresenter {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5886
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, Settings screen is not updated after Jetpack Install succeeds, so the row to install Jetpack is still present afterward.

This PR fixes that by adding a new method for `SettingsViewModel` to be triggered when Jetpack Install is dismissed. This method reloads the sections on Settings screen if the current site is detected to no longer be a Jetpack CP site.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23).
- Launch the app and log in to a JCP site if needed.
- Navigate to Settings screen, notice that there's a menu for Install Jetpack.
- Select the menu and follow the steps to install Jetpack-the-plugin to the store.
- When the install succeeds, dismiss the Install Jetpack modal to get back to the Settings screen.
- Notice that the menu to install Jetpack is no longer present.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/149476031-de217889-b8dc-4a0f-9541-98d4900dfd0f.mp4

---


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
