### PR TITLE
Release Home Screen M2 - My store tab updates for all

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -34,7 +34,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .stripeExtensionInPersonPayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .myStoreTabUpdates:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .couponManagement:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productSKUInputScanner:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 8.5
 -----
+- [***] The My store tab is having a new look with new conversion stats and shows up to 5 top performing products now (used to be 3). [https://github.com/woocommerce/woocommerce-ios/pull/5991]
 
 
 8.4


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR turns on the `myStoreTabUpdates` feature flag for all!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to launch the app and check that the My store tab shows the new design!


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
