### PR TITLE
Simple payments: Show tax breakup in summary

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -177,9 +177,17 @@ private struct PaymentsSection: View {
                         .padding(.horizontal)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    TitleAndValueRow(title: SimplePaymentsSummary.Localization.taxRate(viewModel.taxRate),
-                                     value: .content(viewModel.taxAmount),
-                                     selectable: false) {}
+                    if viewModel.showTaxBreakup {
+                        ForEach(viewModel.taxLines) { taxLine in
+                            TitleAndValueRow(title: taxLine.title,
+                                             value: .content(taxLine.value),
+                                             selectable: false) {}
+                        }
+                    } else {
+                        TitleAndValueRow(title: SimplePaymentsSummary.Localization.taxRate(viewModel.taxRate),
+                                         value: .content(viewModel.taxAmount),
+                                         selectable: false) {}
+                    }
                 }
                 .renderedIf(viewModel.enableTaxes)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -339,25 +339,32 @@ private extension SimplePaymentsSummary {
 // MARK: Previews
 struct SimplePaymentsSummary_Preview: PreviewProvider {
     static var previews: some View {
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "40.0", totalWithTaxes: "$42.3", taxAmount: "$2.3"))
+        SimplePaymentsSummary(viewModel: createSampleViewModel())
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(
-            providedAmount: "$40.0",
-            totalWithTaxes: "$42.3",
-            taxAmount: "$2.3",
-            noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."
-        ))
+        SimplePaymentsSummary(viewModel: createSampleViewModel(noteContent: "Dispatch by tomorrow morning at Fake Street 123, via the boulevard."))
             .environment(\.colorScheme, .light)
             .previewDisplayName("Light Content")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3", taxAmount: "$2.3"))
+        SimplePaymentsSummary(viewModel: createSampleViewModel())
             .environment(\.colorScheme, .dark)
             .previewDisplayName("Dark")
 
-        SimplePaymentsSummary(viewModel: SimplePaymentsSummaryViewModel(providedAmount: "$40.0", totalWithTaxes: "$42.3", taxAmount: "$2.3"))
+        SimplePaymentsSummary(viewModel: createSampleViewModel())
             .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
             .previewDisplayName("Accessibility")
+    }
+
+    static private func createSampleViewModel(noteContent: String? = nil) -> SimplePaymentsSummaryViewModel {
+        let taxAmount = "$2.3"
+        let taxLine: SimplePaymentsSummaryViewModel.TaxLine = .init(id: Int64.random(in: 0 ..< Int64.max),
+                                                                    title: "State Tax (5.55%)",
+                                                                    value: taxAmount)
+        return .init(providedAmount: "40.0",
+                     totalWithTaxes: "$42.3",
+                     taxAmount: taxAmount,
+                     taxLines: [taxLine],
+                     noteContent: noteContent)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import Combine
+import Experiments
 
 /// `ViewModel` to drive the content of the `SimplePaymentsSummary` view.
 ///
@@ -96,6 +97,12 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         return showLoadingIndicator
     }
 
+    /// Show tax break up using `tax_lines` in summary
+    ///
+    var showTaxBreakup: Bool {
+        featureFlagService.isFeatureFlagEnabled(.taxLinesInSimplePayments)
+    }
+
     /// Total to charge with taxes.
     ///
     private let totalWithTaxes: String
@@ -136,6 +143,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     lazy private(set) var noteViewModel = { SimplePaymentsNoteViewModel(analytics: analytics) }()
 
+    /// FeatureFlagService to check `tax_lines` related flag (`taxLinesInSimplePayments`)
+    ///
+    private let featureFlagService: FeatureFlagService
+
     init(providedAmount: String,
          totalWithTaxes: String,
          taxAmount: String,
@@ -148,7 +159,8 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
          presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
         self.orderID = orderID
         self.orderKey = orderKey
@@ -157,6 +169,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.currencyFormatter = currencyFormatter
         self.stores = stores
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
         self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? totalWithTaxes
         self.taxAmount = currencyFormatter.formatAmount(taxAmount) ?? taxAmount

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -40,6 +40,14 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
             title = "\(orderTaxLine.label) (\(orderTaxLine.ratePercent)%)"
             value = currencyFormatter.formatAmount(orderTaxLine.totalTax) ?? orderTaxLine.totalTax
         }
+
+        /// Creates a `TaxLine` with zero tax percentage and tax amount
+        ///
+        static func createZeroValueTaxLine(currencyFormatter: CurrencyFormatter) -> TaxLine {
+            TaxLine(id: 0,
+                    title: "\(Localization.tax) (0.00%)",
+                    value: currencyFormatter.formatAmount(Decimal.zero) ?? "\(Decimal.zero)")
+        }
     }
 
     /// Initial amount to charge. Without taxes.
