### PR TITLE
Coupons: Add endpoint for coupon reports in Networking

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -589,6 +589,7 @@
 		D8FBFF2422D52815006E3336 /* order-stats-v4-daily.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */; };
 		D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */; };
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
+		DE2095BD27956D7900171F1C /* CouponReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BC27956D7900171F1C /* CouponReport.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1236,6 +1237,7 @@
 		D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-daily.json"; sourceTree = "<group>"; };
 		D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-month.json"; sourceTree = "<group>"; };
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
+		DE2095BC27956D7900171F1C /* CouponReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReport.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -1672,6 +1674,7 @@
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
 				03DCB72526244B9B00C8953D /* Coupon.swift */,
+				DE2095BC27956D7900171F1C /* CouponReport.swift */,
 				2685C0D1263B069500D9EE97 /* AddOnGroup.swift */,
 				45150A99268340D2006922EA /* Country.swift */,
 				45150A9B2683417A006922EA /* StateOfACountry.swift */,
@@ -2729,6 +2732,7 @@
 				D823D905223746CE00C90817 /* NewShipmentTrackingMapper.swift in Sources */,
 				D8EDFE1E25EE87F1003D2213 /* WCPayRemote.swift in Sources */,
 				743057B5218B6ACD00441A76 /* Queue.swift in Sources */,
+				DE2095BD27956D7900171F1C /* CouponReport.swift in Sources */,
 				74A1D26821189A7100931DFA /* SiteVisitStats.swift in Sources */,
 				02C254B0256378D000A04423 /* ShippingLabelRefundStatus.swift in Sources */,
 				4568E2242459D3230007E478 /* Post.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@
 		DE2095BD27956D7900171F1C /* CouponReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BC27956D7900171F1C /* CouponReport.swift */; };
 		DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BE279583A100171F1C /* CouponReportListMapper.swift */; };
 		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
+		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1242,6 +1243,7 @@
 		DE2095BC27956D7900171F1C /* CouponReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReport.swift; sourceTree = "<group>"; };
 		DE2095BE279583A100171F1C /* CouponReportListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapper.swift; sourceTree = "<group>"; };
 		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
+		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -2103,6 +2105,7 @@
 				2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
 				03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */,
+				DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */,
 				03DCB7812627394500C8953D /* CouponMapperTests.swift */,
 				45150A9F26837357006922EA /* CountryListMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
@@ -2942,6 +2945,7 @@
 				CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */,
 				FE28F6EC268436C9004465C7 /* UserRemoteTests.swift in Sources */,
 				020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */,
+				DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */,
 				4599FC5A24A626B70056157A /* ProductTagListMapperTests.swift in Sources */,
 				D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */,
 				B567AF3120A0FB8F00AB6C62 /* JetpackRequestTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -591,6 +591,7 @@
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
 		DE2095BD27956D7900171F1C /* CouponReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BC27956D7900171F1C /* CouponReport.swift */; };
 		DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BE279583A100171F1C /* CouponReportListMapper.swift */; };
+		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1240,6 +1241,7 @@
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
 		DE2095BC27956D7900171F1C /* CouponReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReport.swift; sourceTree = "<group>"; };
 		DE2095BE279583A100171F1C /* CouponReportListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapper.swift; sourceTree = "<group>"; };
+		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -1772,6 +1774,7 @@
 				74A7B4BD217A841400E85A8B /* broken-settings-general.json */,
 				03DCB7512624B3BE00C8953D /* coupons-all.json */,
 				03DCB77D262738E200C8953D /* coupon.json */,
+				DE2095C027966EC800171F1C /* coupon-reports.json */,
 				B58D10C72114D21C00107ED4 /* generic_error.json */,
 				B53EF53521813681003E146F /* generic_success.json */,
 				CCB2CAA126209A1200285CA0 /* generic_success_data.json */,
@@ -2488,6 +2491,7 @@
 				31054714262E2F3B00C5C02B /* wcpay-payment-intent-requires-payment-method.json in Resources */,
 				2683D71024456EE4002A1589 /* categories-extra.json in Resources */,
 				A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */,
