### PR TITLE
Refactor store stats data / empty state UI and always show the stats views

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsV4PeriodViewController.swift
@@ -147,7 +147,11 @@ final class OldStoreStatsV4PeriodViewController: UIViewController {
                                                              roundSmallNumbers: false) ?? String()
     }
 
-    private lazy var visitorsEmptyView = StoreStatsSiteVisitEmptyView()
+    private lazy var visitorsEmptyView: StoreStatsEmptyView = {
+        let emptyView = StoreStatsEmptyView()
+        emptyView.showJetpackImage = true
+        return emptyView
+    }()
     // MARK: - Initialization
 
     /// Designated Initializer

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
@@ -1,0 +1,157 @@
+import Combine
+import Foundation
+import UIKit
+
+/// Shows either a data label for store stats (e.g. order/visitor/conversion stats), or a redacted view when data are unavailable.
+final class StoreStatsDataOrRedactedView: UIView {
+    /// State of store stats data UI.
+    enum State {
+        /// Store stats data are available, and a label is shown.
+        case data
+        /// Store stats data are unavailable, and a redacted view is shown.
+        case redacted
+        /// Store stats data are unavailable due to Jetpack-the-plugin, and a redacted view with Jetpack logo is shown.
+        case redactedDueToJetpack
+    }
+
+    @Published var state: State = .data
+    @Published var data: String?
+    @Published var isHighlighted: Bool = false
+
+    private let dataLabel = UILabel()
+    private let redactedView = StoreStatsEmptyView()
+    private let stackView: UIStackView
+
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init() {
+        stackView = UIStackView(arrangedSubviews: [dataLabel, redactedView])
+        super.init(frame: .zero)
+
+        configureView()
+        configureDataLabel()
+        observeStateForUIUpdates()
+        observeIsHighlightedForLabelTextColor()
+        observeDataForLabelText()
+    }
+
+    required convenience init?(coder: NSCoder) {
+        self.init()
+    }
+}
+
+private extension StoreStatsDataOrRedactedView {
+    func configureView() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        pinSubviewToAllEdges(stackView)
+    }
+
+    func configureDataLabel() {
+        dataLabel.font = Constants.statsFont
+        dataLabel.textColor = Constants.statsTextColor
+    }
+}
+
+private extension StoreStatsDataOrRedactedView {
+    func observeStateForUIUpdates() {
+        $state.sink { [weak self] state in
+            self?.updateUI(state: state)
+        }.store(in: &subscriptions)
+    }
+
+    func updateUI(state: State) {
+        let isDataLabelShown = state == .data
+        dataLabel.isHidden = isDataLabelShown == false
+        redactedView.isHidden = !dataLabel.isHidden
+        switch state {
+        case .redacted, .redactedDueToJetpack:
+            redactedView.showJetpackImage = state == .redactedDueToJetpack
+        default:
+            break
+        }
+    }
+
+    func observeDataForLabelText() {
+        $data.sink { [weak self] data in
+            self?.dataLabel.text = data
+        }.store(in: &subscriptions)
+    }
+
+    func observeIsHighlightedForLabelTextColor() {
+        $isHighlighted.sink { [weak self] isHighlighted in
+            self?.dataLabel.textColor = isHighlighted ? Constants.statsHighlightTextColor: Constants.statsTextColor
+        }.store(in: &subscriptions)
+    }
+}
+
+private extension StoreStatsDataOrRedactedView {
+    enum Constants {
+        static let statsTextColor: UIColor = .text
+        static let statsHighlightTextColor: UIColor = .accent
+        static let statsFont: UIFont = .font(forStyle: .title3, weight: .semibold)
+    }
+}
+
+#if canImport(SwiftUI) && DEBUG
+
+import SwiftUI
+
+private struct StoreStatsDataOrRedactedViewRepresentable: UIViewRepresentable {
+    private let state: StoreStatsDataOrRedactedView.State
+    private let isHighlighted: Bool
+    private let data: String?
+
+    init(state: StoreStatsDataOrRedactedView.State, isHighlighted: Bool = false, data: String? = nil) {
+        self.state = state
+        self.isHighlighted = isHighlighted
+        self.data = data
+    }
+
+    func makeUIView(context: Context) -> StoreStatsDataOrRedactedView {
+        let view = StoreStatsDataOrRedactedView()
+        view.state = state
+        view.isHighlighted = isHighlighted
+        view.data = data
+        return view
+    }
+
+    func updateUIView(_ uiView: StoreStatsDataOrRedactedView, context: Context) {
+        uiView.state = state
+        uiView.isHighlighted = isHighlighted
+        uiView.data = data
+    }
+}
+
+struct StoreStatsDataOrRedactedView_Previews: PreviewProvider {
+    private static func makeStack() -> some View {
+        VStack {
+            StoreStatsDataOrRedactedViewRepresentable(state: .data, isHighlighted: false, data: "$32.5")
+            StoreStatsDataOrRedactedViewRepresentable(state: .redacted)
+            StoreStatsDataOrRedactedViewRepresentable(state: .redactedDueToJetpack, isHighlighted: false)
+        }
+        .background(Color(UIColor.systemBackground))
+    }
+
+    static var previews: some View {
+        Group {
+            makeStack()
+                .previewLayout(.fixed(width: 100, height: 150))
+                .previewDisplayName("Light")
+
+            makeStack()
+                .previewLayout(.fixed(width: 100, height: 150))
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark")
+
+            makeStack()
+                .previewLayout(.fixed(width: 100, height: 400))
+                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+                .previewDisplayName("Large Font")
+        }
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
@@ -95,7 +95,7 @@ private extension StoreStatsDataOrRedactedView {
     }
 }
 
-#if canImport(SwiftUI) && DEBUG
+#if DEBUG
 
 import SwiftUI
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsEmptyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsEmptyView.swift
@@ -39,17 +39,31 @@ final class StoreStatsEmptyView: UIView {
         addSubview(emptyView)
         addSubview(jetpackImageView)
 
-        NSLayoutConstraint.activate([
-            self.widthAnchor.constraint(equalToConstant: 48),
-            emptyView.widthAnchor.constraint(equalToConstant: 32),
-            emptyView.heightAnchor.constraint(equalToConstant: 10),
-            emptyView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            emptyView.topAnchor.constraint(equalTo: jetpackImageView.bottomAnchor),
-            jetpackImageView.widthAnchor.constraint(equalToConstant: 14),
-            jetpackImageView.heightAnchor.constraint(equalToConstant: 14),
-            jetpackImageView.leadingAnchor.constraint(equalTo: emptyView.trailingAnchor),
-            jetpackImageView.topAnchor.constraint(equalTo: self.topAnchor, constant: 4)
-        ])
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) {
+            NSLayoutConstraint.activate([
+                emptyView.widthAnchor.constraint(equalToConstant: 32),
+                emptyView.heightAnchor.constraint(equalToConstant: 10),
+                emptyView.centerXAnchor.constraint(equalTo: centerXAnchor),
+                emptyView.centerYAnchor.constraint(equalTo: centerYAnchor),
+                jetpackImageView.widthAnchor.constraint(equalToConstant: 14),
+                jetpackImageView.heightAnchor.constraint(equalToConstant: 14),
+                jetpackImageView.leadingAnchor.constraint(equalTo: emptyView.trailingAnchor, constant: 2),
+                jetpackImageView.bottomAnchor.constraint(equalTo: emptyView.topAnchor),
+                jetpackImageView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 0)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                widthAnchor.constraint(equalToConstant: 48),
+                emptyView.widthAnchor.constraint(equalToConstant: 32),
+                emptyView.heightAnchor.constraint(equalToConstant: 10),
+                emptyView.centerXAnchor.constraint(equalTo: centerXAnchor),
+                emptyView.topAnchor.constraint(equalTo: jetpackImageView.bottomAnchor),
+                jetpackImageView.widthAnchor.constraint(equalToConstant: 14),
+                jetpackImageView.heightAnchor.constraint(equalToConstant: 14),
+                jetpackImageView.leadingAnchor.constraint(equalTo: emptyView.trailingAnchor),
+                jetpackImageView.topAnchor.constraint(equalTo: topAnchor, constant: 4)
+            ])
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsEmptyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsEmptyView.swift
@@ -1,6 +1,15 @@
 import UIKit
 
-final class StoreStatsSiteVisitEmptyView: UIView {
+final class StoreStatsEmptyView: UIView {
+    /// Whether the Jetpack image is shown to indicate the data are unavailable due to Jetpack-the-plugin.
+    var showJetpackImage: Bool = false {
+        didSet {
+            updateJetpackImageVisibility()
+        }
+    }
+
+    private lazy var jetpackImageView = UIImageView(image: .jetpackLogoImage.withRenderingMode(.alwaysTemplate))
+
     convenience init() {
         self.init(frame: .zero)
     }
@@ -22,10 +31,10 @@ final class StoreStatsSiteVisitEmptyView: UIView {
         emptyView.layer.cornerRadius = 2.0
         emptyView.translatesAutoresizingMaskIntoConstraints = false
 
-        let jetpackImageView = UIImageView(image: .jetpackLogoImage.withRenderingMode(.alwaysTemplate))
         jetpackImageView.contentMode = .scaleAspectFit
         jetpackImageView.tintColor = .jetpackGreen
         jetpackImageView.translatesAutoresizingMaskIntoConstraints = false
+        updateJetpackImageVisibility()
 
         addSubview(emptyView)
         addSubview(jetpackImageView)
@@ -41,5 +50,11 @@ final class StoreStatsSiteVisitEmptyView: UIView {
             jetpackImageView.leadingAnchor.constraint(equalTo: emptyView.trailingAnchor),
             jetpackImageView.topAnchor.constraint(equalTo: self.topAnchor, constant: 4)
         ])
+    }
+}
+
+private extension StoreStatsEmptyView {
+    func updateJetpackImageVisibility() {
+        jetpackImageView.isHidden = showJetpackImage == false
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -47,10 +47,9 @@ final class StoreStatsV4PeriodViewController: UIViewController {
     @IBOutlet private weak var visitorsTitle: UILabel!
     @IBOutlet private weak var visitorsDataOrRedactedView: StoreStatsDataOrRedactedView!
     @IBOutlet private weak var ordersTitle: UILabel!
-    @IBOutlet private weak var ordersData: UILabel!
-    @IBOutlet private weak var conversionStackView: UIStackView!
+    @IBOutlet private weak var ordersDataOrRedactedView: StoreStatsDataOrRedactedView!
     @IBOutlet private weak var conversionTitle: UILabel!
-    @IBOutlet private weak var conversionData: UILabel!
+    @IBOutlet private weak var conversionDataOrRedactedView: StoreStatsDataOrRedactedView!
     @IBOutlet private weak var revenueTitle: UILabel!
     @IBOutlet private weak var revenueData: UILabel!
     @IBOutlet private weak var lineChartView: LineChartView!
@@ -181,7 +180,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
 private extension StoreStatsV4PeriodViewController {
     func observeStatsLabels() {
         viewModel.orderStatsText.sink { [weak self] orderStatsLabel in
-            self?.ordersData.text = orderStatsLabel
+            self?.ordersDataOrRedactedView.data = orderStatsLabel
         }.store(in: &cancellables)
 
         viewModel.revenueStatsText.sink { [weak self] revenueStatsLabel in
@@ -193,18 +192,19 @@ private extension StoreStatsV4PeriodViewController {
         }.store(in: &cancellables)
 
         viewModel.conversionStatsText.sink { [weak self] conversionStatsLabel in
-            self?.conversionData.text = conversionStatsLabel
+            self?.conversionDataOrRedactedView.data = conversionStatsLabel
         }.store(in: &cancellables)
     }
 
     func observeSelectedBarIndex() {
         viewModel.$selectedIntervalIndex.sink { [weak self] selectedIndex in
             guard let self = self else { return }
-            let textColor = selectedIndex == nil ? Constants.statsTextColor: Constants.statsHighlightTextColor
-            self.ordersData.textColor = textColor
-            self.visitorsDataOrRedactedView.isHighlighted = selectedIndex != nil
+            let isHighlighted = selectedIndex != nil
+            let textColor = isHighlighted ? Constants.statsHighlightTextColor: Constants.statsTextColor
+            self.ordersDataOrRedactedView.isHighlighted = isHighlighted
+            self.visitorsDataOrRedactedView.isHighlighted = isHighlighted
+            self.conversionDataOrRedactedView.isHighlighted = isHighlighted
             self.revenueData.textColor = textColor
-            self.conversionData.textColor = textColor
 
             self.updateSiteVisitStatsAndConversionRate(selectedIndex: selectedIndex)
         }.store(in: &cancellables)
@@ -469,15 +469,15 @@ private extension StoreStatsV4PeriodViewController {
     }
 
     func updateConversionStatsVisibility(visitStatsMode: SiteVisitStatsMode) {
-        guard conversionData != nil else {
+        guard conversionDataOrRedactedView != nil else {
             return
         }
 
         switch visitStatsMode {
         case .hidden, .redactedDueToJetpack:
-            conversionStackView.isHidden = true
+            conversionDataOrRedactedView.isHidden = true
         case .default:
-            conversionStackView.isHidden = false
+            conversionDataOrRedactedView.isHidden = false
         }
     }
 }
@@ -593,13 +593,13 @@ private extension StoreStatsV4PeriodViewController {
         reloadChart(animateChart: animateChart)
 
         view.accessibilityElements = [ordersTitle as Any,
-                                      ordersData as Any,
+                                      ordersDataOrRedactedView as Any,
                                       visitorsTitle as Any,
                                       visitorsDataOrRedactedView as Any,
                                       revenueTitle as Any,
                                       revenueData as Any,
                                       conversionTitle as Any,
-                                      conversionData as Any,
+                                      conversionDataOrRedactedView as Any,
                                       yAxisAccessibilityView as Any,
                                       xAxisAccessibilityView as Any,
                                       chartAccessibilityView as Any]
@@ -697,10 +697,6 @@ private extension StoreStatsV4PeriodViewController {
     }
 
     func updateStatsDataToDefaultStyles() {
-        [ordersData, conversionData].forEach { label in
-            label?.font = Constants.statsFont
-            label?.textColor = Constants.statsTextColor
-        }
         revenueData.font = Constants.revenueFont
         revenueData.textColor = Constants.statsTextColor
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -588,10 +588,6 @@ private extension StoreStatsV4PeriodViewController {
     }
 
     func reloadSiteVisitUI() {
-        guard visitorsDataOrRedactedView != nil else {
-            return
-        }
-
         switch siteVisitStatsMode {
         case .hidden:
             visitorsDataOrRedactedView.state = .redacted

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -23,7 +23,6 @@ final class StoreStatsV4PeriodViewController: UIViewController {
     var siteVisitStatsMode: SiteVisitStatsMode = .default {
         didSet {
             updateSiteVisitStats(mode: siteVisitStatsMode)
-            updateConversionStatsVisibility(visitStatsMode: siteVisitStatsMode)
         }
     }
 
@@ -304,7 +303,6 @@ private extension StoreStatsV4PeriodViewController {
 
         // Visibility
         updateSiteVisitStats(mode: siteVisitStatsMode)
-        updateConversionStatsVisibility(visitStatsMode: siteVisitStatsMode)
 
         // Accessibility elements
         xAxisAccessibilityView.isAccessibilityElement = true
@@ -407,7 +405,6 @@ private extension StoreStatsV4PeriodViewController {
 private extension StoreStatsV4PeriodViewController {
     func updateSiteVisitStats(mode: SiteVisitStatsMode) {
         reloadSiteVisitUI()
-        updateConversionStatsVisibility(visitStatsMode: mode)
     }
 }
 
@@ -451,7 +448,6 @@ private extension StoreStatsV4PeriodViewController {
         }
 
         updateSiteVisitStats(mode: mode)
-        updateConversionStatsVisibility(visitStatsMode: mode)
 
         switch siteVisitStatsMode {
         case .hidden, .redactedDueToJetpack:
@@ -465,19 +461,6 @@ private extension StoreStatsV4PeriodViewController {
                 return
             }
             visitorsDataOrRedactedView.state = .data
-        }
-    }
-
-    func updateConversionStatsVisibility(visitStatsMode: SiteVisitStatsMode) {
-        guard conversionDataOrRedactedView != nil else {
-            return
-        }
-
-        switch visitStatsMode {
-        case .hidden, .redactedDueToJetpack:
-            conversionDataOrRedactedView.isHidden = true
-        case .default:
-            conversionDataOrRedactedView.isHidden = false
         }
     }
 }
@@ -589,7 +572,6 @@ private extension StoreStatsV4PeriodViewController {
     func reloadAllFields(animateChart: Bool = true) {
         viewModel.selectedIntervalIndex = nil
         reloadSiteVisitUI()
-        updateConversionStatsVisibility(visitStatsMode: siteVisitStatsMode)
         reloadChart(animateChart: animateChart)
 
         view.accessibilityElements = [ordersTitle as Any,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -14,20 +14,18 @@
             <connections>
                 <outlet property="chartAccessibilityView" destination="NEo-bw-gS4" id="Ep1-tI-L3J"/>
                 <outlet property="containerStackView" destination="0he-5g-kXa" id="ni7-uB-XHh"/>
-                <outlet property="conversionData" destination="ukd-qU-WVq" id="7gQ-1E-zCN"/>
-                <outlet property="conversionStackView" destination="EqQ-GQ-06J" id="zT6-NT-JiG"/>
+                <outlet property="conversionDataOrRedactedView" destination="IWE-Kh-JF2" id="gdN-hN-du3"/>
                 <outlet property="conversionTitle" destination="Sam-pk-BxI" id="HI1-z6-dRL"/>
                 <outlet property="lineChartView" destination="zPE-Y0-ax8" id="3VU-s1-JmV"/>
                 <outlet property="noRevenueLabel" destination="5uh-zy-gDZ" id="ZRx-lP-Af2"/>
                 <outlet property="noRevenueView" destination="fg2-ey-bVn" id="LBf-aq-yXB"/>
-                <outlet property="ordersData" destination="6HA-Qe-PkT" id="zOF-dV-3LN"/>
+                <outlet property="ordersDataOrRedactedView" destination="Zw1-qY-9uU" id="jUj-Cc-JG6"/>
                 <outlet property="ordersTitle" destination="vlW-do-oXj" id="zdd-DS-zvJ"/>
                 <outlet property="revenueData" destination="5id-es-0m9" id="TVm-45-zgI"/>
                 <outlet property="revenueTitle" destination="L2i-fw-est" id="1P0-nO-D5E"/>
                 <outlet property="timeRangeBarView" destination="8nR-qE-vPw" id="vbk-sJ-3jq"/>
                 <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
                 <outlet property="visitorsDataOrRedactedView" destination="Afo-HD-3TZ" id="7p2-EZ-KAi"/>
-                <outlet property="visitorsStackView" destination="e8D-G2-abm" id="4R3-bN-edz"/>
                 <outlet property="visitorsTitle" destination="rHw-ak-fRR" id="VJk-10-Z09"/>
                 <outlet property="xAxisAccessibilityView" destination="TTF-Fx-NHe" id="cdX-lJ-DWe"/>
                 <outlet property="yAxisAccessibilityView" destination="yvj-Kj-G3f" id="MRf-C4-jUk"/>
@@ -71,10 +69,10 @@
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
-                            <rect key="frame" x="0.0" y="128" width="375" height="120.5"/>
+                            <rect key="frame" x="0.0" y="128" width="375" height="121.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="g0M-FH-Icp">
-                                    <rect key="frame" x="0.0" y="0.0" width="125.5" height="120.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="125.5" height="121.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6wR-bB-SUi">
                                             <rect key="frame" x="25.5" y="0.0" width="75" height="13"/>
@@ -83,20 +81,21 @@
                                                 <constraint firstAttribute="height" constant="13" id="aSe-hj-qIc"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6HA-Qe-PkT">
-                                            <rect key="frame" x="57.5" y="20" width="11" height="30"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                        <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Zw1-qY-9uU" customClass="StoreStatsDataOrRedactedView" customModule="WooCommerce" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="20" width="125.5" height="50"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="50" placeholder="YES" id="wIi-cu-IWQ"/>
+                                            </constraints>
+                                        </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Orders" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vlW-do-oXj">
-                                            <rect key="frame" x="43.5" y="57" width="39" height="33.5"/>
+                                            <rect key="frame" x="43.5" y="77" width="39" height="14.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZS1-zJ-gIn">
-                                            <rect key="frame" x="25.5" y="97.5" width="75" height="23"/>
+                                            <rect key="frame" x="25.5" y="98.5" width="75" height="23"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="23" id="lpG-gr-MtT"/>
@@ -105,7 +104,7 @@
                                     </subviews>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="e8D-G2-abm">
-                                    <rect key="frame" x="124.5" y="0.0" width="126" height="120.5"/>
+                                    <rect key="frame" x="124.5" y="0.0" width="126" height="121.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gN3-Vd-CTd">
                                             <rect key="frame" x="25.5" y="0.0" width="75" height="13"/>
@@ -115,17 +114,17 @@
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Afo-HD-3TZ" customClass="StoreStatsDataOrRedactedView" customModule="WooCommerce" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="20" width="126" height="49"/>
+                                            <rect key="frame" x="0.0" y="20" width="126" height="50"/>
                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Visitors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rHw-ak-fRR">
-                                            <rect key="frame" x="42" y="76" width="42.5" height="14.5"/>
+                                            <rect key="frame" x="42" y="77" width="42.5" height="14.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NaX-4V-XP2">
-                                            <rect key="frame" x="16" y="97.5" width="94" height="23"/>
+                                            <rect key="frame" x="16" y="98.5" width="94" height="23"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="23" id="Ekr-OV-et5"/>
@@ -134,7 +133,7 @@
                                     </subviews>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="EqQ-GQ-06J">
-                                    <rect key="frame" x="249.5" y="0.0" width="125.5" height="120.5"/>
+                                    <rect key="frame" x="249.5" y="0.0" width="125.5" height="121.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Qe-3G-aXj">
                                             <rect key="frame" x="25" y="0.0" width="75" height="13"/>
@@ -143,20 +142,18 @@
                                                 <constraint firstAttribute="height" constant="13" id="GMI-hJ-Sxq"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ukd-qU-WVq">
-                                            <rect key="frame" x="57" y="20" width="11" height="49"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IWE-Kh-JF2" customClass="StoreStatsDataOrRedactedView" customModule="WooCommerce" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="20" width="125.5" height="50"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Conversion" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sam-pk-BxI">
-                                            <rect key="frame" x="31" y="76" width="63.5" height="14.5"/>
+                                            <rect key="frame" x="31" y="77" width="63.5" height="14.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B7G-os-a7y">
-                                            <rect key="frame" x="25" y="97.5" width="75" height="23"/>
+                                            <rect key="frame" x="25" y="98.5" width="75" height="23"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="23" id="J5a-Si-2T4"/>
@@ -168,38 +165,38 @@
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
-                            <rect key="frame" x="0.0" y="248.5" width="375" height="393.5"/>
+                            <rect key="frame" x="0.0" y="249.5" width="375" height="392.5"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
-                                    <rect key="frame" x="0.0" y="0.0" width="14" height="393.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="14" height="392.5"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="14" id="a3T-HU-g4E"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="LineChartView" customModule="Charts">
-                                    <rect key="frame" x="14" y="0.0" width="347" height="393.5"/>
+                                    <rect key="frame" x="14" y="0.0" width="347" height="392.5"/>
                                     <subviews>
                                         <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">
-                                            <rect key="frame" x="0.0" y="8" width="32" height="369.5"/>
+                                            <rect key="frame" x="0.0" y="8" width="32" height="368.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="32" id="sUS-FA-4ab"/>
                                             </constraints>
                                         </view>
                                         <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe">
-                                            <rect key="frame" x="0.0" y="377.5" width="347" height="16"/>
+                                            <rect key="frame" x="0.0" y="376.5" width="347" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="feO-ed-bxp"/>
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NEo-bw-gS4">
-                                            <rect key="frame" x="40" y="8" width="307" height="369.5"/>
+                                            <rect key="frame" x="40" y="8" width="307" height="368.5"/>
                                             <accessibility key="accessibilityConfiguration">
                                                 <accessibilityTraits key="traits" notEnabled="YES"/>
                                             </accessibility>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fg2-ey-bVn" userLabel="Empty data view">
-                                            <rect key="frame" x="153" y="177.5" width="41.5" height="38.5"/>
+                                            <rect key="frame" x="153" y="177" width="41.5" height="38.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5uh-zy-gDZ">
                                                     <rect key="frame" x="0.0" y="9" width="41.5" height="20.5"/>
@@ -235,7 +232,7 @@
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
-                                    <rect key="frame" x="361" y="0.0" width="14" height="393.5"/>
+                                    <rect key="frame" x="361" y="0.0" width="14" height="392.5"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="14" id="KRJ-Jf-3tM"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -6,6 +6,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,7 +26,7 @@
                 <outlet property="revenueTitle" destination="L2i-fw-est" id="1P0-nO-D5E"/>
                 <outlet property="timeRangeBarView" destination="8nR-qE-vPw" id="vbk-sJ-3jq"/>
                 <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
-                <outlet property="visitorsData" destination="SZF-f7-8Va" id="ZY0-s6-PDq"/>
+                <outlet property="visitorsDataOrRedactedView" destination="Afo-HD-3TZ" id="7p2-EZ-KAi"/>
                 <outlet property="visitorsStackView" destination="e8D-G2-abm" id="4R3-bN-edz"/>
                 <outlet property="visitorsTitle" destination="rHw-ak-fRR" id="VJk-10-Z09"/>
                 <outlet property="xAxisAccessibilityView" destination="TTF-Fx-NHe" id="cdX-lJ-DWe"/>
@@ -48,19 +49,19 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="15r-Bq-Hy6">
-                            <rect key="frame" x="0.0" y="50" width="375" height="97"/>
+                            <rect key="frame" x="0.0" y="50" width="375" height="78"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="VzI-74-cyb">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="97"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="78"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5id-es-0m9" userLabel="-">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="37"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Revenue" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L2i-fw-est" userLabel="Revenue">
-                                            <rect key="frame" x="0.0" y="60" width="375" height="37"/>
+                                            <rect key="frame" x="0.0" y="41" width="375" height="37"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -70,10 +71,10 @@
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
-                            <rect key="frame" x="0.0" y="147" width="375" height="101.5"/>
+                            <rect key="frame" x="0.0" y="128" width="375" height="120.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="g0M-FH-Icp">
-                                    <rect key="frame" x="0.0" y="0.0" width="125.5" height="101.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="125.5" height="120.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6wR-bB-SUi">
                                             <rect key="frame" x="25.5" y="0.0" width="75" height="13"/>
@@ -89,13 +90,13 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Orders" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vlW-do-oXj">
-                                            <rect key="frame" x="43.5" y="57" width="39" height="14.5"/>
+                                            <rect key="frame" x="43.5" y="57" width="39" height="33.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZS1-zJ-gIn">
-                                            <rect key="frame" x="25.5" y="78.5" width="75" height="23"/>
+                                            <rect key="frame" x="25.5" y="97.5" width="75" height="23"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="23" id="lpG-gr-MtT"/>
@@ -104,7 +105,7 @@
                                     </subviews>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="e8D-G2-abm">
-                                    <rect key="frame" x="124.5" y="0.0" width="126" height="101.5"/>
+                                    <rect key="frame" x="124.5" y="0.0" width="126" height="120.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gN3-Vd-CTd">
                                             <rect key="frame" x="25.5" y="0.0" width="75" height="13"/>
@@ -113,20 +114,18 @@
                                                 <constraint firstAttribute="height" constant="13" id="Tc1-gQ-pfk"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SZF-f7-8Va">
-                                            <rect key="frame" x="57.5" y="20" width="11" height="30"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Afo-HD-3TZ" customClass="StoreStatsDataOrRedactedView" customModule="WooCommerce" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="20" width="126" height="49"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Visitors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rHw-ak-fRR">
-                                            <rect key="frame" x="42" y="57" width="42.5" height="14.5"/>
+                                            <rect key="frame" x="42" y="76" width="42.5" height="14.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NaX-4V-XP2">
-                                            <rect key="frame" x="16" y="78.5" width="94" height="23"/>
+                                            <rect key="frame" x="16" y="97.5" width="94" height="23"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="23" id="Ekr-OV-et5"/>
@@ -135,7 +134,7 @@
                                     </subviews>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="EqQ-GQ-06J">
-                                    <rect key="frame" x="249.5" y="0.0" width="125.5" height="101.5"/>
+                                    <rect key="frame" x="249.5" y="0.0" width="125.5" height="120.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Qe-3G-aXj">
                                             <rect key="frame" x="25" y="0.0" width="75" height="13"/>
@@ -145,19 +144,19 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ukd-qU-WVq">
-                                            <rect key="frame" x="57" y="20" width="11" height="30"/>
+                                            <rect key="frame" x="57" y="20" width="11" height="49"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Conversion" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sam-pk-BxI">
-                                            <rect key="frame" x="31" y="57" width="63.5" height="14.5"/>
+                                            <rect key="frame" x="31" y="76" width="63.5" height="14.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B7G-os-a7y">
-                                            <rect key="frame" x="25" y="78.5" width="75" height="23"/>
+                                            <rect key="frame" x="25" y="97.5" width="75" height="23"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="23" id="J5a-Si-2T4"/>
@@ -270,5 +269,8 @@
         <namedColor name="Orange40">
             <color red="0.83921568627450982" green="0.46666666666666667" blue="0.035294117647058823" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */; };
 		0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */; };
 		0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */; };
+		020624F027951113000D024C /* StoreStatsDataOrRedactedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */; };
 		0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206483923FA4160008441BB /* OrdersRootViewController.swift */; };
 		02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */; };
 		020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020886562499E642001D784E /* ProductExternalLinkViewController.swift */; };
@@ -1487,7 +1488,7 @@
 		DEC51B00276AEE91009F3DF4 /* SystemStatusReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AFF276AEE91009F3DF4 /* SystemStatusReportViewModel.swift */; };
 		DEC51B04276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B03276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift */; };
 		DEC51B06276B3F3C009F3DF4 /* Int64+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B05276B3F3C009F3DF4 /* Int64+Helpers.swift */; };
-		DEC6C51827466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51727466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift */; };
+		DEC6C51827466B59006832D3 /* StoreStatsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51727466B59006832D3 /* StoreStatsEmptyView.swift */; };
 		DEC6C51A2747758D006832D3 /* JetpackInstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C5192747758D006832D3 /* JetpackInstallView.swift */; };
 		DEC6C51C27477890006832D3 /* JetpackInstallStepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51B27477890006832D3 /* JetpackInstallStepsView.swift */; };
 		DEC6C51E27479280006832D3 /* JetpackInstallSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6C51D27479280006832D3 /* JetpackInstallSteps.swift */; };
