### PR TITLE
Re-enable reviews test, doc updates

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -21,10 +21,10 @@ public final class SingleOrderScreen: ScreenObject {
         // Expects 2 instances of order.number - one in Header and one in Summary
         app.assertTextVisibilityCount(textToFind: "#\(order.number)", expectedCount: 2)
 
+        // Expects 2 instances of first_name - one in Summary and one in Shipping details
         app.assertTextVisibilityCount(textToFind: order.billing.first_name, expectedCount: 2)
         app.assertElement(matching: "summary-table-view-cell", existsOnCellWithIdentifier: "\(order.billing.first_name) \(order.billing.last_name)")
 
-        // Loops through all products on the order
         for product in order.line_items {
             XCTAssertTrue(app.staticTexts[product.name].isFullyVisibleOnScreen(), "'\(product.name)' is missing!")
         }

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -49,7 +49,8 @@ class WooCommerceScreenshots: XCTestCase {
             .cancel()
 
             // Reviews
-            .tabBar.goToReviewsScreen()
+            .tabBar.goToMenuScreen()
+            .goToReviewsScreen()
             .thenTakeScreenshot(named: "review-list")
             .selectReview(atIndex: 3)
             .thenTakeScreenshot(named: "review-details")

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -16,8 +16,7 @@ final class OrdersTests: XCTestCase {
     func testOrdersScreenLoads() throws {
         let orders = try GetMocks.readOrdersData()
 
-        try TabNavComponent()
-            .goToOrdersScreen()
+        try TabNavComponent().goToOrdersScreen()
             .verifyOrdersScreenLoaded()
             .verifyOrdersList(orders: orders)
             .selectOrder(byOrderNumber: orders[0].number)

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -10,13 +10,12 @@ final class ProductsTests: XCTestCase {
         app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
         try LoginFlow.logInWithWPcom()
-        try TabNavComponent().goToProductsScreen()
     }
 
     func testProductsScreenLoad() throws {
         let products = try GetMocks.readProductsData()
 
-        try ProductsScreen()
+        try TabNavComponent().goToProductsScreen()
             .verifyProductsScreenLoaded()
             .verifyProductList(products: products)
             .selectProduct(byName: products[0].name)

--- a/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
@@ -4,8 +4,6 @@ import XCTest
 final class ReviewsTests: XCTestCase {
 
     override func setUpWithError() throws {
-        try skipTillReviewMenuFixed()
-
         continueAfterFailure = false
 
         let app = XCUIApplication()
@@ -17,18 +15,13 @@ final class ReviewsTests: XCTestCase {
         // GH Issue: https://github.com/woocommerce/woocommerce-ios/issues/1907
         try TabNavComponent()
             .goToProductsScreen()
-
-        try TabNavComponent()
-            .goToMenuScreen()
-            .goToReviewsScreen()
     }
 
     func testReviewsScreenLoad() throws {
-        try skipTillReviewMenuFixed()
-
         let reviews = try GetMocks.readReviewsData()
 
-        try ReviewsScreen()
+        try TabNavComponent().goToMenuScreen()
+            .goToReviewsScreen()
             .verifyReviewsScreenLoaded()
             .verifyReviewList(reviews: reviews)
             .selectReview(byReviewer: reviews[0].reviewer)
@@ -36,12 +29,5 @@ final class ReviewsTests: XCTestCase {
             .verifyReview(review: reviews[0])
             .goBackToReviewsScreen()
             .verifyReviewsScreenLoaded()
-    }
-
-    func skipTillReviewMenuFixed(file: StaticString = #file, line: UInt = #line) throws {
-        try XCTSkipIf(true,
-            """
-            Skipping test because of the reviews menu does not appear on first load. See: https://github.com/woocommerce/woocommerce-ios/issues/5872
-            """, file: file, line: line)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -15,13 +15,12 @@ final class StatsTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    // Disabled test, added to test stats mocks. To be updated into a real test later.
     func testStatsScreenLoad() throws {
         try skipTillImplemented()
         try TabNavComponent().goToMyStoreScreen()
     }
-    
-    
+
+
     func skipTillImplemented(file: StaticString = #file, line: UInt = #line) throws {
         try XCTSkipIf(true,
             "Skipping until test is properly implemented", file: file, line: line)

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -20,7 +20,6 @@ final class StatsTests: XCTestCase {
         try TabNavComponent().goToMyStoreScreen()
     }
 
-
     func skipTillImplemented(file: StaticString = #file, line: UInt = #line) throws {
         try XCTSkipIf(true,
             "Skipping until test is properly implemented", file: file, line: line)

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -4,6 +4,7 @@ import XCTest
 final class StatsTests: XCTestCase {
 
     override func setUpWithError() throws {
+        try skipTillImplemented()
         continueAfterFailure = false
 
         // UI tests must launch the application that they test.
@@ -16,7 +17,13 @@ final class StatsTests: XCTestCase {
 
     // Disabled test, added to test stats mocks. To be updated into a real test later.
     func testStatsScreenLoad() throws {
+        try skipTillImplemented()
         try TabNavComponent().goToMyStoreScreen()
-        sleep(1000)
+    }
+    
+    
+    func skipTillImplemented(file: StaticString = #file, line: UInt = #line) throws {
+        try XCTSkipIf(true,
+            "Skipping until test is properly implemented", file: file, line: line)
     }
 }

--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -17,7 +17,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] Stats Today, This Week, This Month, This Year load
     - [ ] Tap chart on stats
 3. [Orders](../WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift)
-    - [ ] Orders list and single order screens load
+    - [x] Orders list and single order screens load
     - [ ] View product on single order screen
     - [ ] Add customer note
     - [ ] Add order note


### PR DESCRIPTION
### Description
This is a cleanup PR that does a few small things:
1. Re-enable the Reviews Screen test that was previously skipped due to [an issue](https://github.com/woocommerce/woocommerce-ios/issues/5872)
2. Removed/added comments that were missed from a previous PR
3. Updated UI test doc, also missed on the last PR
4. Move some methods from `setup` to inside the test to prevent double instantiation

### Testing instructions
All non-skipped tests should still work on local and CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
