### PR TITLE
Update visitor and conversion stats view states

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -156,14 +156,16 @@ private extension StoreStatsPeriodViewModel {
             return StatsTimeRangeBarViewModel(startDate: startDate,
                                               endDate: endDate,
                                               timeRange: timeRange,
-                                              timezone: siteTimezone)
+                                              timezone: siteTimezone,
+                                              isMyStoreTabUpdatesEnabled: true)
         }
         let date = orderStatsIntervals[selectedIndex].dateStart(timeZone: siteTimezone)
         return StatsTimeRangeBarViewModel(startDate: startDate,
                                           endDate: endDate,
                                           selectedDate: date,
                                           timeRange: timeRange,
-                                          timezone: siteTimezone)
+                                          timezone: siteTimezone,
+                                          isMyStoreTabUpdatesEnabled: true)
     }
 
     func createOrderStatsText(orderStatsData: OrderStatsData, selectedIntervalIndex: Int?) -> String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -15,6 +15,9 @@ final class StoreStatsPeriodViewModel {
     /// Updated externally from user interactions with the chart.
     @Published var selectedIntervalIndex: Int? = nil
 
+    /// Updated externally from visitor stats availability.
+    @Published var siteVisitStatsMode: SiteVisitStatsMode = .default
+
     /// Emits order stats text values based on order stats and selected time interval.
     private(set) lazy var orderStatsText: AnyPublisher<String, Never> =
     Publishers.CombineLatest($orderStatsData.eraseToAnyPublisher(), $selectedIntervalIndex.eraseToAnyPublisher())
@@ -63,6 +66,24 @@ final class StoreStatsPeriodViewModel {
     var reloadChartAnimated: AnyPublisher<Bool, Never> {
         shouldReloadChartAnimated.eraseToAnyPublisher()
     }
+
+    /// Emits the view state for visitor stats based on the visitor stats mode and the selected time interval.
+    private(set) lazy var visitorStatsViewState: AnyPublisher<StoreStatsDataOrRedactedView.State, Never> =
+    Publishers.CombineLatest($siteVisitStatsMode.eraseToAnyPublisher(), $selectedIntervalIndex.eraseToAnyPublisher())
+        .compactMap { [weak self] siteVisitStatsMode, selectedIntervalIndex in
+            return self?.visitorStatsViewState(siteVisitStatsMode: siteVisitStatsMode, selectedIntervalIndex: selectedIntervalIndex)
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+
+    /// Emits the view state for conversion stats based on the visitor stats view state.
+    private(set) lazy var conversionStatsViewState: AnyPublisher<StoreStatsDataOrRedactedView.State, Never> =
+    visitorStatsViewState
+        .compactMap { [weak self] visitorStatsViewState in
+            return self?.conversionStatsViewState(visitorStatsViewState: visitorStatsViewState)
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
 
     // MARK: - Private data
 
@@ -172,15 +193,39 @@ private extension StoreStatsPeriodViewModel {
     func createConversionStats(orderStatsData: OrderStatsData, siteStats: SiteVisitStats?, selectedIntervalIndex: Int?) -> String {
         let visitors = visitorCount(at: selectedIntervalIndex, siteStats: siteStats)
         let orders = orderCount(at: selectedIntervalIndex, orderStats: orderStatsData.stats, orderStatsIntervals: orderStatsData.intervals)
-        if let visitors = visitors, let orders = orders, visitors > 0 {
+
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        numberFormatter.minimumFractionDigits = 1
+
+        if let visitors = visitors, let orders = orders {
             // Maximum conversion rate is 100%.
-            let conversionRate = min(orders/visitors, 1)
-            let numberFormatter = NumberFormatter()
-            numberFormatter.numberStyle = .percent
-            numberFormatter.minimumFractionDigits = 1
+            let conversionRate = visitors > 0 ? min(orders/visitors, 1): 0
             return numberFormatter.string(from: conversionRate as NSNumber) ?? Constants.placeholderText
         } else {
             return Constants.placeholderText
+        }
+    }
+
+    func visitorStatsViewState(siteVisitStatsMode: SiteVisitStatsMode, selectedIntervalIndex: Int?) -> StoreStatsDataOrRedactedView.State {
+        switch siteVisitStatsMode {
+        case .default:
+            return timeRange == .today && selectedIntervalIndex != nil ? .redacted: .data
+        case .redactedDueToJetpack:
+            return .redactedDueToJetpack
+        case .hidden:
+            return .redacted
+        }
+    }
+
+    func conversionStatsViewState(visitorStatsViewState: StoreStatsDataOrRedactedView.State) -> StoreStatsDataOrRedactedView.State {
+        switch visitorStatsViewState {
+        case .data:
+            return .data
+        case .redactedDueToJetpack:
+            return .redacted
+        case .redacted:
+            return .redacted
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -22,7 +22,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
 
     var siteVisitStatsMode: SiteVisitStatsMode = .default {
         didSet {
-            updateSiteVisitStats(mode: siteVisitStatsMode)
+            viewModel.siteVisitStatsMode = siteVisitStatsMode
         }
     }
 
@@ -154,6 +154,8 @@ final class StoreStatsV4PeriodViewController: UIViewController {
         observeSelectedBarIndex()
         observeTimeRangeBarViewModel()
         observeReloadChartAnimated()
+        observeVisitorStatsViewState()
+        observeConversionStatsViewState()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -204,8 +206,6 @@ private extension StoreStatsV4PeriodViewController {
             self.visitorsDataOrRedactedView.isHighlighted = isHighlighted
             self.conversionDataOrRedactedView.isHighlighted = isHighlighted
             self.revenueData.textColor = textColor
-
-            self.updateSiteVisitStatsAndConversionRate(selectedIndex: selectedIndex)
         }.store(in: &cancellables)
     }
 
@@ -218,6 +218,22 @@ private extension StoreStatsV4PeriodViewController {
     func observeReloadChartAnimated() {
         viewModel.reloadChartAnimated.sink { [weak self] animated in
             self?.reloadChart(animateChart: animated)
+        }.store(in: &cancellables)
+    }
+
+    func observeVisitorStatsViewState() {
+        viewModel.visitorStatsViewState
+            .sink { [weak self] viewState in
+                guard let self = self, self.visitorsDataOrRedactedView != nil else { return }
+                self.visitorsDataOrRedactedView.state = viewState
+        }.store(in: &cancellables)
+    }
+
+    func observeConversionStatsViewState() {
+        viewModel.conversionStatsViewState
+            .sink { [weak self] viewState in
+                guard let self = self, self.conversionDataOrRedactedView != nil else { return }
+                self.conversionDataOrRedactedView.state = viewState
         }.store(in: &cancellables)
     }
 }
@@ -300,9 +316,6 @@ private extension StoreStatsV4PeriodViewController {
 
         // Data
         updateStatsDataToDefaultStyles()
-
-        // Visibility
-        updateSiteVisitStats(mode: siteVisitStatsMode)
 
         // Accessibility elements
         xAxisAccessibilityView.isAccessibilityElement = true
@@ -400,14 +413,6 @@ private extension StoreStatsV4PeriodViewController {
     }
 }
 
-// MARK: - UI Updates
-//
-private extension StoreStatsV4PeriodViewController {
-    func updateSiteVisitStats(mode: SiteVisitStatsMode) {
-        reloadSiteVisitUI()
-    }
-}
-
 // MARK: - ChartViewDelegate Conformance (Charts)
 //
 extension StoreStatsV4PeriodViewController: ChartViewDelegate {
@@ -432,36 +437,6 @@ private extension StoreStatsV4PeriodViewController {
     /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
     func updateUI(selectedBarIndex selectedIndex: Int?) {
         viewModel.selectedIntervalIndex = selectedIndex
-    }
-
-    /// Updates visitor and conversion stats based on the selected bar index.
-    ///
-    /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
-    func updateSiteVisitStatsAndConversionRate(selectedIndex: Int?) {
-        let mode: SiteVisitStatsMode
-
-        // Hides site visit stats for "today" when an interval bar is selected.
-        if timeRange == .today, selectedIndex != nil {
-            mode = .hidden
-        } else {
-            mode = siteVisitStatsMode
-        }
-
-        updateSiteVisitStats(mode: mode)
-
-        switch siteVisitStatsMode {
-        case .hidden, .redactedDueToJetpack:
-            break
-        case .default:
-            guard selectedIndex != nil else {
-                reloadSiteVisitUI()
-                return
-            }
-            guard visitorsDataOrRedactedView != nil else {
-                return
-            }
-            visitorsDataOrRedactedView.state = .data
-        }
     }
 }
 
@@ -571,7 +546,6 @@ private extension StoreStatsV4PeriodViewController {
 
     func reloadAllFields(animateChart: Bool = true) {
         viewModel.selectedIntervalIndex = nil
-        reloadSiteVisitUI()
         reloadChart(animateChart: animateChart)
 
         view.accessibilityElements = [ordersTitle as Any,
@@ -585,17 +559,6 @@ private extension StoreStatsV4PeriodViewController {
                                       yAxisAccessibilityView as Any,
                                       xAxisAccessibilityView as Any,
                                       chartAccessibilityView as Any]
-    }
-
-    func reloadSiteVisitUI() {
-        switch siteVisitStatsMode {
-        case .hidden:
-            visitorsDataOrRedactedView.state = .redacted
-        case .redactedDueToJetpack:
-            visitorsDataOrRedactedView.state = .redactedDueToJetpack
-        case .default:
-            visitorsDataOrRedactedView.state = .data
-        }
     }
 
     func reloadChart(animateChart: Bool = true) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -253,7 +253,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         viewModel.selectedIntervalIndex = 0
 
         // Then
-        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Monday, Jan 3", "Monday, Jan 3 › 1 AM"])
+        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Monday, Jan 3", "Monday, Jan 3, 1:00 AM"])
     }
 
     func test_timeRangeBarViewModel_for_thisWeek_is_emitted_twice_after_order_and_visitor_stats_updated_and_selecting_interval() {
@@ -277,12 +277,12 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
                                                                dateEnd: "2022-01-05 23:59:59")])
         insertOrderStats(orderStats, timeRange: timeRange)
 
-        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Jan 3-Jan 5"])
+        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Jan 3 - Jan 5"])
 
         viewModel.selectedIntervalIndex = 1
 
         // Then
-        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Jan 3-Jan 5", "Jan 5"])
+        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Jan 3 - Jan 5", "Jan 5"])
     }
 
     func test_timeRangeBarViewModel_for_thisMonth_is_emitted_twice_after_order_and_visitor_stats_updated_and_selecting_interval() {
@@ -304,12 +304,12 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
                                                                dateEnd: "2022-01-03 23:59:59")])
         insertOrderStats(orderStats, timeRange: timeRange)
 
-        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["January"])
+        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["January 2022"])
 
         viewModel.selectedIntervalIndex = 0
 
         // Then
-        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["January", "Jan 3"])
+        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["January 2022", "Jan 3"])
     }
 
     func test_timeRangeBarViewModel_for_thisYear_is_emitted_twice_after_order_and_visitor_stats_updated_and_selecting_interval() {
@@ -336,7 +336,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         viewModel.selectedIntervalIndex = 0
 
         // Then
-        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["2022", "2022 › January"])
+        XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["2022", "January 2022"])
     }
 
     // MARK: - `reloadChartAnimated`


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Based on the design discussion p1642555588011500/1639990681.280100-slack-CGPNUU63E, this PR updates the conversion stats:
- Show redacted state when the visitor stats are redacted due to Jetpack or redacted in general
- If the visitors count is 0, the conversion stats view now shows 0% instead of `-`

