### PR TITLE
Check for when Stripe is installed but not active

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
@@ -52,7 +52,7 @@ final class CardPresentModalFoundReader: CardPresentPaymentsModalViewModel {
 private extension CardPresentModalFoundReader {
     enum Localization {
         static let title = NSLocalizedString(
-            "Do you want to connect to reader %@?",
+            "Do you want to connect to reader %1$@?",
             comment: "Dialog title that displays the name of a found card reader"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -35,8 +35,8 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsPluginNotInstalled(onRefresh: viewModel.refresh)
             case .pluginUnsupportedVersion(let plugin):
                 InPersonPaymentsPluginNotSupportedVersion(plugin: plugin, onRefresh: viewModel.refresh)
-            case .pluginNotActivated:
-                InPersonPaymentsPluginNotActivated(onRefresh: viewModel.refresh)
+            case .pluginNotActivated(let plugin):
+                InPersonPaymentsPluginNotActivated(plugin: plugin, onRefresh: viewModel.refresh)
             case .pluginInTestModeWithLiveStripeAccount:
                 InPersonPaymentsLiveSiteInTestMode(onRefresh:
                     viewModel.refresh)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -27,7 +27,7 @@ struct InPersonPaymentsCountryNotSupported: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "We don’t support In-Person Payments in %@",
+        "We don’t support In-Person Payments in %1$@",
         comment: "Title for the error screen when WooCommerce Payments is not supported in a specific country"
     )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 struct InPersonPaymentsOnboardingError: View {
     let title: String
@@ -74,6 +75,17 @@ struct InPersonPaymentsOnboardingError: View {
                 }
             }.multilineTextAlignment(.center)
             .frame(maxWidth: 500)
+        }
+    }
+}
+
+extension CardPresentPaymentsPlugins {
+    public var image: UIImage {
+        switch self {
+        case .wcPay:
+            return .wcPayPlugin
+        case .stripe:
+            return .stripePlugin
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
+import Yosemite
 
 struct InPersonPaymentsPluginNotActivated: View {
+    let plugin: CardPresentPaymentsPlugins
     let onRefresh: () -> Void
 
     var body: some View {
         InPersonPaymentsOnboardingError(
-            title: Localization.title,
-            message: Localization.message,
+            title: String(format: Localization.title, plugin.pluginName),
+            message: String(format: Localization.message, plugin.pluginName),
             image: InPersonPaymentsOnboardingError.ImageInfo(
-                image: .wcPayPlugin,
+                image: plugin.image,
                 height: 108.0
             ),
             supportLink: false,
@@ -23,23 +25,23 @@ struct InPersonPaymentsPluginNotActivated: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "Activate WooCommerce Payments",
-        comment: "Title for the error screen when WooCommerce Payments is installed but not activated"
+        "Activate %@",
+        comment: "Title for the error screen when a Card Present Payments extension is installed but not activated"
     )
 
     static let message = NSLocalizedString(
-        "The WooCommerce Payments extension is installed on your store but not activated. Please activate it to accept In-Person Payments",
-        comment: "Error message when WooCommerce Payments is not activated"
+        "The %@ extension is installed on your store but not activated. Please activate it to accept In-Person Payments",
+        comment: "Error message when a Card Present Payments extension is not activated"
     )
 
     static let primaryButton = NSLocalizedString(
         "Refresh After Activating",
-        comment: "Button to reload plugin data after activating the WooCommerce Payments plugin"
+        comment: "Button to reload plugin data after activating a Card Present Payments extension"
     )
 }
 
 struct InPersonPaymentsPluginNotActivated_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotActivated(onRefresh: {})
+        InPersonPaymentsPluginNotActivated(plugin: .wcPay, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -25,12 +25,12 @@ struct InPersonPaymentsPluginNotActivated: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "Activate %@",
+        "Activate %1$@",
         comment: "Title for the error screen when a Card Present Payments extension is installed but not activated"
     )
 
     static let message = NSLocalizedString(
-        "The %@ extension is installed on your store but not activated. Please activate it to accept In-Person Payments",
+        "The %1$@ extension is installed on your store but not activated. Please activate it to accept In-Person Payments",
         comment: "Error message when a Card Present Payments extension is not activated"
     )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -25,12 +25,12 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "Unsupported %@ version",
+        "Unsupported %1$@ version",
         comment: "Title for the error screen when the installed version of a Card Present Payments extension is unsupported"
     )
 
     static let message = NSLocalizedString(
-        "The %@ extension is installed on your store, but needs to be updated for In-Person Payments. "
+        "The %1$@ extension is installed on your store, but needs to be updated for In-Person Payments. "
             + "Please update it to the most recent version.",
         comment: "Error message when a Card Present Payments extension is installed but the version is not supported"
     )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -10,7 +10,7 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
             title: String(format: Localization.title, plugin.pluginName),
             message: String(format: Localization.message, plugin.pluginName),
             image: InPersonPaymentsOnboardingError.ImageInfo(
-                image: image,
+                image: plugin.image,
                 height: 108.0
             ),
             supportLink: false,
@@ -20,15 +20,6 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
                 action: onRefresh
             )
         )
-    }
-
-    var image: UIImage {
-        switch plugin {
-        case .wcPay:
-            return .wcPayPlugin
-        case .stripe:
-            return .stripePlugin
-        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -947,8 +947,6 @@
 		800A5BC7275889ED009DE2CD /* reports_revenue_stats_month.json in Resources */ = {isa = PBXBuildFile; fileRef = 800A5BC3275889EC009DE2CD /* reports_revenue_stats_month.json */; };
 		800A5BC8275889ED009DE2CD /* reports_revenue_stats_year.json in Resources */ = {isa = PBXBuildFile; fileRef = 800A5BC4275889EC009DE2CD /* reports_revenue_stats_year.json */; };
 		800A5BCB2759CE4B009DE2CD /* ProductsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A5BCA2759CE4B009DE2CD /* ProductsTests.swift */; };
-		80AD2CA22782B4EB00A63DE8 /* products_on_review.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AD2CA12782B4EB00A63DE8 /* products_on_review.json */; };
-		80B8D34C278E8A0C00FE6E6B /* MenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B8D34B278E8A0C00FE6E6B /* MenuScreen.swift */; };
 		80AD2CA22782B4EB00A63DE8 /* products_list_1.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AD2CA12782B4EB00A63DE8 /* products_list_1.json */; };
 		80AD2CA427858BAB00A63DE8 /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AD2CA327858BAB00A63DE8 /* StatsTests.swift */; };
 		80AD2CA627859B4400A63DE8 /* reports_leaderboards_stats_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AD2CA527859B4400A63DE8 /* reports_leaderboards_stats_day.json */; };
