### PR TITLE
Fix flaky unit tests in `SimplePaymentsSummaryViewModelTests`

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -293,7 +293,8 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
             WooAnalyticsStat.simplePaymentsFlowTaxesToggled.rawValue   // Taxes disabled
         ])
 
-        assertEqual(mockAnalytics.receivedProperties[0]["state"] as? String, "off")  // Taxes disabled when view model loads the toggle state during initialization
+        assertEqual(mockAnalytics.receivedProperties[0]["state"] as? String,
+                    "off")  // Taxes disabled when view model loads the toggle state during initialization
         assertEqual(mockAnalytics.receivedProperties[1]["state"] as? String, "on")  // Taxes enabled due to setting `enableTaxes` as true
         assertEqual(mockAnalytics.receivedProperties[2]["state"] as? String, "off") // Taxes disabled due to setting `enableTaxes` as false
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -40,8 +40,24 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_provided_amount_gets_properly_formatted() {
         // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .getSimplePaymentsTaxesToggleState(_, onCompletion):
+                onCompletion(.success(false)) // Keep the taxes toggle turned off
+            case .setSimplePaymentsTaxesToggleState:
+                break // No op
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "$4.3", currencyFormatter: currencyFormatter)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100",
+                                                       totalWithTaxes: "104.30",
+                                                       taxAmount: "$4.3",
+                                                       currencyFormatter: currencyFormatter,
+                                                       stores: mockStores)
 
         // When & Then
         XCTAssertEqual(viewModel.providedAmount, "$100.00")
@@ -235,6 +251,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
                                                        totalWithTaxes: "1.0",
                                                        taxAmount: "0.0",
+                                                       stores: mockStores,
                                                        analytics: WooAnalytics(analyticsProvider: mockAnalytics))
 
         // When


### PR DESCRIPTION
Closes: #5907

### Description
Some unit tests are failing in `SimplePaymentsSummaryViewModelTests` when the app is already in `authenticated` state. This PR aims to fix that by mocking the relevant action of `AppSettingsAction `.

### Why?
`AppSettingsStore` is initialized by `AuthenticatedState` class only when the app enters the authenticated state (when logged in) 

These failing tests rely on the "Charge taxes" toggle state which is fetched by `getSimplePaymentsTaxesToggleState` action. 

Since `AppSettingsStore` isn't initialized in `DeauthenticatedState`, dispatching `getSimplePaymentsTaxesToggleState` action doesn't do anything. But, when the app is in the authenticated state, dispatching `getSimplePaymentsTaxesToggleState` action produces a result. This behaviour makes these tests flaky.

This is why the tests fail only when an account is already logged in and a store is connected in the simulator. Also, this is the reason for tests to be successful in CI.

### Changes
1. Mocked the `getSimplePaymentsTaxesToggleState` action of `AppSettingsAction` using `MockStoresManager` inside those failing tests.
1. Alter the tests to expect the actual "Charge taxes" toggle state behaviour as `SimplePaymentsSummaryViewModel` loads the toggle state on `init`.  

### Testing instructions

1. Delete the app from the simulator and run unit tests in `SimplePaymentsSummaryViewModelTests`.
1. Observe that tests are successful.
1. Build and run the app and login into an account and connect a store.
1. Run unit tests again in `SimplePaymentsSummaryViewModelTests`.
1. Observe that tests are successful.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
