### PR TITLE
Coupons: Update Yosemite for coupon analytics reports

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -159,6 +159,17 @@ extension Coupon.DiscountType {
         .percent
     }
 }
+extension CouponReport {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> CouponReport {
+        .init(
+            couponId: .fake(),
+            amount: .fake(),
+            ordersCount: .fake()
+        )
+    }
+}
 extension CreateProductVariation {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -164,7 +164,7 @@ extension CouponReport {
     ///
     public static func fake() -> CouponReport {
         .init(
-            couponId: .fake(),
+            couponID: .fake(),
             amount: .fake(),
             ordersCount: .fake()
         )

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -153,16 +153,16 @@ extension Coupon {
 
 extension CouponReport {
     public func copy(
-        couponId: CopiableProp<Int64> = .copy,
+        couponID: CopiableProp<Int64> = .copy,
         amount: CopiableProp<Double> = .copy,
         ordersCount: CopiableProp<Int64> = .copy
     ) -> CouponReport {
-        let couponId = couponId ?? self.couponId
+        let couponID = couponID ?? self.couponID
         let amount = amount ?? self.amount
         let ordersCount = ordersCount ?? self.ordersCount
 
         return CouponReport(
-            couponId: couponId,
+            couponID: couponID,
             amount: amount,
             ordersCount: ordersCount
         )

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -151,6 +151,24 @@ extension Coupon {
     }
 }
 
+extension CouponReport {
+    public func copy(
+        couponId: CopiableProp<Int64> = .copy,
+        amount: CopiableProp<Double> = .copy,
+        ordersCount: CopiableProp<Int64> = .copy
+    ) -> CouponReport {
+        let couponId = couponId ?? self.couponId
+        let amount = amount ?? self.amount
+        let ordersCount = ordersCount ?? self.ordersCount
+
+        return CouponReport(
+            couponId: couponId,
+            amount: amount,
+            ordersCount: ordersCount
+        )
+    }
+}
+
 extension Order {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Networking
 
 /// Defines the `actions` supported by the `CouponStore`.
 ///

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Networking
 
 /// Defines the `actions` supported by the `CouponStore`.
 ///
@@ -43,4 +44,14 @@ public enum CouponAction: Action {
     ///
     case createCoupon(_ coupon: Coupon,
                       onCompletion: (Result<Coupon, Error>) -> Void)
+
+    /// Loads analytics report for a coupon with the specified coupon ID and site ID.
+    ///
+    /// - `siteID`: ID of the site that the coupon belongs to.
+    /// - `couponID`: ID of the coupon to load analytics report for.
+    /// - `onCompletion`: invoked when the creation finishes.
+    ///
+    case loadCouponReport(siteID: Int64,
+                          couponID: Int64,
+                          onCompletion: (Result<CouponReport, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -17,6 +17,7 @@ public typealias APNSDevice = Networking.APNSDevice
 public typealias FallibleCancelable = Hardware.FallibleCancelable
 public typealias CommentStatus = Networking.CommentStatus
 public typealias Coupon = Networking.Coupon
+public typealias CouponReport = Networking.CouponReport
 public typealias Country = Networking.Country
 public typealias Credentials = Networking.Credentials
 public typealias CreateProductVariation = Networking.CreateProductVariation

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -64,6 +64,8 @@ public final class CouponStore: Store {
             updateCoupon(coupon, onCompletion: onCompletion)
         case .createCoupon(let coupon, let onCompletion):
             createCoupon(coupon, onCompletion: onCompletion)
+        case .loadCouponReport(let siteID, let couponID, let onCompletion):
+            loadCouponReport(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
         }
     }
 }
@@ -176,6 +178,17 @@ private extension CouponStore {
                 }
             }
         }
+    }
+
+    /// Loads analytics report for a coupon with the specified coupon ID and site ID.
+    ///
+    /// - Parameters:
+    ///     - siteID: ID of the site that the coupon belongs to.
+    ///     - couponID: ID of the coupon to load analytics report for.
+    ///     - onCompletion: invoked when the creation finishes.
+    ///
+    func loadCouponReport(siteID: Int64, couponID: Int64, onCompletion: @escaping (Result<CouponReport, Error>) -> Void) {
+        remote.loadCouponReport(for: siteID, couponID: couponID, completion: onCompletion)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -449,7 +449,7 @@ final class CouponStoreTests: XCTestCase {
     func test_loadCouponReport_returns_expected_details_upon_success() throws {
         // Given
         let sampleCouponID: Int64 = 571
-        let expectedReport = CouponReport(couponId: sampleCouponID, amount: 12, ordersCount: 1)
+        let expectedReport = CouponReport(couponID: sampleCouponID, amount: 12, ordersCount: 1)
         network.simulateResponse(requestUrlSuffix: "reports/coupons", filename: "coupon-reports")
 
         // When

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -411,6 +411,59 @@ final class CouponStoreTests: XCTestCase {
         XCTAssertEqual(storedCoupon?.amount, "10.00")
         XCTAssertEqual(storedCoupon?.discountType, Coupon.DiscountType.fixedCart.rawValue)
     }
+
+    func test_loadCouponReport_calls_remote_using_correct_request_parameters() {
+        setUpUsingSpyRemote()
+        // Given
+        let sampleCouponID: Int64 = 571
+        let action = CouponAction.loadCouponReport(siteID: sampleSiteID, couponID: sampleCouponID) { _ in }
+
+        // When
+        store.onAction(action)
+
+        // Then
+        XCTAssertTrue(remote.didCallLoadCouponReport)
+        XCTAssertEqual(remote.spyLoadCouponReportSiteID, sampleSiteID)
+        XCTAssertEqual(remote.spyLoadCouponReportCouponID, sampleCouponID)
+    }
+
+    func test_loadCouponReport_returns_network_error_on_failure() {
+        // Given
+        let sampleCouponID: Int64 = 571
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "coupons", error: expectedError)
+
+        // When
+        let result: Result<Networking.CouponReport, Error> = waitFor { promise in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(result.failure as? NetworkError, expectedError)
+    }
+
+    func test_loadCouponReport_returns_expected_details_upon_success() throws {
+        // Given
+        let sampleCouponID: Int64 = 571
+        let expectedReport = CouponReport(couponId: sampleCouponID, amount: 12, ordersCount: 1)
+        network.simulateResponse(requestUrlSuffix: "reports/coupons", filename: "coupon-reports")
+
+        // When
+        let result: Result<Networking.CouponReport, Error> = waitFor { promise in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(try result.get(), expectedReport)
+    }
 }
 
 private extension CouponStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5911 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR follows up with #5917 to update the Yosemite layer with the new endpoint to load analytics reports for coupons.
These reports need to be updated regularly so I don't think they should be persisted in the local database, so `CouponStore` just simply triggers the API request in `CouponRemote`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This endpoint hasn't been integrated yet so just CI passing should suffice.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