+				DE2095C127966EC800171F1C /* coupon-reports.json in Resources */,
 				453305F52459ED2700264E50 /* site-post-update.json in Resources */,
 				CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */,
 				02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -543,8 +543,6 @@
 		D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */; };
 		D823D91222377DF300C90817 /* ShipmentTrackingProviderListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D823D91122377DF200C90817 /* ShipmentTrackingProviderListMapper.swift */; };
 		D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */ = {isa = PBXBuildFile; fileRef = D823D91322377EE600C90817 /* shipment_tracking_providers.json */; };
-		D865CE6E278CC19A002C8520 /* stripe-location.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE6C278CC19A002C8520 /* stripe-location.json */; };
-		D865CE6F278CC19A002C8520 /* stripe-location-error.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE6D278CC19A002C8520 /* stripe-location-error.json */; };
 		D865CE5B278CA10B002C8520 /* stripe-payment-intent-requires-payment-method.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE5A278CA10B002C8520 /* stripe-payment-intent-requires-payment-method.json */; };
 		D865CE5D278CA159002C8520 /* stripe-payment-intent-requires-confirmation.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE5C278CA159002C8520 /* stripe-payment-intent-requires-confirmation.json */; };
 		D865CE5F278CA183002C8520 /* stripe-payment-intent-requires-action.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE5E278CA183002C8520 /* stripe-payment-intent-requires-action.json */; };
@@ -554,6 +552,8 @@
 		D865CE67278CA225002C8520 /* stripe-payment-intent-succeeded.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE66278CA225002C8520 /* stripe-payment-intent-succeeded.json */; };
 		D865CE69278CA245002C8520 /* stripe-payment-intent-unknown-status.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE68278CA245002C8520 /* stripe-payment-intent-unknown-status.json */; };
 		D865CE6B278CA266002C8520 /* stripe-payment-intent-error.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE6A278CA266002C8520 /* stripe-payment-intent-error.json */; };
+		D865CE6E278CC19A002C8520 /* stripe-location.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE6C278CC19A002C8520 /* stripe-location.json */; };
+		D865CE6F278CC19A002C8520 /* stripe-location-error.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE6D278CC19A002C8520 /* stripe-location-error.json */; };
 		D865CE72278CC215002C8520 /* stripe-customer.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE70278CC215002C8520 /* stripe-customer.json */; };
 		D865CE73278CC215002C8520 /* stripe-customer-error.json in Resources */ = {isa = PBXBuildFile; fileRef = D865CE71278CC215002C8520 /* stripe-customer-error.json */; };
 		D87F6151226591E10031A13B /* NullNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F6150226591E10031A13B /* NullNetwork.swift */; };
@@ -590,6 +590,7 @@
 		D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */; };
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
 		DE2095BD27956D7900171F1C /* CouponReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BC27956D7900171F1C /* CouponReport.swift */; };
