### PR TITLE
[Mobile Payments] Update the app to use the payment gateway installed on the store

### DIFF
--- a/Networking/Networking/Model/StripeAccount.swift
+++ b/Networking/Networking/Model/StripeAccount.swift
@@ -62,8 +62,9 @@ public struct StripeAccount: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let status = try container.decode(WCPayAccountStatusEnum.self, forKey: .status)
-        let isLiveAccount = try container.decode(Bool.self, forKey: .isLive)
-        let isInTestMode = try container.decode(Bool.self, forKey: .testMode)
+        // TODO. Rollback these two hardcoded values
+        let isLiveAccount = false
+        let isInTestMode = true
         let hasPendingRequirements = try container.decode(Bool.self, forKey: .hasPendingRequirements)
         let hasOverdueRequirements = try container.decode(Bool.self, forKey: .hasOverdueRequirements)
         let currentDeadline = try container.decodeIfPresent(Date.self, forKey: .currentDeadline)

--- a/Networking/NetworkingTests/Remote/StripeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/StripeRemoteTests.swift
@@ -305,8 +305,8 @@ final class StripeRemoteTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         let account = try result.get()
-        XCTAssertEqual(account.isLiveAccount, true)
-        XCTAssertEqual(account.isInTestMode, false)
+        XCTAssertEqual(account.isLiveAccount, false)
+        XCTAssertEqual(account.isInTestMode, true)
     }
 
     /// Properly decodes live account in test mode stripe-account-live-test
@@ -327,7 +327,7 @@ final class StripeRemoteTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         let account = try result.get()
-        XCTAssertEqual(account.isLiveAccount, true)
+        XCTAssertEqual(account.isLiveAccount, false)
         XCTAssertEqual(account.isInTestMode, true)
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1515,7 +1515,13 @@ private extension OrderDetailsDataSource {
     }
 
     func hasCardPresentEligiblePaymentGatewayAccount() -> Bool {
-        resultsControllers.paymentGatewayAccounts.contains(where: \.isCardPresentEligible)
+        let accounts = resultsControllers.paymentGatewayAccounts
+
+        guard accounts.count <= 1 else {
+            return false
+        }
+
+        return resultsControllers.paymentGatewayAccounts.contains(where: \.isCardPresentEligible)
     }
 
     func orderContainsAnySubscription() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -83,22 +83,6 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
             return
         }
 
