### PR TITLE
Yosemite: Add tax lines to Orders

### DIFF
--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -43,6 +43,7 @@ final class MockOrders {
                    shippingLines: [ShippingLine] = sampleShippingLines(),
                    refunds: [OrderRefundCondensed] = [],
                    fees: [OrderFeeLine] = []) -> Order {
+        let totalTax = "1.20"
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
@@ -60,7 +61,7 @@ final class MockOrders {
                      shippingTotal: "0.00",
                      shippingTax: "0.00",
                      total: "31.20",
-                     totalTax: "1.20",
+                     totalTax: totalTax,
                      paymentMethodID: "stripe",
                      paymentMethodTitle: "Credit Card (Stripe)",
                      items: items,
@@ -70,7 +71,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: refunds,
                      fees: fees,
-                     taxes: sampleOrderTaxLines()
+                     taxes: [makeOrderTaxLine(totalTax: totalTax)]
         )
     }
 
@@ -91,6 +92,7 @@ final class MockOrders {
     }
 
     func sampleOrderCreatedInCurrentYear() -> Order {
+        let totalTax = "1.20"
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
@@ -108,7 +110,7 @@ final class MockOrders {
                      shippingTotal: "0.00",
                      shippingTax: "0.00",
                      total: "31.20",
-                     totalTax: "1.20",
+                     totalTax: totalTax,
                      paymentMethodID: "stripe",
                      paymentMethodTitle: "Credit Card (Stripe)",
                      items: [],
@@ -118,7 +120,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: [],
                      fees: [],
-                     taxes: sampleOrderTaxLines()
+                     taxes: [makeOrderTaxLine(totalTax: totalTax)]
         )
     }
 
@@ -131,17 +133,16 @@ final class MockOrders {
         taxes: [])]
     }
 
-    func sampleOrderTaxLines() -> [OrderTaxLine] {
-        let tax = OrderTaxLine(taxID: 123,
-                               rateCode: "",
-                               rateID: 1,
-                               label: "State",
-                               isCompoundTaxRate: false,
-                               totalTax: "5.5",
-                               totalShippingTax: "3",
-                               ratePercent: 5.5,
-                               attributes: [])
-        return [tax]
+    func makeOrderTaxLine(totalTax: String) -> OrderTaxLine {
+        .init(taxID: 123,
+              rateCode: "",
+              rateID: 1,
+              label: "State",
+              isCompoundTaxRate: false,
+              totalTax: totalTax,
+              totalShippingTax: "3",
+              ratePercent: 5.5,
+              attributes: [])
     }
 
     func sampleFeeLines() -> [OrderFeeLine] {

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -70,7 +70,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: refunds,
                      fees: fees,
-                     taxes: [] // TODO: 5809 - Add sampleOrderTaxLines method
+                     taxes: sampleOrderTaxLines()
         )
     }
 
@@ -118,7 +118,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: [],
                      fees: [],
-                     taxes: [] // TODO: 5809 - Add sampleOrderTaxLines method
+                     taxes: sampleOrderTaxLines()
         )
     }
 
@@ -129,6 +129,19 @@ final class MockOrders {
         total: cost,
         totalTax: tax,
         taxes: [])]
