### PR TITLE
My store tab: polish chart y-axis range

### DIFF
--- a/WooCommerce/Classes/Extensions/Double+Rounding.swift
+++ b/WooCommerce/Classes/Extensions/Double+Rounding.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Double {
+    /// Returns a rounded value that has the next higher multitude of the same power of 10.
+    /// Examples: 62 --> 70, 134 --> 200, 1450 --> 2000, -579 --> -600
+    /// - Parameter shouldRoundUp: Whether to round up or down.
+    /// - Returns: <#description#>
+    func roundedToTheNextSamePowerOfTen(shouldRoundUp: Bool) -> Double {
+        guard self != 0 else {
+            return 0
+        }
+        let isNegativeValue = self < 0
+        let roundsUp = isNegativeValue ? !shouldRoundUp: shouldRoundUp
+        let absoluteValue = abs(self)
+        let numberOfDigits = max(floor(log10(absoluteValue)), 0)
+        let tenthPowerValue = pow(10, numberOfDigits)
+        let numberOfTenthPowerValues = roundsUp ? ceil(absoluteValue / tenthPowerValue): floor(absoluteValue / tenthPowerValue)
+        let nextTenthPowerValue = numberOfTenthPowerValues * tenthPowerValue
+        return (isNegativeValue ? -1: 1) * nextTenthPowerValue
+    }
+}