@@ -957,6 +955,7 @@
 		80B8D34327859C7F00FE6E6B /* reports_leaderboards_stats_year.json in Resources */ = {isa = PBXBuildFile; fileRef = 80B8D34227859C7F00FE6E6B /* reports_leaderboards_stats_year.json */; };
 		80B8D3452785A08900FE6E6B /* products_list_2.json in Resources */ = {isa = PBXBuildFile; fileRef = 80B8D3442785A08900FE6E6B /* products_list_2.json */; };
 		80B8D3492785A0A900FE6E6B /* products_list_3.json in Resources */ = {isa = PBXBuildFile; fileRef = 80B8D3482785A0A900FE6E6B /* products_list_3.json */; };
+		80B8D34C278E8A0C00FE6E6B /* MenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B8D34B278E8A0C00FE6E6B /* MenuScreen.swift */; };
 		80C3626B27704EE1005CEAD3 /* ProductDataStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C3626A27704EE1005CEAD3 /* ProductDataStructs.swift */; };
 		80C3626F277453E8005CEAD3 /* ReviewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C3626E277453E7005CEAD3 /* ReviewsTests.swift */; };
 		80C3627127745737005CEAD3 /* ReviewDataStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C3627027745737005CEAD3 /* ReviewDataStructs.swift */; };
