### PR TITLE
Created M3 Inbox feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -41,6 +41,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .taxLinesInSimplePayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .inbox:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -81,4 +81,8 @@ public enum FeatureFlag: Int {
     /// Displays the tax lines breakup in simple payments summary screen
     ///
     case taxLinesInSimplePayments
+
+    /// Displays the Inbox option under the Hub Menu.
+    ///
+    case inbox
 }


### PR DESCRIPTION
Closes: #5947 

### Description
This is the first PR for starting the Inbox project, M3 of the Home Screen updates project.

### Testing instructions
For the moment the feature flag is not used anywhere.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
