### PR TITLE
Migrate Observables to Combine for a few classes

### DIFF
--- a/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
@@ -1,15 +1,15 @@
+import Combine
 import UIKit
-import Observables
 
 /// Watches for scroll content offset changes and notifies its subscribers if the scroll position is over a threshold.
 ///
 final class ScrollWatcher {
     /// Emits a stream of scroll position percentages from 0.0 (the beginning) to 1.0 (the end) if over a given threshold whenever the user scrolls a
     /// `UIScrollView` or subclass.
-    var trigger: Observable<Double> {
-        triggerSubject
+    var trigger: AnyPublisher<Double, Never> {
+        triggerSubject.eraseToAnyPublisher()
     }
-    private let triggerSubject: PublishSubject<Double> = PublishSubject<Double>()
+    private let triggerSubject: PassthroughSubject<Double, Never> = .init()
     private let positionThreshold: Double
 
     private var lastPosition: Double = 0.0

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OldStoreStatsAndTopPerformersPeriodViewController.swift
@@ -1,7 +1,7 @@
+import Combine
 import UIKit
 import XLPagerTabStrip
 import Yosemite
-import Observables
 
 /// Container view controller for a stats v4 time range that consists of a scrollable stack view of:
 /// - Store stats data view (managed by child view controller `OldStoreStatsV4PeriodViewController`)
@@ -113,7 +113,7 @@ final class OldStoreStatsAndTopPerformersPeriodViewController: UIViewController 
     private let siteID: Int64
 
     /// Subscriptions that should be cancelled on `deinit`.
-    private var cancellables = [ObservationToken]()
+    private var cancellables = Set<AnyCancellable>()
 
     /// Create an instance of `self`.
     ///
@@ -236,7 +236,7 @@ private extension OldStoreStatsAndTopPerformersPeriodViewController {
             return
         }
 
-        let cancellable = viewModel.isInAppFeedbackCardVisible.subscribe { [weak self] isVisible in
+        viewModel.$isInAppFeedbackCardVisible.sink { [weak self] isVisible in
             guard let self = self else {
                 return
             }
@@ -253,8 +253,7 @@ private extension OldStoreStatsAndTopPerformersPeriodViewController {
                     }
                 }
             }
-        }
-        cancellables.append(cancellable)
+        }.store(in: &cancellables)
     }
 
     func configureSubviews() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -1,8 +1,8 @@
+import Combine
 import UIKit
 import struct WordPressUI.GhostStyle
 import XLPagerTabStrip
 import Yosemite
-import Observables
 
 /// Container view controller for a stats v4 time range that consists of a scrollable stack view of:
 /// - Store stats data view (managed by child view controller `StoreStatsV4PeriodViewController`)
@@ -110,7 +110,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
 
     /// Subscriptions that should be cancelled on `deinit`.
-    private var cancellables = [ObservationToken]()
+    private var subscriptions = Set<AnyCancellable>()
 
     /// Create an instance of `self`.
     ///
@@ -142,7 +142,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     }
 
     deinit {
-        cancellables.forEach {
+        subscriptions.forEach {
             $0.cancel()
         }
     }
@@ -250,7 +250,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             return
         }
 
-        let cancellable = viewModel.isInAppFeedbackCardVisible.subscribe { [weak self] isVisible in
+        viewModel.$isInAppFeedbackCardVisible.sink { [weak self] isVisible in
             guard let self = self else {
                 return
             }
@@ -267,8 +267,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
                     }
                 }
             }
-        }
-        cancellables.append(cancellable)
+        }.store(in: &subscriptions)
     }
 
     func configureSubviews() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -109,7 +109,6 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
 
-    /// Subscriptions that should be cancelled on `deinit`.
     private var subscriptions = Set<AnyCancellable>()
 
     /// Create an instance of `self`.
@@ -139,12 +138,6 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        subscriptions.forEach {
-            $0.cancel()
-        }
     }
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -1,6 +1,6 @@
+import Combine
 import Yosemite
 import class AutomatticTracks.CrashLogging
-import Observables
 
 /// ViewModel for `StoreStatsAndTopPerformersPeriodViewController`.
 ///
@@ -15,10 +15,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     let canDisplayInAppFeedbackCard: Bool
 
     /// An Observable that informs the UI whether the in-app feedback card should be displayed or not.