--- a/WooCommerce/Classes/Extensions/Double+Rounding.swift
+++ b/WooCommerce/Classes/Extensions/Double+Rounding.swift
@@ -2,9 +2,9 @@ import Foundation
 
 extension Double {
     /// Returns a rounded value that has the next higher multitude of the same power of 10.
-    /// Examples: 62 --> 70, 134 --> 200, 1450 --> 2000, -579 --> -600
-    /// - Parameter shouldRoundUp: Whether to round up or down.
-    /// - Returns: <#description#>
+    /// Examples when rounding up: 62 --> 70, 134 --> 200, 1450 --> 2000, -579 --> -500
+    /// Examples when rounding down: 62 --> 60, 134 --> 100, 1450 --> 1000, -579 --> -600
+    /// - Parameter shouldRoundUp: Whether to round the value up or down.
     func roundedToTheNextSamePowerOfTen(shouldRoundUp: Bool) -> Double {
         guard self != 0 else {
             return 0

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -256,7 +256,7 @@ private extension StoreStatsPeriodViewModel {
         guard revenueItems.contains(where: { $0 != 0 }) else {
             return Constants.yAxisMaximumValueWithoutRevenue
         }
-        let hasNegativeRevenueOnly = orderStatsData.intervals.map { $0.revenueValue }.contains(where: { $0 > 0 }) == false
+        let hasNegativeRevenueOnly = revenueItems.contains(where: { $0 > 0 }) == false
         guard hasNegativeRevenueOnly == false else {
             return 0
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -85,6 +85,24 @@ final class StoreStatsPeriodViewModel {
         .removeDuplicates()
         .eraseToAnyPublisher()
 
+    /// Emits the maximum value for the y-axis in the chart based on the order stats data.
+    private(set) lazy var yAxisMaximum: AnyPublisher<Double, Never> =
+    $orderStatsData.eraseToAnyPublisher()
+        .compactMap { [weak self] orderStatsData in
+            return self?.createYAxisMaximum(orderStatsData: orderStatsData)
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+
+    /// Emits the minimum value for the y-axis in the chart based on the order stats data.
+    private(set) lazy var yAxisMinimum: AnyPublisher<Double, Never> =
+    $orderStatsData.eraseToAnyPublisher()
+        .compactMap { [weak self] orderStatsData in
+            return self?.createYAxisMinimum(orderStatsData: orderStatsData)
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+
     // MARK: - Private data
 
     @Published private var siteStats: SiteVisitStats?
@@ -232,6 +250,34 @@ private extension StoreStatsPeriodViewModel {
             return .redacted
         }
     }
+
+    func createYAxisMaximum(orderStatsData: OrderStatsData) -> Double {
+        let revenueItems = orderStatsData.intervals.map({ ($0.revenueValue as NSDecimalNumber).doubleValue })
+        guard revenueItems.contains(where: { $0 != 0 }) else {
+            return Constants.yAxisMaximumValueWithoutRevenue
+        }
+        let hasNegativeRevenueOnly = orderStatsData.intervals.map { $0.revenueValue }.contains(where: { $0 > 0 }) == false
+        guard hasNegativeRevenueOnly == false else {
+            return 0
+        }
+
+        let max = revenueItems.max() ?? 0
+        return max.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+    }
+
+    func createYAxisMinimum(orderStatsData: OrderStatsData) -> Double {
+        let revenueItems = orderStatsData.intervals.map({ ($0.revenueValue as NSDecimalNumber).doubleValue })
+        guard revenueItems.contains(where: { $0 != 0 }) else {
+            return Constants.yAxisMinimumValueWithoutRevenue
+        }
+
+        let min = revenueItems.min() ?? 0
+        if min < 0 {
+            return min.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+        } else {
+            return 0
+        }
+    }
 }
 
 // MARK: - Private data helpers
@@ -329,5 +375,7 @@ private extension StoreStatsPeriodViewModel {
 private extension StoreStatsPeriodViewModel {
     enum Constants {
         static let placeholderText = "-"
+        static let yAxisMaximumValueWithoutRevenue: Double = 1
+        static let yAxisMinimumValueWithoutRevenue: Double = -1
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -156,6 +156,8 @@ final class StoreStatsV4PeriodViewController: UIViewController {
         observeReloadChartAnimated()
         observeVisitorStatsViewState()
         observeConversionStatsViewState()
+        observeYAxisMaximum()
+        observeYAxisMinimum()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -234,6 +236,18 @@ private extension StoreStatsV4PeriodViewController {
             .sink { [weak self] viewState in
                 guard let self = self, self.conversionDataOrRedactedView != nil else { return }
                 self.conversionDataOrRedactedView.state = viewState
+        }.store(in: &cancellables)
+    }
+
+    func observeYAxisMaximum() {
+        viewModel.yAxisMaximum.sink { [weak self] yAxisMaximum in
+            self?.lineChartView.leftAxis.axisMaximum = yAxisMaximum
+        }.store(in: &cancellables)
+    }
+
+    func observeYAxisMinimum() {
+        viewModel.yAxisMinimum.sink { [weak self] yAxisMinimum in
+            self?.lineChartView.leftAxis.axisMinimum = yAxisMinimum
         }.store(in: &cancellables)
     }
 }
@@ -388,7 +402,7 @@ private extension StoreStatsV4PeriodViewController {
         yAxis.drawAxisLineEnabled = false
         yAxis.drawZeroLineEnabled = true
         yAxis.valueFormatter = self
-        yAxis.setLabelCount(3, force: false)
+        yAxis.setLabelCount(3, force: true)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -354,6 +354,8 @@
 		02DD81FA242CAA400060E50B /* Media+WPMediaAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DD81F6242CAA3F0060E50B /* Media+WPMediaAsset.swift */; };
 		02DD81FB242CAA400060E50B /* WordPressMediaLibraryPickerDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DD81F7242CAA3F0060E50B /* WordPressMediaLibraryPickerDataSource.swift */; };
 		02DD81FC242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02DD81F8242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib */; };
+		02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */; };
+		02DE5CAB279F8754007CBEF3 /* Double+RoundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */; };
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */; };
 		02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */; };
@@ -1957,6 +1959,8 @@
 		02DD81F6242CAA3F0060E50B /* Media+WPMediaAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Media+WPMediaAsset.swift"; sourceTree = "<group>"; };
 		02DD81F7242CAA3F0060E50B /* WordPressMediaLibraryPickerDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressMediaLibraryPickerDataSource.swift; sourceTree = "<group>"; };
 		02DD81F8242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WordPressMediaLibraryImagePickerViewController.xib; sourceTree = "<group>"; };
+		02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Rounding.swift"; sourceTree = "<group>"; };
+		02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+RoundingTests.swift"; sourceTree = "<group>"; };
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
 		02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -5939,6 +5943,7 @@
 				D88100D2257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift */,
 				DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */,
 				DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */,
+				02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -6550,6 +6555,7 @@
 				DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */,
 				DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */,
 				DEC51B05276B3F3C009F3DF4 /* Int64+Helpers.swift */,
+				02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -8936,6 +8942,7 @@
 				02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */,
 				4590B6A8261F0F8300A6FCE0 /* SegmentedView.swift in Sources */,
 				DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */,
+				02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */,
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				D449C51D26DE6B5000D75B02 /* LargeTitle.swift in Sources */,
 				456396B625C82691001F1A26 /* ShippingLabelFormStepTableViewCell.swift in Sources */,
@@ -9172,6 +9179,7 @@
 				DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */,
 				023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */,
 				AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */,
+				02DE5CAB279F8754007CBEF3 /* Double+RoundingTests.swift in Sources */,
 				B56C721421B5BBC000E5E85B /* MockStoresManager.swift in Sources */,
 				26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/Double+RoundingTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Double+RoundingTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import WooCommerce
+
+final class Double_RoundingTests: XCTestCase {
+    // MARK: `shouldRoundUp: true`
+
+    func test_rounding_up_10s_number_returns_the_next_higher_10s() {
+        // Given
+        let value: Double = 66
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 70)
+    }
+
+    func test_rounding_up_100s_number_returns_the_next_higher_100s() {
+        // Given
+        let value: Double = 668
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 700)
+    }
+
+    func test_rounding_up_1000s_number_returns_the_next_higher_1000s() {
+        // Given
+        let value: Double = 6687
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 7000)
+    }
+
+    func test_rounding_up_10000s_number_returns_the_next_higher_10000s() {
+        // Given
+        let value: Double = 62251
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 70000)
+    }
+
+    func test_rounding_up_100000s_number_returns_the_next_higher_100000s() {
+        // Given
+        let value: Double = 668788
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 700000)
+    }
+
+    func test_rounding_up_1000000s_number_returns_the_next_higher_1000000s() {
+        // Given
+        let value: Double = 6687898
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 7000000)
+    }
+
+    func test_rounding_up_negative_10s_number_returns_the_next_smaller_10s() {
+        // Given
+        let value: Double = -66
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, -60)
+    }
+
+    func test_rounding_up_0_number_returns_0() {
+        // Given
+        let value: Double = 0
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 0)
+    }
+
+    func test_rounding_up_number_under_1_returns_1() {
+        // Given
+        let value: Double = 0.5
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 1)
+    }
+
+    func test_rounding_up_number_under_10_returns_the_next_higher_integer() {
+        // Given
+        let value: Double = 3.14
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: true)
+
+        // Then
+        XCTAssertEqual(roundedValue, 4)
+    }
+
+    // MARK: `shouldRoundUp: false`
+
+    func test_rounding_down_10s_number_returns_the_next_lower_10s() {
+        // Given
+        let value: Double = 66
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 60)
+    }
+
+    func test_rounding_down_100s_number_returns_the_next_lower_100s() {
+        // Given
+        let value: Double = 668
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 600)
+    }
+
+    func test_rounding_down_1000s_number_returns_the_next_lower_1000s() {
+        // Given
+        let value: Double = 6687
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 6000)
+    }
+
+    func test_rounding_down_10000s_number_returns_the_next_lower_10000s() {
+        // Given
+        let value: Double = 62251
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 60000)
+    }
+
+    func test_rounding_down_100000s_number_returns_the_next_lower_100000s() {
+        // Given
+        let value: Double = 668788
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 600000)
+    }
+
+    func test_rounding_down_1000000s_number_returns_the_next_lower_1000000s() {
+        // Given
+        let value: Double = 6687898
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 6000000)
+    }
+
+    func test_rounding_down_negative_10s_number_returns_the_next_higher_10s() {
+        // Given
+        let value: Double = -66
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, -70)
+    }
+
+    func test_rounding_down_0_number_returns_0() {
+        // Given
+        let value: Double = 0
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 0)
+    }
+
+    func test_rounding_down_number_under_1_returns_0() {
+        // Given
+        let value: Double = 0.5
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 0)
+    }
+
+    func test_rounding_down_number_under_10_returns_the_floor_integer_value() {
+        // Given
+        let value: Double = 3.14
+
+        // When
+        let roundedValue = value.roundedToTheNextSamePowerOfTen(shouldRoundUp: false)
+
+        // Then
+        XCTAssertEqual(roundedValue, 3)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -650,6 +650,139 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         viewModel.selectedIntervalIndex = 0
         XCTAssertEqual(viewStates, [.data, .redacted])
     }