+    }
+
+    func sampleOrderTaxLines() -> [OrderTaxLine] {
+        let tax = OrderTaxLine(taxID: 123,
+                               rateCode: "",
+                               rateID: 1,
+                               label: "State",
+                               isCompoundTaxRate: false,
+                               totalTax: "5.5",
+                               totalShippingTax: "3",
+                               ratePercent: 5.5,
+                               attributes: [])
+        return [tax]
     }
 
     func sampleFeeLines() -> [OrderFeeLine] {

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -42,12 +42,8 @@ final class MockOrders {
                    items: [OrderItem] = [],
                    shippingLines: [ShippingLine] = sampleShippingLines(),
                    refunds: [OrderRefundCondensed] = [],
-                   fees: [OrderFeeLine] = []) -> Order {
-        let shippingTax = "0.00"
-        let totalTax = "1.20"
-        let tax = makeOrderTaxLine(totalShippingTax: shippingTax,
-                                   totalTax: totalTax)
-
+                   fees: [OrderFeeLine] = [],
+                   taxes: [OrderTaxLine] = []) -> Order {
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
@@ -63,9 +59,9 @@ final class MockOrders {
                      discountTotal: "30.00",
                      discountTax: "1.20",
                      shippingTotal: "0.00",
-                     shippingTax: shippingTax,
+                     shippingTax: "0.00",
                      total: "31.20",
-                     totalTax: totalTax,
+                     totalTax: "1.20",
                      paymentMethodID: "stripe",
                      paymentMethodTitle: "Credit Card (Stripe)",
                      items: items,
@@ -75,8 +71,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: refunds,
                      fees: fees,
-                     taxes: [tax]
-        )
+                     taxes: taxes)
     }
 
     func sampleOrder() -> Order {
@@ -96,11 +91,6 @@ final class MockOrders {
     }
 
     func sampleOrderCreatedInCurrentYear() -> Order {
-        let shippingTax = "0.00"
-        let totalTax = "1.20"
-        let tax = makeOrderTaxLine(totalShippingTax: shippingTax,
-                                   totalTax: totalTax)
-
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
@@ -116,9 +106,9 @@ final class MockOrders {
                      discountTotal: "30.00",
                      discountTax: "1.20",
                      shippingTotal: "0.00",
-                     shippingTax: shippingTax,
+                     shippingTax: "0.00",
                      total: "31.20",
-                     totalTax: totalTax,
+                     totalTax: "1.20",
                      paymentMethodID: "stripe",
                      paymentMethodTitle: "Credit Card (Stripe)",
                      items: [],
@@ -128,8 +118,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: [],
                      fees: [],
-                     taxes: [tax]
-        )
+                     taxes: [])
     }
 
     static func sampleShippingLines(cost: String = "133.00", tax: String = "0.00") -> [ShippingLine] {
@@ -139,19 +128,6 @@ final class MockOrders {
         total: cost,
         totalTax: tax,
         taxes: [])]
-    }
-
-    func makeOrderTaxLine(totalShippingTax: String,
-                          totalTax: String) -> OrderTaxLine {
-        .init(taxID: 123,
-              rateCode: "",
-              rateID: 1,
-              label: "State",
-              isCompoundTaxRate: false,
-              totalTax: totalTax,
-              totalShippingTax: totalShippingTax,
-              ratePercent: 5.5,
-              attributes: [])
     }
 
     func sampleFeeLines() -> [OrderFeeLine] {

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -43,7 +43,11 @@ final class MockOrders {
                    shippingLines: [ShippingLine] = sampleShippingLines(),
                    refunds: [OrderRefundCondensed] = [],
                    fees: [OrderFeeLine] = []) -> Order {
+        let shippingTax = "0.00"
         let totalTax = "1.20"
+        let tax = makeOrderTaxLine(totalShippingTax: shippingTax,
+                                   totalTax: totalTax)
+
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
@@ -59,7 +63,7 @@ final class MockOrders {
                      discountTotal: "30.00",
                      discountTax: "1.20",
                      shippingTotal: "0.00",
-                     shippingTax: "0.00",
+                     shippingTax: shippingTax,
                      total: "31.20",
                      totalTax: totalTax,
                      paymentMethodID: "stripe",
@@ -71,7 +75,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: refunds,
                      fees: fees,
-                     taxes: [makeOrderTaxLine(totalTax: totalTax)]
+                     taxes: [tax]
         )
     }
 
@@ -92,7 +96,11 @@ final class MockOrders {
     }
 
     func sampleOrderCreatedInCurrentYear() -> Order {
+        let shippingTax = "0.00"
         let totalTax = "1.20"
+        let tax = makeOrderTaxLine(totalShippingTax: shippingTax,
+                                   totalTax: totalTax)
+
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
@@ -108,7 +116,7 @@ final class MockOrders {
                      discountTotal: "30.00",
                      discountTax: "1.20",
                      shippingTotal: "0.00",
-                     shippingTax: "0.00",
+                     shippingTax: shippingTax,
                      total: "31.20",
                      totalTax: totalTax,
                      paymentMethodID: "stripe",
@@ -120,7 +128,7 @@ final class MockOrders {
                      coupons: [],
                      refunds: [],
                      fees: [],
-                     taxes: [makeOrderTaxLine(totalTax: totalTax)]
+                     taxes: [tax]
         )
     }
 
@@ -133,14 +141,15 @@ final class MockOrders {
         taxes: [])]
     }
 
