### PR TITLE
Coupons: Add search functionality to coupon list screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -161,7 +161,8 @@ private extension CouponListViewController {
             storeID: siteID,
             command: CouponSearchUICommand(),
             cellType: TitleAndSubtitleAndStatusTableViewCell.self,
-            cellSeparator: .singleLine)
+            cellSeparator: .singleLine
+        )
         let navigationController = WooNavigationController(rootViewController: searchViewController)
         present(navigationController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -36,7 +36,7 @@ final class CouponSearchUICommand: SearchUICommand {
         let action = CouponAction.searchCoupons(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { result in
 
             if case .failure(let error) = result {
-                DDLogError("☠️ Order Search Failure! \(error)")
+                DDLogError("☠️ Coupon Search Failure! \(error)")
             }
 
             onCompletion?(result.isSuccess)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -8,7 +8,7 @@ final class CouponSearchUICommand: SearchUICommand {
     typealias CellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
     typealias ResultsControllerModel = StorageCoupon
 
-    let searchBarPlaceholder = NSLocalizedString("Search all coupons", comment: "Coupons Search Placeholder")
+    let searchBarPlaceholder = Localization.searchBarPlaceholder
 
     let searchBarAccessibilityIdentifier = "coupon-search-screen-search-field"
 
@@ -55,11 +55,21 @@ final class CouponSearchUICommand: SearchUICommand {
         let boldSearchKeyword = NSAttributedString(string: searchKeyword,
                                                    attributes: [.font: EmptyStateViewController.Config.messageFont.bold])
 
-        let format = NSLocalizedString("We're sorry, we couldn't find results for “%@”",
-                                       comment: "Message for empty Coupons search results. The %@ is a placeholder for the text entered by the user.")
+        let format = Localization.emptyResultMessage
         let message = NSMutableAttributedString(string: format)
         message.replaceFirstOccurrence(of: "%@", with: boldSearchKeyword)
 
         viewController.configure(.simple(message: message, image: .emptySearchResultsImage))
+    }
+}
+
+// MARK: - Subtypes
+//
+private extension CouponSearchUICommand {
+    enum Localization {
+        static let searchBarPlaceholder = NSLocalizedString("Search all coupons", comment: "Coupons Search Placeholder")
+        static let emptyResultMessage = NSLocalizedString("We're sorry, we couldn't find results for “%@”",
+                                                          comment: "Message for empty Coupons search results. The %@ is a " +
+                                                          "placeholder for the text entered by the user.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -49,4 +49,17 @@ final class CouponSearchUICommand: SearchUICommand {
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
         // TODO: Show coupon details screen
     }
+
+    func configureEmptyStateViewControllerBeforeDisplay(viewController: EmptyStateViewController,
+                                                        searchKeyword: String) {
+        let boldSearchKeyword = NSAttributedString(string: searchKeyword,
+                                                   attributes: [.font: EmptyStateViewController.Config.messageFont.bold])
+
+        let format = NSLocalizedString("We're sorry, we couldn't find results for “%@”",
+                                       comment: "Message for empty Coupons search results. The %@ is a placeholder for the text entered by the user.")
+        let message = NSMutableAttributedString(string: format)
+        message.replaceFirstOccurrence(of: "%@", with: boldSearchKeyword)
+
+        viewController.configure(.simple(message: message, image: .emptySearchResultsImage))
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Yosemite
+
+/// Implementation of `SearchUICommand` for Coupon search.
+final class CouponSearchUICommand: SearchUICommand {
+
+    typealias Model = Coupon
+    typealias CellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
+    typealias ResultsControllerModel = StorageCoupon
+
+    let searchBarPlaceholder = NSLocalizedString("Search all coupons", comment: "Coupons Search Placeholder")
+
+    let searchBarAccessibilityIdentifier = "coupon-search-screen-search-field"
+
+    let cancelButtonAccessibilityIdentifier = "coupon-search-screen-cancel-button"
+
+    func createResultsController() -> ResultsController<StorageCoupon> {
+        let storageManager = ServiceLocator.storageManager
+        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated, ascending: false)
+        return ResultsController<StorageCoupon>(storageManager: storageManager, sortedBy: [descriptor])
+    }
+
+    func createStarterViewController() -> UIViewController? {
+        nil
+    }
+
+    func createCellViewModel(model: Coupon) -> TitleAndSubtitleAndStatusTableViewCell.ViewModel {
+        CellViewModel(title: model.code,
+                      subtitle: model.discountType.localizedName, // to be updated after UI is finalized
+                      accessibilityLabel: model.description.isEmpty ? model.description : model.code,
+                      status: model.expiryStatus().localizedName,
+                      statusBackgroundColor: model.expiryStatus().statusBackgroundColor)
+    }
+
+    func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+        let action = CouponAction.searchCoupons(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { result in
+
+            if case .failure(let error) = result {
+                DDLogError("☠️ Order Search Failure! \(error)")
+            }
+
+            onCompletion?(result.isSuccess)
+        }
+
+        ServiceLocator.stores.dispatch(action)
+        // TODO: add analytics
+    }
+
+    func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
+        // TODO: Show coupon details screen
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.swift
@@ -1,6 +1,7 @@
 import UIKit
 
-final class TitleAndSubtitleAndStatusTableViewCell: UITableViewCell {
+final class TitleAndSubtitleAndStatusTableViewCell: UITableViewCell, SearchResultCell {
+    typealias SearchModel = ViewModel
 
     @IBOutlet private var subtitleLabel: UILabel!
     @IBOutlet private var titleLabel: UILabel!
@@ -15,6 +16,10 @@ final class TitleAndSubtitleAndStatusTableViewCell: UITableViewCell {
         super.awakeFromNib()
         configureBackground()
         configureLabels()
+    }
+
+    func configureCell(searchModel: ViewModel) {
+        configureCell(viewModel: searchModel)
     }
 
     func configureCell(viewModel: ViewModel) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1474,6 +1474,7 @@
 		DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */; };
 		DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1726EF35F40071200C /* ConnectivityObserver.swift */; };
 		DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */; };
+		DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
@@ -3085,6 +3086,7 @@
 		DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Connectivity.swift"; sourceTree = "<group>"; };
 		DE792E1726EF35F40071200C /* ConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
+		DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponSearchUICommand.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
@@ -4188,6 +4190,7 @@
 				03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */,
 				03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */,
 				DE26B52B277DA11800A2EA0A /* CouponListView.swift */,
+				DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */,
 			);
 			path = Coupons;
 			sourceTree = "<group>";
@@ -8112,6 +8115,7 @@
 				D8815ADF26383EE700EDAD62 /* CardPresentPaymentsModalViewController.swift in Sources */,
 				57896D6625362B0C000E8C4D /* TitleAndEditableValueTableViewCellViewModel.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
+				DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */,
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,
 				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5768
⚠️ Please make sure that #5975 is reviewed and merged first ⚠️
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR completes the search functionality for coupons. Tracks will be added in a separate PR when the tracking plan is prepared and approved.

Changes:
- Added CouponSearchUICommand for the UI of the search controller
- Added a bar button item on the coupon list screen for searching
- Added navigation to the search controller from the search bar button item.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build the app to a device, make sure that the feature flag for coupons management is enabled.
- Navigate to Menu tab > select Coupons.
- On the Coupons screen, notice that there is now a button on the navigation bar with the search icon.
- Tap on the search button, notice a new screen for searching coupons is displayed. Play with the search functionality, make sure that the empty view is displayed when no matching result is found.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/151149062-a75e1600-b97a-44cb-ac8b-1dd2c9256793.mp4

---


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