When selecting an hour in the Today tab, the visitor stats view now shows the redacted state.

While running unit tests locally, I noticed test cases on the time range text failed due to the `myStoreTabUpdates` feature flag value `true` from the previous simulator runs. In https://github.com/woocommerce/woocommerce-ios/commit/3c4cde3143731ab6df67a562b5e2b720456f006e, the feature value is now always `true` from the new store stats view model and the time range text tests were updated. The legacy version does not use this view model.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the site has at least one order today
- Launch the app with a Jetpack site --> all stats should be shown
- Select an hour in the Today tab --> visitor and conversion stats are redacted
- Deselect the hour --> visitor stats view now shows a value, and if visitors count is 0 the conversion rate shows 0%

Other scenarios:
- [x] @jaclync tests JCP sites: all stats should be shown where the visitor stats still show the redacted state with a Jetpack logo
- [x] @jaclync tests when `myStoreTabUpdates` feature is disabled

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

visitor stats unavailable due to Jetpack (JCP site) | today tab with 0 visitors count | today tab - selected
-- | -- | --
![Simulator Screen Shot - iPhone 12 - 2022-01-21 at 13 51 35](https://user-images.githubusercontent.com/1945542/150475518-a573d24e-fcd1-4984-a31b-6d1ccb624acb.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-21 at 13 52 21](https://user-images.githubusercontent.com/1945542/150475538-43d8f29f-735e-4294-9f31-d2ef5f022aa1.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-21 at 13 52 31](https://user-images.githubusercontent.com/1945542/150475542-43e9f2ad-0ec0-4c59-81d0-c6aa441c1c93.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
