### PR TITLE
Remove "excluding taxes" message

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -39,7 +39,7 @@ private extension OrderPaymentSection {
         static let payment = NSLocalizedString("Payment", comment: "Title text of the section that shows Payment details when creating a new order")
         static let productsTotal = NSLocalizedString("Products Total", comment: "Label for the row showing the total cost of products in the order")
         static let orderTotal = NSLocalizedString("Order Total", comment: "Label for the the row showing the total cost of the order")
-        static let taxesInfo = NSLocalizedString("Total excluding taxes. Taxes will be automatically calculated based on your store settings.",
+        static let taxesInfo = NSLocalizedString("Taxes will be automatically calculated based on your store settings.",
                                                  comment: "Information about taxes and the order total when creating a new order")
     }
 }


### PR DESCRIPTION
Technically, some product prices can have taxes in them because of the "Prices entered with tax" setting in Core.

cc @hichamboushaba 

Closes #5966 

## Design

Before | After 
--------|-------
![Simulator Screen Shot - iPhone 13 - 2022-01-27 at 11 52 49](https://user-images.githubusercontent.com/198826/151425976-63c47d1d-d10e-40a3-9195-986ed3e46282.png)        |       ![Simulator Screen Shot - iPhone 13 - 2022-01-27 at 11 58 37](https://user-images.githubusercontent.com/198826/151425986-73c98028-d341-4a50-9858-c3e3d00b3bbf.png)


## Testing

1. Create an order. 
2. Add a product.
3. Confirm the text has been updated correctly.

## Reviewing

Only 1 reviewer is needed but anyone can review.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