-    func makeOrderTaxLine(totalTax: String) -> OrderTaxLine {
+    func makeOrderTaxLine(totalShippingTax: String,
+                          totalTax: String) -> OrderTaxLine {
         .init(taxID: 123,
               rateCode: "",
               rateID: 1,
               label: "State",
               isCompoundTaxRate: false,
               totalTax: totalTax,
-              totalShippingTax: "3",
+              totalShippingTax: totalShippingTax,
               ratePercent: 5.5,
               attributes: [])
     }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		B5EED1A820F4F3CF00652449 /* Account+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EED1A720F4F3CF00652449 /* Account+ReadOnlyConvertible.swift */; };
 		B5F2AE9520EBAD6000FEDC59 /* ResultsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F2AE9420EBAD6000FEDC59 /* ResultsControllerTests.swift */; };
 		B5F2AE9720EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F2AE9620EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift */; };
+		BAB3737927964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */; };
 		CC2C036C262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */; };
 		CC2C0372262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */; };
 		CC7D89F62767A9FB00046E8D /* Product+OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7D89F52767A9FB00046E8D /* Product+OrderItem.swift */; };
@@ -686,6 +687,7 @@
 		B5EED1A720F4F3CF00652449 /* Account+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Account+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		B5F2AE9420EBAD6000FEDC59 /* ResultsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsControllerTests.swift; sourceTree = "<group>"; };
 		B5F2AE9620EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedResultsControllerDelegateWrapper.swift; sourceTree = "<group>"; };
+		BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderTaxLine+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAccountSettings+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelPaymentMethod+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1203,6 +1205,7 @@
 				02C255012563C76A00A04423 /* ShippingLabel+ReadOnlyConvertible.swift */,
 				DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */,
 				077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */,
+				BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -1793,6 +1796,7 @@
 				B5C9DE152087FF0E006B910A /* Dispatcher.swift in Sources */,
 				247CE8402582F39900F9D9D1 /* MockActionHandler.swift in Sources */,
 				247CE7C82582DF5500F9D9D1 /* MockStoresManager.swift in Sources */,
