### PR TITLE
Coupons: Update Networking with new endpoint for searching coupons

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -10,6 +10,12 @@ public protocol CouponsRemoteProtocol {
                         pageSize: Int,
                         completion: @escaping (Result<[Coupon], Error>) -> ())
 
+    func searchCoupons(for siteID: Int64,
+                       keyword: String,
+                       pageNumber: Int,
+                       pageSize: Int,
+                       completion: @escaping (Result<[Coupon], Error>) -> ())
+
     func deleteCoupon(for siteID: Int64,
                       couponID: Int64,
                       completion: @escaping (Result<Coupon, Error>) -> Void)
@@ -57,6 +63,27 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    public func searchCoupons(for siteID: Int64,
+                              keyword: String,
+                              pageNumber: Int,
+                              pageSize: Int,
+                              completion: @escaping (Result<[Coupon], Error>) -> ()) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.keyword: String(keyword)
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.coupons,
+                                     parameters: parameters)
+
+        let mapper = CouponListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
     // MARK: - Delete Coupon
 
     /// Deletes a `Coupon`.
@@ -185,5 +212,6 @@ public extension CouponsRemote {
         static let perPage = "per_page"
         static let force = "force"
         static let coupons = "coupons"
+        static let keyword = "search"
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -264,7 +264,7 @@ final class CouponsRemoteTests: XCTestCase {
 
     // MARK: - Load coupon report
 
-    /// Verifies that loadCouponReport properly parses the `CouponReport` sample response.
+    /// Verifies that loadCouponReport properly parses the `coupon-reports` sample response.
     ///
     func test_loadCouponReport_properly_returns_parsed_report() throws {
         // Given
@@ -297,6 +297,50 @@ final class CouponsRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.loadCouponReport(for: self.sampleSiteID, couponID: 571) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
+    }
+
+    // MARK: - Search couponss
+
+    /// Verifies that searchCoupons properly parses the `coupons-all` sample response.
+    ///
+    func test_searchCoupons_properly_returns_parsed_report() throws {
+        // Given
+        let remote = CouponsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
+
+        // When
+        let result = waitFor { promise in
+            remote.searchCoupons(for: self.sampleSiteID, keyword: "test", pageNumber: 0, pageSize: 20) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssert(result.isSuccess)
+        let coupons = try XCTUnwrap(result.get())
+        XCTAssertEqual(coupons.count, 4)
+    }
+
+    /// Verifies that searchCoupons properly relays Networking Layer errors.
+    ///
+    func test_searchCoupons_properly_relays_networking_errors() throws {
+        // Given
+        let remote = CouponsRemote(network: network)
+
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "coupons", error: error)
+
+        // When
+        let result = waitFor { promise in
+            remote.searchCoupons(for: self.sampleSiteID, keyword: "test", pageNumber: 0, pageSize: 20) { (result) in
                 promise(result)
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -9,6 +9,12 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     var spyLoadAllCouponsPageNumber: Int?
     var spyLoadAllCouponsPageSize: Int?
 
+    var didCallSearchCoupons = false
+    var spySearchCouponsSiteID: Int64?
+    var spySearchCouponsPageNumber: Int?
+    var spySearchCouponsPageSize: Int?
+    var spySearchCouponsKeyword: String?
+
     var didCallDeleteCoupon = false
     var spyDeleteCouponSiteID: Int64?
     var spyDeleteCouponWithID: Int64?
@@ -37,6 +43,18 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
         spyLoadAllCouponsPageSize = pageSize
         guard let result = resultForLoadAllCoupons else { return }
         completion(result)
+    }
+
+    func searchCoupons(for siteID: Int64,
+                       keyword: String,
+                       pageNumber: Int,
+                       pageSize: Int,
+                       completion: @escaping (Result<[Coupon], Error>) -> ()) {
+        didCallSearchCoupons = true
+        spySearchCouponsKeyword = keyword
+        spySearchCouponsSiteID = siteID
+        spySearchCouponsPageSize = pageSize
+        spySearchCouponsPageNumber = pageNumber
     }
 
     func deleteCoupon(for siteID: Int64,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5768 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To prepare for the searching coupons functionality, this PR updates the Networking layer with a new endpoint for coupon search.

This endpoint uses the same API endpoint with synchronizing coupons, however, I figure a separate endpoint in CouponsRemote is necessary to make it clearer.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This endpoint hasn't been integrated so just CI passing is sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