+
+    // MARK: - `yAxisMaximum` and `yAxisMinimum`
+
+    func test_yAxisMaximum_and_yAxisMaximum_are_1_and_minus_1_when_there_is_no_revenue() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        var yAxisMaximumValues: [Double] = []
+        viewModel.yAxisMaximum.sink { yAxisMaximum in
+            yAxisMaximumValues.append(yAxisMaximum)
+        }.store(in: &cancellables)
+
+        var yAxisMinimumValues: [Double] = []
+        viewModel.yAxisMinimum.sink { yAxisMinimum in
+            yAxisMinimumValues.append(yAxisMinimum)
+        }.store(in: &cancellables)
+
+        XCTAssertEqual(yAxisMaximumValues, [1])
+        XCTAssertEqual(yAxisMinimumValues, [-1])
+
+        // When
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 0),
+                                      intervals: [.fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: 0))])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(yAxisMaximumValues, [1])
+        XCTAssertEqual(yAxisMinimumValues, [-1])
+    }
+
+    func test_yAxisMaximum_is_the_next_higher_power_of_ten_when_max_revenue_is_in_the_10s() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        var yAxisMaximumValues: [Double] = []
+        viewModel.yAxisMaximum.dropFirst().sink { yAxisMaximum in
+            yAxisMaximumValues.append(yAxisMaximum)
+        }.store(in: &cancellables)
+
+        // When
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 0),
+                                      intervals: [.fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: 68)),
+                                                  .fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: 25))])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(yAxisMaximumValues, [70])
+    }
+
+    func test_yAxisMaximum_is_0_when_revenue_is_all_negative() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        var yAxisMaximumValues: [Double] = []
+        viewModel.yAxisMaximum.dropFirst().sink { yAxisMaximum in
+            yAxisMaximumValues.append(yAxisMaximum)
+        }.store(in: &cancellables)
+
+        // When
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 0),
+                                      intervals: [.fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: -2)),
+                                                  .fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: -61))])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(yAxisMaximumValues, [0])
+    }
+
+    func test_yAxisMinimum_is_0_when_min_revenue_is_positive() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        var yAxisMinimumValues: [Double] = []
+        viewModel.yAxisMinimum.dropFirst().sink { yAxisMinimum in
+            yAxisMinimumValues.append(yAxisMinimum)
+        }.store(in: &cancellables)
+
+        // When
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 0),
+                                      intervals: [.fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: 68)),
+                                                  .fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: 2))])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(yAxisMinimumValues, [0])
+    }
+
+    func test_yAxisMinimum_is_the_next_lower_power_of_ten_when_min_revenue_is_in_the_negative_10s() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        var yAxisMinimumValues: [Double] = []
+        viewModel.yAxisMinimum.dropFirst().sink { yAxisMinimum in
+            yAxisMinimumValues.append(yAxisMinimum)
+        }.store(in: &cancellables)
+
+        // When
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 0),
+                                      intervals: [.fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: 68)),
+                                                  .fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                               dateEnd: "2022-01-03 23:59:59",
+                                                               subtotals: .fake().copy(grossRevenue: -61))])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(yAxisMinimumValues, [-70])
+    }
 }
 
 private extension StoreStatsPeriodViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the y-axis in the dashboard charts shows the absolute number for the highest revenue for the maximum and a negative number for the minimum. To polish the y-axis labels, this PR updates the y-axis range so that:

