### PR TITLE
`TitleAndValueRow` long texts - Add `multilineTextAlignment` modifier for `title` and `value`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -103,6 +103,10 @@ struct TitleAndValueRow_Previews: PreviewProvider {
             .previewLayout(.fixed(width: 375, height: 100))
             .previewDisplayName("Row Not Selectable")
 
+        TitleAndValueRow(title: "This is a really long title which will take multiple lines", value: .placeholder("This is a really long value which will take multiple lines"), selectable: false, action: { })
+            .previewLayout(.fixed(width: 375, height: 150))
+            .previewDisplayName("Long title and value")
+
         TitleAndValueRow(title: "Package selected", value: .placeholder("Small"), selectable: true, action: { })
             .environment(\.sizeCategory, .accessibilityExtraLarge)
             .previewLayout(.fixed(width: 375, height: 150))

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -18,8 +18,11 @@ struct TitleAndValueRow: View {
                 AdaptiveStack(horizontalAlignment: .leading) {
                     Text(title)
                         .style(bold: bold)
+                        .multilineTextAlignment(.leading)
+
                     Text(value.text)
                         .style(for: value, bold: bold)
+                        .multilineTextAlignment(.trailing)
                         .frame(maxWidth: .infinity, alignment: .trailing)
                         .padding(.vertical, Constants.verticalPadding)
                 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -103,7 +103,10 @@ struct TitleAndValueRow_Previews: PreviewProvider {
             .previewLayout(.fixed(width: 375, height: 100))
             .previewDisplayName("Row Not Selectable")
 
-        TitleAndValueRow(title: "This is a really long title which will take multiple lines", value: .placeholder("This is a really long value which will take multiple lines"), selectable: false, action: { })
+        TitleAndValueRow(title: "This is a really long title which will take multiple lines",
+                         value: .placeholder("This is a really long value which will take multiple lines"),
+                         selectable: false,
+                         action: { })
             .previewLayout(.fixed(width: 375, height: 150))
             .previewDisplayName("Long title and value")
 


### PR DESCRIPTION
Part of: #5809

### Description
This PR adds `multilineTextAlignment` for `title` and `value` in `TitleAndValueRow` to make long texts look nicer.
- Apply `.leading` alignment using `multilineTextAlignment` modifier for `title`.
- Apply `.trailing` alignment using `multilineTextAlignment` modifier for `value`.
- Add a preview to `TitleAndValueRow_Previews` to demo long texts.

### Testing instructions
- In the preview named `"Long title and value"` in `TitleAndValueRow_Previews`, observe that `title` is `leading` aligned and value is `trailing` aligned.

### Screenshots
| Before | With `multilineTextAlignment` |
| ------------- | ------------- |
| <img width="450" alt="Screenshot 2022-01-25 at 3 54 18 PM" src="https://user-images.githubusercontent.com/524475/150959206-57ad5680-7a4e-42ae-ad02-645a1234757d.png">  | <img width="458" alt="Screenshot 2022-01-25 at 3 54 03 PM" src="https://user-images.githubusercontent.com/524475/150959219-8c5d1df4-5406-4d7a-98e4-e34edbf7dac2.png">  

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