@@ -1627,6 +1628,7 @@
 		0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsTabProductViewModel+ProductVariation.swift"; sourceTree = "<group>"; };
 		0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooTab+Tag.swift"; sourceTree = "<group>"; };
 		0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Order.swift"; sourceTree = "<group>"; };
+		020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsDataOrRedactedView.swift; sourceTree = "<group>"; };
 		0206483923FA4160008441BB /* OrdersRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRootViewController.swift; sourceTree = "<group>"; };
 		02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+ReadonlyProductTests.swift"; sourceTree = "<group>"; };
 		020886562499E642001D784E /* ProductExternalLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductExternalLinkViewController.swift; sourceTree = "<group>"; };
@@ -3094,7 +3096,7 @@
 		DEC51AFF276AEE91009F3DF4 /* SystemStatusReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusReportViewModel.swift; sourceTree = "<group>"; };
 		DEC51B03276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusReportViewModelTests.swift; sourceTree = "<group>"; };
 		DEC51B05276B3F3C009F3DF4 /* Int64+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int64+Helpers.swift"; sourceTree = "<group>"; };
-		DEC6C51727466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsSiteVisitEmptyView.swift; sourceTree = "<group>"; };
+		DEC6C51727466B59006832D3 /* StoreStatsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsEmptyView.swift; sourceTree = "<group>"; };
 		DEC6C5192747758D006832D3 /* JetpackInstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallView.swift; sourceTree = "<group>"; };
 		DEC6C51B27477890006832D3 /* JetpackInstallStepsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepsView.swift; sourceTree = "<group>"; };
 		DEC6C51D27479280006832D3 /* JetpackInstallSteps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallSteps.swift; sourceTree = "<group>"; };
@@ -3898,8 +3900,9 @@
 				02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */,
 				0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */,
 				5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */,
