### PR TITLE
Fix in-app review notification and track viewing in-app notifications

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -288,6 +288,7 @@ public enum WooAnalyticsStat: String {
     case pushNotificationOSAlertAllowed = "push_notification_os_alert_allowed"
     case pushNotificationOSAlertDenied = "push_notification_os_alert_denied"
     case pushNotificationOSAlertShown = "push_notification_os_alert_shown"
+    case viewInAppPushNotificationPressed = "view_in_app_push_notification_pressed"
 
     // MARK: Notification View Events
     //

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -524,8 +524,13 @@ private extension PushNotificationsManager {
             properties[AnalyticKey.fromSelectedSite] = siteID == notificationSiteID
         }
 
-        let event: WooAnalyticsStat = (applicationState == .background) ? .pushNotificationReceived : .pushNotificationAlertPressed
-        ServiceLocator.analytics.track(event, withProperties: properties)
+        switch applicationState {
+        case .inactive:
+            ServiceLocator.analytics.track(.pushNotificationAlertPressed, withProperties: properties)
+        default:
+            properties[AnalyticKey.appState] = applicationState.rawValue
+            ServiceLocator.analytics.track(.pushNotificationReceived, withProperties: properties)
+        }
     }
 }
 
@@ -605,6 +610,7 @@ private enum AnalyticKey {
     static let type = "push_notification_type"
     static let token = "push_notification_token"
     static let fromSelectedSite = "is_from_selected_site"
+    static let appState = "app_state"
 }
 
 private enum PushType {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -371,6 +371,7 @@ private extension PushNotificationsManager {
                     guard let self = self else { return }
                     self.presentDetails(for: foregroundNotification)
                     self.foregroundNotificationsToViewSubject.send(foregroundNotification)
+                    ServiceLocator.analytics.track(.viewInAppPushNotificationPressed)
                 }
 
             foregroundNotificationsSubject.send(foregroundNotification)

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -29,7 +29,7 @@ final class PushNotificationsManager: PushNotesManager {
     /// in the foreground.
     ///
     var foregroundNotificationsToView: AnyPublisher<PushNotification, Never> {
-        foregroundNotificationsSubject.eraseToAnyPublisher()
+        foregroundNotificationsToViewSubject.eraseToAnyPublisher()
     }
 
     /// Mutable reference to `foregroundNotificationsToView`.

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -371,7 +371,7 @@ private extension PushNotificationsManager {
                     guard let self = self else { return }
                     self.presentDetails(for: foregroundNotification)
                     self.foregroundNotificationsToViewSubject.send(foregroundNotification)
-                    ServiceLocator.analytics.track(.viewInAppPushNotificationPressed)
+                    ServiceLocator.analytics.track(.viewInAppPushNotificationPressed, withProperties: [AnalyticKey.type: foregroundNotification.kind.rawValue])
                 }
 
             foregroundNotificationsSubject.send(foregroundNotification)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #5330 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue where an in-app review notification automatically navigates to show review details, and tracks the event `view_in_app_push_notification_pressed` when viewing an in-app notification. The issue was caused by returning the incorrect subject to the observable 🤦🏻‍♀️

There is an [open discussion](https://github.com/woocommerce/woocommerce-ios/issues/5330#issuecomment-1014055140) on whether to replace the in-app notifications with the default iOS push notifications. Since the iOS foreground push notifications would be non-trivial work with lots of testing, I will make the changes in a later sprint if we decide to remove the current in-app notifications. For now, let's track the event to understand how many merchants find it useful.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please test this on a device for remote push notifications to work.

- Launch the app and keep the app in the foreground
- In web, leave a review on a product in any connected store --> the app should show an in-app notice at the bottom for the new review with a "View" CTA
- Don't take any actions on the notice --> the notice should disappear and the app does not navigate to review details
- In web, leave another review on a product in any connected store --> the app should show an in-app notice at the bottom for the new review with a "View" CTA
- Tap on the "View" CTA --> in the console, there should be an event `🔵 Tracked view_in_app_push_notification_pressed, properties: [AnyHashable("push_notification_type"): "comment", ...]`
- In web, place an order in any connected store --> the app should show an in-app notice at the bottom for the new order with a "View" CTA
- Tap on the "View" CTA --> in the console, there should be an event `🔵 Tracked view_in_app_push_notification_pressed, properties: [AnyHashable("push_notification_type"): "store_order", ...]`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
