### PR TITLE
Order Creation: Refactor address form, prepare for reusability

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -6,12 +6,12 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
 
     /// Address update callback
     ///
-    private let onAddressUpdate: ((Address) -> Void)?
+    private let onAddressUpdate: ((Address, Address) -> Void)?
 
     init(siteID: Int64,
-         onAddressUpdate: ((Address) -> Void)?,
          address1: Address?,
          address2: Address?,
+         onAddressUpdate: ((Address, Address) -> Void)?,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
@@ -59,7 +59,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
-        onAddressUpdate?(updatedAddress)
+        onAddressUpdate?(updatedAddress, updatedAddress)
         onFinish(true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -34,15 +34,27 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     var sectionTitle: String {
-        Localization.addressSection
+        if showDifferentAddressForm {
+            return Localization.billingAddressSection
+        } else {
+            return Localization.addressSection
+        }
     }
 
     var showAlternativeUsageToggle: Bool {
         false
     }
 
-    var alternativeUsageToggleTitle: String {
-        ""
+    var alternativeUsageToggleTitle: String? {
+        nil
+    }
+
+    var showDifferentAddressToggle: Bool {
+        true
+    }
+
+    var differentAddressToggleTitle: String? {
+        Localization.differentAddressToggleTitle
     }
 
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
@@ -68,5 +80,8 @@ private extension CreateOrderAddressFormViewModel {
 
         static let shippingAddressSection = NSLocalizedString("SHIPPING ADDRESS", comment: "Details section title in the Edit Address Form")
         static let billingAddressSection = NSLocalizedString("BILLING ADDRESS", comment: "Details section title in the Edit Address Form")
+
+        static let differentAddressToggleTitle = NSLocalizedString("Add a different shipping address",
+                                                                   comment: "Title for the Add a Different Address switch in the Address form")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -9,15 +9,16 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     private let onAddressUpdate: ((Address) -> Void)?
 
     init(siteID: Int64,
-         address: Address?,
          onAddressUpdate: ((Address) -> Void)?,
+         address1: Address?,
+         address2: Address?,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.onAddressUpdate = onAddressUpdate
 
         super.init(siteID: siteID,
-                   address: address ?? .empty,
+                   address: address1 ?? .empty,
                    storageManager: storageManager,
                    stores: stores,
                    analytics: analytics)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -4,21 +4,25 @@ import protocol Storage.StorageManagerType
 
 final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormViewModelProtocol {
 
+    struct NewOrderAddressData {
+        let billingAddress: Address?
+        let shippingAddress: Address?
+    }
+
     /// Address update callback
     ///
-    private let onAddressUpdate: ((Address, Address) -> Void)?
+    private let onAddressUpdate: ((NewOrderAddressData) -> Void)?
 
     init(siteID: Int64,
-         address1: Address?,
-         address2: Address?,
-         onAddressUpdate: ((Address, Address) -> Void)?,
+         addressData: NewOrderAddressData,
+         onAddressUpdate: ((NewOrderAddressData) -> Void)?,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.onAddressUpdate = onAddressUpdate
 
         super.init(siteID: siteID,
-                   address: address1 ?? .empty,
+                   address: addressData.billingAddress ?? .empty,
                    storageManager: storageManager,
                    stores: stores,
                    analytics: analytics)
@@ -59,7 +63,8 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
-        onAddressUpdate?(updatedAddress, updatedAddress)
+        onAddressUpdate?(.init(billingAddress: updatedAddress,
+                               shippingAddress: updatedAddress))
         onFinish(true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -141,8 +141,9 @@ final class NewOrderViewModel: ObservableObject {
     ///
     func createOrderAddressFormViewModel() -> CreateOrderAddressFormViewModel {
         CreateOrderAddressFormViewModel(siteID: siteID,
-                                        address: orderDetails.billingAddress,
                                         onAddressUpdate: { [weak self] updatedAddress in
+                                        address1: orderDetails.billingAddress,
+                                        address2: orderDetails.shippingAddress,
             self?.orderDetails.billingAddress = updatedAddress
             self?.orderDetails.shippingAddress = updatedAddress
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -141,11 +141,11 @@ final class NewOrderViewModel: ObservableObject {
     ///
     func createOrderAddressFormViewModel() -> CreateOrderAddressFormViewModel {
         CreateOrderAddressFormViewModel(siteID: siteID,
-                                        address1: orderDetails.billingAddress,
-                                        address2: orderDetails.shippingAddress,
-                                        onAddressUpdate: { [weak self] updatedAddress, updatedSecondaryAddress in
-            self?.orderDetails.billingAddress = updatedAddress
-            self?.orderDetails.shippingAddress = updatedSecondaryAddress
+                                        addressData: .init(billingAddress: orderDetails.billingAddress,
+                                                           shippingAddress: orderDetails.shippingAddress),
+                                        onAddressUpdate: { [weak self] updatedAddressData in
+            self?.orderDetails.billingAddress = updatedAddressData.billingAddress
+            self?.orderDetails.shippingAddress = updatedAddressData.shippingAddress
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -141,11 +141,11 @@ final class NewOrderViewModel: ObservableObject {
     ///
     func createOrderAddressFormViewModel() -> CreateOrderAddressFormViewModel {
         CreateOrderAddressFormViewModel(siteID: siteID,
-                                        onAddressUpdate: { [weak self] updatedAddress in
                                         address1: orderDetails.billingAddress,
                                         address2: orderDetails.shippingAddress,
+                                        onAddressUpdate: { [weak self] updatedAddress, updatedSecondaryAddress in
             self?.orderDetails.billingAddress = updatedAddress
-            self?.orderDetails.shippingAddress = updatedAddress
+            self?.orderDetails.shippingAddress = updatedSecondaryAddress
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -10,6 +10,10 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     ///
     var fields: AddressFormFields { get set }
 
+    /// Define if address form should be expanded (show second set of fields for different address)
+    ///
+    var showDifferentAddressForm: Bool { get set }
+
     /// Active navigation bar trailing item.
     /// Defaults to a disabled done button.
     ///
@@ -45,7 +49,15 @@ protocol AddressFormViewModelProtocol: ObservableObject {
 
     /// Defines "use as billing/shipping" toggle title
     ///
-    var alternativeUsageToggleTitle: String { get }
+    var alternativeUsageToggleTitle: String? { get }
+
+    /// Defines if "add different address" toggle should be displayed.
+    ///
+    var showDifferentAddressToggle: Bool { get }
+
+    /// Defines "add different address" toggle title
+    ///
+    var differentAddressToggleTitle: String? { get }
 
     /// Save the address and invoke a completion block when finished
     ///
@@ -208,6 +220,10 @@ open class AddressFormViewModel: ObservableObject {
     /// Address form fields
     ///
     @Published var fields = AddressFormFields()
+
+    /// Define if address form should be expanded (show second set of fields for different address)
+    ///
+    @Published var showDifferentAddressForm: Bool = false
 
     /// Trigger to perform any one time setups.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -232,31 +232,31 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground))
                 }
+
+                // Go to edit country
+                LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
+                    EmptyView()
+                }
+
+                // Go to edit state
+                LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createStateViewModel()), isActive: $showStateSelector) {
+                    EmptyView()
+                }
+
+                ///
+                /// iOS 14.5 has a bug where
+                /// Pushing a view while having "exactly two" navigation links makes the pushed view to be popped when the initial view changes its state.
+                /// EG: AddressForm -> CountrySelector -> Country is selected -> AddressForm updates country -> CountrySelector is popped automatically.
+                /// Adding an extra and useless navigation link fixes the problem but throws a warning in the console.
+                /// Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279
+                ///
+                NavigationLink(destination: EmptyView()) {
+                    EmptyView()
+                }
             }
             .disableAutocorrection(true)
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
-
-            // Go to edit country
-            LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
-                EmptyView()
-            }
-
-            // Go to edit state
-            LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createStateViewModel()), isActive: $showStateSelector) {
-                EmptyView()
-            }
-
-            ///
-            /// iOS 14.5 has a bug where
-            /// Pushing a view while having "exactly two" navigation links makes the pushed view to be popped when the initial view changes its state.
-            /// EG: AddressForm -> CountrySelector -> Country is selected -> AddressForm updates country -> CountrySelector is popped automatically.
-            /// Adding an extra and useless navigation link fixes the problem but throws a warning in the console.
-            /// Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279
-            ///
-            NavigationLink(destination: EmptyView()) {
-                EmptyView()
-            }
         }
         .navigationTitle(viewModel.viewTitle)
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -1,7 +1,7 @@
-import Foundation
 import Combine
 import SwiftUI
 import UIKit
+import Yosemite
 
 /// Hosting controller that wraps an `EditOrderAddressForm`.
 ///
@@ -113,109 +113,17 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
     ///
     @ObservedObject private(set) var viewModel: ViewModel
 
-    /// Set it to `true` to present the country selector.
-    ///
-    @State private var showCountrySelector: Bool = false
-
-    /// Set it to `true` to present the state selector.
-    ///
-    @State private var showStateSelector = false
-
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
     var body: some View {
         Group {
             ScrollView {
-                ListHeaderView(text: Localization.detailsSection, alignment: .left)
-                    .padding(.horizontal, insets: safeAreaInsets)
-                VStack(spacing: 0) {
-                    TitleAndTextFieldRow(title: Localization.firstNameField,
-                                         placeholder: "",
-                                         text: $viewModel.fields.firstName,
-                                         symbol: nil,
-                                         keyboardType: .default)
-                    Divider()
-                        .padding(.leading, Constants.dividerPadding)
-                    TitleAndTextFieldRow(title: Localization.lastNameField,
-                                         placeholder: "",
-                                         text: $viewModel.fields.lastName,
-                                         symbol: nil,
-                                         keyboardType: .default)
-                    Divider()
-                        .padding(.leading, Constants.dividerPadding)
-                    TitleAndTextFieldRow(title: Localization.emailField,
-                                         placeholder: "",
-                                         text: $viewModel.fields.email,
-                                         symbol: nil,
-                                         keyboardType: .emailAddress)
-                        .autocapitalization(.none)
-                        .renderedIf(viewModel.showEmailField)
-                    Divider()
-                        .padding(.leading, Constants.dividerPadding)
-                        .renderedIf(viewModel.showEmailField)
-                    TitleAndTextFieldRow(title: Localization.phoneField,
-                                         placeholder: "",
-                                         text: $viewModel.fields.phone,
-                                         symbol: nil,
-                                         keyboardType: .phonePad)
-                }
-                .padding(.horizontal, insets: safeAreaInsets)
-                .background(Color(.systemBackground))
-
-                ListHeaderView(text: viewModel.sectionTitle, alignment: .left)
-                    .padding(.horizontal, insets: safeAreaInsets)
-                VStack(spacing: 0) {
-                    Group {
-                        TitleAndTextFieldRow(title: Localization.companyField,
-                                             placeholder: Localization.placeholderOptional,
-                                             text: $viewModel.fields.company,
-                                             symbol: nil,
-                                             keyboardType: .default)
-                        Divider()
-                            .padding(.leading, Constants.dividerPadding)
-                        TitleAndTextFieldRow(title: Localization.address1Field,
-                                             placeholder: "",
-                                             text: $viewModel.fields.address1,
-                                             symbol: nil,
-                                             keyboardType: .default)
-                        Divider()
-                            .padding(.leading, Constants.dividerPadding)
-                        TitleAndTextFieldRow(title: Localization.address2Field,
-                                             placeholder: "Optional",
-                                             text: $viewModel.fields.address2,
-                                             symbol: nil,
-                                             keyboardType: .default)
-                        Divider()
-                            .padding(.leading, Constants.dividerPadding)
-                        TitleAndTextFieldRow(title: Localization.cityField,
-                                             placeholder: "",
-                                             text: $viewModel.fields.city,
-                                             symbol: nil,
-                                             keyboardType: .default)
-                        Divider()
-                            .padding(.leading, Constants.dividerPadding)
-                        TitleAndTextFieldRow(title: Localization.postcodeField,
-                                             placeholder: "",
-                                             text: $viewModel.fields.postcode,
-                                             symbol: nil,
-                                             keyboardType: .default)
-                        Divider()
-                            .padding(.leading, Constants.dividerPadding)
-                    }
-
-                    Group {
-                        TitleAndValueRow(title: Localization.countryField,
-                                         value: .init(placeHolder: Localization.placeholderSelectOption, content: viewModel.fields.country),
-                                         selectable: true) {
-                            showCountrySelector = true
-                        }
-                        Divider()
-                            .padding(.leading, Constants.dividerPadding)
-                        stateRow()
-                    }
-                }
-                .padding(.horizontal, insets: safeAreaInsets)
-                .background(Color(.systemBackground))
+                SingleAddressForm(fields: $viewModel.fields,
+                                  countryViewModelClosure: viewModel.createCountryViewModel,
+                                  stateViewModelClosure: viewModel.createStateViewModel,
+                                  sectionTitle: viewModel.sectionTitle,
+                                  showEmailField: viewModel.showEmailField,
+                                  showStateFieldAsSelector: viewModel.showStateFieldAsSelector)
 
                 if viewModel.showAlternativeUsageToggle, let alternativeUsageToggleTitle = viewModel.alternativeUsageToggleTitle {
                     TitleAndToggleRow(title: alternativeUsageToggleTitle, isOn: $viewModel.fields.useAsToggle)
@@ -233,25 +141,13 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                         .background(Color(.systemBackground))
                 }
 
-                // Go to edit country
-                LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
-                    EmptyView()
-                }
-
-                // Go to edit state
-                LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createStateViewModel()), isActive: $showStateSelector) {
-                    EmptyView()
-                }
-
-                ///
-                /// iOS 14.5 has a bug where
-                /// Pushing a view while having "exactly two" navigation links makes the pushed view to be popped when the initial view changes its state.
-                /// EG: AddressForm -> CountrySelector -> Country is selected -> AddressForm updates country -> CountrySelector is popped automatically.
-                /// Adding an extra and useless navigation link fixes the problem but throws a warning in the console.
-                /// Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279
-                ///
-                NavigationLink(destination: EmptyView()) {
-                    EmptyView()
+                if viewModel.showDifferentAddressForm {
+                    SingleAddressForm(fields: $viewModel.fields,
+                                      countryViewModelClosure: viewModel.createCountryViewModel,
+                                      stateViewModelClosure: viewModel.createStateViewModel,
+                                      sectionTitle: viewModel.sectionTitle,
+                                      showEmailField: false,
+                                      showStateFieldAsSelector: viewModel.showStateFieldAsSelector)
                 }
             }
             .disableAutocorrection(true)
@@ -281,7 +177,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
 
     /// Decides if the navigation trailing item should be a done button or a loading indicator.
     ///
-    @ViewBuilder private func navigationBarTrailingItem() -> some View {
+    @ViewBuilder func navigationBarTrailingItem() -> some View {
         switch viewModel.navigationTrailingItem {
         case .done(let enabled):
             Button(Localization.done) {
@@ -296,20 +192,148 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
             ProgressView()
         }
     }
+}
+
+struct SingleAddressForm: View {
+
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
+    @Binding var fields: AddressFormFields
+
+    let countryViewModelClosure: () -> CountrySelectorViewModel
+    let stateViewModelClosure: () -> StateSelectorViewModel
+
+    let sectionTitle: String
+    let showEmailField: Bool
+    let showStateFieldAsSelector: Bool
+
+    /// Set it to `true` to present the country selector.
+    ///
+    @State private var showCountrySelector = false
+
+    /// Set it to `true` to present the state selector.
+    ///
+    @State private var showStateSelector = false
+
+    var body: some View {
+        ListHeaderView(text: Localization.detailsSection, alignment: .left)
+            .padding(.horizontal, insets: safeAreaInsets)
+        VStack(spacing: 0) {
+            TitleAndTextFieldRow(title: Localization.firstNameField,
+                                 placeholder: "",
+                                 text: $fields.firstName,
+                                 symbol: nil,
+                                 keyboardType: .default)
+            Divider()
+                .padding(.leading, Constants.dividerPadding)
+            TitleAndTextFieldRow(title: Localization.lastNameField,
+                                 placeholder: "",
+                                 text: $fields.lastName,
+                                 symbol: nil,
+                                 keyboardType: .default)
+            Divider()
+                .padding(.leading, Constants.dividerPadding)
+
+            if showEmailField {
+                TitleAndTextFieldRow(title: Localization.emailField,
+                                     placeholder: "",
+                                     text: $fields.email,
+                                     symbol: nil,
+                                     keyboardType: .emailAddress)
+                    .autocapitalization(.none)
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
+
+            }
+
+            TitleAndTextFieldRow(title: Localization.phoneField,
+                                 placeholder: "",
+                                 text: $fields.phone,
+                                 symbol: nil,
+                                 keyboardType: .phonePad)
+        }
+        .padding(.horizontal, insets: safeAreaInsets)
+        .background(Color(.systemBackground))
+
+        ListHeaderView(text: sectionTitle, alignment: .left)
+            .padding(.horizontal, insets: safeAreaInsets)
+        VStack(spacing: 0) {
+            Group {
+                TitleAndTextFieldRow(title: Localization.companyField,
+                                     placeholder: Localization.placeholderOptional,
+                                     text: $fields.company,
+                                     symbol: nil,
+                                     keyboardType: .default)
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
+                TitleAndTextFieldRow(title: Localization.address1Field,
+                                     placeholder: "",
+                                     text: $fields.address1,
+                                     symbol: nil,
+                                     keyboardType: .default)
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
+                TitleAndTextFieldRow(title: Localization.address2Field,
+                                     placeholder: Localization.placeholderOptional,
+                                     text: $fields.address2,
+                                     symbol: nil,
+                                     keyboardType: .default)
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
+                TitleAndTextFieldRow(title: Localization.cityField,
+                                     placeholder: "",
+                                     text: $fields.city,
+                                     symbol: nil,
+                                     keyboardType: .default)
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
+                TitleAndTextFieldRow(title: Localization.postcodeField,
+                                     placeholder: "",
+                                     text: $fields.postcode,
+                                     symbol: nil,
+                                     keyboardType: .default)
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
+            }
+
+            Group {
+                // Go to edit country
+                LazyNavigationLink(destination: FilterListSelector(viewModel: countryViewModelClosure()), isActive: $showCountrySelector) {
+                    EmptyView()
+                }
+
+                // Go to edit state
+                LazyNavigationLink(destination: FilterListSelector(viewModel: stateViewModelClosure()), isActive: $showStateSelector) {
+                    EmptyView()
+                }
+
+                TitleAndValueRow(title: Localization.countryField,
+                                 value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.country),
+                                 selectable: true) {
+                    showCountrySelector = true
+                }
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
+                stateRow()
+            }
+        }
+        .padding(.horizontal, insets: safeAreaInsets)
+        .background(Color(.systemBackground))
+    }
 
     /// Decides if the state row should be rendered as a list selector field or as a text input field.
     ///
     @ViewBuilder private func stateRow() -> some View {
-        if viewModel.showStateFieldAsSelector {
+        if showStateFieldAsSelector {
             TitleAndValueRow(title: Localization.stateField,
-                             value: .init(placeHolder: Localization.placeholderSelectOption, content: viewModel.fields.state),
+                             value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.state),
                              selectable: true) {
                 showStateSelector = true
             }
         } else {
             TitleAndTextFieldRow(title: Localization.stateField,
                                  placeholder: "",
-                                 text: $viewModel.fields.state,
+                                 text: $fields.state,
                                  symbol: nil,
                                  keyboardType: .default)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -308,7 +308,7 @@ struct SingleAddressForm: View {
                 }
 
                 TitleAndValueRow(title: Localization.countryField,
-                                 value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.country),
+                                 value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.countryName),
                                  selectable: true) {
                     showCountrySelector = true
                 }
@@ -326,14 +326,14 @@ struct SingleAddressForm: View {
     @ViewBuilder private func stateRow() -> some View {
         if showStateFieldAsSelector {
             TitleAndValueRow(title: Localization.stateField,
-                             value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.state),
+                             value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.stateName),
                              selectable: true) {
                 showStateSelector = true
             }
         } else {
             TitleAndTextFieldRow(title: Localization.stateField,
                                  placeholder: "",
-                                 text: $fields.state,
+                                 text: $fields.stateName,
                                  symbol: nil,
                                  keyboardType: .default)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -215,8 +215,16 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                 .padding(.horizontal, insets: geometry.safeAreaInsets)
                 .background(Color(.systemBackground))
 
-                if viewModel.showAlternativeUsageToggle {
-                    TitleAndToggleRow(title: viewModel.alternativeUsageToggleTitle, isOn: $viewModel.fields.useAsToggle)
+                if viewModel.showAlternativeUsageToggle, let alternativeUsageToggleTitle = viewModel.alternativeUsageToggleTitle {
+                    TitleAndToggleRow(title: alternativeUsageToggleTitle, isOn: $viewModel.fields.useAsToggle)
+                        .padding(.horizontal, Constants.horizontalPadding)
+                        .padding(.vertical, Constants.verticalPadding)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        .background(Color(.systemBackground))
+                }
+
+                if viewModel.showDifferentAddressToggle, let differentAddressToggleTitle = viewModel.differentAddressToggleTitle {
+                    TitleAndToggleRow(title: differentAddressToggleTitle, isOn: $viewModel.showDifferentAddressForm)
                         .padding(.horizontal, Constants.horizontalPadding)
                         .padding(.vertical, Constants.verticalPadding)
                         .padding(.horizontal, insets: geometry.safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -121,11 +121,13 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
     ///
     @State private var showStateSelector = false
 
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     var body: some View {
-        GeometryReader { geometry in
+        Group {
             ScrollView {
                 ListHeaderView(text: Localization.detailsSection, alignment: .left)
-                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                    .padding(.horizontal, insets: safeAreaInsets)
                 VStack(spacing: 0) {
                     TitleAndTextFieldRow(title: Localization.firstNameField,
                                          placeholder: "",
@@ -157,11 +159,11 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                                          symbol: nil,
                                          keyboardType: .phonePad)
                 }
-                .padding(.horizontal, insets: geometry.safeAreaInsets)
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.systemBackground))
 
                 ListHeaderView(text: viewModel.sectionTitle, alignment: .left)
-                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                    .padding(.horizontal, insets: safeAreaInsets)
                 VStack(spacing: 0) {
                     Group {
                         TitleAndTextFieldRow(title: Localization.companyField,
@@ -212,14 +214,14 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                         stateRow()
                     }
                 }
-                .padding(.horizontal, insets: geometry.safeAreaInsets)
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.systemBackground))
 
                 if viewModel.showAlternativeUsageToggle, let alternativeUsageToggleTitle = viewModel.alternativeUsageToggleTitle {
                     TitleAndToggleRow(title: alternativeUsageToggleTitle, isOn: $viewModel.fields.useAsToggle)
                         .padding(.horizontal, Constants.horizontalPadding)
                         .padding(.vertical, Constants.verticalPadding)
-                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground))
                 }
 
@@ -227,7 +229,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                     TitleAndToggleRow(title: differentAddressToggleTitle, isOn: $viewModel.showDifferentAddressForm)
                         .padding(.horizontal, Constants.horizontalPadding)
                         .padding(.vertical, Constants.verticalPadding)
-                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground))
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -85,13 +85,21 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
         true
     }
 
-    var alternativeUsageToggleTitle: String {
+    var alternativeUsageToggleTitle: String? {
         switch type {
         case .shipping:
             return Localization.useAsBillingToggle
         case .billing:
             return Localization.useAsShippingToggle
         }
+    }
+
+    var showDifferentAddressToggle: Bool {
+        false
+    }
+
+    var differentAddressToggleTitle: String? {
+        nil
     }
 
     /// Update the address remotely and invoke a completion block when finished

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -45,8 +45,8 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.fields.postcode, address.postcode)
 
         let country = Self.sampleCountries.first { $0.code == address.country }
-        XCTAssertEqual(viewModel.fields.country, country?.name)
-        XCTAssertEqual(viewModel.fields.state, country?.states.first?.name) // Only one state supported in tests
+        XCTAssertEqual(viewModel.fields.countryName, country?.name)
+        XCTAssertEqual(viewModel.fields.stateName, country?.states.first?.name) // Only one state supported in tests
 
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
@@ -246,7 +246,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         countryViewModel.command.handleSelectedChange(selected: newCountry, viewController: viewController)
 
         // Then
-        XCTAssertEqual(viewModel.fields.country, newCountry.name)
+        XCTAssertEqual(viewModel.fields.countryName, newCountry.name)
     }
 
     func test_view_model_only_updates_shipping_address_field() {
@@ -337,7 +337,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         stateViewModel.command.handleSelectedChange(selected: newState, viewController: viewController)
 
         // Then
-        XCTAssertEqual(viewModel.fields.state, newState.name)
+        XCTAssertEqual(viewModel.fields.stateName, newState.name)
     }
 
     func test_view_model_updates_billing_and_shipping_address_fields_when_use_as_toggle_is_on() {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/5412.

## Description

This PR adds support for multiple nested forms to address flow UI and updates country/state values handling in address flow.

The plan is to consolidate all address data in `fields` and add second property similar to existing
```
var fields: AddressFormFields
```
This will likely require a few additional properties, like a second pair of country/state view models constructors. I aim to keep them in `CreateOrderAddressFormViewModel`, but some (at least second `fields`) will have to be added on top level (`AddressFormViewModelProtocol`).

I have a working draft of the next step, but if you have any ideas for architecture improvements in this scope - please share!

## Changes

- Adds `differentAddressToggle` support to address form.
- Adds `SingleAddressForm` to allow multiple reusable nested forms in address flow.
- Adds second address input and output arguments for creation flow (unused now).
- Updates country and state values flow to keep all values in `fields` and simplify update flow.
- Replaces `GeometryReader` with `safeAreaInsets` from Environment.

### Known limitations

The second address form is unused, just a placeholder now. First address data will be duplicated there.

## Testing

There is not much new functionality added, focus on existing new order and edit order flows.

Setup:
1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.

Try new order address flow:
1. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
2. Tap "+ Add customer" button to display the address form.
3. Enter some data (pay attention to Country and State).
4. Tap "Done" to save and close the address form.
5. Confirm that the customer section is updated with new data.
6. Tap "Edit" in the customer section.
7. Confirm that address form. shows correct data.
8. Clear all fields and tap "Done".
9. Confirm that the empty state for both addresses shows "No address specified.".
10. Tap "Create" to create an order. Confirm that the order displays the correct address.

Try existing order editing flow:
11. In order details tap the pencil icon to edit the shipping address.
12. Update some data (pay attention to Country and State).
13. Tap "Done" to save and close the address form.
14. Confirm that the customer section is updated with new data.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