-				DEC6C51727466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift */,
+				DEC6C51727466B59006832D3 /* StoreStatsEmptyView.swift */,
 				579CDEFE274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift */,
+				020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */,
 			);
 			path = "Stats v4";
 			sourceTree = "<group>";
@@ -8115,7 +8118,7 @@
 				7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */,
 				CC53FB3C2757EC7200C4CA4F /* AddProductToOrderViewModel.swift in Sources */,
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,
-				DEC6C51827466B59006832D3 /* StoreStatsSiteVisitEmptyView.swift in Sources */,
+				DEC6C51827466B59006832D3 /* StoreStatsEmptyView.swift in Sources */,
 				31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */,
 				02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */,
 				E11228BE2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift in Sources */,
@@ -8898,6 +8901,7 @@
 				57A25C7625ACE9BC00A54A62 /* OrderFulfillmentUseCase.swift in Sources */,
 				262C922126F1370000011F92 /* StorePickerError.swift in Sources */,
 				4515C89825D6C00E0099C8E3 /* ShippingLabelAddressFormViewModel.swift in Sources */,
+				020624F027951113000D024C /* StoreStatsDataOrRedactedView.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
 				0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */,
 				B53B898D20D462A000EDB467 /* DefaultStoresManager.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Based on the design decision in this thread p1642555588011500/1639990681.280100-slack-CGPNUU63E, we now always show the visitor/order/conversion stats. In addition, when visitor stats are unavailable due to Jetpack or API reasons, we are introducing the third state of stats view - redacted (without the Jetpack logo). The redacted states apply to not only visitor stats, but also conversion stats. Before making the final design changes, I decided to refactor the stats views with a new view class `StoreStatsDataOrRedactedView` to encapsulate the "data or redacted" states. `StoreStatsDataOrRedactedView` now has three states: `data`, `redacted`, and `redactedDueToJetpack`.

The original `StoreStatsSiteVisitEmptyView` for the visitor stats empty state was renamed to `StoreStatsEmptyView` with two changes:
- `showJetpackImage: Bool` is set to show the Jetpack logo or not
- Auto Layout constraints are updated when the `myStoreTabUpdates` feature flag is enabled

Finally, `StoreStatsV4PeriodViewController` was updated to use `StoreStatsDataOrRedactedView` for the order/visitor/conversion stats. The updates on visitor and conversion stats states will be in a future PR due to the PR size.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The only visual change should be showing visitor and conversion stats all the time.

Prerequisite: the site has at least one order today
- Launch the app --> all stats should be shown
- Select an hour in the Today tab --> all stats should be shown

- [x] @jaclync tests JCP sites: all stats should be shown where the visitor stats still show the redacted state with a Jetpack logo

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

JCP site | today tab - selected | today tab
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2022-01-20 at 16 00 54](https://user-images.githubusercontent.com/1945542/150297378-f5c71568-bb95-413c-8d54-8082256e5e6b.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-20 at 16 01 13](https://user-images.githubusercontent.com/1945542/150297384-35baede8-5ecf-4f9f-925b-ed6ad5550748.png) | ![Simulator Screen Shot - iPhone 11 - 2022-01-20 at 16 01 18](https://user-images.githubusercontent.com/1945542/150297391-5efe0fdd-9ed8-44a7-8666-4d136ee80ff1.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->