@@ -177,10 +185,8 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         if taxLines.isNotEmpty {
             self.taxLines = taxLines
         } else {
-            // Create a `TaxLine` with zero values to represent that there are no taxes configured in `wp-admin`.
-            self.taxLines = [TaxLine(id: 0,
-                                     title: "\(Localization.tax) (0.00%)",
-                                     value: currencyFormatter.formatAmount(Decimal.zero) ?? "\(Decimal.zero)")]
+            // Assigning `taxLines` with a zero value `TaxLine` to represent that there are no taxes configured in `wp-admin`.
+            self.taxLines = [TaxLine.createZeroValueTaxLine(currencyFormatter: currencyFormatter)]
         }
 
         // rate_percentage = taxAmount / providedAmount * 100

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -184,6 +184,13 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                      presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      stores: StoresManager = ServiceLocator.stores) {
+
+        // Generate `TaxLine`s to represent `taxes` inside `View`.
+        let taxLines = order.taxes.map({
+            TaxLine(orderTaxLine: $0,
+                    currencyFormatter: currencyFormatter)
+        })
+
         self.init(providedAmount: providedAmount,
                   totalWithTaxes: order.total,
                   taxAmount: order.totalTax,

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -173,7 +173,15 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
         self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? totalWithTaxes
         self.taxAmount = currencyFormatter.formatAmount(taxAmount) ?? taxAmount
-        self.taxLines = taxLines
+
+        if taxLines.isNotEmpty {
+            self.taxLines = taxLines
+        } else {
+            // Create a `TaxLine` with zero values to represent that there are no taxes configured in `wp-admin`.
+            self.taxLines = [TaxLine(id: 0,
+                                     title: "\(Localization.tax) (0.00%)",
+                                     value: currencyFormatter.formatAmount(Decimal.zero) ?? "\(Decimal.zero)")]
+        }
 
         // rate_percentage = taxAmount / providedAmount * 100
         self.taxRate = {
@@ -301,5 +309,8 @@ private extension SimplePaymentsSummaryViewModel {
     enum Localization {
         static let updateError = NSLocalizedString("There was an error updating the order",
                                                    comment: "Notice text after failing to update a simple payments order.")
+        static let tax = NSLocalizedString("Tax",
+                                             comment: "Tax label for the tax detail row.")
+
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -49,6 +49,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     let taxRate: String
 
+    /// Store tax lines.
+    ///
+    let taxLines: [TaxLine]
+
     /// Tax amount to charge.
     ///
     let taxAmount: String
@@ -135,6 +139,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     init(providedAmount: String,
          totalWithTaxes: String,
          taxAmount: String,
+         taxLines: [TaxLine],
          noteContent: String? = nil,
          siteID: Int64 = 0,
          orderID: Int64 = 0,
@@ -155,6 +160,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
         self.totalWithTaxes = currencyFormatter.formatAmount(totalWithTaxes) ?? totalWithTaxes
         self.taxAmount = currencyFormatter.formatAmount(taxAmount) ?? taxAmount
+        self.taxLines = taxLines
 
         // rate_percentage = taxAmount / providedAmount * 100
         self.taxRate = {
@@ -194,6 +200,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.init(providedAmount: providedAmount,
                   totalWithTaxes: order.total,
                   taxAmount: order.totalTax,
+                  taxLines: taxLines,
                   siteID: order.siteID,
                   orderID: order.orderID,
                   orderKey: order.orderKey,

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -6,6 +6,41 @@ import Combine
 ///
 final class SimplePaymentsSummaryViewModel: ObservableObject {
 
+    /// Wraps the `Order`'s tax breakup (`tax_lines`) information
+    ///
+    /// `Identifiable` conformance added for SwiftUI purpose
+    ///
+    struct TaxLine: Identifiable {
+        /// `taxID` of `OrderTaxLine`
+        ///
+        let id: Int64
+
+        /// Tax label appended with tax percentage
+        ///
+        let title: String
+
+        /// Tax amount
+        ///
+        let value: String
+
+        init(id: Int64,
+             title: String,
+             value: String) {
+            self.id = id
+            self.title = title
+            self.value = value
+        }
+
+        /// For initializing TaxLine from `OrderTaxLine`
+        ///
+        init(orderTaxLine: OrderTaxLine,
+             currencyFormatter: CurrencyFormatter) {
+            id = orderTaxLine.taxID
+            title = "\(orderTaxLine.label) (\(orderTaxLine.ratePercent)%)"
+            value = currencyFormatter.formatAmount(orderTaxLine.totalTax) ?? orderTaxLine.totalTax
+        }
+    }
+
     /// Initial amount to charge. Without taxes.
     ///
     let providedAmount: String

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -11,6 +11,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isJetpackConnectionPackageSupportOn: Bool
     private let isHubMenuOn: Bool
     private let isMyStoreTabUpdatesOn: Bool
+    private let isTaxLinesInSimplePaymentsOn: Bool
 
     init(isShippingLabelsM2M3On: Bool = false,
          isInternationalShippingLabelsOn: Bool = false,
@@ -20,7 +21,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isPushNotificationsForAllStoresOn: Bool = false,
          isJetpackConnectionPackageSupportOn: Bool = false,
          isHubMenuOn: Bool = false,
-         isMyStoreTabUpdatesOn: Bool = false) {
+         isMyStoreTabUpdatesOn: Bool = false,
+         isTaxLinesInSimplePaymentsOn: Bool = false) {
         self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
         self.isInternationalShippingLabelsOn = isInternationalShippingLabelsOn
         self.isShippingLabelsPaymentMethodCreationOn = isShippingLabelsPaymentMethodCreationOn
@@ -30,6 +32,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isJetpackConnectionPackageSupportOn = isJetpackConnectionPackageSupportOn
         self.isHubMenuOn = isHubMenuOn
         self.isMyStoreTabUpdatesOn = isMyStoreTabUpdatesOn
+        self.isTaxLinesInSimplePaymentsOn = isTaxLinesInSimplePaymentsOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -52,6 +55,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isHubMenuOn
         case .myStoreTabUpdates:
             return isMyStoreTabUpdatesOn
+        case .taxLinesInSimplePayments:
+            return isTaxLinesInSimplePaymentsOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -11,8 +11,10 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_updating_noteViewModel_updates_noteContent_property() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30", taxAmount: "$4.3")
-
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00",
+                                                       totalWithTaxes: "$104.30",
+                                                       taxAmount: "$4.3",
+                                                       taxLines: [])
         // When
         viewModel.noteViewModel.newNote = "Updated note"
 
@@ -22,8 +24,10 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
 
     func test_calling_reloadContent_triggers_viewModel_update() {
         // Given
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00", totalWithTaxes: "$104.30", taxAmount: "$4.3")
-
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "$100.00",
+                                                       totalWithTaxes: "$104.30",
+                                                       taxAmount: "$4.3",
+                                                       taxLines: [])
         // When
         let triggeredUpdate: Bool = waitFor { promise in
             viewModel.objectWillChange.sink {
@@ -56,6 +60,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100",
                                                        totalWithTaxes: "104.30",
                                                        taxAmount: "$4.3",
+                                                       taxLines: [],
                                                        currencyFormatter: currencyFormatter,
                                                        stores: mockStores)
 
@@ -67,8 +72,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_provided_amount_with_taxes_gets_properly_formatted() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "$4.3", currencyFormatter: currencyFormatter)
-
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100",
+                                                       totalWithTaxes: "104.30",
+                                                       taxAmount: "$4.3",
+                                                       taxLines: [],
+                                                       currencyFormatter: currencyFormatter)
         // When
         viewModel.enableTaxes = true
 
@@ -80,8 +88,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_tax_amount_is_properly_formatted() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "4.3", currencyFormatter: currencyFormatter)
-
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100",
+                                                       totalWithTaxes: "104.30",
+                                                       taxAmount: "4.3",
+                                                       taxLines: [],
+                                                       currencyFormatter: currencyFormatter)
         // When & Then
         XCTAssertEqual(viewModel.taxAmount, "$4.30")
     }
@@ -89,8 +100,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_tax_rate_is_calculated_properly() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US.
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100", totalWithTaxes: "104.30", taxAmount: "$4.3", currencyFormatter: currencyFormatter)
-
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100",
+                                                       totalWithTaxes: "104.30",
+                                                       taxAmount: "$4.3",
+                                                       taxLines: [],
+                                                       currencyFormatter: currencyFormatter)
         // When & Then
         XCTAssertEqual(viewModel.taxRate, "4.30")
     }
@@ -98,7 +112,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_when_order_is_updated_loading_indicator_is_toggled() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       taxLines: [],
+                                                       stores: mockStores)
         mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
@@ -132,6 +150,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
                                                        totalWithTaxes: "1.0",
                                                        taxAmount: "0.0",
+                                                       taxLines: [],
                                                        presentNoticeSubject: noticeSubject,
                                                        stores: mockStores)
         mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
@@ -164,7 +183,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_when_order_is_updated_navigation_to_payments_method_is_triggered() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       taxLines: [],
+                                                       stores: mockStores)
         mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