+				BAB3737927964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift in Sources */,
 				D83B093525DECFCC00B21F45 /* CardPresentPaymentAction.swift in Sources */,
 				B52E0030211A439E00700FDE /* Account+ReadOnlyType.swift in Sources */,
 				4591A6B0274BB23000F51DCD /* OrderDateRangeFilter.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -42,6 +42,7 @@ public typealias OrderCouponLine = Networking.OrderCouponLine
 public typealias OrderFeeLine = Networking.OrderFeeLine
 public typealias OrderFeeTaxStatus = Networking.OrderFeeTaxStatus
 public typealias OrderNote = Networking.OrderNote
+public typealias OrderTaxLine = Networking.OrderTaxLine
 public typealias OrderRefundCondensed = Networking.OrderRefundCondensed
 public typealias OrderStatsV4 = Networking.OrderStatsV4
 public typealias OrderStatsV4Interval = Networking.OrderStatsV4Interval

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -70,6 +70,7 @@ extension Storage.Order: ReadOnlyConvertible {
         let orderRefunds = refunds?.map { $0.toReadOnly() } ?? [Yosemite.OrderRefundCondensed]()
         let orderShippingLines = shippingLines?.map { $0.toReadOnly() } ?? [Yosemite.ShippingLine]()
         let orderFeeLines = fees?.map { $0.toReadOnly() } ?? [Yosemite.OrderFeeLine]()
+        let orderTaxLines = taxes?.map { $0.toReadOnly() } ?? [Yosemite.OrderTaxLine]()
 
         return Order(siteID: siteID,
                      orderID: orderID,
@@ -98,7 +99,7 @@ extension Storage.Order: ReadOnlyConvertible {
                      coupons: orderCoupons,
                      refunds: orderRefunds,
                      fees: orderFeeLines,
-                     taxes: []) // TODO: 5809 - Handle OrderTaxLine
+                     taxes: orderTaxLines)
 
     }
 

--- a/Yosemite/Yosemite/Model/Storage/OrderTaxLine+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderTaxLine+ReadOnlyConvertible.swift
@@ -5,7 +5,9 @@ import Storage
 //
 extension Storage.OrderTaxLine: ReadOnlyConvertible {
 
-    /// Updates the Storage.OrderTaxLine with the ReadOnly.
+    /// Updates the `Storage.OrderTaxLine` using the ReadOnly representation (`Networking.OrderTaxLine`)
+    ///
+    /// - Parameter taxLine: ReadOnly representation of OrderTaxLine
     ///
     public func update(with taxLine: Yosemite.OrderTaxLine) {
         taxID = taxLine.taxID
@@ -18,7 +20,7 @@ extension Storage.OrderTaxLine: ReadOnlyConvertible {
         ratePercent = taxLine.ratePercent
     }
 
-    /// Returns a ReadOnly version of the receiver.
+    /// Returns a ReadOnly (`Networking.OrderTaxLine`) version of the `Storage.OrderTaxLine`
     ///
     public func toReadOnly() -> Yosemite.OrderTaxLine {
         let taxAttributes = attributes?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemAttribute]()

--- a/Yosemite/Yosemite/Model/Storage/OrderTaxLine+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderTaxLine+ReadOnlyConvertible.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Storage
+
+// MARK: - Storage.OrderTaxLine: ReadOnlyConvertible
+//
+extension Storage.OrderTaxLine: ReadOnlyConvertible {
+
+    /// Updates the Storage.OrderTaxLine with the ReadOnly.
+    ///
+    public func update(with taxLine: Yosemite.OrderTaxLine) {
+        taxID = taxLine.taxID
+        rateCode = taxLine.rateCode
+        rateID = taxLine.rateID
+        label = taxLine.label
+        isCompoundTaxRate = taxLine.isCompoundTaxRate
+        totalTax = taxLine.totalTax
+        totalShippingTax = taxLine.totalShippingTax
+        ratePercent = taxLine.ratePercent
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.OrderTaxLine {
+        let taxAttributes = attributes?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemAttribute]()
+
+        return OrderTaxLine(taxID: taxID,
+                            rateCode: rateCode ?? "",
+                            rateID: rateID,
+                            label: label ?? "",
+                            isCompoundTaxRate: isCompoundTaxRate,
+                            totalTax: totalTax ?? "",
+                            totalShippingTax: totalShippingTax ?? "",
+                            ratePercent: ratePercent,
+                            attributes: taxAttributes)
+    }
+}

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -275,10 +275,10 @@ struct OrdersUpsertUseCase {
         }
 
         // Now, remove any objects that exist in `storageOrder.taxes` but not in `readOnlyOrder.taxes`
-        storageOrder.taxes?.forEach { storageFee in
-            if readOnlyOrder.taxes.first(where: { $0.taxID == storageFee.taxID } ) == nil {
-                storageOrder.removeFromTaxes(storageFee)
-                storage.deleteObject(storageFee)
+        storageOrder.taxes?.forEach { storageTax in
+            if readOnlyOrder.taxes.first(where: { $0.taxID == storageTax.taxID } ) == nil {
+                storageOrder.removeFromTaxes(storageTax)
+                storage.deleteObject(storageTax)
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -260,10 +260,10 @@ struct OrdersUpsertUseCase {
         }
     }
 
-    /// Updates, inserts, or prunes the provided StorageOrder's taxes using the provided read-only Order's taxes
+    /// Updates, inserts, or prunes the provided `storageOrder`'s taxes using the provided `readOnlyOrder`'s taxes
     ///
     private func handleOrderTaxes(_ readOnlyOrder: Networking.Order, _ storageOrder: Storage.Order, _ storage: StorageType) {
-        // Upsert the taxes from the read-only order
+        // Upsert the `taxes` from the `readOnlyOrder`
         readOnlyOrder.taxes.forEach { readOnlyTax in
             if let existingStorageTax = storage.loadOrderTaxLine(siteID: readOnlyOrder.siteID, taxID: readOnlyTax.taxID) {
                 existingStorageTax.update(with: readOnlyTax)
@@ -274,7 +274,7 @@ struct OrdersUpsertUseCase {
             }
         }
 
-        // Now, remove any objects that exist in storageOrder.taxes but not in readOnlyOrder.taxes
+        // Now, remove any objects that exist in `storageOrder.taxes` but not in `readOnlyOrder.taxes`
         storageOrder.taxes?.forEach { storageFee in
             if readOnlyOrder.taxes.first(where: { $0.taxID == storageFee.taxID } ) == nil {
                 storageOrder.removeFromTaxes(storageFee)

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -123,7 +123,7 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
 
     func test_it_persists_order_tax_line_in_storage() throws {
         // Given
-        let taxLine = makeOrderTaxLine().copy(taxID: 1)
+        let taxLine = OrderTaxLine.fake().copy(taxID: 1)
         let order = makeOrder().copy(siteID: 3, taxes: [taxLine])
         let useCase = OrdersUpsertUseCase(storage: viewStorage)
 
@@ -137,13 +137,13 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
 
     func test_it_replaces_existing_order_tax_line_in_storage() throws {
         // Given
-        let originalTaxLine = makeOrderTaxLine().copy(taxID: 1, ratePercent: 0.0)
+        let originalTaxLine = OrderTaxLine.fake().copy(taxID: 1, ratePercent: 0.0)
         let order = makeOrder().copy(siteID: 3, taxes: [originalTaxLine])
         let useCase = OrdersUpsertUseCase(storage: viewStorage)
         useCase.upsert([order])
 
         // When
-        let taxLine = makeOrderTaxLine().copy(taxID: 1, ratePercent: 5.0)
+        let taxLine = OrderTaxLine.fake().copy(taxID: 1, ratePercent: 5.0)
         useCase.upsert([order.copy(taxes: [taxLine])])
 
         // Then
@@ -256,17 +256,5 @@ private extension OrdersUpsertUseCaseTests {
               total: "-18.00",
               totalTax: "0.00",
               attributes: attributes)
-    }
-
-    func makeOrderTaxLine() -> Networking.OrderTaxLine {
-        .init(taxID: 0,
-              rateCode: "TAX",
-              rateID: 0,
-              label: "Tax label",
-              isCompoundTaxRate: true,
-              totalTax: "0.0",
-              totalShippingTax: "0.0",
-              ratePercent: 0.0,
-              attributes: [])
     }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -912,40 +912,23 @@ private extension OrderStoreTests {
         return [coupon1, coupon2]
     }
 
+    func sampleOrderTaxLine() -> Networking.OrderTaxLine {
+        OrderTaxLine.fake().copy(taxID: 1330,
+                                 rateCode: "US-NY-STATE-2",
+                                 rateID: 6,
+                                 label: "State",
+                                 totalTax: "7.71",
+                                 ratePercent: 4.5)
+    }
+
     func sampleOrderTaxLines() -> [Networking.OrderTaxLine] {
-        [
-            .init(taxID: 1330,
-                  rateCode: "US-NY-STATE-2",
-                  rateID: 6,
-                  label: "State",
-                  isCompoundTaxRate: true,
-                  totalTax: "7.71",
-                  totalShippingTax: "0.00",
-                  ratePercent: 4.5,
-                  attributes: [])
-        ]
+        [sampleOrderTaxLine()]
     }
 
     func sampleOrderTaxLinesMutated() -> [Networking.OrderTaxLine] {
         [
-            .init(taxID: 1330,
-                  rateCode: "US-NY-STATE-2",
-                  rateID: 6,
-                  label: "State",
-                  isCompoundTaxRate: true,
-                  totalTax: "55",
-                  totalShippingTax: "0.00",
-                  ratePercent: 5.5,
-                  attributes: []),
-            .init(taxID: 124,
-                  rateCode: "",
-                  rateID: 2,
-                  label: "Central",
-                  isCompoundTaxRate: true,
-                  totalTax: "2.5",
-                  totalShippingTax: "3",
-                  ratePercent: 2.5,
-                  attributes: [])
+            sampleOrderTaxLine().copy(totalTax: "55", ratePercent: 5.5),
+            OrderTaxLine.fake()
         ]
     }
 

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -340,12 +340,14 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 0)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 0)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 0)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderTaxLine.self), 0)
 
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrder(), in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 2)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 2)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 1)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderTaxLine.self), 1)
 
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrderMutated(), in: viewStorage)
         let storageOrder1 = viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderMutated().orderID)
@@ -354,6 +356,7 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 3)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 3)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 2)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderTaxLine.self), 2)
 
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrderMutated2(), in: viewStorage)
         let storageOrder2 = viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderMutated2().orderID)
@@ -362,6 +365,7 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 4)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 0)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderTaxLine.self), 0)
     }
 
     /// Verifies that `upsertStoredOrder` effectively inserts a new Order, with the specified payload.
@@ -571,12 +575,14 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 2)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 1)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderTaxLine.self), 1)
 
         let expectation = self.expectation(description: "Stored Orders Reset")
         let action = OrderAction.resetStoredOrders {
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderItem.self), 0)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 0)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderTaxLine.self), 0)
 
             expectation.fulfill()
         }
@@ -796,7 +802,7 @@ private extension OrderStoreTests {
                      coupons: sampleCoupons(),
                      refunds: [],
                      fees: [],
-                     taxes: []) // TODO: 5809 - Add sampleOrderTaxLines method and update tests
+                     taxes: sampleOrderTaxLines())
     }
 
     func sampleOrderMutated() -> Networking.Order {
@@ -827,7 +833,7 @@ private extension OrderStoreTests {
                      coupons: sampleCouponsMutated(),
                      refunds: [],
                      fees: [],
-                     taxes: []) // TODO: 5809 - Add sampleOrderTaxLinesMutated method and update tests
+                     taxes: sampleOrderTaxLinesMutated())
     }
 
     func sampleOrderMutated2() -> Networking.Order {
@@ -858,7 +864,7 @@ private extension OrderStoreTests {
                      coupons: [],
                      refunds: [],
                      fees: [],
-                     taxes: []) // TODO: 5809 - Add sampleOrderTaxLinesMutated2 method and update tests
+                     taxes: [])
     }
 
     func sampleAddress() -> Networking.Address {
@@ -904,6 +910,41 @@ private extension OrderStoreTests {
                                       discountTax: "0.66")
 
         return [coupon1, coupon2]
+    }
+
+    func sampleOrderTaxLines() -> [Networking.OrderTaxLine] {
+        let tax = OrderTaxLine(taxID: 1330,
+                               rateCode: "US-NY-STATE-2",
+                               rateID: 6,
+                               label: "State",
+                               isCompoundTaxRate: true,
+                               totalTax: "7.71",
+                               totalShippingTax: "0.00",
+                               ratePercent: 4.5,
+                               attributes: [])
+        return [tax]
+    }
+
+    func sampleOrderTaxLinesMutated() -> [Networking.OrderTaxLine] {
+        let tax1 = OrderTaxLine(taxID: 1330,
+                               rateCode: "US-NY-STATE-2",
+                               rateID: 6,
+                               label: "State",
+                               isCompoundTaxRate: true,
+                               totalTax: "55",
+                               totalShippingTax: "0.00",
+                               ratePercent: 5.5,
+                               attributes: [])
+        let tax2 = OrderTaxLine(taxID: 124,
+                                rateCode: "",
+                                rateID: 2,
+                                label: "Central",
+                                isCompoundTaxRate: true,
+                                totalTax: "2.5",
+                                totalShippingTax: "3",
+                                ratePercent: 2.5,
+                                attributes: [])
+        return [tax1, tax2]
     }
 
     func sampleItems() -> [Networking.OrderItem] {

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -927,25 +927,26 @@ private extension OrderStoreTests {
     }
 
     func sampleOrderTaxLinesMutated() -> [Networking.OrderTaxLine] {
-        let tax1 = OrderTaxLine(taxID: 1330,
-                               rateCode: "US-NY-STATE-2",
-                               rateID: 6,
-                               label: "State",
-                               isCompoundTaxRate: true,
-                               totalTax: "55",
-                               totalShippingTax: "0.00",
-                               ratePercent: 5.5,
-                               attributes: [])
-        let tax2 = OrderTaxLine(taxID: 124,
-                                rateCode: "",
-                                rateID: 2,
-                                label: "Central",
-                                isCompoundTaxRate: true,
-                                totalTax: "2.5",
-                                totalShippingTax: "3",
-                                ratePercent: 2.5,
-                                attributes: [])
-        return [tax1, tax2]
+        [
+            .init(taxID: 1330,
+                  rateCode: "US-NY-STATE-2",
+                  rateID: 6,
+                  label: "State",
+                  isCompoundTaxRate: true,
+                  totalTax: "55",
+                  totalShippingTax: "0.00",
+                  ratePercent: 5.5,
+                  attributes: []),
+            .init(taxID: 124,
+                  rateCode: "",
+                  rateID: 2,
+                  label: "Central",
+                  isCompoundTaxRate: true,
+                  totalTax: "2.5",
+                  totalShippingTax: "3",
+                  ratePercent: 2.5,
+                  attributes: [])
+        ]
     }
 
     func sampleItems() -> [Networking.OrderItem] {

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -913,16 +913,17 @@ private extension OrderStoreTests {
     }
 
     func sampleOrderTaxLines() -> [Networking.OrderTaxLine] {
-        let tax = OrderTaxLine(taxID: 1330,
-                               rateCode: "US-NY-STATE-2",
-                               rateID: 6,
-                               label: "State",
-                               isCompoundTaxRate: true,
-                               totalTax: "7.71",
-                               totalShippingTax: "0.00",
-                               ratePercent: 4.5,
-                               attributes: [])
-        return [tax]
+        [
+            .init(taxID: 1330,
+                  rateCode: "US-NY-STATE-2",
+                  rateID: 6,
+                  label: "State",
+                  isCompoundTaxRate: true,
+                  totalTax: "7.71",
+                  totalShippingTax: "0.00",
+                  ratePercent: 4.5,
+                  attributes: [])
+        ]
     }
 
     func sampleOrderTaxLinesMutated() -> [Networking.OrderTaxLine] {

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -434,7 +434,7 @@ private extension ReceiptStoreTests {
               coupons: coupons,
               refunds: [],
               fees: fees,
-              taxes: []) // TODO: 5809 - Add makeOrderTaxLine method
+              taxes: [makeOrderTaxLine(totalTax: totalTax)])
     }
 
     func expectedDiscountLineDescription() -> String {
@@ -473,5 +473,17 @@ private extension ReceiptStoreTests {
                            total: total,
                            totalTax: "",
                            attributes: [])
+    }
+
+    func makeOrderTaxLine(totalTax: String) -> Yosemite.OrderTaxLine {
+        .init(taxID: 123,
+              rateCode: "",
+              rateID: 1,
+              label: "State",
+              isCompoundTaxRate: false,
+              totalTax: totalTax,
+              totalShippingTax: "3",
+              ratePercent: 5.5,
+              attributes: [])
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -434,7 +434,7 @@ private extension ReceiptStoreTests {
               coupons: coupons,
               refunds: [],
               fees: fees,
-              taxes: [makeOrderTaxLine(totalTax: totalTax)])
+              taxes: [makeOrderTaxLine(totalShippingTax: shippingTax, totalTax: totalTax)])
     }
 
     func expectedDiscountLineDescription() -> String {
@@ -475,14 +475,15 @@ private extension ReceiptStoreTests {
                            attributes: [])
     }
 
-    func makeOrderTaxLine(totalTax: String) -> Yosemite.OrderTaxLine {
+    func makeOrderTaxLine(totalShippingTax: String,
+                          totalTax: String) -> Yosemite.OrderTaxLine {
         .init(taxID: 123,
               rateCode: "",
               rateID: 1,
               label: "State",
               isCompoundTaxRate: false,
               totalTax: totalTax,
-              totalShippingTax: "3",
+              totalShippingTax: totalShippingTax,
               ratePercent: 5.5,
               attributes: [])
     }

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -406,7 +406,8 @@ private extension ReceiptStoreTests {
                    totalTax: String = "",
                    items: [Yosemite.OrderItem] = [],
                    coupons: [OrderCouponLine] = [],
-                   fees: [Yosemite.OrderFeeLine] = []) -> Networking.Order {
+                   fees: [Yosemite.OrderFeeLine] = [],
+                   taxes: [Yosemite.OrderTaxLine] = []) -> Networking.Order {
         Order(siteID: 1234,
               orderID: 0,
               parentID: 0,
@@ -434,7 +435,7 @@ private extension ReceiptStoreTests {
               coupons: coupons,
               refunds: [],
               fees: fees,
-              taxes: [makeOrderTaxLine(totalShippingTax: shippingTax, totalTax: totalTax)])
+              taxes: taxes)
     }
 
     func expectedDiscountLineDescription() -> String {
@@ -473,18 +474,5 @@ private extension ReceiptStoreTests {
                            total: total,
                            totalTax: "",
                            attributes: [])
-    }
-
-    func makeOrderTaxLine(totalShippingTax: String,
-                          totalTax: String) -> Yosemite.OrderTaxLine {
-        .init(taxID: 123,
-              rateCode: "",
-              rateID: 1,
-              label: "State",
-              isCompoundTaxRate: false,
-              totalTax: totalTax,
-              totalShippingTax: totalShippingTax,
-              ratePercent: 5.5,
-              attributes: [])
     }
 }

--- a/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
@@ -556,7 +556,7 @@ private extension RefundStoreTests {
             coupons: [],
             refunds: [],
             fees: [],
-            taxes: [] // TODO: 5809 - Add sampleOrderTaxLines method
+            taxes: []
         )
     }
 


### PR DESCRIPTION
Part of #5809

### Description
Part of the work of removing on-device tax calculation and displaying tax breakup details in Simple payments.

This PR aims to add support for `tax_lines` in Yosemite.

#### Changes
- Add `OrderTaxLine+ReadOnlyConvertible` to convert core data managed object instance into read only instance.
- Add `OrderTaxLine` to `Model.swift` file. 
- Add `handleOrderTaxes` to `OrdersUpsertUseCase` to cover upserting tax lines of order.
- Add tests to `OrdersUpsertUseCaseTests` to validate tax lines upsert behaviour.
- Update tests in `OrderStoreTests` to validate mutation and deletion behaviour of tax lines in `Order`.
- Introduce `makeOrderTaxLine` method to the files `ReceiptStoreTests` and `MockOrders`, to generate mock `Order` with tax lines.

### Testing
- Run the app and make sure that Orders are loading properly.

### Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
