### PR TITLE
[Mobile Payments] [Stripe Backend] Prompt merchant to take live account sites out of test mode for IPP

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -185,7 +185,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         }
 
         // Account checks
-        return accountChecks()
+        return accountChecks(plugin: .wcPay)
     }
 
     func stripeGatewayOnlyOnboardingState(plugin: SystemPlugin) -> CardPresentPaymentOnboardingState {
@@ -196,10 +196,10 @@ private extension CardPresentPaymentsOnboardingUseCase {
             return .pluginNotActivated(plugin: .stripe)
         }
 
-        return accountChecks()
+        return accountChecks(plugin: .stripe)
     }
 
-    func accountChecks() -> CardPresentPaymentOnboardingState {
+    func accountChecks(plugin: CardPresentPaymentsPlugins) -> CardPresentPaymentOnboardingState {
         guard let account = getPaymentGatewayAccount() else {
             return .genericError
         }
@@ -207,7 +207,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             return .pluginSetupNotCompleted
         }
         guard !isPluginInTestModeWithLiveStripeAccount(account: account) else {
-            return .pluginInTestModeWithLiveStripeAccount
+            return .pluginInTestModeWithLiveStripeAccount(plugin: plugin)
         }
         guard !isStripeAccountUnderReview(account: account) else {
             return .stripeAccountUnderReview

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -37,8 +37,8 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsPluginNotSupportedVersion(plugin: plugin, onRefresh: viewModel.refresh)
             case .pluginNotActivated(let plugin):
                 InPersonPaymentsPluginNotActivated(plugin: plugin, onRefresh: viewModel.refresh)
-            case .pluginInTestModeWithLiveStripeAccount:
-                InPersonPaymentsLiveSiteInTestMode(onRefresh:
+            case .pluginInTestModeWithLiveStripeAccount(let plugin):
+                InPersonPaymentsLiveSiteInTestMode(plugin: plugin, onRefresh:
                     viewModel.refresh)
             case .pluginSetupNotCompleted:
                 InPersonPaymentsWCPayNotSetup(onRefresh: viewModel.refresh)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
+import Yosemite
 
 struct InPersonPaymentsLiveSiteInTestMode: View {
+    let plugin: CardPresentPaymentsPlugins
     let onRefresh: () -> Void
 
     var body: some View {
         InPersonPaymentsOnboardingError(
-            title: Localization.title,
-            message: Localization.message,
+            title: String(format: Localization.title, plugin.pluginName),
+            message: String(format: Localization.message, plugin.pluginName),
             image: InPersonPaymentsOnboardingError.ImageInfo(
-                image: .wcPayPlugin,
+                image: plugin.image,
                 height: 108.0
             ),
             supportLink: false,
@@ -23,24 +25,24 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "WooCommerce Payments is in Test Mode",
-        comment: "Title for the error screen when WooCommerce Payments is in test mode on a live site"
+        "%1$@ is in Test Mode",
+        comment: "Title for the error screen when a card present payments plugin is in test mode on a live site"
     )
 
     static let message = NSLocalizedString(
-        "The WooCommerce Payments extension cannot be in test mode for In-Person Payments. "
+        "The %1$@ extension cannot be in test mode for In-Person Payments. "
             + "Please disable test mode.",
-        comment: "Error message when WooCommerce Payments is in test mode on a live site"
+        comment: "Error message when a card present payments plugin is in test mode on a live site"
     )
 
     static let primaryButton = NSLocalizedString(
         "Refresh After Updating",
-        comment: "Button to reload plugin data after updating the WooCommerce Payments plugin settings"
+        comment: "Button to reload plugin data after updating a card present payments plugin settings"
     )
 }
 
 struct InPersonPaymentsLiveSiteInTestMode_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsLiveSiteInTestMode(onRefresh: {})
+        InPersonPaymentsLiveSiteInTestMode(plugin: .wcPay, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -26,13 +26,13 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
 private enum Localization {
     static let title = NSLocalizedString(
         "%1$@ is in Test Mode",
-        comment: "Title for the error screen when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name, e.g. WooCommerce Stripe Gateway"
+        comment: "Title for the error screen when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name."
     )
 
     static let message = NSLocalizedString(
         "The %1$@ extension cannot be in test mode for In-Person Payments. "
             + "Please disable test mode.",
-        comment: "Error message when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name, e.g. WooCommerce Stripe Gateway"
+        comment: "Error message when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name."
     )
 
     static let primaryButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -26,7 +26,7 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
 private enum Localization {
     static let title = NSLocalizedString(
         "%1$@ is in Test Mode",
-        comment: "Title for the error screen when a card present payments plugin is in test mode on a live site"
+        comment: "Title for the error screen when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name, e.g. WooCommerce Stripe Gateway"
     )
 
     static let message = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -32,7 +32,7 @@ private enum Localization {
     static let message = NSLocalizedString(
         "The %1$@ extension cannot be in test mode for In-Person Payments. "
             + "Please disable test mode.",
-        comment: "Error message when a card present payments plugin is in test mode on a live site"
+        comment: "Error message when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name, e.g. WooCommerce Stripe Gateway"
     )
 
     static let primaryButton = NSLocalizedString(

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -141,7 +141,21 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .pluginInTestModeWithLiveStripeAccount)
+        XCTAssertEqual(state, .pluginInTestModeWithLiveStripeAccount(plugin: .wcPay))
+    }
+
+    func test_onboarding_returns_stripe_in_test_mode_with_live_stripe_account_when_live_account_in_test_mode() {
+        // Given
+        setupCountry(country: .us)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(status: .complete, isLive: true, isInTestMode: true)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginInTestModeWithLiveStripeAccount(plugin: .stripe))
     }
 
     func test_onboarding_returns_wcpay_unsupported_version_when_patched_wcpay_plugin_outdated() {

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -32,10 +32,10 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     ///
     case pluginSetupNotCompleted
 
-    /// This is a bit special case: WCPay is set to "dev mode" but the connected Stripe account is in live mode.
+    /// This is a bit special case: The plugin is set to test mode but the connected Stripe account is a real (live) account.
     /// Connecting to a reader or accepting payments is not supported in this state.
     ///
-    case pluginInTestModeWithLiveStripeAccount
+    case pluginInTestModeWithLiveStripeAccount(plugin: CardPresentPaymentsPlugins)
 
     /// The connected Stripe account has not been reviewed by Stripe yet. This is a temporary state and the user needs to wait.
     ///


### PR DESCRIPTION
Closes: #5933

### Description
- In Person Payments are not supported by Stripe for live (real, not developer created) account sites in test mode
- Prompt merchants to deactivate test mode to process in-person payments for their site

### Testing instructions
- Until version 6.1.0 of the WooCommerce Stripe Gateway plugin is released, it is easiest to modify StripeAccount's hardcoding of isLiveAccount to true for this test
- Then, open the app and point it at a store running the WooCommerce Stripe Gateway plugin and with an account (a developer account is fine) setup
- Navigate to Menu > Settings (Gear) > In-Person Payments and ensure you are prompted to take the live account site out of test mode
- Also ensure the new unit test passes

### Screenshots

<img src="https://user-images.githubusercontent.com/1595739/150605912-abc3df17-219f-4f49-9545-4d366a1e4596.PNG" width=50% />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