-    var isInAppFeedbackCardVisible: Observable<Bool> {
-        isInAppFeedbackCardVisibleSubject
-    }
-    private let isInAppFeedbackCardVisibleSubject = BehaviorSubject(false)
+    @Published private(set) var isInAppFeedbackCardVisible: Bool = false
 
     private let storesManager: StoresManager
     private let analytics: Analytics
@@ -47,7 +44,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
         refreshIsInAppFeedbackCardVisibleValue()
     }
 
-    /// Updates the card visibility state stored in `isInAppFeedbackCardVisibleSubject` by updating the app last feedback date.
+    /// Updates the card visibility state stored in `isInAppFeedbackCardVisible` by updating the app last feedback date.
     ///
     func onInAppFeedbackCardAction() {
         let action = AppSettingsAction.updateFeedbackStatus(type: .general, status: .given(Date())) { [weak self] result in
@@ -64,7 +61,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
         storesManager.dispatch(action)
     }
 
-    /// Calculates and updates the value of `isInAppFeedbackCardVisibleSubject`.
+    /// Calculates and updates the value of `isInAppFeedbackCardVisible`.
     private func refreshIsInAppFeedbackCardVisibleValue() {
         // Abort right away if we don't need to calculate the real value.
         guard canDisplayInAppFeedbackCard else {
@@ -88,12 +85,12 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
         storesManager.dispatch(action)
     }
 
-    /// Updates the value of `isInAppFeedbackCardVisibileSubject` and tracks a "shown" event
+    /// Updates the value of `isInAppFeedbackCardVisible` and tracks a "shown" event
     /// if the value changed from `false` to `true`.
     private func sendIsInAppFeedbackCardVisibleValueAndTrackIfNeeded(_ newValue: Bool) {
-        let trackEvent = isInAppFeedbackCardVisibleSubject.value == false && newValue == true
+        let trackEvent = isInAppFeedbackCardVisible == false && newValue == true
 
-        isInAppFeedbackCardVisibleSubject.send(newValue)
+        isInAppFeedbackCardVisible = newValue
         if trackEvent {
             analytics.track(event: .appFeedbackPrompt(action: .shown))
         }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -201,7 +201,6 @@ private extension FilterListViewController {
     }
 
     func observeListSelectorCommandItemSelection() {
-        selectedFilterTypeSubscription?.cancel()
         selectedFilterTypeSubscription = listSelectorCommand.onItemSelected.sink { [weak self] selected in
             guard let self = self else {
                 return
@@ -220,7 +219,6 @@ private extension FilterListViewController {
 
             switch selected.listSelectorConfig {
             case .staticOptions(let options):
-                self.selectedFilterValueSubscription?.cancel()
                 let command = StaticListSelectorCommand(navigationBarTitle: selected.title,
                                                         data: options,
                                                         selected: selected.selectedValue)

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -1,7 +1,7 @@
+import Combine
 import UIKit
 import WordPressUI
 import Yosemite
-import Observables
 
 import class AutomatticTracks.CrashLogging
 
@@ -95,7 +95,7 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
     private let scrollWatcher = ScrollWatcher()
     private let paginationTracker = PaginationTracker()
 
-    private var cancellableScrollWatcher: ObservationToken?
+    private var scrollWatcherSubscription: AnyCancellable?
 
     /// Keep track of the (Autosizing Cell's) Height. This helps us prevent UI flickers, due to sizing recalculations.
     ///
@@ -328,7 +328,7 @@ private extension PaginatedListSelectorViewController {
 
     func configurePaginationTracker() {
         paginationTracker.delegate = self
-        cancellableScrollWatcher = scrollWatcher.trigger.subscribe { [weak self] _ in
+        scrollWatcherSubscription = scrollWatcher.trigger.sink { [weak self] _ in
             self?.paginationTracker.ensureNextPageIsSynced()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -67,7 +67,7 @@ final class RefundConfirmationViewModel {
         let shippingLine = details.refundsShipping ? details.order.shippingLines.first : nil
         let fees = details.refundsFees ? details.order.fees : []
         let useCase = RefundCreationUseCase(amount: details.amount,
-                                            reason: reasonForRefundCellViewModel.currentValue,
+                                            reason: reasonForRefundCellViewModel.value,
                                             automaticallyRefundsPayment: gatewaySupportsAutomaticRefunds(),
                                             items: details.items,
                                             shippingLine: shippingLine,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -1,3 +1,4 @@
+import Combine
 import UIKit
 import Yosemite
 import Storage
@@ -30,6 +31,8 @@ final class ManualTrackingViewController: UIViewController {
         }
         return keyboardFrameObserver
     }()
+
+    private var valueSubscriptions: Set<AnyCancellable> = []
 
     init(viewModel: ManualTrackingViewModel) {
         self.viewModel = viewModel
@@ -238,9 +241,9 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.update(viewModel: cellViewModel)
         cell.accessoryType = .none
 
-        _ = cellViewModel.value.subscribe { [weak self] in
+        cellViewModel.value.sink { [weak self] in
             self?.didChangeProviderName(value: $0)
-        }
+        }.store(in: &valueSubscriptions)
     }
 
     private func configureTrackingNumber(cell: TitleAndEditableValueTableViewCell) {
@@ -253,9 +256,9 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.update(viewModel: cellViewModel)
         cell.accessoryType = .none
 
-        _ = cellViewModel.value.subscribe { [weak self] in
+        cellViewModel.value.sink { [weak self] in
             self?.didChangeTrackingNumber(value: $0)
-        }
+        }.store(in: &valueSubscriptions)
     }
 
     private func configureTrackingLink(cell: TitleAndEditableValueTableViewCell) {
@@ -267,9 +270,9 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.update(viewModel: cellViewModel)
         cell.accessoryType = .none
 
-        _ = cellViewModel.value.subscribe { [weak self] in
+        cellViewModel.value.sink { [weak self] in
             self?.didChangeTrackingLink(value: $0)
-        }
+        }.store(in: &valueSubscriptions)
     }
 
     private func configureDateShipped(cell: TitleAndEditableValueTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -241,7 +241,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.update(viewModel: cellViewModel)
         cell.accessoryType = .none
 
-        cellViewModel.value.sink { [weak self] in
+        cellViewModel.$value.sink { [weak self] in
             self?.didChangeProviderName(value: $0)
         }.store(in: &valueSubscriptions)
     }
@@ -256,7 +256,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.update(viewModel: cellViewModel)
         cell.accessoryType = .none
 
-        cellViewModel.value.sink { [weak self] in
+        cellViewModel.$value.sink { [weak self] in
             self?.didChangeTrackingNumber(value: $0)
         }.store(in: &valueSubscriptions)
     }
@@ -270,7 +270,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.update(viewModel: cellViewModel)
         cell.accessoryType = .none
 
-        cellViewModel.value.sink { [weak self] in
+        cellViewModel.$value.sink { [weak self] in
             self?.didChangeTrackingLink(value: $0)
         }.store(in: &valueSubscriptions)
     }
@@ -441,7 +441,7 @@ private extension ManualTrackingViewController {
 
 // MARK: - Navigation bar management
 //
-/// Activates the action button (Add/Edit) if there is anough data to add or edit a shipment tracking
+/// Activates the action button (Add/Edit) if there is enough data to add or edit a shipment tracking
 private extension ManualTrackingViewController {
     private func activateActionButtonIfNecessary() {
         navigationItem.rightBarButtonItem?.isEnabled = viewModel.canCommit

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -29,7 +29,7 @@ final class ProductInventorySettingsViewController: UIViewController {
 
     private var skuBarcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
 
-    private var cancellable: AnyCancellable?
+    private var sectionsSubscription: AnyCancellable?
 
     init(product: ProductFormDataModel, formType: FormType = .inventory, completion: @escaping Completion) {
         self.viewModel = ProductInventorySettingsViewModel(formType: formType, productModel: product)
@@ -131,7 +131,7 @@ private extension ProductInventorySettingsViewController {
     }
 
     func observeSections() {
-        cancellable = viewModel.sections.sink { [weak self] sections in
+        sectionsSubscription = viewModel.sections.sink { [weak self] sections in
             self?.sections = sections
             self?.tableView.reloadData()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -1,6 +1,6 @@
+import Combine
 import UIKit
 import Yosemite
-import Observables
 
 final class ProductInventorySettingsViewController: UIViewController {
 
@@ -29,7 +29,7 @@ final class ProductInventorySettingsViewController: UIViewController {
 
     private var skuBarcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
 
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     init(product: ProductFormDataModel, formType: FormType = .inventory, completion: @escaping Completion) {
         self.viewModel = ProductInventorySettingsViewModel(formType: formType, productModel: product)
@@ -131,7 +131,7 @@ private extension ProductInventorySettingsViewController {
     }
 
     func observeSections() {
-        cancellable = viewModel.sections.subscribe { [weak self] sections in
+        cancellable = viewModel.sections.sink { [weak self] sections in
             self?.sections = sections
             self?.tableView.reloadData()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -1,5 +1,5 @@
+import Combine
 import Yosemite
-import Observables
 
 /// Provides data needed for inventory settings.
 ///
@@ -7,7 +7,7 @@ protocol ProductInventorySettingsViewModelOutput {
     typealias Section = ProductInventorySettingsViewController.Section
 
     /// Observable table view sections.
-    var sections: Observable<[Section]> { get }
+    var sections: AnyPublisher<[Section], Never> { get }
 
     /// Potential error from input changes.
     var error: ProductUpdateError? { get }
@@ -79,10 +79,10 @@ final class ProductInventorySettingsViewModel: ProductInventorySettingsViewModel
 
     /// Table Sections to be rendered
     ///
-    var sections: Observable<[Section]> {
-        sectionsSubject
+    var sections: AnyPublisher<[Section], Never> {
+        $sectionsSubject.eraseToAnyPublisher()
     }
-    private let sectionsSubject: BehaviorSubject<[Section]> = BehaviorSubject<[Section]>([])
+    @Published private var sectionsSubject: [Section] = []
 
     private(set) var error: ProductUpdateError?
 
@@ -253,7 +253,7 @@ private extension ProductInventorySettingsViewModel {
                 createSKUSection()
             ]
         }
-        sectionsSubject.send(sections)
+        sectionsSubject = sections
     }
 
     func createSKUSection() -> Section {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
@@ -29,7 +29,7 @@ final class TitleAndEditableValueTableViewCell: UITableViewCell {
     func update(style: Style = .condensed, viewModel: TitleAndEditableValueTableViewCellViewModel?) {
         title.text = viewModel?.title
         value.placeholder = viewModel?.placeholder
-        value.text = viewModel?.currentValue
+        value.text = viewModel?.value
         value.isEnabled = viewModel?.allowsEditing ?? false
 
         if viewModel?.hidesKeyboardOnReturn == true {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModel.swift
@@ -16,19 +16,10 @@ final class TitleAndEditableValueTableViewCellViewModel {
     /// If `true`, the keyboard will be dismissed on tapping return. Defaults to `false`.
     let hidesKeyboardOnReturn: Bool
 
-    private let valueSubject: CurrentValueSubject<String?, Never>
-
     /// Emits values whenever the text field changes.
     ///
     /// This is connected with the view's text field through the `update(value:)`.
-    var value: AnyPublisher<String?, Never> {
-        valueSubject.eraseToAnyPublisher()
-    }
-
-    /// The last value of the text field.
-    var currentValue: String? {
-        valueSubject.value
-    }
+    @Published private(set) var value: String?
 
     init(title: String?, placeholder: String? = nil, initialValue: String? = nil, allowsEditing: Bool = true, hidesKeyboardOnReturn: Bool = false) {
         self.title = title
@@ -36,13 +27,13 @@ final class TitleAndEditableValueTableViewCellViewModel {
         self.allowsEditing = allowsEditing
         self.hidesKeyboardOnReturn = hidesKeyboardOnReturn
 
-        valueSubject = CurrentValueSubject(initialValue)
+        value = initialValue
     }
 
-    /// Updates the value of the `self.value` `Observable`.
+    /// Updates the value of the `self.value` observable.
     ///
     /// This is generally used by the view represented by this `ViewModel`.
     func update(value: String?) {
-        valueSubject.send(value)
+        self.value = value
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModel.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observables
 
 /// Observable ViewModel for `TitleAndEditableValueTableViewCell`.
 ///
@@ -16,13 +16,13 @@ final class TitleAndEditableValueTableViewCellViewModel {
     /// If `true`, the keyboard will be dismissed on tapping return. Defaults to `false`.
     let hidesKeyboardOnReturn: Bool
 
-    private let valueSubject: BehaviorSubject<String?>
+    private let valueSubject: CurrentValueSubject<String?, Never>
 
     /// Emits values whenever the text field changes.
     ///
     /// This is connected with the view's text field through the `update(value:)`.
-    var value: Observable<String?> {
-        valueSubject
+    var value: AnyPublisher<String?, Never> {
+        valueSubject.eraseToAnyPublisher()
     }
 
     /// The last value of the text field.
@@ -36,7 +36,7 @@ final class TitleAndEditableValueTableViewCellViewModel {
         self.allowsEditing = allowsEditing
         self.hidesKeyboardOnReturn = hidesKeyboardOnReturn
 
-        valueSubject = BehaviorSubject(initialValue)
+        valueSubject = CurrentValueSubject(initialValue)
     }
 
     /// Updates the value of the `self.value` `Observable`.

--- a/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
@@ -1,13 +1,13 @@
+import Combine
 import XCTest
-import Observables
 
 @testable import WooCommerce
 
 final class ScrollWatcherTests: XCTestCase {
-    private var cancellable: ObservationToken?
+    private var subscription: AnyCancellable?
 
     override func tearDown() {
-        cancellable?.cancel()
+        subscription?.cancel()
 
         super.tearDown()
     }
@@ -22,7 +22,7 @@ final class ScrollWatcherTests: XCTestCase {
         let scrollWatcher = ScrollWatcher(positionThreshold: threshold)
         scrollWatcher.startObservingScrollPosition(tableView: tableView)
         var triggeredScrollPositions = [Double]()
-        cancellable = scrollWatcher.trigger.subscribe { scrollPosition in
+        subscription = scrollWatcher.trigger.sink { scrollPosition in
             triggeredScrollPositions.append(scrollPosition)
         }
 
@@ -50,7 +50,7 @@ final class ScrollWatcherTests: XCTestCase {
         let scrollWatcher = ScrollWatcher(positionThreshold: threshold)
         scrollWatcher.startObservingScrollPosition(tableView: tableView)
         var triggeredScrollPositions = [Double]()
-        cancellable = scrollWatcher.trigger.subscribe { scrollPosition in
+        subscription = scrollWatcher.trigger.sink { scrollPosition in
             triggeredScrollPositions.append(scrollPosition)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 import TestKit
 
@@ -11,6 +12,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
     private var storesManager: MockStoresManager!
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
+    private var subscription: AnyCancellable?
 
     override func setUp() {
         super.setUp()
@@ -31,7 +33,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         let viewModel = makeViewModel()
 
         var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+        subscription = viewModel.$isInAppFeedbackCardVisible.sink { value in
             emittedValues.append(value)
         }
 
@@ -45,7 +47,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         let viewModel = makeViewModel(canDisplayInAppFeedbackCard: false)
 
         var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+        subscription = viewModel.$isInAppFeedbackCardVisible.sink { value in
             emittedValues.append(value)
         }
 
@@ -68,7 +70,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         }
 
         var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+        subscription = viewModel.$isInAppFeedbackCardVisible.sink { value in
             emittedValues.append(value)
         }
 
@@ -113,7 +115,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         }
 
         var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+        subscription = viewModel.$isInAppFeedbackCardVisible.sink { value in
             emittedValues.append(value)
         }
 
@@ -136,7 +138,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         }
 
         var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+        subscription = viewModel.$isInAppFeedbackCardVisible.sink { value in
             emittedValues.append(value)
         }
 
@@ -159,7 +161,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         }
 
         var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+        subscription = viewModel.$isInAppFeedbackCardVisible.sink { value in
             emittedValues.append(value)
         }
 
@@ -173,7 +175,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         XCTAssertEqual([false, true, true], emittedValues)
     }
 
-    func test_isInAppFedbackCardVisible_is_false_after_tapping_on_card_CTAs() {
+    func test_isInAppFeedbackCardVisible_is_false_after_tapping_on_card_CTAs() {
         // Given
         let viewModel = makeViewModel()
 
@@ -192,7 +194,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
         // When
         var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+        subscription = viewModel.$isInAppFeedbackCardVisible.sink { value in
             emittedValues.append(value)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModel+VariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModel+VariationTests.swift
@@ -1,12 +1,12 @@
+import Combine
 import XCTest
-import Observables
 @testable import WooCommerce
 @testable import Yosemite
 
 final class ProductInventorySettingsViewModel_VariationTests: XCTestCase {
     typealias Section = ProductInventorySettingsViewController.Section
 
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     override func tearDown() {
         cancellable = nil
@@ -25,7 +25,7 @@ final class ProductInventorySettingsViewModel_VariationTests: XCTestCase {
         // Act
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -53,7 +53,7 @@ final class ProductInventorySettingsViewModel_VariationTests: XCTestCase {
         // Act
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
@@ -1,12 +1,12 @@
+import Combine
 import XCTest
-import Observables
 @testable import WooCommerce
 @testable import Yosemite
 
 final class ProductInventorySettingsViewModelTests: XCTestCase {
     typealias Section = ProductInventorySettingsViewController.Section
 
-    private var cancellable: ObservationToken?
+    private var cancellable: AnyCancellable?
 
     override func tearDown() {
         cancellable = nil
@@ -25,7 +25,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         // Act
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -54,7 +54,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         // Act
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -80,7 +80,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         // Act
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -101,7 +101,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         // Act
         let viewModel = ProductInventorySettingsViewModel(formType: .sku, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -123,7 +123,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         let stores = MockProductSKUValidationStoresManager(existingSKUs: [sku])
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model, stores: stores)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -158,7 +158,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         let stores = MockProductSKUValidationStoresManager(existingSKUs: [sku])
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model, stores: stores)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -195,7 +195,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 
@@ -219,7 +219,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
         var sections: [Section] = []
-        cancellable = viewModel.sections.subscribe { sectionsValue in
+        cancellable = viewModel.sections.sink { sectionsValue in
             sections = sectionsValue
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import TestKit
-import Observables
 
 @testable import WooCommerce
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellTests.swift
@@ -50,14 +50,14 @@ final class TitleAndEditableValueTableViewCellTests: XCTestCase {
 
         cell.update(viewModel: viewModel)
 
-        XCTAssertNil(viewModel.currentValue)
+        XCTAssertNil(viewModel.value)
 
         // When
         mirror.value.text = "Ut ullam itaque"
         mirror.value.sendActions(for: .editingChanged)
 
         // Then
-        XCTAssertEqual(viewModel.currentValue, "Ut ullam itaque")
+        XCTAssertEqual(viewModel.value, "Ut ullam itaque")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModelTests.swift
@@ -13,7 +13,7 @@ final class TitleAndEditableValueTableViewCellViewModelTests: XCTestCase {
         let viewModel = TitleAndEditableValueTableViewCellViewModel(title: nil)
 
         var emittedValues = [String?]()
-        valueSubscription = viewModel.value.sink {
+        valueSubscription = viewModel.$value.sink {
             emittedValues.append($0)
         }
 
@@ -32,13 +32,13 @@ final class TitleAndEditableValueTableViewCellViewModelTests: XCTestCase {
         // Given
         let viewModel = TitleAndEditableValueTableViewCellViewModel(title: nil)
 
-        XCTAssertNil(viewModel.currentValue)
+        XCTAssertNil(viewModel.value)
 
         // When
         viewModel.update(value: "aut")
         viewModel.update(value: "laudantium")
 
         // Then
-        XCTAssertEqual(viewModel.currentValue, "laudantium")
+        XCTAssertEqual(viewModel.value, "laudantium")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModelTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 
 @testable import WooCommerce
@@ -5,13 +6,14 @@ import XCTest
 /// Test cases for `TitleAndEditableValueTableViewCellViewModel`.
 ///
 final class TitleAndEditableValueTableViewCellViewModelTests: XCTestCase {
+    private var valueSubscription: AnyCancellable?
 
     func test_value_Observable_emits_new_values_when_update_is_called() {
         // Given
         let viewModel = TitleAndEditableValueTableViewCellViewModel(title: nil)
 
         var emittedValues = [String?]()
-        _ = viewModel.value.subscribe {
+        valueSubscription = viewModel.value.sink {
             emittedValues.append($0)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #4379 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We used to have our own implementation of observables before we can use Combine in iOS 13, and now we're ready to migrate to Combine in the codebase. This PR contains the changes for a few classes:

- `ScrollWatcher` - subscribed in `PaginatedListSelectorViewController`
- `StoreStatsAndTopPerformersPeriodViewModel` - subscribed in `OldStoreStatsAndTopPerformersPeriodViewController` and `StoreStatsAndTopPerformersPeriodViewController`
- `ProductInventorySettingsViewModel` - subscribed in `ProductInventorySettingsViewController`
- `FilterListViewController.StaticListSelectorCommand` - subscribed in `FilterListViewController`
- `TitleAndEditableValueTableViewCellViewModel` - subscribed in `ManualTrackingViewController`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please feel free to do a confidence check on any of the following screens:

- Add/Edit Product > Shipping > Shipping class
- Add/Edit Product > Price > Tax class
- Add/Edit Product > Inventory --> the sections should be shown as before
- My store tab: in-app feedback card visibility
- Orders tab > Filter
- Products tab > Filter
- Order details > Add tracking


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
