### PR TITLE
[Mobile Payments] Add feature flag for Canada Payments

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -39,6 +39,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productSKUInputScanner:
             return true
+        case .canadaInPersonPayments:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .taxLinesInSimplePayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inbox:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -78,6 +78,10 @@ public enum FeatureFlag: Int {
     ///
     case productSKUInputScanner
 
+    /// Support for In-Person Payments in Canada
+    ///
+    case canadaInPersonPayments
+
     /// Displays the tax lines breakup in simple payments summary screen
     ///
     case taxLinesInSimplePayments


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5972
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

Adds a feature flag to support In-Person Payments in stores in Canada.
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Not used anywhere yet, nothing to test


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
