### PR TITLE
Remove decimal points for revenue integer values

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -228,15 +228,16 @@ public class CurrencyFormatter {
     ///     - amount: a NSDecimalNumber representation of the amount, from the API, with no formatting applied. e.g. "19.87"
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///     - locale: the locale that is used to format the currency amount string.
+    ///     - numberOfDecimals: optional number of decimal points to show for the amount. If nil, the currency settings value is used.
     ///
-    func formatAmount(_ amount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current) -> String? {
+    func formatAmount(_ amount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current, numberOfDecimals: Int? = nil) -> String? {
         let currency = currency ?? currencySettings.currencyCode.rawValue
         // Get the currency code
         let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
         // Grab the read-only currency options. These are set by the user in Site > Settings.
         let symbol = currencySettings.symbol(from: code)
         let separator = currencySettings.decimalSeparator
-        let numberOfDecimals = currencySettings.numberOfDecimals
+        let numberOfDecimals = numberOfDecimals ?? currencySettings.numberOfDecimals
         let position = currencySettings.currencyPosition
         let thousandSeparator = currencySettings.thousandSeparator
 
@@ -267,8 +268,8 @@ public class CurrencyFormatter {
     ///     - amount: a Decimal representation of the amount, from the API, with no formatting applied. e.g. "19.87"
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///     - locale: the locale that is used to format the currency amount string.
-    ///
-    func formatAmount(_ amount: Decimal, with currency: String? = nil, locale: Locale = .current) -> String? {
-        formatAmount(amount as NSDecimalNumber, with: currency, locale: locale)
+    ///     - numberOfDecimals: optional number of decimal points to show for the amount. If nil, the currency settings value is used.
+    func formatAmount(_ amount: Decimal, with currency: String? = nil, locale: Locale = .current, numberOfDecimals: Int? = nil) -> String? {
+        formatAmount(amount as NSDecimalNumber, with: currency, locale: locale, numberOfDecimals: numberOfDecimals)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -178,7 +178,9 @@ private extension StoreStatsPeriodViewModel {
 
     func createRevenueStats(orderStatsData: OrderStatsData, selectedIntervalIndex: Int?) -> String {
         if let revenue = revenue(at: selectedIntervalIndex, orderStats: orderStatsData.stats, orderStatsIntervals: orderStatsData.intervals) {
-            return currencyFormatter.formatAmount(revenue, with: currencyCode) ?? String()
+            // If revenue is an integer, no decimal points are shown.
+            let numberOfDecimals: Int? = revenue.isInteger ? 0: nil
+            return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -216,9 +216,47 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(orderStatsTextValues, ["-", "3", "1"])
-        XCTAssertEqual(revenueStatsTextValues, ["-", "$62.70", "$25.00"])
+        XCTAssertEqual(revenueStatsTextValues, ["-", "$62.70", "$25"])
         XCTAssertEqual(visitorStatsTextValues, ["-"])
         XCTAssertEqual(conversionStatsTextValues, ["-"])
+    }
+
+    func test_revenueStatsText_does_not_show_decimal_points_for_integer_value() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        XCTAssertEqual(revenueStatsTextValues, ["-"])
+
+        // When
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 62),
+                                      intervals: [])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(revenueStatsTextValues, ["-", "$62"])
+    }
+
+    func test_revenueStatsText_show_decimal_points_from_currency_settings_for_noninteger_value() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        XCTAssertEqual(revenueStatsTextValues, ["-"])
+
+        // When
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 62.856),
+                                      intervals: [])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(revenueStatsTextValues, ["-", "$62.86"])
     }
 
     func test_visitorStatsText_is_emitted_after_visitor_stats_updated_with_selected_interval() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Based on p1643092966031400/1642515603.003200-slack-C02N7N92DEV, we want to hide the decimal points when revenue stats are integer values. An optional parameter `numberOfDecimals: Int?` is added to `CurrencyFormatter` so that we can pass in `0` when the revenue value is an integer. Otherwise, the number decimal points is from the currency settings.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Tap on each time range tab --> if the revenue stats are integer, no decimal points should be shown

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

value `0` | value `185` | decimal value
-- | -- | --
![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 16 01 13](https://user-images.githubusercontent.com/1945542/151119675-01716996-50cc-46f9-94e0-8a589b987589.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 16 01 15](https://user-images.githubusercontent.com/1945542/151119680-cffb7b79-5f72-4ebf-9ae2-0dd3078efd5a.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-25 at 16 01 40](https://user-images.githubusercontent.com/1945542/151119686-95416e32-8ae8-4ee7-b228-923306e9e242.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->