### PR TITLE
Remove decimal points for abbreviated integer values in chart y-axis labels

### DIFF
--- a/WooCommerce/Classes/Extensions/Double+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Double+Woo.swift
@@ -52,7 +52,7 @@ private extension Double {
 
     func abbreviatedString(for number: Double) -> String {
         let absNumber = fabs(number)
-        let abbreviation: Abbrevation = {
+        let abbreviation: Abbreviation = {
             var prevAbbreviation = Constants.abbreviations[0]
             for tmpAbbreviation in Constants.abbreviations {
                 if absNumber < tmpAbbreviation.threshold {
@@ -78,13 +78,13 @@ private extension Double {
 //
 private extension Double {
 
-    typealias Abbrevation = (threshold: Double, divisor: Double, suffix: String)
+    typealias Abbreviation = (threshold: Double, divisor: Double, suffix: String)
 
     enum Constants {
         static let negativeZeroString = "-0"
         static let zeroString         = "0"
 
-        static let abbreviations: [Abbrevation] = [(0, 1, ""),
+        static let abbreviations: [Abbreviation] = [(0, 1, ""),
                                                    (999.0, 1_000.0, "k"),
                                                    (999_999.0, 1_000_000.0, "m"),
                                                    (999_999_999.0, 1_000_000_000.0, "b"),

--- a/WooCommerce/Classes/Extensions/Double+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Double+Woo.swift
@@ -29,7 +29,8 @@ extension Double {
     ///
     /// Note: This helper function does work with negative values as well.
     ///
-    /// - Parameter shouldHideDecimalsForIntegerAbbreviatedValue: Whether decimal digits should be hidden when the abbreviated value is an integer. If `false`, a decimal digit is always shown.
+    /// - Parameter shouldHideDecimalsForIntegerAbbreviatedValue: Whether decimal digits should be hidden when the abbreviated value is an integer.
+    ///                                                           If `false`, a decimal digit is always shown.
     func humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: Bool = false) -> String {
         let num = Double(self)
 

--- a/WooCommerce/Classes/Extensions/Double+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Double+Woo.swift
@@ -29,7 +29,8 @@ extension Double {
     ///
     /// Note: This helper function does work with negative values as well.
     ///
-    func humanReadableString() -> String {
+    /// - Parameter shouldHideDecimalsForIntegerAbbreviatedValue: Whether decimal digits should be hidden when the abbreviated value is an integer. If `false`, a decimal digit is always shown.
+    func humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: Bool = false) -> String {
         let num = Double(self)
 
         // If the starting value is between -1000 and 1000, return the rounded Int version
@@ -41,7 +42,7 @@ extension Double {
             return returnString == Constants.negativeZeroString ? Constants.zeroString : returnString
         }
 
-        return abbreviatedString(for: num)
+        return abbreviatedString(for: num, shouldHideDecimalsForIntegerAbbreviatedValue: shouldHideDecimalsForIntegerAbbreviatedValue)
     }
 }
 
@@ -50,7 +51,7 @@ extension Double {
 //
 private extension Double {
 
-    func abbreviatedString(for number: Double) -> String {
+    func abbreviatedString(for number: Double, shouldHideDecimalsForIntegerAbbreviatedValue: Bool) -> String {
         let absNumber = fabs(number)
         let abbreviation: Abbreviation = {
             var prevAbbreviation = Constants.abbreviations[0]
@@ -67,6 +68,10 @@ private extension Double {
         let numFormatter = Formatters.largeNumberFormatter
         numFormatter.positiveSuffix = abbreviation.suffix
         numFormatter.negativeSuffix = abbreviation.suffix
+
+        if shouldHideDecimalsForIntegerAbbreviatedValue {
+            numFormatter.minimumFractionDigits = 0
+        }
 
         let finalValue = NSNumber(value: value)
         return numFormatter.string(from: finalValue) ?? Constants.zeroString
@@ -95,7 +100,7 @@ private extension Double {
 
         /// Formatter used for numbers between -1000 and 1000 (exclusive)
         ///
-        public static let smallNumberFormatter: NumberFormatter = {
+        static let smallNumberFormatter: NumberFormatter = {
             let numFormatter = NumberFormatter()
             numFormatter.allowsFloats = true
             numFormatter.minimumIntegerDigits = 1
@@ -106,7 +111,7 @@ private extension Double {
 
         /// Formatter used for numbers greater than -1000 and greater that 1000 (inclusive)
         ///
-        public static var largeNumberFormatter: NumberFormatter {
+        static var largeNumberFormatter: NumberFormatter {
             let numFormatter = NumberFormatter()
             numFormatter.allowsFloats = true
             numFormatter.minimumIntegerDigits = 1

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -474,7 +474,7 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
                 return "   "
             } else {
                 return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-                                    .formatCurrency(using: value.humanReadableString(),
+                    .formatCurrency(using: value.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true),
                                     at: ServiceLocator.currencySettings.currencyPosition,
                                     with: currencySymbol,
                                     isNegative: value.sign == .minus)

--- a/WooCommerce/WooCommerceTests/Extensions/DoubleWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DoubleWooTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// Double+Woo: Unit Tests
 ///
-class DoubleWooTests: XCTestCase {
+final class DoubleWooTests: XCTestCase {
 
     func testHumanReadableStringWorksWithZeroValue() {
         XCTAssertEqual(Double(0).humanReadableString(), "0")
@@ -99,5 +99,15 @@ class DoubleWooTests: XCTestCase {
         XCTAssertEqual(Double(-999_999_999_999).humanReadableString(), "-1.0t") // "-1.0t"
         XCTAssertEqual(Double(-999_000_000_000_000.00001).humanReadableString(), "-999.0t") // "-999.0t"
         XCTAssertEqual(Double(-9_000_000_000_000_000.00001).humanReadableString(), "-9000.0t") // "-9000.0t"
+    }
+
+    func test_humanReadableString_that_shouldHideDecimalsForIntegerAbbreviatedValue_does_not_show_decimal_digits_for_abbreviated_integer_values() {
+        XCTAssertEqual(Double(198.44).humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true), "198")
+        XCTAssertEqual(Double(1000).humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true), "1k")
+        XCTAssertEqual(Double(1099.9).humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true), "1.1k")
+        XCTAssertEqual(Double(-9_999).humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true), "-10k")
+        XCTAssertEqual(Double(-99_899_999_999).humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true), "-99.9b")
+        XCTAssertEqual(Double(-999_000_000_000_000.00001).humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true), "-999t")
+        XCTAssertEqual(Double(-9_000_000_000_000_000.00001).humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true), "-9000t")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In this comment https://github.com/woocommerce/woocommerce-ios/pull/5970#issuecomment-1022842985, Joe noticed the y-axis labels still show a decimal digit for integer abbreviated values in the chart y-axis labels. The way to remove the decimal digits for this case is different from the revenue stats in https://github.com/woocommerce/woocommerce-ios/pull/5970, since the y-axis labels show an abbreviated string with thousand/million/trillion characters. Right now, we always show one decimal digit via `Double.humanReadableString`:

https://github.com/woocommerce/woocommerce-ios/blob/d9e5292b52e53e04a8233abb48db5d2cb68516ac/WooCommerce/Classes/Extensions/Double+Woo.swift#L113-L114

This PR adds a boolean flag `shouldHideDecimalsForIntegerAbbreviatedValue` to set the `NumberFormatter`'s `minimumFractionDigits` to `0` so that when the abbreviated value is an integer, no decimal digits are shown.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Tap on each time range tab --> if the y-axis labels have an integer abbreviated value, no decimal digits are shown

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screen Shot - iPhone 12 - 2022-01-28 at 14 08 17](https://user-images.githubusercontent.com/1945542/151500160-7538d488-9dba-417b-8918-7252770839e6.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-28 at 14 32 54](https://user-images.githubusercontent.com/1945542/151500173-08712aa4-41c3-4ae6-9569-602561c2fd06.png)
![Simulator Screen Shot - iPhone 12 - 2022-01-28 at 14 08 20](https://user-images.githubusercontent.com/1945542/151500166-b30ee6cb-e8f4-49c6-80af-b89ed9e8123d.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-28 at 14 32 56](https://user-images.githubusercontent.com/1945542/151500174-158c5261-f430-4ad3-92b2-8bd046ac533f.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
