### PR TITLE
Simple payments: Add feature flag to display tax breakup in summary screen.

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -39,6 +39,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productSKUInputScanner:
             return true
+        case .taxLinesInSimplePayments:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -77,4 +77,8 @@ public enum FeatureFlag: Int {
     /// Barcode scanner for product SKU input
     ///
     case productSKUInputScanner
+
+    /// Displays the tax lines breakup in simple payments summary screen
+    ///
+    case taxLinesInSimplePayments
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5809

### Description
This work is part of the task of removing on-device tax calculation and displaying tax breakup details in Simple payments. This PR adds a feature flag behind which, we will be hiding the tax breakup details in a future PR.


### Testing instructions
- CI should be successful.

### Screenshots
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