@@ -185,7 +208,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_when_order_is_updated_email_is_trimmed() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       taxLines: [],
+                                                       stores: mockStores)
         viewModel.email = " some@email.com "
 
         // When
@@ -209,7 +236,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_empty_emails_are_send_as_nil_when_updating_orders() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       taxLines: [],
+                                                       stores: mockStores)
         viewModel.email = ""
 
         // When
@@ -247,6 +278,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
                                                        totalWithTaxes: "1.0",
                                                        taxAmount: "0.0",
+                                                       taxLines: [],
                                                        stores: mockStores,
                                                        analytics: WooAnalytics(analyticsProvider: mockAnalytics))
 
@@ -279,6 +311,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
                                                        totalWithTaxes: "1.0",
                                                        taxAmount: "0.0",
+                                                       taxLines: [],
                                                        stores: mockStores,
                                                        analytics: WooAnalytics(analyticsProvider: mockAnalytics))
 
@@ -315,6 +348,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
                                                        totalWithTaxes: "1.0",
                                                        taxAmount: "0.0",
+                                                       taxLines: [],
                                                        stores: mockStores,
                                                        analytics: WooAnalytics(analyticsProvider: mockAnalytics))
 
@@ -341,7 +375,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       taxLines: [],
+                                                       stores: mockStores)
 
         // Then
         XCTAssertTrue(viewModel.enableTaxes)