@@ -2517,8 +2516,6 @@
 		800A5BC3275889EC009DE2CD /* reports_revenue_stats_month.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reports_revenue_stats_month.json; sourceTree = "<group>"; };
 		800A5BC4275889EC009DE2CD /* reports_revenue_stats_year.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reports_revenue_stats_year.json; sourceTree = "<group>"; };
 		800A5BCA2759CE4B009DE2CD /* ProductsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTests.swift; sourceTree = "<group>"; };
-		80AD2CA12782B4EB00A63DE8 /* products_on_review.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_on_review.json; sourceTree = "<group>"; };
-		80B8D34B278E8A0C00FE6E6B /* MenuScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuScreen.swift; sourceTree = "<group>"; };
 		80AD2CA12782B4EB00A63DE8 /* products_list_1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_list_1.json; sourceTree = "<group>"; };
 		80AD2CA327858BAB00A63DE8 /* StatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
 		80AD2CA527859B4400A63DE8 /* reports_leaderboards_stats_day.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reports_leaderboards_stats_day.json; sourceTree = "<group>"; };
@@ -2527,6 +2524,7 @@
 		80B8D34227859C7F00FE6E6B /* reports_leaderboards_stats_year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reports_leaderboards_stats_year.json; sourceTree = "<group>"; };
 		80B8D3442785A08900FE6E6B /* products_list_2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_list_2.json; sourceTree = "<group>"; };
 		80B8D3482785A0A900FE6E6B /* products_list_3.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_list_3.json; sourceTree = "<group>"; };
+		80B8D34B278E8A0C00FE6E6B /* MenuScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuScreen.swift; sourceTree = "<group>"; };
 		80C3626A27704EE1005CEAD3 /* ProductDataStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDataStructs.swift; sourceTree = "<group>"; };
 		80C3626E277453E7005CEAD3 /* ReviewsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewsTests.swift; sourceTree = "<group>"; };
 		80C3627027745737005CEAD3 /* ReviewDataStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDataStructs.swift; sourceTree = "<group>"; };
@@ -8084,7 +8082,6 @@
 				3F0CF3132704490A00EF3D71 /* PrologueScreen.swift in Sources */,
 				3F0CF3102704490A00EF3D71 /* SingleOrderScreen.swift in Sources */,
 				3F0CF3062704490A00EF3D71 /* SingleReviewScreen.swift in Sources */,