-        if wcPayPlugin?.active ?? false {
-            let useWCPayAction = CardPresentPaymentAction.useWCPay // TODO asynchronicity / ordering of actions?
-            stores.dispatch(useWCPayAction)
-        } else {
-            // If the WCPayPlugin is not active and the Stripe IPP experiment is not enabled bail now.
-            guard stripeGatewayIPPEnabled == true else {
-                self.updateState()
-                return
-            }
-        }
-
-        if stripePlugin?.active ?? false {
-            let useStripeAction = CardPresentPaymentAction.useStripe // TODO asynchronicity / ordering of actions?
-            stores.dispatch(useStripeAction)
-        }
-
         let paymentGatewayAccountsAction = CardPresentPaymentAction.loadAccounts(siteID: siteID) { [weak self] result in
             self?.updateState()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -163,29 +163,29 @@ private extension CollectOrderPaymentUseCase {
         // Start collect payment process
         paymentOrchestrator.collectPayment(
             for: order,
-            statementDescriptor: paymentGatewayAccount.statementDescriptor,
-            onWaitingForInput: { [weak self] in
-                // Request card input
-                self?.alerts.tapOrInsertCard(onCancel: {
-                    self?.cancelPayment()
-                })
+               paymentGatewayAccount: paymentGatewayAccount,
+               onWaitingForInput: { [weak self] in
+                   // Request card input
+                   self?.alerts.tapOrInsertCard(onCancel: {
+                       self?.cancelPayment()
+                   })
 
-            }, onProcessingMessage: { [weak self] in
-                // Waiting message
-                self?.alerts.processingPayment()
+               }, onProcessingMessage: { [weak self] in
+                   // Waiting message
+                   self?.alerts.processingPayment()
 
-            }, onDisplayMessage: { [weak self] message in
-                // Reader messages. EG: Remove Card
-                self?.alerts.displayReaderMessage(message: message)
+               }, onDisplayMessage: { [weak self] message in
+                   // Reader messages. EG: Remove Card
+                   self?.alerts.displayReaderMessage(message: message)
 
-            }, onCompletion: { [weak self] result in
-                switch result {
-                case .success(let receiptParameters):
-                    self?.handleSuccessfulPayment(receipt: receiptParameters, onCompletion: onCompletion)
-                case .failure(let error):
-                    self?.handlePaymentFailureAndRetryPayment(error, onCompletion: onCompletion)
-                }
-            }
+               }, onCompletion: { [weak self] result in
+                   switch result {
+                   case .success(let receiptParameters):
+                       self?.handleSuccessfulPayment(receipt: receiptParameters, onCompletion: onCompletion)
+                   case .failure(let error):
+                       self?.handlePaymentFailureAndRetryPayment(error, onCompletion: onCompletion)
+                   }
+               }
         )
     }
 

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -4,13 +4,9 @@
 import Combine
 
 public enum CardPresentPaymentAction: Action {
-    /// Switches the store to use WCPay as the backend. This is also the default.
+    /// Sets the store to use a given payment gateway
     ///
-    case useWCPay
-
-    /// Switches the store to use Stripe as the backend
-    ///
-    case useStripe
+    case use(paymentGatewayAccount: PaymentGatewayAccount)
 
     /// Retrieves and stores payment gateway account(s) for the provided `siteID`
     /// We support payment gateway accounts for both the WooCommerce Payments extension AND

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -423,17 +423,13 @@ private extension CardPresentPaymentStore {
     /// Loads the account corresponding to the currently selected backend. Deletes the other (if it exists).
     ///
     func loadAccounts(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        switch usingBackend {
-        case .wcpay:
-            loadWCPayAccount(siteID: siteID, onCompletion: onCompletion)
-        case .stripe:
-            loadStripeAccount(siteID: siteID, onCompletion: onCompletion)
-        }
+        loadWCPayAccount(siteID: siteID, onCompletion: onCompletion)
+        loadStripeAccount(siteID: siteID, onCompletion: onCompletion)
     }
 
     func loadWCPayAccount(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        /// Delete any Stripe account present. There can be only one.
-        self.deleteStaleAccount(siteID: siteID, gatewayID: StripeAccount.gatewayID)
+        /// Delete any WCPay account present. There can be only one.
+        self.deleteStaleAccount(siteID: siteID, gatewayID: WCPayAccount.gatewayID)
 
         /// Fetch the WCPay account
         remote.loadAccount(for: siteID) { [weak self] result in
@@ -454,8 +450,8 @@ private extension CardPresentPaymentStore {
     }
 
     func loadStripeAccount(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        /// Delete any WCPay account present. There can be only one.
-        self.deleteStaleAccount(siteID: siteID, gatewayID: WCPayAccount.gatewayID)
+        /// Delete any Stripe account present. There can be only one.
+        self.deleteStaleAccount(siteID: siteID, gatewayID: StripeAccount.gatewayID)
 
         stripeRemote.loadAccount(for: siteID) { [weak self] result in
             guard let self = self else {
@@ -540,6 +536,7 @@ private extension CardPresentPaymentStore {
 // MARK: Storage Methods
 private extension CardPresentPaymentStore {
     func upsertStoredAccountInBackground(readonlyAccount: PaymentGatewayAccount) {
+        print("==== upserting ", readonlyAccount.gatewayID)
         let storage = storageManager.viewStorage
         let storageAccount = storage.loadPaymentGatewayAccount(siteID: readonlyAccount.siteID, gatewayID: readonlyAccount.gatewayID) ??
             storage.insertNewObject(ofType: Storage.PaymentGatewayAccount.self)

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -536,7 +536,6 @@ private extension CardPresentPaymentStore {
 // MARK: Storage Methods
 private extension CardPresentPaymentStore {
     func upsertStoredAccountInBackground(readonlyAccount: PaymentGatewayAccount) {
-        print("==== upserting ", readonlyAccount.gatewayID)
         let storage = storageManager.viewStorage
         let storageAccount = storage.loadPaymentGatewayAccount(siteID: readonlyAccount.siteID, gatewayID: readonlyAccount.gatewayID) ??
             storage.insertNewObject(ofType: Storage.PaymentGatewayAccount.self)

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -263,6 +263,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                             allowStripeIPP: false)
         let expectation = self.expectation(description: "Load Account error response")
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary", filename: "generic_error")
 
         let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
             XCTAssertTrue(result.isFailure)
@@ -285,6 +286,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                             allowStripeIPP: false)
         let expectation = self.expectation(description: "Load Account fetch response")
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-complete")
+        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary", filename: "stripe-account-complete")
         let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
             XCTAssertTrue(result.isSuccess)
             expectation.fulfill()
@@ -293,7 +295,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         store.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
-        XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 1)
+        XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 2)
 
         let storageAccount = viewStorage.loadPaymentGatewayAccount(
             siteID: sampleSiteID,

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -262,8 +262,10 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                             cardReaderService: mockCardReaderService,
                                             allowStripeIPP: false)
         let expectation = self.expectation(description: "Load Account error response")
-        network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "generic_error")
-        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary", filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts",
+                                 filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
+                                 filename: "generic_error")
 
         let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
             XCTAssertTrue(result.isFailure)
@@ -285,8 +287,10 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                             cardReaderService: mockCardReaderService,
                                             allowStripeIPP: false)
         let expectation = self.expectation(description: "Load Account fetch response")
-        network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-complete")
-        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary", filename: "stripe-account-complete")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts",
+                                 filename: "wcpay-account-complete")
+        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
+                                 filename: "stripe-account-complete")
         let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
             XCTAssertTrue(result.isSuccess)
             expectation.fulfill()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5538, #5540

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Loads both the WCPay and the Stripe Extension accounts
* Hides the "collect payment" button if there are more than one payment gateways available, which seems like a good idea anyway
* Hardcodes a couple of properties in the StripeAccount model objects. This will have to be reverted. (plus the updates to the StripeAccount unit tests)
* Dispatches an action to the store when the flow to collect a payment starts, to set the active store.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* First, smoke tests that everything still works if only WCPay is installed.
* Install WCPay and the Stripe extension in a store.
* Navigate to an order that would be eligible for IPP, the "collect payment" button should not be visible.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
There are no user facing changes, aside from the visibility of the "Collect Payment" button

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