@@ -350,8 +388,11 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_taxes_toggle_state_is_stored_after_toggling_taxes() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxAmount: "0.0", stores: mockStores)
-
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       taxLines: [],
+                                                       stores: mockStores)
         // When
         let stateStored: Bool = waitFor { promise in
             mockStores.whenReceivingAction(ofType: AppSettingsAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -109,6 +109,30 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.taxRate, "4.30")
     }
 
+    func test_showTaxBreakup_is_false_if_taxLinesInSimplePayments_feature_flag_is_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isTaxLinesInSimplePaymentsOn: false)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100",
+                                                       totalWithTaxes: "104.30",
+                                                       taxAmount: "$4.3",
+                                                       taxLines: [],
+                                                       featureFlagService: featureFlagService)
+        // Then
+        XCTAssertFalse(viewModel.showTaxBreakup)
+    }
+
+    func test_showTaxBreakup_is_true_if_taxLinesInSimplePayments_feature_flag_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isTaxLinesInSimplePaymentsOn: true)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "100",
+                                                       totalWithTaxes: "104.30",
+                                                       taxAmount: "$4.3",
+                                                       taxLines: [],
+                                                       featureFlagService: featureFlagService)
+        // Then
+        XCTAssertTrue(viewModel.showTaxBreakup)
+    }
+
     func test_when_order_is_updated_loading_indicator_is_toggled() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
Closes: #5809

### Description

#### What?
1. Get the tax breakup details (`tax_lines`) from the server and display them in the simple payments summary screen. (when `taxLinesInSimplePayments` feature flag is turned on)
2. Show zero value tax row in tax summary section based on the tax configuration in `wp-admin`. i.e. If `wp-admin` is configured to charge no taxes, then we show a zero value tax row to indicate the user that "no taxes configured".

#### Why?
The tax percentage displayed in simple payment's summary screen is calculated locally on device and is inaccurate. To fix the inaccuracy and to provide more detailed tax information, we decided to get the detailed tax breakup details from the server and display it. 