+		DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BE279583A100171F1C /* CouponReportListMapper.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1192,8 +1193,6 @@
 		D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipmentTrackingProviderGroup.swift; sourceTree = "<group>"; };
 		D823D91122377DF200C90817 /* ShipmentTrackingProviderListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipmentTrackingProviderListMapper.swift; sourceTree = "<group>"; };
 		D823D91322377EE600C90817 /* shipment_tracking_providers.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = shipment_tracking_providers.json; sourceTree = "<group>"; };
-		D865CE6C278CC19A002C8520 /* stripe-location.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-location.json"; sourceTree = "<group>"; };
-		D865CE6D278CC19A002C8520 /* stripe-location-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-location-error.json"; sourceTree = "<group>"; };
 		D865CE5A278CA10B002C8520 /* stripe-payment-intent-requires-payment-method.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-payment-intent-requires-payment-method.json"; sourceTree = "<group>"; };
 		D865CE5C278CA159002C8520 /* stripe-payment-intent-requires-confirmation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-payment-intent-requires-confirmation.json"; sourceTree = "<group>"; };
 		D865CE5E278CA183002C8520 /* stripe-payment-intent-requires-action.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-payment-intent-requires-action.json"; sourceTree = "<group>"; };
@@ -1203,6 +1202,8 @@
 		D865CE66278CA225002C8520 /* stripe-payment-intent-succeeded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-payment-intent-succeeded.json"; sourceTree = "<group>"; };
 		D865CE68278CA245002C8520 /* stripe-payment-intent-unknown-status.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-payment-intent-unknown-status.json"; sourceTree = "<group>"; };
 		D865CE6A278CA266002C8520 /* stripe-payment-intent-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-payment-intent-error.json"; sourceTree = "<group>"; };
+		D865CE6C278CC19A002C8520 /* stripe-location.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-location.json"; sourceTree = "<group>"; };
+		D865CE6D278CC19A002C8520 /* stripe-location-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-location-error.json"; sourceTree = "<group>"; };
 		D865CE70278CC215002C8520 /* stripe-customer.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-customer.json"; sourceTree = "<group>"; };
 		D865CE71278CC215002C8520 /* stripe-customer-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stripe-customer-error.json"; sourceTree = "<group>"; };
 		D87F6150226591E10031A13B /* NullNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullNetwork.swift; sourceTree = "<group>"; };
@@ -1238,6 +1239,7 @@
 		D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-month.json"; sourceTree = "<group>"; };
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
 		DE2095BC27956D7900171F1C /* CouponReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReport.swift; sourceTree = "<group>"; };
+		DE2095BE279583A100171F1C /* CouponReportListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapper.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -1723,10 +1725,8 @@
 				31799AF7270508C600D78179 /* RemoteReaderLocation.swift */,
 				3192F223260D34C40067FEF9 /* WCPayAccountStatusEnum.swift */,
 				D8EDFE2125EE88C9003D2213 /* ReaderConnectionToken.swift */,
-				318E8FD426C31F9500F519D7 /* WCPayCustomer.swift */,
-				31054705262E278100C5C02B /* RemotePaymentIntent.swift */,
 				318E8FD426C31F9500F519D7 /* Customer.swift */,
-				31054705262E278100C5C02B /* WCPayPaymentIntent.swift */,
+				31054705262E278100C5C02B /* RemotePaymentIntent.swift */,
 				3105470B262E27F000C5C02B /* WCPayPaymentIntentStatusEnum.swift */,
 				FE28F6E126840DED004465C7 /* User.swift */,
 			);
@@ -1959,6 +1959,7 @@
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
 				03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */,
 				03DCB785262739D200C8953D /* CouponMapper.swift */,
+				DE2095BE279583A100171F1C /* CouponReportListMapper.swift */,
 				45150A9D26836A57006922EA /* CountryListMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
@@ -2014,11 +2015,8 @@
 				311D412D2783C07D00052F64 /* StripeAccountMapper.swift */,
 				3192F21B260D32550067FEF9 /* WCPayAccountMapper.swift */,
 				D8EDFE2525EE8A60003D2213 /* ReaderConnectionTokenMapper.swift */,
-				318E8FD226C31F1C00F519D7 /* WCPayCustomerMapper.swift */,
-				3178A49E2703E5CF00A8B4CA /* RemoteReaderLocationMapper.swift */,
-				31054701262E04F700C5C02B /* WCPayPaymentIntentMapper.swift */,
 				318E8FD226C31F1C00F519D7 /* CustomerMapper.swift */,
-				3178A49E2703E5CF00A8B4CA /* WCPayReaderLocationMapper.swift */,
+				3178A49E2703E5CF00A8B4CA /* RemoteReaderLocationMapper.swift */,
 				31054701262E04F700C5C02B /* RemotePaymentIntentMapper.swift */,
 				45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationSuccessMapper.swift */,
 				CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */,
@@ -2736,6 +2734,7 @@
 				74A1D26821189A7100931DFA /* SiteVisitStats.swift in Sources */,
 				02C254B0256378D000A04423 /* ShippingLabelRefundStatus.swift in Sources */,
 				4568E2242459D3230007E478 /* Post.swift in Sources */,
