### PR TITLE
JCP: handle shop manager edge case and enable feature flag for all

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -24,7 +24,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .orderListFilters:
             return true
         case .jetpackConnectionPackageSupport:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .orderCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .hubMenu:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 8.4
 -----
 - [***] In-Person Payments: Support for Stripe M2 card reader. [https://github.com/woocommerce/woocommerce-ios/pull/5844]
+- [***] Store admins can now access sites with plugins that have Jetpack Connection Package (e.g. WooCommerce Payments, Jetpack Backup) in the app. These sites do not require Jetpack-the-plugin to connect anymore. Store admins can still install Jetpack-the-plugin from the app through settings or a Jetpack banner. [https://github.com/woocommerce/woocommerce-ios/pull/5924]
 - [*] Add/Edit Product screen: Fix transient product name while adding images.[https://github.com/woocommerce/woocommerce-ios/pull/5840]
 
 8.3

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -140,12 +140,12 @@ private extension AccountStore {
                                 .map {
                                     (site, isWooCommerceActiveResult, wpSiteSettingsResult) -> Site in
                                     var site = site
-                                    if case let .success(isWooCommerceActive) = isWooCommerceActiveResult {
-                                        site = site.copy(isWooCommerceActive: isWooCommerceActive)
-                                    }
-                                    if case let .success(wpSiteSettings) = wpSiteSettingsResult {
-                                        site = site.copy(name: wpSiteSettings.name, description: wpSiteSettings.description, url: wpSiteSettings.url)
-                                    }
+                                    guard case let .success(isWooCommerceActive) = isWooCommerceActiveResult,
+                                          case let .success(wpSiteSettings) = wpSiteSettingsResult else {
+                                              return site
+                                          }
+                                    site = site.copy(isWooCommerceActive: isWooCommerceActive)
+                                    site = site.copy(name: wpSiteSettings.name, description: wpSiteSettings.description, url: wpSiteSettings.url)
                                     return site
                                 }.eraseToAnyPublisher()
                         } else {

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -356,9 +356,9 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(jetpackSite.siteID, siteIDOfJetpackSite)
     }
 
-    /// Verifies that `synchronizeSites` effectively persists a Jetpack Connection Package site with original metadata when WP site settings request fails.
+    /// Verifies that `synchronizeSites` effectively persists a Jetpack Connection Package site without any changes when WP site settings request fails.
     ///
-    func test_synchronizeSites_persists_a_jetpack_cp_site_with_existing_metadata_when_wp_settings_request_fails() throws {
+    func test_synchronizeSites_persists_a_jetpack_cp_site_without_any_changes_when_wp_settings_request_fails() throws {
         // Given
         let siteID = Int64(255)
         let remote = MockAccountRemote()
@@ -368,7 +368,8 @@ final class AccountStoreTests: XCTestCase {
                              description: "old description",
                              url: "oldurl",
                              isJetpackThePluginInstalled: false,
-                             isJetpackConnected: true)
+                             isJetpackConnected: true,
+                             isWooCommerceActive: false)
         ])
         remote.whenFetchingWordPressSiteSettings(siteID: siteID, thenReturn: .failure(NetworkError.timeout))
         remote.whenCheckingIfWooCommerceIsActive(siteID: siteID, thenReturn: .success(true))
@@ -396,17 +397,23 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(jcpSite.name, "old name")
         XCTAssertEqual(jcpSite.tagline, "old description")
         XCTAssertEqual(jcpSite.url, "oldurl")
-        XCTAssertTrue(jcpSite.isWooCommerceActive?.boolValue == true)
+        XCTAssertTrue(jcpSite.isWooCommerceActive?.boolValue == false)
     }
 
-    /// Verifies that `synchronizeSites` persists a Jetpack Connection Package site with original isWooCommerceActive when WC site settings request fails.
+    /// Verifies that `synchronizeSites` persists a Jetpack Connection Package site without any changes when WC site settings request fails.
     ///
-    func test_synchronizeSites_persists_a_jetpack_cp_site_without_isWooCommerceActive_change_when_wc_settings_request_fails() throws {
+    func test_synchronizeSites_persists_a_jetpack_cp_site_without_any_changes_when_wc_settings_request_fails() throws {
         // Given
         let siteID = Int64(255)
         let remote = MockAccountRemote()
         remote.loadSitesResult = .success([
-            Site.fake().copy(siteID: siteID, isJetpackThePluginInstalled: false, isJetpackConnected: true, isWooCommerceActive: false)
+            Site.fake().copy(siteID: siteID,
+                             name: "old name",
+                             description: "old description",
+                             url: "oldurl",
+                             isJetpackThePluginInstalled: false,
+                             isJetpackConnected: true,
+                             isWooCommerceActive: false)
         ])
         remote.whenFetchingWordPressSiteSettings(siteID: siteID, thenReturn: .success(.init(name: "new name",
                                                                                                      description: "new description",
@@ -431,6 +438,9 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self, matching: jcpSitePredicate), 1)
         let jcpSite = try XCTUnwrap(viewStorage.firstObject(ofType: Storage.Site.self, matching: jcpSitePredicate))
         XCTAssertEqual(jcpSite.siteID, siteID)
+        XCTAssertEqual(jcpSite.name, "old name")
+        XCTAssertEqual(jcpSite.tagline, "old description")
+        XCTAssertEqual(jcpSite.url, "oldurl")
         XCTAssertTrue(jcpSite.isWooCommerceActive?.boolValue == false)
         XCTAssertFalse(jcpSite.isJetpackThePluginInstalled)
         XCTAssertTrue(jcpSite.isJetpackConnected)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5910 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From p1642409838012200-slack-C02HHDEUEH2, we are handling an edge case where a shop manager user can access a JCP site in the app because we ignore errors from JCP site workarounds (`/wp/v2/settings`). To align with Android, this PR updates to ensure both JCP API workarounds succeed before we apply the site workarounds which mean that shop managers cannot access JCP sites. This PR also enables the JCP feature for all for release 8.4.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Create a site with WC but no Jetpack
- In wp-admin > Plugins, install WooCommerce Payments plugin and activate it without setting it up
- In wp-admin > Users, add a user with shop manager role
- In a separate web session, log in to wp-admin with the shop manager user. Then go to wp-admin > Payments to set up WCPay and connect the site to a WP.com account
- In the app, switch stores or log in to the app with the WP.com account from the previous step --> the JCP site should not be listed (you can check that it is listed before this PR)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->