### PR TITLE
Coupons: Add coupon details UI

### DIFF
--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -82,7 +82,7 @@ extension Coupon {
 // MARK: - Sample Data
 extension Coupon {
     static let sampleCoupon = Coupon(couponID: 720,
-                                     code: "free shipping",
+                                     code: "AGK32FD",
                                      amount: "10.00",
                                      dateCreated: Date(timeIntervalSinceNow: -1000),
                                      dateModified: Date(timeIntervalSinceNow: -1000),
@@ -90,7 +90,8 @@ extension Coupon {
                                      description: "Coupon description",
                                      dateExpires: Date(timeIntervalSinceNow: 1000),
                                      usageCount: 10,
-                                     individualUse: true, productIds: [12893712, 12389],
+                                     individualUse: true,
+                                     productIds: [],
                                      excludedProductIds: [12213],
                                      usageLimit: 1200,
                                      usageLimitPerUser: 3,

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -78,3 +78,29 @@ extension Coupon {
         }
     }
 }
+
+// MARK: - Sample Data
+extension Coupon {
+    static let sampleCoupon = Coupon(couponID: 720,
+                                     code: "free shipping",
+                                     amount: "10.00",
+                                     dateCreated: Date(timeIntervalSinceNow: -1000),
+                                     dateModified: Date(timeIntervalSinceNow: -1000),
+                                     discountType: .fixedCart,
+                                     description: "Coupon description",
+                                     dateExpires: Date(timeIntervalSinceNow: 1000),
+                                     usageCount: 10,
+                                     individualUse: true, productIds: [12893712, 12389],
+                                     excludedProductIds: [12213],
+                                     usageLimit: 1200,
+                                     usageLimitPerUser: 3,
+                                     limitUsageToXItems: 10,
+                                     freeShipping: true,
+                                     productCategories: [123, 435, 232],
+                                     excludedProductCategories: [908],
+                                     excludeSaleItems: false,
+                                     minimumAmount: "5.00",
+                                     maximumAmount: "500.00",
+                                     emailRestrictions: ["*@a8c.com", "someone.else@example.com"],
+                                     usedBy: ["someone.else@example.com", "person@a8c.com"])
+}

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -39,10 +39,10 @@ extension Coupon {
             return .expired
         }
 
-        var calender = Calendar.current
-        calender.timeZone = gmtTimeZone
+        var calendar = Calendar.current
+        calendar.timeZone = gmtTimeZone
 
-        let result = calender.compare(expiryDate, to: now, toGranularity: .day)
+        let result = calendar.compare(expiryDate, to: now, toGranularity: .day)
         return result == .orderedDescending ? .active : .expired
     }
 

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -80,6 +80,7 @@ extension Coupon {
 }
 
 // MARK: - Sample Data
+#if DEBUG
 extension Coupon {
     static let sampleCoupon = Coupon(couponID: 720,
                                      code: "AGK32FD",
@@ -105,3 +106,4 @@ extension Coupon {
                                      emailRestrictions: ["*@a8c.com", "someone.else@example.com"],
                                      usedBy: ["someone.else@example.com", "person@a8c.com"])
 }
+#endif

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CouponDetails: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct CouponDetails_Previews: PreviewProvider {
+    static var previews: some View {
+        CouponDetails()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -9,20 +9,26 @@ struct CouponDetails: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                Text(Localization.detailSectionTitle)
-                    .bold()
-                    .padding(Constants.margin)
-                Divider()
-                    .padding(.leading, Constants.margin)
-                TitleAndValueRow(title: Localization.couponCode,
-                                 value: .content(viewModel.couponCode),
-                                 selectable: true) {}
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(Localization.detailSectionTitle)
+                        .bold()
+                        .padding(Constants.margin)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                    Divider()
+                        .padding(.leading, Constants.margin)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                    TitleAndValueRow(title: Localization.couponCode,
+                                     value: .content(viewModel.couponCode),
+                                     selectable: true) {}
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                }
+                .background(Color(.listForeground))
             }
-            .background(Color(.listForeground))
+            .background(Color(.listBackground))
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
-        .background(Color(.listBackground))
         .navigationTitle(Localization.navigationTitle)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
@@ -13,9 +14,7 @@ struct CouponDetails: View {
 }
 
 struct CouponDetails_Previews: PreviewProvider {
-    static let sampleViewModel: CouponDetailsViewModel = .init(couponID: 123, siteID: 456)
-
     static var previews: some View {
-        CouponDetails(viewModel: sampleViewModel)
+        CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -13,7 +13,7 @@ struct CouponDetails: View {
             .init(title: Localization.couponCode, content: viewModel.couponCode, action: {}),
             .init(title: Localization.description, content: viewModel.description, action: {}),
             .init(title: Localization.discount, content: viewModel.amount, action: {}),
-            .init(title: Localization.applyTo, content: viewModel.applyTo, action: {}),
+            .init(title: Localization.applyTo, content: viewModel.productsAppliedTo, action: {}),
             .init(title: Localization.expiryDate, content: viewModel.expiryDate, action: {})
         ]
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -74,8 +74,10 @@ private extension CouponDetails {
     }
 }
 
+#if DEBUG
 struct CouponDetails_Previews: PreviewProvider {
     static var previews: some View {
         CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon))
     }
 }
+#endif

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -1,13 +1,21 @@
 import SwiftUI
 
 struct CouponDetails: View {
+    @ObservedObject private var viewModel: CouponDetailsViewModel
+
+    init(viewModel: CouponDetailsViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }
 }
 
 struct CouponDetails_Previews: PreviewProvider {
+    static let sampleViewModel: CouponDetailsViewModel = .init(couponID: 123, siteID: 456)
+
     static var previews: some View {
-        CouponDetails()
+        CouponDetails(viewModel: sampleViewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -8,6 +8,16 @@ struct CouponDetails: View {
         self.viewModel = viewModel
     }
 
+    private var detailRows: [DetailRow] {
+        [
+            .init(title: Localization.couponCode, content: viewModel.couponCode, action: {}),
+            .init(title: Localization.description, content: viewModel.description, action: {}),
+            .init(title: Localization.discount, content: viewModel.amount, action: {}),
+            .init(title: Localization.applyTo, content: viewModel.applyTo, action: {}),
+            .init(title: Localization.expiryDate, content: viewModel.expiryDate, action: {})
+        ]
+    }
+
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
@@ -16,13 +26,17 @@ struct CouponDetails: View {
                         .bold()
                         .padding(Constants.margin)
                         .padding(.horizontal, insets: geometry.safeAreaInsets)
-                    Divider()
-                        .padding(.leading, Constants.margin)
-                        .padding(.horizontal, insets: geometry.safeAreaInsets)
-                    TitleAndValueRow(title: Localization.couponCode,
-                                     value: .content(viewModel.couponCode),
-                                     selectable: true) {}
-                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                    ForEach(detailRows) { row in
+                        TitleAndValueRow(title: row.title,
+                                         value: .content(row.content),
+                                         selectable: true,
+                                         action: row.action)
+                            .padding(.vertical, Constants.verticalSpacing)
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
+                            .padding(.leading, Constants.margin)
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                    }
                 }
                 .background(Color(.listForeground))
             }
@@ -33,15 +47,30 @@ struct CouponDetails: View {
     }
 }
 
+// MARK: - Subtypes
+//
 private extension CouponDetails {
     enum Constants {
         static let margin: CGFloat = 16
+        static let verticalSpacing: CGFloat = 8
     }
 
     enum Localization {
         static let navigationTitle = NSLocalizedString("Coupon", comment: "Title of Coupon Details screen")
         static let detailSectionTitle = NSLocalizedString("Coupon Details", comment: "Title of Details section in Coupon Details screen")
         static let couponCode = NSLocalizedString("Coupon Code", comment: "Title of the Coupon Code row in Coupon Details screen")
+        static let description = NSLocalizedString("Description", comment: "Title of the Description row in Coupon Details screen")
+        static let discount = NSLocalizedString("Discount", comment: "Title of the Discount row in Coupon Details screen")
+        static let applyTo = NSLocalizedString("Apply To", comment: "Title of the Apply To row in Coupon Details screen")
+        static let expiryDate = NSLocalizedString("Coupon Expiry Date", comment: "Title of the Coupon Expiry Date row in Coupon Details screen")
+    }
+
+    struct DetailRow: Identifiable {
+        var id: String { title }
+
+        let title: String
+        let content: String
+        let action: () -> Void
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -9,7 +9,33 @@ struct CouponDetails: View {
     }
 
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(Localization.detailSectionTitle)
+                    .bold()
+                    .padding(Constants.margin)
+                Divider()
+                    .padding(.leading, Constants.margin)
+                TitleAndValueRow(title: Localization.couponCode,
+                                 value: .content(viewModel.couponCode),
+                                 selectable: true) {}
+            }
+            .background(Color(.listForeground))
+        }
+        .background(Color(.listBackground))
+        .navigationTitle(Localization.navigationTitle)
+    }
+}
+
+private extension CouponDetails {
+    enum Constants {
+        static let margin: CGFloat = 16
+    }
+
+    enum Localization {
+        static let navigationTitle = NSLocalizedString("Coupon", comment: "Title of Coupon Details screen")
+        static let detailSectionTitle = NSLocalizedString("Coupon Details", comment: "Title of Details section in Coupon Details screen")
+        static let couponCode = NSLocalizedString("Coupon Code", comment: "Title of the Coupon Code row in Coupon Details screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -4,21 +4,15 @@ import Yosemite
 /// View model for `CouponDetails` view
 ///
 final class CouponDetailsViewModel: ObservableObject {
-    /// ID of the coupon
+    /// The current coupon
     ///
-    private let couponID: Int64
-
-    /// ID of the site that the coupon belongs to
-    ///
-    private let siteID: Int64
+    private let coupon: Coupon
 
     private let stores: StoresManager
 
-    init(couponID: Int64,
-         siteID: Int64,
+    init(coupon: Coupon,
          stores: StoresManager = ServiceLocator.stores) {
-        self.couponID = couponID
-        self.siteID = siteID
+        self.coupon = coupon
         self.stores = stores
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -4,6 +4,26 @@ import Yosemite
 /// View model for `CouponDetails` view
 ///
 final class CouponDetailsViewModel: ObservableObject {
+    /// Code of the coupon
+    ///
+    @Published private(set) var couponCode: String = ""
+
+    /// Description of the coupon
+    ///
+    @Published private(set) var description: String = ""
+
+    /// Amount of the coupon
+    ///
+    @Published private(set) var amount: String = ""
+
+    /// Product limit for the coupon to be applied to
+    ///
+    @Published private(set) var applyTo: String = ""
+
+    /// Expiry date of the coupon
+    ///
+    @Published private(set) var expiryDate: String = ""
+    
     /// The current coupon
     ///
     private let coupon: Coupon
@@ -14,5 +34,27 @@ final class CouponDetailsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores) {
         self.coupon = coupon
         self.stores = stores
+        populateDetails()
+    }
+}
+
+// MARK: - Private helpers
+//
+private extension CouponDetailsViewModel {
+    func populateDetails() {
+        couponCode = coupon.code
+        description = coupon.description
+        amount = coupon.amount
+        // TODO: match product IDs to names
+        applyTo = coupon.productIds.isEmpty ? Localization.allProducts : "Some Products"
+        expiryDate = coupon.dateExpires?.toString(dateStyle: .medium, timeStyle: .none) ?? ""
+    }
+}
+
+// MARK: - Subtypes
+//
+private extension CouponDetailsViewModel {
+    enum Localization {
+        static let allProducts = NSLocalizedString("All Products", comment: "The text to be displayed in when the coupon is not limit to any specific product")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -23,7 +23,7 @@ final class CouponDetailsViewModel: ObservableObject {
     /// Expiry date of the coupon
     ///
     @Published private(set) var expiryDate: String = ""
-    
+
     /// The current coupon
     ///
     private let coupon: Coupon

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -29,11 +29,14 @@ final class CouponDetailsViewModel: ObservableObject {
     private let coupon: Coupon
 
     private let stores: StoresManager
+    private let currencySettings: CurrencySettings
 
     init(coupon: Coupon,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.coupon = coupon
         self.stores = stores
+        self.currencySettings = currencySettings
         populateDetails()
     }
 }
@@ -54,7 +57,7 @@ private extension CouponDetailsViewModel {
                 amount = percentFormatter.string(from: amountNumber) ?? ""
             }
         case .fixedCart, .fixedProduct:
-            let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+            let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
             amount = currencyFormatter.formatAmount(coupon.amount) ?? ""
         case .other: // TODO: confirm this case
             amount = coupon.amount

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Yosemite
+
+/// View model for `CouponDetails` view
+///
+final class CouponDetailsViewModel: ObservableObject {
+    /// ID of the coupon
+    ///
+    private let couponID: Int64
+
+    /// ID of the site that the coupon belongs to
+    ///
+    private let siteID: Int64
+
+    private let stores: StoresManager
+
+    init(couponID: Int64,
+         siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.couponID = couponID
+        self.siteID = siteID
+        self.stores = stores
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -44,10 +44,25 @@ private extension CouponDetailsViewModel {
     func populateDetails() {
         couponCode = coupon.code
         description = coupon.description
-        amount = coupon.amount
+
+        switch coupon.discountType {
+        case .percent:
+            let percentFormatter = NumberFormatter()
+            percentFormatter.numberStyle = .percent
+            if let amountDouble = Double(coupon.amount) {
+                let amountNumber = NSNumber(value: amountDouble / 100)
+                amount = percentFormatter.string(from: amountNumber) ?? ""
+            }
+        case .fixedCart, .fixedProduct:
+            let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+            amount = currencyFormatter.formatAmount(coupon.amount) ?? ""
+        case .other: // TODO: confirm this case
+            amount = coupon.amount
+        }
+
         // TODO: match product IDs to names
         applyTo = coupon.productIds.isEmpty ? Localization.allProducts : "Some Products"
-        expiryDate = coupon.dateExpires?.toString(dateStyle: .medium, timeStyle: .none) ?? ""
+        expiryDate = coupon.dateExpires?.toString(dateStyle: .long, timeStyle: .none) ?? ""
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -18,7 +18,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     /// Product limit for the coupon to be applied to
     ///
-    @Published private(set) var applyTo: String = ""
+    @Published private(set) var productsAppliedTo: String = ""
 
     /// Expiry date of the coupon
     ///
@@ -64,7 +64,7 @@ private extension CouponDetailsViewModel {
         }
 
         // TODO: match product IDs to names
-        applyTo = coupon.productIds.isEmpty ? Localization.allProducts : "Some Products"
+        productsAppliedTo = coupon.productIds.isEmpty ? Localization.allProducts : "Some Products"
         expiryDate = coupon.dateExpires?.toString(dateStyle: .long, timeStyle: .none) ?? ""
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -1,7 +1,7 @@
 import Combine
 import UIKit
 import WordPressUI
-import SwiftUI
+import class SwiftUI.UIHostingController
 
 final class CouponListViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -136,7 +136,7 @@ extension CouponListViewController: UITableViewDelegate {
         guard let coupon = viewModel.coupon(at: indexPath) else {
             return
         }
-        let detailsViewModel = CouponDetailsViewModel(couponID: coupon.couponID, siteID: coupon.siteID)
+        let detailsViewModel = CouponDetailsViewModel(coupon: coupon)
         let couponDetails = CouponDetails(viewModel: detailsViewModel)
         let hostingController = UIHostingController(rootView: couponDetails)
         navigationController?.pushViewController(hostingController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -1,6 +1,7 @@
 import Combine
 import UIKit
 import WordPressUI
+import SwiftUI
 
 final class CouponListViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
@@ -128,6 +129,17 @@ private extension CouponListViewController {
 extension CouponListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         viewModel.tableWillDisplayCell(at: indexPath)
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let coupon = viewModel.coupon(at: indexPath) else {
+            return
+        }
+        let detailsViewModel = CouponDetailsViewModel(couponID: coupon.couponID, siteID: coupon.siteID)
+        let couponDetails = CouponDetails(viewModel: detailsViewModel)
+        let hostingController = UIHostingController(rootView: couponDetails)
+        navigationController?.pushViewController(hostingController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -48,7 +48,7 @@ final class CouponSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-        let detailsViewModel = CouponDetailsViewModel(couponID: model.couponID, siteID: model.siteID)
+        let detailsViewModel = CouponDetailsViewModel(coupon: model)
         let couponDetails = CouponDetails(viewModel: detailsViewModel)
         let hostingController = UIHostingController(rootView: couponDetails)
         viewController.navigationController?.pushViewController(hostingController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import class SwiftUI.UIHostingController
 
 /// Implementation of `SearchUICommand` for Coupon search.
 final class CouponSearchUICommand: SearchUICommand {
@@ -47,7 +48,10 @@ final class CouponSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-        // TODO: Show coupon details screen
+        let detailsViewModel = CouponDetailsViewModel(couponID: model.couponID, siteID: model.siteID)
+        let couponDetails = CouponDetails(viewModel: detailsViewModel)
+        let hostingController = UIHostingController(rootView: couponDetails)
+        viewController.navigationController?.pushViewController(hostingController, animated: true)
     }
 
     func configureEmptyStateViewControllerBeforeDisplay(viewController: EmptyStateViewController,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1478,6 +1478,7 @@
 		DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */; };
 		DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */; };
 		DE7B479327A38ADA0018742E /* CouponDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479227A38ADA0018742E /* CouponDetails.swift */; };
+		DE7B479527A38B8F0018742E /* CouponDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479427A38B8F0018742E /* CouponDetailsViewModel.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
@@ -3093,6 +3094,7 @@
 		DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponSearchUICommand.swift; sourceTree = "<group>"; };
 		DE7B479227A38ADA0018742E /* CouponDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetails.swift; sourceTree = "<group>"; };
+		DE7B479427A38B8F0018742E /* CouponDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetailsViewModel.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
@@ -7253,6 +7255,7 @@
 			isa = PBXGroup;
 			children = (
 				DE7B479227A38ADA0018742E /* CouponDetails.swift */,
+				DE7B479427A38B8F0018742E /* CouponDetailsViewModel.swift */,
 			);
 			path = CouponDetails;
 			sourceTree = "<group>";
@@ -8783,6 +8786,7 @@
 				5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */,
 				028BAC4022F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
 				26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */,
+				DE7B479527A38B8F0018742E /* CouponDetailsViewModel.swift in Sources */,
 				DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */,
 				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,
 				7E7C5F862719A93C00315B61 /* ProductCategoryViewModelBuilder.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1477,6 +1477,7 @@
 		DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1726EF35F40071200C /* ConnectivityObserver.swift */; };
 		DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */; };
 		DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */; };
+		DE7B479327A38ADA0018742E /* CouponDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479227A38ADA0018742E /* CouponDetails.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
@@ -3091,6 +3092,7 @@
 		DE792E1726EF35F40071200C /* ConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponSearchUICommand.swift; sourceTree = "<group>"; };
+		DE7B479227A38ADA0018742E /* CouponDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetails.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
@@ -4190,6 +4192,7 @@
 		03FBDA9B263AD47200ACE257 /* Coupons */ = {
 			isa = PBXGroup;
 			children = (
+				DE7B479127A38ABC0018742E /* CouponDetails */,
 				03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */,
 				03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */,
 				03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */,
@@ -7246,6 +7249,14 @@
 			path = Connectivity;
 			sourceTree = "<group>";
 		};
+		DE7B479127A38ABC0018742E /* CouponDetails */ = {
+			isa = PBXGroup;
+			children = (
+				DE7B479227A38ADA0018742E /* CouponDetails.swift */,
+			);
+			path = CouponDetails;
+			sourceTree = "<group>";
+		};
 		DE8C9464264698E800C94823 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -8920,6 +8931,7 @@
 				D449C52626DFBBDB00D75B02 /* WhatsNewFactory.swift in Sources */,
 				028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */,
 				0235595924496D70004BE2B8 /* ProductsSortOrderBottomSheetListSelectorCommand.swift in Sources */,
+				DE7B479327A38ADA0018742E /* CouponDetails.swift in Sources */,
 				57A25C7625ACE9BC00A54A62 /* OrderFulfillmentUseCase.swift in Sources */,
 				262C922126F1370000011F92 /* StorePickerError.swift in Sources */,
 				4515C89825D6C00E0099C8E3 /* ShippingLabelAddressFormViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1479,6 +1479,7 @@
 		DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */; };
 		DE7B479327A38ADA0018742E /* CouponDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479227A38ADA0018742E /* CouponDetails.swift */; };
 		DE7B479527A38B8F0018742E /* CouponDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479427A38B8F0018742E /* CouponDetailsViewModel.swift */; };
+		DE7B479727A3C4980018742E /* CouponDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479627A3C4980018742E /* CouponDetailsViewModelTests.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
@@ -3095,6 +3096,7 @@
 		DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponSearchUICommand.swift; sourceTree = "<group>"; };
 		DE7B479227A38ADA0018742E /* CouponDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetails.swift; sourceTree = "<group>"; };
 		DE7B479427A38B8F0018742E /* CouponDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetailsViewModel.swift; sourceTree = "<group>"; };
+		DE7B479627A3C4980018742E /* CouponDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
@@ -4208,6 +4210,7 @@
 			isa = PBXGroup;
 			children = (
 				03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */,
+				DE7B479627A3C4980018742E /* CouponDetailsViewModelTests.swift */,
 			);
 			path = Coupons;
 			sourceTree = "<group>";
@@ -9143,6 +9146,7 @@
 				2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */,
 				45DB7076261623410064A6CF /* ShippingLabelPackageDetailsViewModelTests.swift in Sources */,
 				021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */,
+				DE7B479727A3C4980018742E /* CouponDetailsViewModelTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,
 				D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */,
 				2655905B27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -4,17 +4,44 @@ import XCTest
 
 final class CouponDetailsViewModelTests: XCTestCase {
 
-    func test_coupon_details_are_correct() {
+    func test_coupon_details_are_correct_for_fixedProduct_discount_type() {
         // Given
-        let sampleCoupon = Coupon.sampleCoupon
-        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+        let sampleCoupon = Coupon.fake().copy(
+            code: "AGK32FD",
+            amount: "10.00",
+            discountType: .fixedProduct,
+            description: "Coupon description",
+            dateExpires: Date(timeIntervalSince1970: 1642755825), // GMT: January 21, 2022
+            productIds: []
+        )
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon, currencySettings: CurrencySettings())
 
         // Then
         XCTAssertEqual(viewModel.couponCode, "AGK32FD")
         XCTAssertEqual(viewModel.amount, "$10.00")
         XCTAssertEqual(viewModel.description, "Coupon description")
         XCTAssertEqual(viewModel.applyTo, "All Products")
-        XCTAssertEqual(viewModel.expiryDate, "January 28, 2022")
+        XCTAssertEqual(viewModel.expiryDate, "January 21, 2022")
+    }
+
+    func test_coupon_details_are_correct_for_percentage_discount_type() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(
+            code: "AGK32FD",
+            amount: "10.00",
+            discountType: .percent,
+            description: "Coupon description",
+            dateExpires: Date(timeIntervalSince1970: 1642755825), // GMT: January 21, 2022
+            productIds: []
+        )
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertEqual(viewModel.couponCode, "AGK32FD")
+        XCTAssertEqual(viewModel.amount, "10%")
+        XCTAssertEqual(viewModel.description, "Coupon description")
+        XCTAssertEqual(viewModel.applyTo, "All Products")
+        XCTAssertEqual(viewModel.expiryDate, "January 21, 2022")
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Yosemite
+@testable import WooCommerce
+
+final class CouponDetailsViewModelTests: XCTestCase {
+
+    func test_coupon_details_are_correct() {
+        // Given
+        let sampleCoupon = Coupon.sampleCoupon
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertEqual(viewModel.couponCode, "AGK32FD")
+        XCTAssertEqual(viewModel.amount, "$10.00")
+        XCTAssertEqual(viewModel.description, "Coupon description")
+        XCTAssertEqual(viewModel.applyTo, "All Products")
+        XCTAssertEqual(viewModel.expiryDate, "January 28, 2022")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -20,7 +20,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.couponCode, "AGK32FD")
         XCTAssertEqual(viewModel.amount, "$10.00")
         XCTAssertEqual(viewModel.description, "Coupon description")
-        XCTAssertEqual(viewModel.applyTo, "All Products")
+        XCTAssertEqual(viewModel.productsAppliedTo, "All Products")
         XCTAssertEqual(viewModel.expiryDate, "January 21, 2022")
     }
 
@@ -40,7 +40,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.couponCode, "AGK32FD")
         XCTAssertEqual(viewModel.amount, "10%")
         XCTAssertEqual(viewModel.description, "Coupon description")
-        XCTAssertEqual(viewModel.applyTo, "All Products")
+        XCTAssertEqual(viewModel.productsAppliedTo, "All Products")
         XCTAssertEqual(viewModel.expiryDate, "January 21, 2022")
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5765 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new screen for coupon details. This screen should be navigated from the coupon list and the coupon search screen.

The screen is currently showing the main details of the coupon that is passed to the view model. Retrieving details from the API will be added in the next PR. The details include:
- Coupon code
- Coupon description
- Coupon discount: formatted based on discount type. I will have to confirm with the team how to format the amount for non-default discount types later.
- Coupon product limit: Currently only displaying All Products if there is no limit. Handling mapping product IDs to product names will be handled in another PR.
- Coupon expiry date

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that your test store has at least one coupon and the coupon management feature flag is enabled.
- Navigate to the Menu tab, select Coupons.
- In the Coupon list, select a coupon. Notice that the details are displayed correctly.
- Navigate back to the list, tap the Search icon and select a coupon from the Search screen. Notice that you are navigated the expected Coupon Details screen.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Portrait mode | Landscape mode | 
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/151495286-2cb4e006-2106-4c68-bcb1-5faabb7dfac5.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/151495325-8757c811-0bd3-48fc-bf10-6d27f46c9010.png" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