#### How?
1. We receive the tax breakup details in the POST Order response under `tax_lines`.  We have stored the `tax_lines` information along with the `Order` (work completed [in past PRs](https://github.com/woocommerce/woocommerce-ios/issues/5809#issuecomment-1014552642)). In this PR, we use the `tax_lines` information of `Order` to display the tax breakup details in the summary screen. 
2. We will receive empty `tax_lines` in the Order response if the merchant configured the taxes in `wp-admin` to not charge any taxes. In that case, we will show a zero value tax row in the summary screen.

More details at p91TBi-7cZ-p2

### Changes
#### SimplePaymentsSummaryViewModel
- Introduce `showTaxBreakup` property to decide whether to show the tax breakup details or not. (`taxLinesInSimplePayments` feature flag decides)
- Introduce `TaxLine` struct to store the `tax_lines` information.
- Generate  `TaxLine`s from `Order`'s `taxes` property.
- Create a zero value `TaxLine` if `Order`'s `taxes` is empty.
- Not appending any string like "Tax" to the `label` received from the server. Because the merchant would already have the "tax" appended to the `label` in `wp-admin`. (In their preferred language) For example, "State Tax" received from the server might end up into "State Tax Tax" if we try to manipulate the label on the device. It will get weird for labels configured in other languages.

#### SimplePaymentsSummaryViewModelTests
- Add tests to validate `showTaxBreakup` behaviour.
- Add tests to validate that zero value tax line exists when `Order`'s `taxes` is empty. 
- Add tests to validate `TaxLine` generation process.

#### SimplePaymentsSummaryView
- Show the tax breakup information if the feature flag is turned on.
- Update SwiftUI previews to include the new `taxLines` parameter.

### Testing instructions

#### Scenario 1
**Taxes configured in `wp-admin`**
1. Configure taxes in wp-admin.
1. Navigate to `Settings` and make sure that `Order creation` is turned on under `Experimental Features`
1. Navigate to `Orders` tab.
1. Tap on `+` button on top right and select `Simple payment` from the action sheet.
1. Enter an amount and tap `Next`.
1. Turn on "Charge Taxes" toggle and observe that the tax breakup information is displayed.
1. Validate that the tax breakup details match the details from `wp-admin`.
1. Turn off "Charge Taxes" toggle and observe that the tax breakup information is hidden.

#### Scenario 2
**No taxes configured in `wp-admin`**
1. Configure `wp-admin` to charge no taxes. (Delete all taxes.)
1. Navigate to `Settings` and make sure that `Order creation` is turned on under `Experimental Features`
1. Navigate to `Orders` tab.
1. Tap on `+` button on top right and select `Simple payment` from the action sheet.
1. Enter an amount and tap `Next`.
1. Turn on "Charge Taxes" toggle and observe the zero value tax row being displayed.
1. Turn off "Charge Taxes" toggle and observe that the zero value tax row is hidden.

### Screenshots

#### Tax configuration in `wp-admin`

<img width="1586" alt="Screenshot 2022-01-22 at 7 54 22 AM" src="https://user-images.githubusercontent.com/524475/150621294-60d7278e-3a6c-4a83-a48e-37dad8aad5df.png">

| Tax breakup when `taxLinesInSimplePayments` feature flag is ON | Dark | Light |
| --- | --- | --- |
| When `tax_lines` is not empty and </br> when "Charge Taxes" toggle is turned on  </br></br> We show tax breakup details | <img src="https://user-images.githubusercontent.com/524475/150993198-20f3424e-0b97-4d60-a2da-77706ac20155.png" width="350"> | <img src="https://user-images.githubusercontent.com/524475/150993264-6d26a789-b237-4da9-8e1a-0929e5f8503f.png"  width="350"> |
| When `tax_lines` is empty and </br> when "Charge Taxes" toggle is turned on </br></br> We show a zero value tax row | <img src="https://user-images.githubusercontent.com/524475/150993944-dd587676-1036-4d5b-8576-6391c820a4d5.png" width="350"> | <img src="https://user-images.githubusercontent.com/524475/150994030-2017d6e9-b91d-4a8a-a963-35ab2001c0a5.png"  width="350"> |
| When "Charge Taxes" toggle is turned off | <img src="https://user-images.githubusercontent.com/524475/150993472-45b9d08a-9f83-4cc2-ac20-6816c762f890.png" width="350"> | <img src="https://user-images.githubusercontent.com/524475/150993535-97286f14-5b52-4f00-a5e1-4a6be45f03b2.png"  width="350"> |

#### Large fonts 
| Dark | Light |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/524475/150994600-e1a1b491-ad8f-4f4b-be90-5c7872d859fe.png" width="350"> | <img src="https://user-images.githubusercontent.com/524475/150994614-f50f2c26-68e6-4a89-b795-dae1754d973c.png"  width="350"> |

#### Long tax label text
| Dark | Light |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/524475/150995174-4d7b3134-9a48-429f-ae9c-22d694bda729.png" width="350"> | <img src="https://user-images.githubusercontent.com/524475/150995127-bc2e6c69-3529-4d8b-a1fa-87382fa6331c.png"  width="350"> |


#### Landscape
| Dark | Light |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/524475/150994346-691dbe81-0d13-4138-835c-7b3da939f43e.png" width="350"> | <img src="https://user-images.githubusercontent.com/524475/150994359-677e8ea8-cd19-4668-8208-4f66b8955365.png"  width="350"> |

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.