### PR TITLE
Fix broken test build caused by outdated helper method call

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -161,7 +161,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(status: .complete, isLive: true, isInTestMode: true)
+        setupPaymentGatewayAccount(accountType: StripeAccount.self, status: .complete, isLive: true, isInTestMode: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The test build was failing after I merged #5866. This was due to a preceding merge which added [test_onboarding_returns_stripe_in_test_mode_with_live_stripe_account_when_live_account_in_test_mode](https://github.com/woocommerce/woocommerce-ios/blob/d11e0d5278f35f582b70e82f1992facaa4453cff/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift#L147) to `CardPresentPaymentsOnboardingUseCaseTests`.

Since the helper method had the old signature when that branch was taken, and this was a new method using that helper, it retained the use of that old signature even after #5866 was merged, which failed in the CI tests after the merge (but not before)

### Testing instructions
Run unit tests



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
