### PR TITLE
Migrate Observables to Combine for product list selector data source

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSource.swift
@@ -1,6 +1,6 @@
+import Combine
 import UIKit
 import Yosemite
-import Observables
 
 /// Configures the results and cells for a paginated list of linked products, syncs each page of products,
 /// and handles actions that could alter the linked products.
@@ -21,10 +21,10 @@ final class LinkedProductListSelectorDataSource: PaginatedListSelectorDataSource
     }
 
     // Observable list of the latest linked product IDs
-    var productIDs: Observable<[Int64]> {
-        productIDsSubject
+    var productIDs: AnyPublisher<[Int64], Never> {
+        productIDsSubject.eraseToAnyPublisher()
     }
-    private let productIDsSubject: PublishSubject<[Int64]> = PublishSubject<[Int64]>()
+    private let productIDsSubject: PassthroughSubject<[Int64], Never> = PassthroughSubject<[Int64], Never>()
 
     private let originalLinkedProductIDs: [Int64]
     private(set) var linkedProductIDs: [Int64] = [] {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
@@ -29,7 +29,7 @@ final class LinkedProductsListSelectorViewController: UIViewController {
             return PaginatedListSelectorViewController(viewProperties: viewProperties, dataSource: dataSource, onDismiss: { _ in })
     }()
 
-    private var cancellable: AnyCancellable?
+    private var productIDsSubscription: AnyCancellable?
 
     // Completion callback
     //
@@ -168,7 +168,7 @@ private extension LinkedProductsListSelectorViewController {
     }
 
     func observeLinkedProductIDs() {
-        cancellable = dataSource.productIDs.sink { [weak self] productIDs in
+        productIDsSubscription = dataSource.productIDs.sink { [weak self] productIDs in
             self?.paginatedListSelector.updateResultsController()
             self?.updateNavigationRightBarButtonItem()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
@@ -1,7 +1,7 @@
+import Combine
 import UIKit
 import WordPressUI
 import Yosemite
-import Observables
 
 /// Displays a paginated list of products given product IDs, with a CTA to add more products.
 final class LinkedProductsListSelectorViewController: UIViewController {
@@ -29,7 +29,7 @@ final class LinkedProductsListSelectorViewController: UIViewController {
             return PaginatedListSelectorViewController(viewProperties: viewProperties, dataSource: dataSource, onDismiss: { _ in })
     }()
 
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     // Completion callback
     //
@@ -168,7 +168,7 @@ private extension LinkedProductsListSelectorViewController {
     }
 
     func observeLinkedProductIDs() {
-        cancellable = dataSource.productIDs.subscribe { [weak self] productIDs in
+        cancellable = dataSource.productIDs.sink { [weak self] productIDs in
             self?.paginatedListSelector.updateResultsController()
             self?.updateNavigationRightBarButtonItem()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListMultiSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListMultiSelectorDataSource.swift
@@ -1,15 +1,15 @@
+import Combine
 import Yosemite
-import Observables
 
 /// Enables the user to select multiple products from a paginated list.
 final class ProductListMultiSelectorDataSource: PaginatedListSelectorDataSource {
     typealias StorageModel = StorageProduct
 
     // Observable list of the latest product IDs
-    var productIDs: Observable<[Int64]> {
-        productIDsSubject
+    var productIDs: AnyPublisher<[Int64], Never> {
+        productIDsSubject.eraseToAnyPublisher()
     }
-    private let productIDsSubject: PublishSubject<[Int64]> = PublishSubject<[Int64]>()
+    private let productIDsSubject: PassthroughSubject<[Int64], Never> = PassthroughSubject<[Int64], Never>()
 
     // Not used: since multiple products can be selected in this use case, the single selected product is not used.
     var selected: Product?

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
@@ -15,7 +15,7 @@ final class ProductListSelectorViewController: UIViewController {
     }
 
     private let siteID: Int64
-    private var cancellable: AnyCancellable?
+    private var selectedProductIDsSubscription: AnyCancellable?
 
     private lazy var dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: excludedProductIDs)
 
@@ -160,7 +160,7 @@ private extension ProductListSelectorViewController {
     }
 
     func observeSelectedProductIDs(observableProductIDs: AnyPublisher<[Int64], Never>) {
-        cancellable = observableProductIDs.sink { [weak self] selectedProductIDs in
+        selectedProductIDsSubscription = observableProductIDs.sink { [weak self] selectedProductIDs in
             self?.productIDs = selectedProductIDs
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
@@ -1,6 +1,6 @@
+import Combine
 import UIKit
 import Yosemite
-import Observables
 
 /// Displays a paginated list of products where the user can select.
 final class ProductListSelectorViewController: UIViewController {
@@ -15,7 +15,7 @@ final class ProductListSelectorViewController: UIViewController {
     }
 
     private let siteID: Int64
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     private lazy var dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: excludedProductIDs)
 
@@ -159,8 +159,8 @@ private extension ProductListSelectorViewController {
         view.pinSubviewToAllEdges(paginatedListSelector.view)
     }
 
-    func observeSelectedProductIDs(observableProductIDs: Observable<[Int64]>) {
-        cancellable = observableProductIDs.subscribe { [weak self] selectedProductIDs in
+    func observeSelectedProductIDs(observableProductIDs: AnyPublisher<[Int64], Never>) {
+        cancellable = observableProductIDs.sink { [weak self] selectedProductIDs in
             self?.productIDs = selectedProductIDs
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductListMultiSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductListMultiSelectorDataSourceTests.swift
@@ -1,5 +1,5 @@
+import Combine
 import XCTest
-import Observables
 
 @testable import Storage
 @testable import WooCommerce
@@ -14,7 +14,7 @@ final class ProductListMultiSelectorDataSourceTests: XCTestCase {
         storageManager.viewStorage
     }
 
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     override func setUp() {
         super.setUp()
@@ -51,7 +51,7 @@ final class ProductListMultiSelectorDataSourceTests: XCTestCase {
         let siteID: Int64 = 1
         let dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: [])
         var productsSequence = [[Int64]]()
-        cancellable = dataSource.productIDs.subscribe { productIDs in
+        cancellable = dataSource.productIDs.sink { productIDs in
             productsSequence.append(productIDs)
         }
 
@@ -92,7 +92,7 @@ final class ProductListMultiSelectorDataSourceTests: XCTestCase {
         let siteID: Int64 = 1
         let dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: [])
         var productsSequence = [[Int64]]()
-        cancellable = dataSource.productIDs.subscribe { productIDs in
+        cancellable = dataSource.productIDs.sink { productIDs in
             productsSequence.append(productIDs)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductListMultiSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductListMultiSelectorDataSourceTests.swift
@@ -14,12 +14,12 @@ final class ProductListMultiSelectorDataSourceTests: XCTestCase {
         storageManager.viewStorage
     }
 
-    private var cancellable: AnyCancellable?
+    private var productIDsSubscription: AnyCancellable?
 
     override func setUp() {
         super.setUp()
 
-        cancellable = nil
+        productIDsSubscription = nil
     }
 
     func test_dataSource_creates_ResultsController_excluding_specified_product_ids() throws {
@@ -51,7 +51,7 @@ final class ProductListMultiSelectorDataSourceTests: XCTestCase {
         let siteID: Int64 = 1
         let dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: [])
         var productsSequence = [[Int64]]()
-        cancellable = dataSource.productIDs.sink { productIDs in
+        productIDsSubscription = dataSource.productIDs.sink { productIDs in
             productsSequence.append(productIDs)
         }
 
@@ -92,7 +92,7 @@ final class ProductListMultiSelectorDataSourceTests: XCTestCase {
         let siteID: Int64 = 1
         let dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: [])
         var productsSequence = [[Int64]]()
-        cancellable = dataSource.productIDs.sink { productIDs in
+        productIDsSubscription = dataSource.productIDs.sink { productIDs in
             productsSequence.append(productIDs)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSourceTests.swift
@@ -1,12 +1,12 @@
+import Combine
 import XCTest
-import Observables
 
 @testable import WooCommerce
 import Yosemite
 
 /// Unit tests for public properties/functions in `LinkedProductListSelectorDataSource`.
 final class LinkedProductListSelectorDataSourceTests: XCTestCase {
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     override func tearDown() {
         cancellable = nil
@@ -23,7 +23,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.subscribe { ids in
+        cancellable = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -44,7 +44,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.subscribe { ids in
+        cancellable = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -69,7 +69,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.subscribe { ids in
+        cancellable = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -92,7 +92,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.subscribe { ids in
+        cancellable = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -116,7 +116,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.subscribe { ids in
+        cancellable = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -138,7 +138,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.subscribe { ids in
+        cancellable = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSourceTests.swift
@@ -6,10 +6,10 @@ import Yosemite
 
 /// Unit tests for public properties/functions in `LinkedProductListSelectorDataSource`.
 final class LinkedProductListSelectorDataSourceTests: XCTestCase {
-    private var cancellable: AnyCancellable?
+    private var productIDsSubscription: AnyCancellable?
 
     override func tearDown() {
-        cancellable = nil
+        productIDsSubscription = nil
         super.tearDown()
     }
 
@@ -23,7 +23,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.sink { ids in
+        productIDsSubscription = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -44,7 +44,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.sink { ids in
+        productIDsSubscription = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -69,7 +69,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.sink { ids in
+        productIDsSubscription = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -92,7 +92,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.sink { ids in
+        productIDsSubscription = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -116,7 +116,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.sink { ids in
+        productIDsSubscription = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 
@@ -138,7 +138,7 @@ final class LinkedProductListSelectorDataSourceTests: XCTestCase {
                                                              linkedProductIDs: preselectedProductIDs,
                                                              trackingContext: "test_context")
         var updatedProductIDs: [Int64]?
-        cancellable = dataSource.productIDs.sink { ids in
+        productIDsSubscription = dataSource.productIDs.sink { ids in
             updatedProductIDs = ids
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #4379 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We used to have our own implementation of observables before we can use Combine in iOS 13, and now we're ready to migrate to Combine in the codebase. This PR only contains the changes for product list selector files for easier review & testing.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please feel free to make sure there are no regressions on the affected features:

- Launch the app
- Go to the products tab
- Tap on a grouped product
- Tap "Grouped products" row
- Tap "Add Products" and select/deselect some products --> the multi-product selection should work as before
- Go back to the products tab
- Tap on an editable product
- Tap "+ Add more details > Linked Products" at the bottom if "Linked Products" row isn't visible already
- Tap "Edit Products" or "Add Products" depending on whether there are existing linked products
- Tap "Add Products" and select/deselect some products --> the multi-product selection should work as before

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