- Always 3 labels are shown at even spacing from min to max by setting `yAxis.setLabelCount(3, force: true)`
- Manually calculate the y-axis maximum value:
  - The nearest higher multitude of power of tens (e.g. 62.5 --> 70) if there is any positive revenue
  - `0` if revenue is all negative
  - `1` if there is no revenue
- Manually calculate the y-axis minimum value:
  - `0` if there is any positive revenue
  - The nearest lower multitude of power of tens (e.g. -62.5 --> -70) if revenue is all negative
  - `-1` if there is no revenue

I created a `Double` extension for calculating the "nearest higher/lower multitude of power of tens" `roundedToTheNextSamePowerOfTen` with a boolean parameter `shouldRoundUp` for y-axis maximum and minimum. I'm not quite sure about the naming, please feel free to suggest other names 😅 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Tap each time range tab --> if there is no revenue (like for today), the chart shouldn't show any y-axis labels. If there is any positive revenue, 3 chart y-axis labels should be shown with the max being the "nearest higher multitude of power of tens." If revenue is all negative, the y-axis max should be 0 and the min should be the "nearest lower multitude of power of tens"

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

mix of positive and negative values | positive values | large positive values
-- | -- | --
![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 14 29 30](https://user-images.githubusercontent.com/1945542/150927253-c47c8096-ca56-4d53-b267-03111a22a31f.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 14 29 39](https://user-images.githubusercontent.com/1945542/150927262-56737e8f-29bb-4a87-86b2-1ad703afdaea.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 14 30 01](https://user-images.githubusercontent.com/1945542/150927269-9d5ba207-cd51-412f-ba3c-191496a24d8d.png)

large positive values - selected | no revenue | negative revenue only
-- | -- | --
![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 14 30 12](https://user-images.githubusercontent.com/1945542/150927271-8699b62c-2d0c-4304-8479-329f55f3c70e.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 15 03 49](https://user-images.githubusercontent.com/1945542/150929125-7e2a9f6f-3cf9-452f-9ad8-db07e74aa018.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 15 16 10](https://user-images.githubusercontent.com/1945542/150929131-afc5290b-35ce-4d08-bcf5-8562e8d44805.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
