### PR TITLE
Coupons: Update Yosemite to add search coupons functionality

### DIFF
--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -61,12 +61,10 @@ public enum CouponAction: Action {
     /// - `pageNumber`: page of results based on the `pageSize` provided. 1-indexed.
     /// - `pageSize`: number of results per page.
     /// - `onCompletion`: invoked when the search finishes.
-    ///     - `result.success(Bool)`: value indicates whether there are further pages to retrieve.
-    ///     - `result.failure(Error)`: error indicates issues searching the coupons.
     ///
     case searchCoupons(siteID: Int64,
                        keyword: String,
                        pageNumber: Int,
                        pageSize: Int,
-                       onCompletion: (Result<Bool, Error>) -> Void)
+                       onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -53,4 +53,20 @@ public enum CouponAction: Action {
     case loadCouponReport(siteID: Int64,
                           couponID: Int64,
                           onCompletion: (Result<CouponReport, Error>) -> Void)
+
+    /// Search Coupons matching a given keyword for a site
+    ///
+    /// - `siteID`: the site for which coupons should be fetched.
+    /// - `keyword`: the keyword to match the results with.
+    /// - `pageNumber`: page of results based on the `pageSize` provided. 1-indexed.
+    /// - `pageSize`: number of results per page.
+    /// - `onCompletion`: invoked when the search finishes.
+    ///     - `result.success(Bool)`: value indicates whether there are further pages to retrieve.
+    ///     - `result.failure(Error)`: error indicates issues searching the coupons.
+    ///
+    case searchCoupons(siteID: Int64,
+                       keyword: String,
+                       pageNumber: Int,
+                       pageSize: Int,
+                       onCompletion: (Result<Bool, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -148,6 +148,7 @@ public typealias StorageAccount = Storage.Account
 public typealias StorageAccountSettings = Storage.AccountSettings
 public typealias StorageAttribute = Storage.GenericAttribute
 public typealias StorageCoupon = Storage.Coupon
+public typealias StorageCouponSearchResult = Storage.CouponSearchResult
 public typealias StorageAddOnGroup = Storage.AddOnGroup
 public typealias StorageAnnouncement = Storage.Announcement
 public typealias StorageEligibilityErrorInfo = Storage.EligibilityErrorInfo

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -66,6 +66,12 @@ public final class CouponStore: Store {
             createCoupon(coupon, onCompletion: onCompletion)
         case .loadCouponReport(let siteID, let couponID, let onCompletion):
             loadCouponReport(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
+        case .searchCoupons(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
+            searchCoupons(siteID: siteID,
+                          keyword: keyword,
+                          pageNumber: pageNumber,
+                          pageSize: pageSize,
+                          onCompletion: onCompletion)
         }
     }
 }
@@ -189,6 +195,39 @@ private extension CouponStore {
     ///
     func loadCouponReport(siteID: Int64, couponID: Int64, onCompletion: @escaping (Result<CouponReport, Error>) -> Void) {
         remote.loadCouponReport(for: siteID, couponID: couponID, completion: onCompletion)
+    }
+
+    /// Search coupons from a Site that match a specified keyword.
+    /// Search results are persisted in the local storage to ensure
+    /// good performance for future search of the same keyword.
+    ///
+    /// - Parameters:
+    ///   - siteId: The site to search coupons for.
+    ///   - keyword: The string to match the results with.
+    ///   - pageNumber: Page number of coupons to fetch from the API
+    ///   - pageSize: Number of coupons per page to fetch from the API
+    ///   - onCompletion: Closure to call after the search is complete. Called on the main thread.
+    ///   - result: `.success(hasNextPage: Bool)` or `.failure(error: Error)`
+    ///
+    func searchCoupons(siteID: Int64,
+                       keyword: String,
+                       pageNumber: Int,
+                       pageSize: Int,
+                       onCompletion: @escaping (_ result: Result<Bool, Error>) -> Void) {
+        remote.searchCoupons(for: siteID,
+                                keyword: keyword,
+                                pageNumber: pageNumber,
+                                pageSize: pageSize) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+                
+            case .success(let coupons):
+                // TODO
+                break
+            }
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -215,17 +215,20 @@ private extension CouponStore {
                        pageSize: Int,
                        onCompletion: @escaping (_ result: Result<Bool, Error>) -> Void) {
         remote.searchCoupons(for: siteID,
-                                keyword: keyword,
-                                pageNumber: pageNumber,
-                                pageSize: pageSize) { [weak self] result in
+                             keyword: keyword,
+                             pageNumber: pageNumber,
+                             pageSize: pageSize) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
-                
             case .success(let coupons):
-                // TODO
-                break
+                let hasNextPage = coupons.count == pageSize
+                self.upsertSearchResultsInBackground(siteID: siteID,
+                                                     keyword: keyword,
+                                                     readOnlyCoupons: coupons) {
+                    onCompletion(.success(hasNextPage))
+                }
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -207,13 +207,12 @@ private extension CouponStore {
     ///   - pageNumber: Page number of coupons to fetch from the API
     ///   - pageSize: Number of coupons per page to fetch from the API
     ///   - onCompletion: Closure to call after the search is complete. Called on the main thread.
-    ///   - result: `.success(hasNextPage: Bool)` or `.failure(error: Error)`
     ///
     func searchCoupons(siteID: Int64,
                        keyword: String,
                        pageNumber: Int,
                        pageSize: Int,
-                       onCompletion: @escaping (_ result: Result<Bool, Error>) -> Void) {
+                       onCompletion: @escaping (_ result: Result<Void, Error>) -> Void) {
         remote.searchCoupons(for: siteID,
                              keyword: keyword,
                              pageNumber: pageNumber,
@@ -223,11 +222,10 @@ private extension CouponStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let coupons):
-                let hasNextPage = coupons.count == pageSize
                 self.upsertSearchResultsInBackground(siteID: siteID,
                                                      keyword: keyword,
                                                      readOnlyCoupons: coupons) {
-                    onCompletion(.success(hasNextPage))
+                    onCompletion(.success(()))
                 }
             }
         }

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -527,8 +527,8 @@ final class CouponStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(storedCouponsCount, 3)
-        XCTAssertEqual(storedSearchResultsCount, 3)
+        XCTAssertEqual(storedCouponsCount, 4)
+        XCTAssertEqual(storedSearchResultsCount, 1)
         let storedCoupon = viewStorage.loadCoupon(siteID: sampleSiteID, couponID: sampleCouponID)
         XCTAssertNotNil(storedCoupon)
         XCTAssertEqual(storedCoupon?.amount, "10.00") // Updated amount reflecting the response.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5768 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates CouponAction and CouponStore with the functionality to search coupons. When the `searchCoupons` action is dispatched, CouponStore triggers a call to the remote to send an API request for the search and then upserts the coupons and search results when receiving a response.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The new search action hasn't been integrated yet so just CI passing should be sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