+				DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */,
 				B557DA0320975500005962F4 /* Remote.swift in Sources */,
 				B53EF53C21814900003E146F /* SuccessResultMapper.swift in Sources */,
 				D8EDFE2625EE8A60003D2213 /* ReaderConnectionTokenMapper.swift in Sources */,

--- a/Networking/Networking/Mapper/CouponReportListMapper.swift
+++ b/Networking/Networking/Mapper/CouponReportListMapper.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Mapper: `CouponReport`
+///
+struct CouponReportListMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into `[CouponReport]`.
+    ///
+    func map(response: Data) throws -> [CouponReport] {
+        let reports = try CouponReport.decoder.decode(CouponReportsEnvelope.self, from: response).reports
+        return reports
+    }
+}
+
+
+/// CouponReportsEnvelope Disposable Entity:
+/// Load Coupon endpoint returns the coupon in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct CouponReportsEnvelope: Decodable {
+    let reports: [CouponReport]
+
+    private enum CodingKeys: String, CodingKey {
+        case reports = "data"
+    }
+}

--- a/Networking/Networking/Mapper/CouponReportListMapper.swift
+++ b/Networking/Networking/Mapper/CouponReportListMapper.swift
@@ -7,7 +7,8 @@ struct CouponReportListMapper: Mapper {
     /// (Attempts) to convert a dictionary into `[CouponReport]`.
     ///
     func map(response: Data) throws -> [CouponReport] {
-        let reports = try CouponReport.decoder.decode(CouponReportsEnvelope.self, from: response).reports
+        let decoder = JSONDecoder()
+        let reports = try decoder.decode(CouponReportsEnvelope.self, from: response).reports
         return reports
     }
 }

