### PR TITLE
[Mobile Payments] Add unit tests to IPP Onboarding to cover Stripe Gateway specific logic

### DIFF
--- a/Networking/Networking/Model/PaymentGatewayAccount.swift
+++ b/Networking/Networking/Model/PaymentGatewayAccount.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Payment Gateway Account.
 ///
-public struct PaymentGatewayAccount: GeneratedCopiable, GeneratedFakeable {
+public struct PaymentGatewayAccount: Equatable, GeneratedCopiable, GeneratedFakeable {
 
     /// Site identifier.
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -227,7 +227,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // If we've gotten this far, tell the Card Present Payment Store which backend to use
         let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: account)
-        ServiceLocator.stores.dispatch(setAccount)
+        stores.dispatch(setAccount)
 
         return .completed
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -240,6 +240,25 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .completed)
     }
 
+    func test_onboarding_returns_complete_when_stripe_plugin_is_used_with_an_account_meeting_requirements() {
+        // Given
+        setupCountry(country: .us)
+        setupStripePlugin(status: .networkActive, version: StripePluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(status: .complete,
+                                   hasPendingRequirements: false,
+                                   hasOverdueRequirements: false,
+                                   isLive: true,
+                                   isInTestMode: false)
+
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed)
+    }
+
     // MARK: - Payment Account checks
 
     func test_onboarding_returns_generic_error_with_no_account_for_wcplay_plugin() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -255,6 +255,19 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .genericError)
     }
 
+    func test_onboarding_returns_generic_error_with_no_account_for_stripe_plugin() {
+        // Given
+        setupCountry(country: .us)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .genericError)
+    }
+
     func test_onboarding_returns_generic_error_when_account_is_not_eligible_for_wcplay_plugin() {
         // Given
         setupCountry(country: .us)

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -64,7 +64,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
     // MARK: - Plugin checks
 
-    func test_onboarding_returns_wcpay_not_installed_when_wcpay_plugin_not_installed() {
+    func test_onboarding_returns_plugin_not_installed_when_neither_wcpay_nor_stripe_plugin_installed() {
         // Given
         setupCountry(country: .us)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -130,6 +130,19 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .pluginUnsupportedVersion(plugin: .wcPay))
     }
 
+    func test_onboarding_returns_stripe_plugin_unsupported_version_when_stripe_outdated() {
+        // Given
+        setupCountry(country: .us)
+        setupStripePlugin(status: .active, version: StripePluginVersion.unsupportedVersion)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginUnsupportedVersion(plugin: .stripe))
+    }
+
     func test_onboarding_returns_wcpay_in_test_mode_with_live_stripe_account_when_live_account_in_test_mode() {
         // Given
         setupCountry(country: .us)
@@ -489,6 +502,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
 
     enum StripePluginVersion: String {
         case minimumSupportedVersion = "5.9.0" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
+        case unsupportedVersion = "5.8.1"
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -147,7 +147,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete, isLive: true, isInTestMode: true)
+        setupPaymentGatewayAccount(accountType: StripeAccount.self, status: .complete, isLive: true, isInTestMode: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -174,7 +174,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -188,7 +188,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -202,7 +202,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -216,7 +216,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -230,7 +230,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -244,7 +244,8 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupStripePlugin(status: .networkActive, version: StripePluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete,
+        setupPaymentGatewayAccount(accountType: StripeAccount.self,
+                                   status: .complete,
                                    hasPendingRequirements: false,
                                    hasOverdueRequirements: false,
                                    isLive: true,
@@ -291,7 +292,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete, isCardPresentEligible: false)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete, isCardPresentEligible: false)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -305,7 +306,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .noAccount)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .noAccount)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -319,7 +320,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .restricted, hasPendingRequirements: true)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restricted, hasPendingRequirements: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -333,7 +334,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .restrictedSoon, hasPendingRequirements: true)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restrictedSoon, hasPendingRequirements: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -347,7 +348,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .restricted, hasOverdueRequirements: true)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restricted, hasOverdueRequirements: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -361,7 +362,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .restricted, hasPendingRequirements: true, hasOverdueRequirements: true)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restricted, hasPendingRequirements: true, hasOverdueRequirements: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -375,7 +376,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .restricted)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restricted)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -390,7 +391,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .rejectedFraud)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .rejectedFraud)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -404,7 +405,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .rejectedTermsOfService)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .rejectedTermsOfService)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -418,7 +419,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .rejectedListed)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .rejectedListed)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -432,7 +433,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .rejectedOther)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .rejectedOther)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -446,7 +447,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .unknown)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .unknown)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -460,7 +461,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -542,6 +543,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
 // MARK: - Account helpers
 private extension CardPresentPaymentsOnboardingUseCaseTests {
     func setupPaymentGatewayAccount(
+        accountType: GatewayAccountProtocol.Type,
         status: WCPayAccountStatusEnum,
         hasPendingRequirements: Bool = false,
         hasOverdueRequirements: Bool = false,
@@ -553,7 +555,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
             .fake()
             .copy(
                 siteID: sampleSiteID,
-                gatewayID: WCPayAccount.gatewayID,
+                gatewayID: accountType.gatewayID,
                 status: status.rawValue,
                 hasPendingRequirements: hasPendingRequirements,
                 hasOverdueRequirements: hasOverdueRequirements,
@@ -564,3 +566,10 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
         storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
     }
 }
+
+private protocol GatewayAccountProtocol {
+    static var gatewayID: String { get }
+}
+
+extension WCPayAccount: GatewayAccountProtocol {}
+extension StripeAccount: GatewayAccountProtocol {}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5866 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds unit tests checking that the correct onboarding states are produced for:
- When the Stripe plugin doesn't meet the minimum version
- When no `PaymentGatewayAccount` is available for Stripe
- When the onboarding is successful with the Stripe plugin

🏕️ Also adds tests for the `CardPresentPaymentAction.use(paymentGatewayAccount:)` being sent when onboarding is successful with either plugin, 


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Run unit tests

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
