### PR TITLE
Design polishes based on design review

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -38,7 +38,9 @@ final class DashboardViewController: UIViewController {
     ///
     private lazy var innerStackView: UIStackView = {
         let view = UIStackView()
-        view.layoutMargins = UIEdgeInsets(top: 0, left: Constants.horizontalMargin, bottom: 0, right: Constants.horizontalMargin)
+        let horizontalMargin = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) ?
+        Constants.horizontalMargin: Constants.legacyHorizontalMargin
+        view.layoutMargins = UIEdgeInsets(top: 0, left: horizontalMargin, bottom: 0, right: horizontalMargin)
         view.isLayoutMarginsRelativeArrangement = true
         return view
     }()
@@ -169,6 +171,9 @@ private extension DashboardViewController {
 
     func configureSubtitle() {
         storeNameLabel.text = ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.title
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) {
+            storeNameLabel.textColor = Constants.storeNameTextColor
+        }
         innerStackView.addArrangedSubview(storeNameLabel)
         headerStackView.addArrangedSubview(innerStackView)
     }
@@ -478,7 +483,9 @@ private extension DashboardViewController {
 
     enum Constants {
         static let bannerBottomMargin = CGFloat(8)
-        static let horizontalMargin = CGFloat(20)
+        static let horizontalMargin = CGFloat(16)
+        static let legacyHorizontalMargin = CGFloat(20)
+        static let storeNameTextColor: UIColor = .secondaryLabel
         static let backgroundColor: UIColor = .systemBackground
         static let legacyBackgroundColor: UIColor = .listBackground
         static let collapsedNavigationBarHeight = CGFloat(44)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -471,7 +471,7 @@ private extension StoreStatsAndTopPerformersViewController {
 //
 private extension StoreStatsAndTopPerformersViewController {
     enum TabStrip {
-        static let buttonLeftRightMargin: CGFloat   = 14.0
+        static let buttonLeftRightMargin: CGFloat   = 16.0
         static let selectedBarHeight: CGFloat       = 3.0
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -203,6 +203,8 @@ private extension StoreStatsPeriodViewModel {
         if let visitors = visitors, let orders = orders {
             // Maximum conversion rate is 100%.
             let conversionRate = visitors > 0 ? min(orders/visitors, 1): 0
+            let minimumFractionDigits = floor(conversionRate * 100.0) == conversionRate * 100.0 ? 0: 1
+            numberFormatter.minimumFractionDigits = minimumFractionDigits
             return numberFormatter.string(from: conversionRate as NSNumber) ?? Constants.placeholderText
         } else {
             return Constants.placeholderText

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -388,7 +388,7 @@ private extension StoreStatsV4PeriodViewController {
         yAxis.drawAxisLineEnabled = false
         yAxis.drawZeroLineEnabled = true
         yAxis.valueFormatter = self
-        yAxis.setLabelCount(3, force: true)
+        yAxis.setLabelCount(3, force: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -667,7 +667,7 @@ private extension StoreStatsV4PeriodViewController {
         static let chartXAxisGranularity: Double        = 1.0
 
         static var chartLineColor: UIColor {
-            UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
+            UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade50),
                     dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
         }
         static let chartHighlightLineColor: UIColor = .accent

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -148,7 +148,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureView()
-        configureBarChart()
+        configureChart()
         configureNoRevenueView()
         observeStatsLabels()
         observeSelectedBarIndex()
@@ -346,7 +346,7 @@ private extension StoreStatsV4PeriodViewController {
         noRevenueLabel.textColor = .text
     }
 
-    func configureBarChart() {
+    func configureChart() {
         lineChartView.marker = StoreStatsChartCircleMarker()
         lineChartView.chartDescription?.enabled = false
         lineChartView.dragXEnabled = true

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -364,6 +364,7 @@ private extension StoreStatsV4PeriodViewController {
 
         let xAxis = lineChartView.xAxis
         xAxis.labelPosition = .bottom
+        xAxis.yOffset = 8
         xAxis.labelFont = StyleManager.chartLabelFont
         xAxis.labelTextColor = .textSubtle
         xAxis.axisLineColor = .systemColor(.separator)
@@ -454,6 +455,9 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
             if value == 0.0 {
                 // Do not show the "0" label on the Y axis
                 return ""
+            } else if hasRevenue() == false {
+                // Extra spaces are necessary so that the first x-axis label is not truncated.
+                return "   "
             } else {
                 return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
                                     .formatCurrency(using: value.humanReadableString(),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -196,10 +196,10 @@
                                             </accessibility>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fg2-ey-bVn" userLabel="Empty data view">
-                                            <rect key="frame" x="153" y="177" width="41.5" height="38.5"/>
+                                            <rect key="frame" x="145" y="177" width="57.5" height="38.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5uh-zy-gDZ">
-                                                    <rect key="frame" x="0.0" y="9" width="41.5" height="20.5"/>
+                                                    <rect key="frame" x="8" y="9" width="41.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -207,10 +207,10 @@
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="5uh-zy-gDZ" secondAttribute="trailing" id="kKN-cg-YhY"/>
+                                                <constraint firstAttribute="trailing" secondItem="5uh-zy-gDZ" secondAttribute="trailing" constant="8" id="kKN-cg-YhY"/>
                                                 <constraint firstItem="5uh-zy-gDZ" firstAttribute="top" secondItem="fg2-ey-bVn" secondAttribute="top" constant="9" id="od2-Oi-xwq"/>
                                                 <constraint firstAttribute="bottom" secondItem="5uh-zy-gDZ" secondAttribute="bottom" constant="9" id="uQ7-1p-B6d"/>
-                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="leading" secondItem="fg2-ey-bVn" secondAttribute="leading" id="ylg-AY-x2q"/>
+                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="leading" secondItem="fg2-ey-bVn" secondAttribute="leading" constant="8" id="ylg-AY-x2q"/>
                                             </constraints>
                                         </view>
                                     </subviews>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -47,19 +47,19 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="15r-Bq-Hy6">
-                            <rect key="frame" x="0.0" y="50" width="375" height="78"/>
+                            <rect key="frame" x="0.0" y="50" width="375" height="86"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="VzI-74-cyb">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="78"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="86"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5id-es-0m9" userLabel="-">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="37"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Revenue" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L2i-fw-est" userLabel="Revenue">
-                                            <rect key="frame" x="0.0" y="41" width="375" height="37"/>
+                                            <rect key="frame" x="0.0" y="49" width="375" height="37"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -69,7 +69,7 @@
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
-                            <rect key="frame" x="0.0" y="128" width="375" height="121.5"/>
+                            <rect key="frame" x="0.0" y="136" width="375" height="121.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="g0M-FH-Icp">
                                     <rect key="frame" x="0.0" y="0.0" width="125.5" height="121.5"/>
@@ -165,7 +165,7 @@
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
-                            <rect key="frame" x="0.0" y="249.5" width="375" height="392.5"/>
+                            <rect key="frame" x="0.0" y="257.5" width="375" height="392.5"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
                                     <rect key="frame" x="0.0" y="0.0" width="14" height="392.5"/>
@@ -241,10 +241,10 @@
                             </subviews>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Ra-EQ-KPf" userLabel="Spacer View">
-                            <rect key="frame" x="0.0" y="642" width="375" height="25"/>
+                            <rect key="frame" x="0.0" y="650" width="375" height="17"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="25" id="dH2-Fd-IgS"/>
+                                <constraint firstAttribute="height" constant="17" id="dH2-Fd-IgS"/>
                             </constraints>
                         </view>
                     </subviews>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
@@ -87,7 +87,7 @@ private extension TopPerformersSectionHeaderView {
         let label: UILabel = {
             let label = UILabel(frame: .zero)
             label.text = labelText
-            label.applyFootnoteStyle()
+            label.applyCalloutStyle()
             label.numberOfLines = 0
             label.textColor = .listIcon
             return label

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/TopPerformersSectionHeaderView.swift
@@ -134,7 +134,7 @@ private extension TopPerformersSectionHeaderView {
     }
 
     enum Constants {
-        static let labelInsets = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
+        static let labelInsets = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
         static let backgroundColor: UIColor = .systemBackground
         static let columnHorizontalSpacing: CGFloat = 30
         static let titleAndColumnSpacing: CGFloat = 16

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -111,7 +111,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         insertOrderStats(orderStats, timeRange: timeRange)
 
         // Then
-        XCTAssertEqual(conversionStatsTextValues, ["-", "20.0%"]) // order count: 3, visitor count: 15 => 0.2 (20%)
+        XCTAssertEqual(conversionStatsTextValues, ["-", "20%"]) // order count: 3, visitor count: 15 => 0.2 (20%)
     }
 
     func test_placeholder_conversionStatsText_is_emitted_when_visitor_count_is_zero() {
@@ -136,6 +136,54 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(conversionStatsTextValues, ["-", "0.0%"])
+    }
+
+    func test_conversionStatsText_shows_one_decimal_point_when_percentage_value_has_two_decimal_points() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        // When
+        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [
+            .fake().copy(visitors: 10000)
+        ])
+        insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
+
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3557, grossRevenue: 62.7),
+                                      intervals: [.fake()])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(conversionStatsTextValues, ["-", "35.6%"]) // order count: 3557, visitor count: 10000 => 0.3557 (35.57%)
+    }
+
+    func test_conversionStatsText_shows_no_decimal_point_when_percentage_value_is_integer() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        // When
+        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [
+            .fake().copy(visitors: 10)
+        ])
+        insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
+
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 62.7),
+                                      intervals: [.fake()])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(conversionStatsTextValues, ["-", "30%"]) // order count: 3, visitor count: 10 => 0.3 (30%)
     }
 
     // MARK: - Stats text values while selecting a time interval
@@ -224,7 +272,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         viewModel.selectedIntervalIndex = 0
 
         // Then
-        XCTAssertEqual(conversionStatsTextValues, ["-", "20.0%", "10.0%"])
+        XCTAssertEqual(conversionStatsTextValues, ["-", "20%", "10%"])
     }
 
     // MARK: `StatsTimeRangeBarViewModel`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -135,7 +135,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         insertOrderStats(orderStats, timeRange: timeRange)
 
         // Then
-        XCTAssertEqual(conversionStatsTextValues, ["-", "0.0%"])
+        XCTAssertEqual(conversionStatsTextValues, ["-", "0%"])
     }
 
     func test_conversionStatsText_shows_one_decimal_point_when_percentage_value_has_two_decimal_points() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #5745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After design review in vbzgTKHV9XsyyN5cxxAuhv-fi-1799%3A86756, this PR updates the dashboard design for the following items:

- Align time range tab title to store name label and large title
- Update store name label text color
- Redistribute top padding for the top performers label so that it has top padding when the in-app feedback card is shown
- Remove decimal point in conversion stats when it's an integer with test cases
- Update the top performers two-column label title to callout font
- Chart:
  - Add 8px horizontal padding to "No revenue this period" label
  - Update the spacing between the x-axis and labels to 8px
  - Highlighted color is purple 50 in light mode
  - Hide y-axis labels when there is no revenue

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has no orders for today

- Launch the app --> in the My store tab, the large title, store name, and "Today" tab label should be aligned
- After the stats are loaded, tap on each time range tab --> the chart and top performers header should look as in design (except for the y-axis labels that we can't customize their location)

Other scenarios:
- [ ] @jaclync tests when `myStoreTabUpdates` feature is disabled

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | dark | light
-- | -- | --
empty state | <img src="https://user-images.githubusercontent.com/1945542/150720098-d26cd5c9-c754-47bb-929f-ca7f295b3384.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1945542/150720107-3ac7e73c-adfd-4cb8-a8e0-618a816a69e5.png" width="300" />
revenue data | <img src="https://user-images.githubusercontent.com/1945542/150720342-f251a6cb-d4a6-4743-99a4-23143a525471.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1945542/150720350-5143d852-a028-4698-8b15-f1b6def24a56.png" width="300" />
revenue - highlighted | <img src="https://user-images.githubusercontent.com/1945542/150720456-54002dde-136b-44ed-a662-3b98e9cafc50.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1945542/150720461-62ea4451-73c3-480c-aa64-f730d2de90d2.png" width="300" />
in-app feedback card shown | <img src="https://user-images.githubusercontent.com/1945542/150720543-b2b76a0d-052f-4928-9abd-b73b439e8e81.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1945542/150720548-1c31fc8c-a0db-4d77-beb2-069538734eae.png" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