-				80B8D350279123D500FE6E6B /* MenuScreen.swift in Sources */,
 				3F0CF3112704490A00EF3D71 /* ProductsScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -80,7 +80,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_plugin_not_activated_when_wcpay_installed_but_not_active() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .inactive, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .inactive, version: WCPayPluginVersion.minimumSupportedVersion)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -93,21 +93,21 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_stripe_plugin_not_activated_when_stripe_installed_but_not_active() {
         // Given
         setupCountry(country: .us)
-        setupStripePlugin(status: .inactive, version: .minimumSupportedVersion)
+        setupStripePlugin(status: .inactive, version: StripePluginVersion.minimumSupportedVersion)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .pluginNotActivated(plugin: .wcPay))
+        XCTAssertEqual(state, .pluginNotActivated(plugin: .stripe))
     }
 
     func test_onboarding_returns_select_plugin_when_both_stripe_and_wcpay_plugins_are_active() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
-        setupStripePlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -120,7 +120,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_plugin_unsupported_version_when_unpatched_wcpay_outdated() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .unsupportedVersionWithoutPatch)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.unsupportedVersionWithoutPatch)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -133,7 +133,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_in_test_mode_with_live_stripe_account_when_live_account_in_test_mode() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete, isLive: true, isInTestMode: true)
 
         // When
@@ -147,7 +147,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_unsupported_version_when_patched_wcpay_plugin_outdated() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .unsupportedVersionWithPatch)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.unsupportedVersionWithPatch)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -160,7 +160,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_wcpay_plugin_version_matches_minimum_exactly() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .networkActive, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -174,7 +174,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_wcpay_plugin_version_has_newer_patch_release() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .networkActive, version: .supportedVersionWithPatch)
+        setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -188,7 +188,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_wcpay_plugin_version_has_newer_unpatched_release() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .networkActive, version: .supportedVersionWithoutPatch)
+        setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -202,7 +202,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_wcpay_plugin_active() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -216,7 +216,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_wcpay_plugin_is_network_active() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .networkActive, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -232,7 +232,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_generic_error_with_no_account_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -245,7 +245,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_generic_error_when_account_is_not_eligible_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete, isCardPresentEligible: false)
 
         // When
@@ -259,7 +259,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_not_completed_when_account_is_not_connected_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .noAccount)
 
         // When
@@ -273,7 +273,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_pending_requirements_when_account_is_restricted_with_pending_requirements_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .restricted, hasPendingRequirements: true)
 
         // When
@@ -287,7 +287,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_pending_requirements_when_account_is_restricted_soon_with_pending_requirements_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .restrictedSoon, hasPendingRequirements: true)
 
         // When
@@ -301,7 +301,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_requirements_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .restricted, hasOverdueRequirements: true)
 
         // When
@@ -315,7 +315,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_and_pending_requirements_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .restricted, hasPendingRequirements: true, hasOverdueRequirements: true)
 
         // When
@@ -329,7 +329,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_review_when_account_is_restricted_with_no_requirements_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .restricted)
 
         // When
@@ -344,7 +344,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_rejected_for_fraud_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .rejectedFraud)
 
         // When
@@ -358,7 +358,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_rejected_for_tos_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .rejectedTermsOfService)
 
         // When
@@ -372,7 +372,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_listed_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .rejectedListed)
 
         // When
@@ -386,7 +386,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_rejected_when_account_is_rejected_for_other_reasons_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .rejectedOther)
 
         // When
@@ -400,7 +400,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_generic_error_when_account_status_unknown_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .unknown)
 
         // When
@@ -414,7 +414,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_complete_when_account_is_setup_successfully_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(status: .complete)
 
         // When
@@ -447,7 +447,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
 
 // MARK: - Plugin helpers
 private extension CardPresentPaymentsOnboardingUseCaseTests {
-    func setupWCPayPlugin(status: SitePluginStatusEnum, version: PluginVersion) {
+    func setupWCPayPlugin(status: SitePluginStatusEnum, version: WCPayPluginVersion) {
         let active = status == .active || status == .networkActive
         let networkActivated = status == .networkActive
         let plugin = SystemPlugin
@@ -463,7 +463,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
         storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
     }
 
-    func setupStripePlugin(status: SitePluginStatusEnum, version: PluginVersion) {
+    func setupStripePlugin(status: SitePluginStatusEnum, version: StripePluginVersion) {
         let active = status == .active || status == .networkActive
         let networkActivated = status == .networkActive
         let plugin = SystemPlugin
@@ -478,13 +478,19 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
             )
         storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
     }
-    enum PluginVersion: String {
+
+    enum WCPayPluginVersion: String {
         case unsupportedVersionWithPatch = "2.4.2"
         case unsupportedVersionWithoutPatch = "3.2"
-        case minimumSupportedVersion = "3.2.1" /// Should match `minimumSupportedWCPayVersion` in `CardPresentPaymentsOnboardingUseCase`
+        case minimumSupportedVersion = "3.2.1" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
         case supportedVersionWithPatch = "3.2.5"
         case supportedVersionWithoutPatch = "3.3"
     }
+
+    enum StripePluginVersion: String {
+        case minimumSupportedVersion = "5.9.0" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
+    }
+
 }
 
 // MARK: - Account helpers

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -26,7 +26,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// CPP plugin is installed on the store but is not activated.
     ///
-    case pluginNotActivated
+    case pluginNotActivated(plugin: CardPresentPaymentsPlugins)
 
     /// CPP plugin is installed and activated but requires to be setup first.
     ///

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -114,6 +114,8 @@ public enum CardPresentPaymentsPlugins: Equatable {
         }
     }
 
+    /// Changing values here? You'll need to also update `CardPresentPaymentsOnboardingUseCaseTests`
+    ///
     public var minimumSupportedPluginVersion: String {
         switch self {
         case .wcPay:


### PR DESCRIPTION
Closes: #5934

### Description
- If WCPay is not installed, and Stripe is, but isn't activated, prompt the merchant to activate the plugin.

### Nuances
- I extended `CardPresentPaymentsPlugins` with `image` so that all these onboarding views could just use it as the source for images. This improves upon what was done in #5930 and keeps things DRYer.
- I added unit tests for `test_onboarding_returns_stripe_plugin_not_activated_when_stripe_installed_but_not_active` but also `test_onboarding_returns_select_plugin_when_both_stripe_and_wcpay_plugins_are_active`

### Testing instructions
- Direct the app to a site with Stripe installed (but not active) and WITHOUT WCPay installed
- Enter Menu > Settings (gear) > In-Person Payments
- Ensure you are prompted to activate the plugin
- New unit tests were added. Ensure they pass as well

### Screenshots

<img src="https://user-images.githubusercontent.com/1595739/150431646-4fd41dfe-2092-42ca-8110-d67abf193311.jpg" width=50% />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