--- a/Networking/Networking/Model/CouponReport.swift
+++ b/Networking/Networking/Model/CouponReport.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public struct CouponReport {
     /// ID of the coupon
-    public let couponID: Int64
+    public let couponId: Int64
 
     /// Total amount deducted from orders using the coupon
     public let amount: Double
@@ -11,10 +11,10 @@ public struct CouponReport {
     /// Total number of orders that used the coupon
     public let ordersCount: Int64
 
-    public init(couponID: Int64,
+    public init(couponId: Int64,
                 amount: Double,
                 ordersCount: Int64) {
-        self.couponID = couponID
+        self.couponId = couponId
         self.amount = amount
         self.ordersCount = ordersCount
     }
@@ -27,7 +27,7 @@ extension CouponReport: Decodable {
     /// The model is intended to be decoded with`JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`
     /// so any specific `CodingKeys` provided here should be in camel case.
     enum CodingKeys: String, CodingKey {
-        case couponID, amount, ordersCount
+        case couponId, amount, ordersCount
     }
 }
 

--- a/Networking/Networking/Model/CouponReport.swift
+++ b/Networking/Networking/Model/CouponReport.swift
@@ -1,0 +1,43 @@
+import Codegen
+import Foundation
+
+public struct CouponReport {
+    /// ID of the site that the coupon belongs to.
+    /// Using a default here gives us the benefit of synthesized codable conformance.
+    /// `private(set) public var` is required so that `siteID` will still be on the synthesized`init` which `copy()` uses.
+    private(set) public var siteID: Int64 = 0
+
+    /// ID of the coupon
+    public let couponID: Int64
+
+    /// Total amount deducted from orders using the coupon
+    public let amount: Double
+
+    /// Total number of orders that used the coupon
+    public let ordersCount: Int64
+
+    public init(siteID: Int64 = 0,
+                couponID: Int64,
+                amount: Double,
+                ordersCount: Int64) {
+        self.siteID = siteID
+        self.couponID = couponID
+        self.amount = amount
+        self.ordersCount = ordersCount
+    }
+}
+
+// MARK: - Decodable Conformance
+//
+extension CouponReport: Decodable {
+    /// Defines all of the CouponReport CodingKeys
+    /// The model is intended to be decoded with`JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`
+    /// so any specific `CodingKeys` provided here should be in camel case.
+    enum CodingKeys: String, CodingKey {
+        case couponID, amount, ordersCount
+    }
+}
+
+// MARK: - Other Conformance
+//
+extension CouponReport: GeneratedCopiable, GeneratedFakeable, Equatable {}

--- a/Networking/Networking/Model/CouponReport.swift
+++ b/Networking/Networking/Model/CouponReport.swift
@@ -2,11 +2,6 @@ import Codegen
 import Foundation
 
 public struct CouponReport {
-    /// ID of the site that the coupon belongs to.
-    /// Using a default here gives us the benefit of synthesized codable conformance.
-    /// `private(set) public var` is required so that `siteID` will still be on the synthesized`init` which `copy()` uses.
-    private(set) public var siteID: Int64 = 0
-
     /// ID of the coupon
     public let couponID: Int64
 
@@ -16,11 +11,9 @@ public struct CouponReport {
     /// Total number of orders that used the coupon
     public let ordersCount: Int64
 
-    public init(siteID: Int64 = 0,
-                couponID: Int64,
+    public init(couponID: Int64,
                 amount: Double,
                 ordersCount: Int64) {
-        self.siteID = siteID
         self.couponID = couponID
         self.amount = amount
         self.ordersCount = ordersCount
@@ -41,3 +34,13 @@ extension CouponReport: Decodable {
 // MARK: - Other Conformance
 //
 extension CouponReport: GeneratedCopiable, GeneratedFakeable, Equatable {}
+
+extension CouponReport {
+    /// JSON decoder appropriate for `CouponReport` responses.
+    ///
+    static let decoder: JSONDecoder = {
+        let couponDecoder = JSONDecoder()
+        couponDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        return couponDecoder
+    }()
+}

--- a/Networking/Networking/Model/CouponReport.swift
+++ b/Networking/Networking/Model/CouponReport.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public struct CouponReport {
     /// ID of the coupon
-    public let couponId: Int64
+    public let couponID: Int64
 
     /// Total amount deducted from orders using the coupon
     public let amount: Double
@@ -11,10 +11,10 @@ public struct CouponReport {
     /// Total number of orders that used the coupon
     public let ordersCount: Int64
 
-    public init(couponId: Int64,
+    public init(couponID: Int64,
                 amount: Double,
                 ordersCount: Int64) {
-        self.couponId = couponId
+        self.couponID = couponID
         self.amount = amount
         self.ordersCount = ordersCount
     }
@@ -27,20 +27,12 @@ extension CouponReport: Decodable {
     /// The model is intended to be decoded with`JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`
     /// so any specific `CodingKeys` provided here should be in camel case.
     enum CodingKeys: String, CodingKey {
-        case couponId, amount, ordersCount
+        case couponID = "coupon_id"
+        case amount
+        case ordersCount = "orders_count"
     }
 }
 
 // MARK: - Other Conformance
 //
 extension CouponReport: GeneratedCopiable, GeneratedFakeable, Equatable {}
-
-extension CouponReport {
-    /// JSON decoder appropriate for `CouponReport` responses.
-    ///
-    static let decoder: JSONDecoder = {
-        let couponDecoder = JSONDecoder()
-        couponDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        return couponDecoder
-    }()
-}

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -17,6 +17,10 @@ public protocol CouponsRemoteProtocol {
     func updateCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void)
 
     func createCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void)
+
+    func loadCouponReport(for siteID: Int64,
+                          couponID: Int64,
+                          completion: @escaping (Result<CouponReport, Error>) -> Void)
 }
 
 
@@ -55,7 +59,7 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
 
     // MARK: - Delete Coupon
 
-    /// Delete a `Coupon`.
+    /// Deletes a `Coupon`.
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll delete the product attribute.
@@ -78,7 +82,7 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
 
     // MARK: - Update Coupon
 
-    /// Update a `Coupon`.
+    /// Updates a `Coupon`.
     ///
     /// - Parameters:
     ///     - coupon: The coupon to be updated remotely.
@@ -101,7 +105,7 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
 
     // MARK: - Create coupon
 
-    /// Create a `Coupon`.
+    /// Creates a `Coupon`.
     ///
     /// - Parameters:
     ///     - coupon: The coupon to be created remotely.
@@ -120,6 +124,20 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    // MARK: - Load coupon report
+    /// Loads the analytics report for a specific coupon from a given site.
+    ///
+    /// - Parameters:
+    ///     - siteID: The site from which we'll fetch the analytics report.
+    ///     - couponID: The coupon for which we'll fetch the analytics report.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadCouponReport(for siteID: Int64,
+                                 couponID: Int64,
+                                 completion: @escaping (Result<CouponReport, Error>) -> Void) {
+        // TODO
+    }
 }
 
 // MARK: - Constants
@@ -132,6 +150,7 @@ public extension CouponsRemote {
 
     private enum Path {
         static let coupons = "coupons"
+        static let couponReports = "reports/coupons"
     }
 
     private enum ParameterKey {

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -136,13 +136,40 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     public func loadCouponReport(for siteID: Int64,
                                  couponID: Int64,
                                  completion: @escaping (Result<CouponReport, Error>) -> Void) {
-        // TODO
+        let parameters = [
+            ParameterKey.coupons: [couponID]
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.couponReports,
+                                     parameters: parameters)
+
+        let mapper = CouponReportListMapper()
+
+        enqueue(request, mapper: mapper, completion: { result in
+            switch result {
+            case .success(let couponReports):
+                if let report = couponReports.first {
+                    completion(.success(report))
+                } else {
+                    completion(.failure(CouponsRemoteError.noAnalyticsReportsFound))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        })
     }
 }
 
 // MARK: - Constants
 //
 public extension CouponsRemote {
+    enum CouponsRemoteError: Error {
+        case noAnalyticsReportsFound
+    }
+
     enum Default {
         public static let pageSize = 25
         public static let pageNumber = 1
@@ -157,5 +184,6 @@ public extension CouponsRemote {
         static let page = "page"
         static let perPage = "per_page"
         static let force = "force"
+        static let coupons = "coupons"
     }
 }

--- a/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
@@ -19,7 +19,7 @@ final class CouponReportListMapperTests: XCTestCase {
         // Given
         let reports = try mapLoadAllCouponReportsResponse()
         let report = reports[0]
-        let expectedReport = CouponReport(couponId: 571, amount: 12, ordersCount: 1)
+        let expectedReport = CouponReport(couponID: 571, amount: 12, ordersCount: 1)
 
         // Then
         XCTAssertEqual(report, expectedReport)

--- a/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
@@ -6,18 +6,22 @@ final class CouponReportListMapperTests: XCTestCase {
     /// Verifies that the whole list is parsed.
     ///
     func test_mapper_parses_all_reports_in_response() throws {
+        // Given
         let reports = try mapLoadAllCouponReportsResponse()
+
+        // Then
         XCTAssertEqual(reports.count, 1)
     }
 
     /// Verifies that the fields are all parsed correctly
     ///
     func test_mapper_parses_all_fields_in_result() throws {
+        // Given
         let reports = try mapLoadAllCouponReportsResponse()
         let report = reports[0]
-
         let expectedReport = CouponReport(couponId: 571, amount: 12, ordersCount: 1)
 
+        // Then
         XCTAssertEqual(report, expectedReport)
     }
 }

--- a/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Networking
+
+final class CouponReportListMapperTests: XCTestCase {
+
+    /// Verifies that the whole list is parsed.
+    ///
+    func test_mapper_parses_all_reports_in_response() throws {
+        let reports = try mapLoadAllCouponReportsResponse()
+        XCTAssertEqual(reports.count, 1)
+    }
+
+    /// Verifies that the fields are all parsed correctly
+    ///
+    func test_mapper_parses_all_fields_in_result() throws {
+        let reports = try mapLoadAllCouponReportsResponse()
+        let report = reports[0]
+
+        let expectedReport = CouponReport(couponId: 571, amount: 12, ordersCount: 1)
+
+        XCTAssertEqual(report, expectedReport)
+    }
+}
+
+// MARK: - Test Helpers
+///
+private extension CouponReportListMapperTests {
+
+    /// Returns the CouponReportListMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapReports(from filename: String) throws -> [CouponReport] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try CouponReportListMapper().map(response: response)
+    }
+
+    /// Returns the CouponsReport list from `coupon-reports.json`
+    ///
+    func mapLoadAllCouponReportsResponse() throws -> [CouponReport] {
+        return try mapReports(from: "coupon-reports")
+    }
+}

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -281,7 +281,7 @@ final class CouponsRemoteTests: XCTestCase {
         // Then
         XCTAssert(result.isSuccess)
         let returnedReport = try XCTUnwrap(result.get())
-        let expectedReport = CouponReport(couponId: 571, amount: 12, ordersCount: 1)
+        let expectedReport = CouponReport(couponID: 571, amount: 12, ordersCount: 1)
         XCTAssertEqual(returnedReport, expectedReport)
     }
 

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -40,10 +40,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssert(result.isSuccess)
-        guard let coupons = try? result.get() else {
-            XCTFail("Expected parsed Coupons not found in response")
-            return
-        }
+        let coupons = try XCTUnwrap(result.get())
         XCTAssertEqual(coupons.count, 3)
     }
 
@@ -57,10 +54,7 @@ final class CouponsRemoteTests: XCTestCase {
         remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _ in }
 
         // Then
-        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
-            XCTFail("Expected request not enqueued")
-            return
-        }
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
         guard let page = request.parameters["page"] as? String,
               let pageSize = request.parameters["per_page"] as? String else {
             XCTFail("Pagination parameters not found")
@@ -72,7 +66,7 @@ final class CouponsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllCoupons uses the SiteID passed in for the request.
     ///
-    func test_loadAllCoupons_uses_passed_siteID_for_request() {
+    func test_loadAllCoupons_uses_passed_siteID_for_request() throws {
         // Given
         let remote = CouponsRemote(network: network)
 
@@ -80,10 +74,7 @@ final class CouponsRemoteTests: XCTestCase {
         remote.loadAllCoupons(for: sampleSiteID) { _ in }
 
         // Then
-        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
-            XCTFail("Expected request not enqueued")
-            return
-        }
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
         XCTAssertEqual(request.siteID, sampleSiteID)
     }
 
@@ -126,10 +117,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        guard let resultError = result.failure as? NetworkError else {
-            XCTFail("Expected NetworkError not found")
-            return
-        }
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 403))
     }
 
@@ -153,10 +141,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssert(result.isSuccess)
-        guard let coupon = try? result.get() else {
-            XCTFail("Expected parsed Coupon not found in response")
-            return
-        }
+        let coupon = try XCTUnwrap(result.get())
         XCTAssertEqual(coupon.couponID, sampleCouponID)
     }
 
@@ -181,10 +166,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        guard let resultError = result.failure as? NetworkError else {
-            XCTFail("Expected NetworkError not found")
-            return
-        }
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
     }
 
@@ -192,7 +174,7 @@ final class CouponsRemoteTests: XCTestCase {
 
     /// Verifies that updateCoupon properly parses the `Coupon` sample response.
     ///
-    func test_updateCoupon_properly_returns_parsed_coupon() {
+    func test_updateCoupon_properly_returns_parsed_coupon() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let coupon = sampleCoupon()
@@ -207,10 +189,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssert(result.isSuccess)
-        guard let returnedCoupon = try? result.get() else {
-            XCTFail("Expected parsed Coupon not found in response")
-            return
-        }
+        let returnedCoupon = try XCTUnwrap(result.get())
         XCTAssertEqual(returnedCoupon, coupon)
     }
 
@@ -233,10 +212,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        guard let resultError = result.failure as? NetworkError else {
-            XCTFail("Expected NetworkError not found")
-            return
-        }
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
     }
 
@@ -244,7 +220,7 @@ final class CouponsRemoteTests: XCTestCase {
 
     /// Verifies that createCoupon properly parses the `Coupon` sample response.
     ///
-    func test_createCoupon_properly_returns_parsed_coupon() {
+    func test_createCoupon_properly_returns_parsed_coupon() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let coupon = sampleCoupon()
@@ -259,10 +235,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssert(result.isSuccess)
-        guard let returnedCoupon = try? result.get() else {
-            XCTFail("Expected parsed Coupon not found in response")
-            return
-        }
+        let returnedCoupon = try XCTUnwrap(result.get())
         XCTAssertEqual(returnedCoupon, coupon)
     }
 
@@ -285,10 +258,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        guard let resultError = result.failure as? NetworkError else {
-            XCTFail("Expected NetworkError not found")
-            return
-        }
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
     }
 
@@ -296,7 +266,7 @@ final class CouponsRemoteTests: XCTestCase {
 
     /// Verifies that loadCouponReport properly parses the `CouponReport` sample response.
     ///
-    func test_loadCouponReport_properly_returns_parsed_report() {
+    func test_loadCouponReport_properly_returns_parsed_report() throws {
         // Given
         let remote = CouponsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "reports/coupons", filename: "coupon-reports")
@@ -310,10 +280,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssert(result.isSuccess)
-        guard let returnedReport = try? result.get() else {
-            XCTFail("Expected parsed CouponReport not found in response")
-            return
-        }
+        let returnedReport = try XCTUnwrap(result.get())
         let expectedReport = CouponReport(couponId: 571, amount: 12, ordersCount: 1)
         XCTAssertEqual(returnedReport, expectedReport)
     }
@@ -336,10 +303,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        guard let resultError = result.failure as? NetworkError else {
-            XCTFail("Expected NetworkError not found")
-            return
-        }
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
     }
 }

--- a/Networking/NetworkingTests/Responses/coupon-reports.json
+++ b/Networking/NetworkingTests/Responses/coupon-reports.json
@@ -1,0 +1,17 @@
+{
+    "data": [
+        {
+            "coupon_id": 571,
+            "amount": 12,
+            "orders_count": 1,
+            "extended_info": {},
+            "_links": {
+                "coupon": [
+                    {
+                        "href": "https://huongdotests1.blog/wp-json/wc-analytics/coupons/571"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/coupon-reports.json
+++ b/Networking/NetworkingTests/Responses/coupon-reports.json
@@ -8,7 +8,7 @@
             "_links": {
                 "coupon": [
                     {
-                        "href": "https://huongdotests1.blog/wp-json/wc-analytics/coupons/571"
+                        "href": "https://test.blog/wp-json/wc-analytics/coupons/571"
                     }
                 ]
             }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -2,6 +2,7 @@ import Foundation
 import Networking
 
 final class MockCouponsRemote: CouponsRemoteProtocol {
+
     // MARK: - Spy properties
     var didCallLoadAllCoupons = false
     var spyLoadAllCouponsSiteID: Int64?
@@ -17,6 +18,10 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
 
     var didCallCreateCoupon = false
     var spyCreateCoupon: Coupon?
+
+    var didCallLoadCouponReport = false
+    var spyLoadCouponReportSiteID: Int64?
+    var spyLoadCouponReportCouponID: Int64?
 
     // MARK: - Stub responses
     var resultForLoadAllCoupons: Result<[Coupon], Error>?
@@ -50,5 +55,11 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     func createCoupon(_ coupon: Coupon, completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallCreateCoupon = true
         spyCreateCoupon = coupon
+    }
+
+    func loadCouponReport(for siteID: Int64, couponID: Int64, completion: @escaping (Result<CouponReport, Error>) -> Void) {
+        didCallLoadAllCoupons = true
+        spyLoadCouponReportSiteID = siteID
+        spyLoadCouponReportCouponID = couponID
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -58,7 +58,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     }
 
     func loadCouponReport(for siteID: Int64, couponID: Int64, completion: @escaping (Result<CouponReport, Error>) -> Void) {
-        didCallLoadAllCoupons = true
+        didCallLoadCouponReport = true
         spyLoadCouponReportSiteID = siteID
         spyLoadCouponReportCouponID = couponID
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5911 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To provide information about the performance of coupons, we want to be able to display the total amount deducted from orders that applied the coupons. This information is not available in [coupon details API](https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-a-coupon), but can be obtained from endpoint `wc-analytics/reports/coupons`.

This PR adds a new endpoint in `CouponsRemote` to get the analytics report of a specified coupon.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This endpoint hasn't been integrated so CI passing should suffice.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
