### PR TITLE
Migrate Observables to Combine: product form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -1,7 +1,7 @@
+import Combine
 import UIKit
 import Yosemite
 import Photos
-import Observables
 
 final class ProductDownloadListViewController: UIViewController {
     private let product: ProductFormDataModel
@@ -25,7 +25,7 @@ final class ProductDownloadListViewController: UIViewController {
     private var onDeviceMediaLibraryPickerCompletion: DeviceMediaLibraryPicker.Completion?
     private var onWPMediaPickerCompletion: WordPressMediaLibraryImagePickerViewController.Completion?
     private let productImageActionHandler: ProductImageActionHandler?
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     /// Loading view displayed while an user is uploading a new image
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -49,10 +49,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private var navigationRightBarButtonItems: AnyPublisher<[UIBarButtonItem], Never> {
         navigationRightBarButtonItemsSubject.eraseToAnyPublisher()
     }
-    private var cancellableProduct: AnyCancellable?
-    private var cancellableProductName: AnyCancellable?
-    private var cancellableUpdateEnabled: AnyCancellable?
-    private var cancellableNewVariationsPrice: AnyCancellable?
+    private var productSubscription: AnyCancellable?
+    private var productNameSubscription: AnyCancellable?
+    private var updateEnabledSubscription: AnyCancellable?
+    private var newVariationsPriceSubscription: AnyCancellable?
     private var productImageStatusesSubscription: AnyCancellable?
 
     init(viewModel: ViewModel,
@@ -89,10 +89,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     }
 
     deinit {
-        cancellableProduct?.cancel()
-        cancellableProductName?.cancel()
-        cancellableUpdateEnabled?.cancel()
-        cancellableNewVariationsPrice?.cancel()
+        productSubscription?.cancel()
+        productNameSubscription?.cancel()
+        updateEnabledSubscription?.cancel()
+        newVariationsPriceSubscription?.cancel()
     }
 
     override func viewDidLoad() {
@@ -487,7 +487,7 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func observeProduct() {
-        cancellableProduct = viewModel.observableProduct.sink { [weak self] product in
+        productSubscription = viewModel.observableProduct.sink { [weak self] product in
             self?.onProductUpdated(product: product)
         }
     }
@@ -503,7 +503,7 @@ private extension ProductFormViewController {
     /// The "happened outside" condition is needed to not reload the view while the user is typing a new name.
     ///
     func observeProductName() {
-        cancellableProductName = viewModel.productName?.sink { [weak self] _ in
+        productNameSubscription = viewModel.productName?.sink { [weak self] _ in
             guard let self = self else { return }
             self.updateBackButtonTitle()
             if self.view.window == nil { // If window is nil, this screen isn't the active screen.
@@ -513,7 +513,7 @@ private extension ProductFormViewController {
     }
 
     func observeUpdateCTAVisibility() {
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { [weak self] _ in
+        updateEnabledSubscription = viewModel.isUpdateEnabled.sink { [weak self] _ in
             self?.updateNavigationBar()
         }
     }
@@ -522,7 +522,7 @@ private extension ProductFormViewController {
     /// Needed to show/hide the `.noPriceWarning` row.
     ///
     func observeVariationsPriceChanges() {
-        cancellableNewVariationsPrice = viewModel.newVariationsPrice.sink { [weak self] in
+        newVariationsPriceSubscription = viewModel.newVariationsPrice.sink { [weak self] in
             self?.onVariationsPriceChanged()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -53,6 +53,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private var cancellableProductName: AnyCancellable?
     private var cancellableUpdateEnabled: AnyCancellable?
     private var cancellableNewVariationsPrice: AnyCancellable?
+    private var productImageStatusesSubscription: AnyCancellable?
 
     init(viewModel: ViewModel,
          eventLogger: ProductFormEventLoggerProtocol,
@@ -111,7 +112,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         observeUpdateCTAVisibility()
         observeVariationsPriceChanges()
 
-        productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
+        productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
             guard let self = self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -1,5 +1,5 @@
+import Combine
 import Yosemite
-import Observables
 
 import protocol Storage.StorageManagerType
 
@@ -11,23 +11,23 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     var productionVariationID: Int64? = nil
 
     /// Emits product on change, except when the product name is the only change (`productName` is emitted for this case).
-    var observableProduct: Observable<EditableProductModel> {
-        productSubject
+    var observableProduct: AnyPublisher<EditableProductModel, Never> {
+        productSubject.eraseToAnyPublisher()
     }
 
     /// Emits product name on change.
-    var productName: Observable<String>? {
-        productNameSubject
+    var productName: AnyPublisher<String, Never>? {
+        productNameSubject.eraseToAnyPublisher()
     }
 
     /// Emits a boolean of whether the product has unsaved changes for remote update.
-    var isUpdateEnabled: Observable<Bool> {
-        isUpdateEnabledSubject
+    var isUpdateEnabled: AnyPublisher<Bool, Never> {
+        isUpdateEnabledSubject.eraseToAnyPublisher()
     }
 
     /// Emits a void value informing when there is a new variation price state available
-    var newVariationsPrice: Observable<Void> {
-        newVariationsPriceSubject
+    var newVariationsPrice: AnyPublisher<Void, Never> {
+        newVariationsPriceSubject.eraseToAnyPublisher()
     }
 
     /// The latest product value.
@@ -46,10 +46,10 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     /// Creates actions available on the bottom sheet.
     private(set) var actionsFactory: ProductFormActionsFactoryProtocol
 
-    private let productSubject: PublishSubject<EditableProductModel> = PublishSubject<EditableProductModel>()
-    private let productNameSubject: PublishSubject<String> = PublishSubject<String>()
-    private let isUpdateEnabledSubject: PublishSubject<Bool>
-    private let newVariationsPriceSubject = PublishSubject<Void>()
+    private let productSubject: PassthroughSubject<EditableProductModel, Never> = PassthroughSubject<EditableProductModel, Never>()
+    private let productNameSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
+    private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never>
+    private let newVariationsPriceSubject = PassthroughSubject<Void, Never>()
 
     private lazy var variationsResultsController = createVariationsResultsController()
 
@@ -152,7 +152,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let productImageActionHandler: ProductImageActionHandler
 
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     private let stores: StoresManager
 
@@ -168,7 +168,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.originalProduct = product
         self.product = product
         self.actionsFactory = ProductFormActionsFactory(product: product, formType: formType)
-        self.isUpdateEnabledSubject = PublishSubject<Bool>()
+        self.isUpdateEnabledSubject = PassthroughSubject<Bool, Never>()
         self.stores = stores
         self.storageManager = storageManager
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -48,7 +48,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let productSubject: PassthroughSubject<EditableProductModel, Never> = PassthroughSubject<EditableProductModel, Never>()
     private let productNameSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
-    private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never>
+    private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never> = PassthroughSubject<Bool, Never>()
     private let newVariationsPriceSubject = PassthroughSubject<Void, Never>()
 
     private lazy var variationsResultsController = createVariationsResultsController()
@@ -168,7 +168,6 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.originalProduct = product
         self.product = product
         self.actionsFactory = ProductFormActionsFactory(product: product, formType: formType)
-        self.isUpdateEnabledSubject = PassthroughSubject<Bool, Never>()
         self.stores = stores
         self.storageManager = storageManager
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -1,5 +1,5 @@
+import Combine
 import Yosemite
-import Observables
 
 /// The type of product form: adding a new one or editing an existing one.
 enum ProductFormType {
@@ -29,19 +29,19 @@ protocol ProductFormViewModelProtocol {
     associatedtype ProductModel: ProductFormDataModel & TaxClassRequestable
 
     /// Emits product on change, except when the product name is the only change (`productName` is emitted for this case).
-    var observableProduct: Observable<ProductModel> { get }
+    var observableProduct: AnyPublisher<ProductModel, Never> { get }
 
     /// The type of form: adding a new product or editing an existing product.
     var formType: ProductFormType { get }
 
     /// Emits product name on change. If the name is not editable (e.g. when the product model is `ProductVariation`), `nil` is returned.
-    var productName: Observable<String>? { get }
+    var productName: AnyPublisher<String, Never>? { get }
 
     /// Emits a boolean of whether the product has unsaved changes for remote update.
-    var isUpdateEnabled: Observable<Bool> { get }
+    var isUpdateEnabled: AnyPublisher<Bool, Never> { get }
 
     /// Emits a void value informing when there is a new variation price state available
-    var newVariationsPrice: Observable<Void> { get }
+    var newVariationsPrice: AnyPublisher<Void, Never> { get }
 
     /// Creates actions available on the bottom sheet.
     var actionsFactory: ProductFormActionsFactoryProtocol { get }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -1,5 +1,5 @@
+import Combine
 import Yosemite
-import Observables
 
 /// Provides data for product form UI on a `ProductVariation`, and handles product editing actions.
 final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
@@ -7,8 +7,8 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     typealias ProductModel = EditableProductVariationModel
 
     /// Emits product variation on change.
-    var observableProduct: Observable<EditableProductVariationModel> {
-        productVariationSubject
+    var observableProduct: AnyPublisher<EditableProductVariationModel, Never> {
+        productVariationSubject.eraseToAnyPublisher()
     }
 
     /// The latest product variation including potential edits.
@@ -22,8 +22,8 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     }
 
     /// Emits a boolean of whether the product variation has unsaved changes for remote update.
-    var isUpdateEnabled: Observable<Bool> {
-        isUpdateEnabledSubject
+    var isUpdateEnabled: AnyPublisher<Bool, Never> {
+        isUpdateEnabledSubject.eraseToAnyPublisher()
     }
 
     /// The product variation ID
@@ -32,7 +32,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     }
 
     /// Emits a void value informing when there is a new variation price state available
-    var newVariationsPrice: Observable<Void> = PublishSubject<Void>()
+    var newVariationsPrice: AnyPublisher<Void, Never> = PassthroughSubject<Void, Never>().eraseToAnyPublisher()
 
     /// Creates actions available on the bottom sheet.
     private(set) var actionsFactory: ProductFormActionsFactoryProtocol
@@ -46,10 +46,10 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     private(set) var password: String? = nil
 
     /// Not applicable to product variation form
-    private(set) var productName: Observable<String>? = nil
+    private(set) var productName: AnyPublisher<String, Never>? = nil
 
-    private let productVariationSubject: PublishSubject<EditableProductVariationModel> = PublishSubject<EditableProductVariationModel>()
-    private let isUpdateEnabledSubject: PublishSubject<Bool>
+    private let productVariationSubject: PassthroughSubject<EditableProductVariationModel, Never> = PassthroughSubject<EditableProductVariationModel, Never>()
+    private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never>
 
     /// The product variation before any potential edits; reset after a remote update.
     private var originalProductVariation: EditableProductVariationModel {
@@ -97,7 +97,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     private let parentProductSKU: String?
     private let productImageActionHandler: ProductImageActionHandler
     private let storesManager: StoresManager
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     init(productVariation: EditableProductVariationModel,
          allAttributes: [ProductAttribute],
@@ -114,7 +114,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         self.formType = formType
         self.editable = formType != .readonly
         self.actionsFactory = ProductVariationFormActionsFactory(productVariation: productVariation, editable: editable)
-        self.isUpdateEnabledSubject = PublishSubject<Bool>()
+        self.isUpdateEnabledSubject = PassthroughSubject<Bool, Never>()
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             if allStatuses.productImageStatuses.hasPendingUpload {
                 self?.isUpdateEnabledSubject.send(true)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -1,6 +1,6 @@
+import Combine
 import Photos
 import Yosemite
-import Observables
 
 /// Encapsulates the implementation of Product images actions from the UI.
 ///
@@ -56,7 +56,7 @@ final class ProductImageActionHandler {
     ///               if `observer` is not nil.
     @discardableResult
     func addUpdateObserver<T: AnyObject>(_ observer: T,
-                                         onUpdate: @escaping OnAllStatusesUpdate) -> ObservationToken {
+                                         onUpdate: @escaping OnAllStatusesUpdate) -> AnyCancellable {
         let id = UUID()
 
         queue.async { [weak self] in
@@ -83,7 +83,7 @@ final class ProductImageActionHandler {
             onUpdate(self.allStatuses)
         }
 
-        return ObservationToken { [weak self] in
+        return AnyCancellable { [weak self] in
             self?.queue.async { [weak self] in
                 self?.observations.allStatusesUpdated.removeValue(forKey: id)
             }
@@ -97,7 +97,7 @@ final class ProductImageActionHandler {
     ///   - onAssetUpload: called when an asset has been uploaded, if `observer` is not nil.
     @discardableResult
     func addAssetUploadObserver<T: AnyObject>(_ observer: T,
-                                              onAssetUpload: @escaping OnAssetUpload) -> ObservationToken {
+                                              onAssetUpload: @escaping OnAssetUpload) -> AnyCancellable {
         let id = UUID()
 
         queue.async { [weak self] in
@@ -117,7 +117,7 @@ final class ProductImageActionHandler {
             }
         }
 
-        return ObservationToken { [weak self] in
+        return AnyCancellable { [weak self] in
             self?.queue.async { [weak self] in
                 self?.observations.assetUploaded.removeValue(forKey: id)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -1,7 +1,7 @@
+import Combine
 import Photos
 import UIKit
 import Yosemite
-import Observables
 
 /// Displays Product images with edit functionality.
 ///
@@ -33,7 +33,7 @@ final class ProductImagesViewController: UIViewController {
             }
         }
     }
-    private var productImageStatusesObservationToken: ObservationToken?
+    private var productImageStatusesObservationToken: AnyCancellable?
 
     private var allowsMultipleImages: Bool {
         product.allowsMultipleImages()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Photos
 import XCTest
 import Fakes
@@ -8,6 +9,7 @@ import Yosemite
 /// Unit tests for unsaved changes (`hasUnsavedChanges`)
 final class ProductFormViewModel_ChangesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
+    private var productImageStatusesSubscription: AnyCancellable?
 
     func testProductHasNoChangesFromEditActionsOfTheSameData() {
         // Arrange
@@ -89,7 +91,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         let expectation = self.expectation(description: "Wait for image upload")
-        productImageActionHandler.addUpdateObserver(self) { statuses in
+        productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { statuses in
             if statuses.productImageStatuses.isNotEmpty {
                 expectation.fulfill()
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -10,20 +10,20 @@ import Yosemite
 /// Unit tests for observables (`observableProduct`, `productName`, `isUpdateEnabled`)
 final class ProductFormViewModel_ObservablesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
-    private var cancellableProduct: AnyCancellable?
-    private var cancellableProductName: AnyCancellable?
-    private var cancellableUpdateEnabled: AnyCancellable?
-    private var cancellableVariationPrice: AnyCancellable?
+    private var productSubscription: AnyCancellable?
+    private var productNameSubscription: AnyCancellable?
+    private var updateEnabledSubscription: AnyCancellable?
+    private var variationPriceSubscription: AnyCancellable?
 
 
     override func tearDown() {
-        [cancellableProduct, cancellableProductName, cancellableUpdateEnabled, cancellableVariationPrice].forEach { cancellable in
+        [productSubscription, productNameSubscription, updateEnabledSubscription, variationPriceSubscription].forEach { cancellable in
             cancellable?.cancel()
         }
-        cancellableProduct = nil
-        cancellableProductName = nil
-        cancellableUpdateEnabled = nil
-        cancellableVariationPrice = nil
+        productSubscription = nil
+        productNameSubscription = nil
+        updateEnabledSubscription = nil
+        variationPriceSubscription = nil
 
         super.tearDown()
     }
@@ -37,15 +37,15 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
-        cancellableProduct = viewModel.observableProduct.sink { _ in
+        productSubscription = viewModel.observableProduct.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
-        cancellableProductName = viewModel.productName?.sink { _ in
+        productNameSubscription = viewModel.productName?.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { _ in
+        updateEnabledSubscription = viewModel.isUpdateEnabled.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
@@ -88,14 +88,14 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
         let expectationForProductName = self.expectation(description: "Product name updates")
         expectationForProductName.expectedFulfillmentCount = 1
-        cancellableProductName = viewModel.productName?.sink { productName in
+        productNameSubscription = viewModel.productName?.sink { productName in
             updatedProductName = productName
             expectationForProductName.fulfill()
         }
@@ -103,7 +103,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         var updatedUpdateEnabled: Bool?
         let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
         expectationForUpdateEnabled.expectedFulfillmentCount = 1
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
+        updateEnabledSubscription = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -129,19 +129,19 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
-        cancellableProductName = viewModel.productName?.sink { productName in
+        productNameSubscription = viewModel.productName?.sink { productName in
             updatedProductName = productName
         }
 
         var updatedUpdateEnabled: Bool?
         let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
         expectationForUpdateEnabled.expectedFulfillmentCount = 1
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
+        updateEnabledSubscription = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -169,12 +169,12 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         viewModel.resetPassword("134")
 
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
-        cancellableProductName = viewModel.productName?.sink { productName in
+        productNameSubscription = viewModel.productName?.sink { productName in
             updatedProductName = productName
         }
 
@@ -183,7 +183,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         expectationForUpdateEnabled.expectedFulfillmentCount = 2
         // The update enabled boolean should be set to true from the password change, and then back to false after resetting with
         // the same password after remote update.
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
+        updateEnabledSubscription = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -210,19 +210,19 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
-        cancellableProductName = viewModel.productName?.sink { productName in
+        productNameSubscription = viewModel.productName?.sink { productName in
             updatedProductName = productName
         }
 
         var updatedUpdateEnabled: Bool?
         let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
         expectationForUpdateEnabled.expectedFulfillmentCount = 1
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
+        updateEnabledSubscription = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -251,7 +251,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
 
         // When
         let priceUpdated: Bool = waitFor { promise in
-            self.cancellableVariationPrice = viewModel.newVariationsPrice.sink { promise(true) }
+            self.variationPriceSubscription = viewModel.newVariationsPrice.sink { promise(true) }
 
             let newVariation = ProductVariation.fake().copy(siteID: self.defaultSiteID, productID: productID,
                                                             productVariationID: variationID,
@@ -281,7 +281,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
 
         // When
         let priceUpdated: Bool = waitFor { promise in
-            self.cancellableVariationPrice = viewModel.newVariationsPrice.sink { promise(true) }
+            self.variationPriceSubscription = viewModel.newVariationsPrice.sink { promise(true) }
 
             let newVariation = variation.copy(regularPrice: "")
             mockStorage.insertSampleProductVariation(readOnlyProductVariation: newVariation, on: product)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -1,7 +1,7 @@
+import Combine
 import Photos
 import XCTest
 import Fakes
-import Observables
 
 @testable import WooCommerce
 @testable import Storage
@@ -10,10 +10,10 @@ import Yosemite
 /// Unit tests for observables (`observableProduct`, `productName`, `isUpdateEnabled`)
 final class ProductFormViewModel_ObservablesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
-    private var cancellableProduct: ObservationToken?
-    private var cancellableProductName: ObservationToken?
-    private var cancellableUpdateEnabled: ObservationToken?
-    private var cancellableVariationPrice: ObservationToken?
+    private var cancellableProduct: AnyCancellable?
+    private var cancellableProductName: AnyCancellable?
+    private var cancellableUpdateEnabled: AnyCancellable?
+    private var cancellableVariationPrice: AnyCancellable?
 
 
     override func tearDown() {
@@ -37,15 +37,15 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
-        cancellableProduct = viewModel.observableProduct.subscribe { _ in
+        cancellableProduct = viewModel.observableProduct.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
-        cancellableProductName = viewModel.productName?.subscribe { _ in
+        cancellableProductName = viewModel.productName?.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { _ in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
@@ -88,14 +88,14 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.subscribe { product in
+        cancellableProduct = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
         let expectationForProductName = self.expectation(description: "Product name updates")
         expectationForProductName.expectedFulfillmentCount = 1
-        cancellableProductName = viewModel.productName?.subscribe { productName in
+        cancellableProductName = viewModel.productName?.sink { productName in
             updatedProductName = productName
             expectationForProductName.fulfill()
         }
@@ -103,7 +103,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         var updatedUpdateEnabled: Bool?
         let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
         expectationForUpdateEnabled.expectedFulfillmentCount = 1
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -129,19 +129,19 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.subscribe { product in
+        cancellableProduct = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
-        cancellableProductName = viewModel.productName?.subscribe { productName in
+        cancellableProductName = viewModel.productName?.sink { productName in
             updatedProductName = productName
         }
 
         var updatedUpdateEnabled: Bool?
         let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
         expectationForUpdateEnabled.expectedFulfillmentCount = 1
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -169,12 +169,12 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         viewModel.resetPassword("134")
 
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.subscribe { product in
+        cancellableProduct = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
-        cancellableProductName = viewModel.productName?.subscribe { productName in
+        cancellableProductName = viewModel.productName?.sink { productName in
             updatedProductName = productName
         }
 
@@ -183,7 +183,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         expectationForUpdateEnabled.expectedFulfillmentCount = 2
         // The update enabled boolean should be set to true from the password change, and then back to false after resetting with
         // the same password after remote update.
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -210,19 +210,19 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.subscribe { product in
+        cancellableProduct = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedProductName: String?
-        cancellableProductName = viewModel.productName?.subscribe { productName in
+        cancellableProductName = viewModel.productName?.sink { productName in
             updatedProductName = productName
         }
 
         var updatedUpdateEnabled: Bool?
         let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
         expectationForUpdateEnabled.expectedFulfillmentCount = 1
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
             expectationForUpdateEnabled.fulfill()
         }
@@ -251,7 +251,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
 
         // When
         let priceUpdated: Bool = waitFor { promise in
-            self.cancellableVariationPrice = viewModel.newVariationsPrice.subscribe { promise(true) }
+            self.cancellableVariationPrice = viewModel.newVariationsPrice.sink { promise(true) }
 
             let newVariation = ProductVariation.fake().copy(siteID: self.defaultSiteID, productID: productID,
                                                             productVariationID: variationID,
@@ -281,7 +281,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
 
         // When
         let priceUpdated: Bool = waitFor { promise in
-            self.cancellableVariationPrice = viewModel.newVariationsPrice.subscribe { promise(true) }
+            self.cancellableVariationPrice = viewModel.newVariationsPrice.sink { promise(true) }
 
             let newVariation = variation.copy(regularPrice: "")
             mockStorage.insertSampleProductVariation(readOnlyProductVariation: newVariation, on: product)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Photos
 import XCTest
 
@@ -7,6 +8,7 @@ import Yosemite
 /// Unit tests for unsaved changes (`hasUnsavedChanges`)
 final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
+    private var productImageStatusesSubscription: AnyCancellable?
 
     func test_product_variation_has_no_changes_from_edit_actions_of_the_same_data() {
         // Arrange
@@ -45,7 +47,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
 
         // Action
         waitForExpectation { expectation in
-            productImageActionHandler.addUpdateObserver(self) { statuses in
+            self.productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { statuses in
                 if statuses.productImageStatuses.isNotEmpty {
                     expectation.fulfill()
                 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -1,6 +1,6 @@
+import Combine
 import Photos
 import XCTest
-import Observables
 
 @testable import WooCommerce
 import Yosemite
@@ -8,9 +8,9 @@ import Yosemite
 /// Unit tests for observables (`observableProduct`, `productName`, `isUpdateEnabled`)
 final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
-    private var cancellableProduct: ObservationToken?
-    private var cancellableProductName: ObservationToken?
-    private var cancellableUpdateEnabled: ObservationToken?
+    private var cancellableProduct: AnyCancellable?
+    private var cancellableProductName: AnyCancellable?
+    private var cancellableUpdateEnabled: AnyCancellable?
 
     override func tearDown() {
         [cancellableProduct, cancellableProductName, cancellableUpdateEnabled].forEach { cancellable in
@@ -42,11 +42,11 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
         let model = EditableProductVariationModel(productVariation: productVariation)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductVariationFormViewModel(productVariation: model, productImageActionHandler: productImageActionHandler)
-        cancellableProduct = viewModel.observableProduct.subscribe { _ in
+        cancellableProduct = viewModel.observableProduct.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { _ in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { _ in
             // Assert
             XCTFail("Should not be triggered from edit actions of the same data")
         }
@@ -76,14 +76,14 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductVariationFormViewModel(productVariation: model, productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.subscribe { product in
+        cancellableProduct = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         // Action
         var updatedUpdateEnabled: Bool?
         waitForExpectation { expectation in
-            cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+            cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
                 updatedUpdateEnabled = isUpdateEnabled
                 expectation.fulfill()
             }
@@ -109,12 +109,12 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
                                                       storesManager: mockStoresManager)
 
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.subscribe { product in
+        cancellableProduct = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedUpdateEnabled: Bool?
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
         }
 
@@ -146,12 +146,12 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
                                                       storesManager: mockStoresManager)
 
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.subscribe { product in
+        cancellableProduct = viewModel.observableProduct.sink { product in
             isProductUpdated = true
         }
 
         var updatedUpdateEnabled: Bool?
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.sink { isUpdateEnabled in
             updatedUpdateEnabled = isUpdateEnabled
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageActionHandlerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Photos
 import XCTest
 @testable import WooCommerce
@@ -17,6 +18,9 @@ extension ProductImageStatus: Equatable {
 }
 
 final class ProductImageActionHandlerTests: XCTestCase {
+    private var productImageStatusesSubscription: AnyCancellable?
+    private var assetUploadSubscription: AnyCancellable?
+
     func testUploadingMediaSuccessfully() {
         let mockMedia = createMockMedia()
         let mockUploadedProductImage = ProductImage(imageID: mockMedia.mediaID,
@@ -50,7 +54,7 @@ final class ProductImageActionHandlerTests: XCTestCase {
         waitForStatusUpdates.expectedFulfillmentCount = 1
 
         var observedProductImageStatusChanges: [[ProductImageStatus]] = []
-        productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
+        productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
             XCTAssertTrue(Thread.current.isMainThread)
             observedProductImageStatusChanges.append(productImageStatuses)
             if observedProductImageStatusChanges.count >= expectedStatusUpdates.count {
@@ -59,7 +63,7 @@ final class ProductImageActionHandlerTests: XCTestCase {
         }
 
         let waitForAssetUpload = self.expectation(description: "Wait for asset upload callback from image upload")
-        productImageActionHandler.addAssetUploadObserver(self) { (asset, productImage) in
+        assetUploadSubscription = productImageActionHandler.addAssetUploadObserver(self) { (asset, productImage) in
             XCTAssertTrue(Thread.current.isMainThread)
             XCTAssertEqual(asset, mockAsset)
             XCTAssertEqual(productImage, mockUploadedProductImage)
@@ -101,7 +105,7 @@ final class ProductImageActionHandlerTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var observedProductImageStatusChanges: [[ProductImageStatus]] = []
-        productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
+        productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
             XCTAssertTrue(Thread.current.isMainThread)
             observedProductImageStatusChanges.append(productImageStatuses)
             if observedProductImageStatusChanges.count >= expectedStatusUpdates.count {
@@ -139,7 +143,7 @@ final class ProductImageActionHandlerTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var observedProductImageStatusChanges: [[ProductImageStatus]] = []
-        productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
+        productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
             XCTAssertTrue(Thread.current.isMainThread)
             observedProductImageStatusChanges.append(productImageStatuses)
             if observedProductImageStatusChanges.count >= expectedStatusUpdates.count {
@@ -194,7 +198,7 @@ final class ProductImageActionHandlerTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var observedProductImageStatusChanges: [[ProductImageStatus]] = []
-        productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
+        productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { (productImageStatuses, error) in
             XCTAssertTrue(Thread.current.isMainThread)
             observedProductImageStatusChanges.append(productImageStatuses)
             if observedProductImageStatusChanges.count >= expectedStatusUpdates.count {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #4379 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We used to have our own implementation of observables before we can use Combine in iOS 13, and now we're ready to migrate to Combine in the codebase. This PR only contains the changes for product form related files for easier review & testing.

During testing, I noticed an issue where the product images aren't updated in product form after uploading an image. This was due to the `AnyCancellable` subscription not being held onto and was canceled immediately in Combine, and fixed in https://github.com/woocommerce/woocommerce-ios/commit/bd5f046c7ac1e47fc5460cb0e16ea479c34a0ef0. Similarly, failing unit tests were fixed this way.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please test for regressions on product editing:

- Launch the app
- Go to the products tab
- Tap on an editable product
- Try updating product images, name, description, etc. --> the "Update"/"Save" button should be shown only when there are actual changes on the product. everything should work as before in product editing
- Feel free to try editing the downloadable files for a downloadable product

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
