### PR TITLE
Coupons: Update Networking and Yosemite to retrieve a single coupon by ID

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -102,8 +102,7 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .get,
                                      siteID: siteID,
-                                     path: Path.coupons + "/\(couponID)",
-                                     parameters: [ParameterKey.force: true])
+                                     path: Path.coupons + "/\(couponID)")
 
         let mapper = CouponMapper(siteID: siteID)
 

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -16,6 +16,10 @@ public protocol CouponsRemoteProtocol {
                        pageSize: Int,
                        completion: @escaping (Result<[Coupon], Error>) -> ())
 
+    func retrieveCoupon(for siteID: Int64,
+                        couponID: Int64,
+                        completion: @escaping (Result<Coupon, Error>) -> Void)
+
     func deleteCoupon(for siteID: Int64,
                       couponID: Int64,
                       completion: @escaping (Result<Coupon, Error>) -> Void)
@@ -84,12 +88,34 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Retrieves a `Coupon`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch the coupon.
+    ///     - couponID: ID of the Coupon that will be retrieved.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func retrieveCoupon(for siteID: Int64,
+                               couponID: Int64,
+                               completion: @escaping (Result<Coupon, Error>) -> Void) {
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.coupons + "/\(couponID)",
+                                     parameters: [ParameterKey.force: true])
+
+        let mapper = CouponMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     // MARK: - Delete Coupon
 
     /// Deletes a `Coupon`.
     ///
     /// - Parameters:
-    ///     - siteID: Site for which we'll delete the product attribute.
+    ///     - siteID: Site for which we'll delete the coupon.
     ///     - couponID: ID of the Coupon that will be deleted.
     ///     - completion: Closure to be executed upon completion.
     ///

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -382,7 +382,7 @@ final class CouponsRemoteTests: XCTestCase {
         let sampleCouponID: Int64 = 720
         let remote = CouponsRemote(network: network)
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)
-        network.simulateError(requestUrlSuffix: "coupons", error: error)
+        network.simulateError(requestUrlSuffix: "coupons/\(sampleCouponID)", error: error)
 
         // When
         let result = waitFor { promise in

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -401,7 +401,8 @@ final class CouponsRemoteTests: XCTestCase {
 // MARK: - Private helpers
 private extension CouponsRemoteTests {
     func sampleCoupon() -> Coupon {
-        Coupon(couponID: 720,
+        Coupon(siteID: sampleSiteID,
+               couponID: 720,
                code: "free shipping",
                amount: "10.00",
                dateCreated: date(with: "2017-03-21T18:25:02"),

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -307,11 +307,11 @@ final class CouponsRemoteTests: XCTestCase {
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
     }
 
-    // MARK: - Search couponss
+    // MARK: - Search coupons
 
     /// Verifies that searchCoupons properly parses the `coupons-all` sample response.
     ///
-    func test_searchCoupons_properly_returns_parsed_report() throws {
+    func test_searchCoupons_properly_returns_parsed_coupons() throws {
         // Given
         let remote = CouponsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
@@ -341,6 +341,52 @@ final class CouponsRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.searchCoupons(for: self.sampleSiteID, keyword: "test", pageNumber: 0, pageSize: 20) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
+    }
+
+    // MARK: - Retrieve coupon
+
+    /// Verifies that retrieveCoupon properly parses the `coupon` sample response.
+    ///
+    func test_retrieveCoupon_properly_returns_parsed_coupon() throws {
+        // Given
+        let sampleCouponID: Int64 = 720
+        let remote = CouponsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
+
+        // When
+        let result = waitFor { promise in
+            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssert(result.isSuccess)
+        let coupon = try XCTUnwrap(result.get())
+        let expectedCoupon = sampleCoupon()
+        XCTAssertEqual(coupon, expectedCoupon)
+    }
+
+    /// Verifies that retrieveCoupon properly relays Networking Layer errors.
+    ///
+    func test_retrieveCoupon_properly_relays_networking_errors() throws {
+        // Given
+        let sampleCouponID: Int64 = 720
+        let remote = CouponsRemote(network: network)
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "coupons", error: error)
+
+        // When
+        let result = waitFor { promise in
+            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { (result) in
                 promise(result)
             }
         }

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -71,7 +71,7 @@ public enum CouponAction: Action {
     /// Retrieve a Coupon for a site given the coupon ID
     ///
     /// - `siteID`: the site for which coupons should be fetched.
-    /// - `couponID`: ID of the coupon to be retrieve
+    /// - `couponID`: ID of the coupon to be retrieved.
     /// - `onCompletion`: invoked upon completion.
     ///
     case retrieveCoupon(siteID: Int64,

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -67,4 +67,14 @@ public enum CouponAction: Action {
                        pageNumber: Int,
                        pageSize: Int,
                        onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Retrieve a Coupon for a site given the coupon ID
+    ///
+    /// - `siteID`: the site for which coupons should be fetched.
+    /// - `couponID`: ID of the coupon to be retrieve
+    /// - `onCompletion`: invoked upon completion.
+    ///
+    case retrieveCoupon(siteID: Int64,
+                        couponID: Int64,
+                        onCompletion: (Result<Coupon, Error>) -> Void)
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -16,7 +16,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     var spySearchCouponsKeyword: String?
 
     var didCallRetrieveCoupon = false
-    var spyRetrieveCouponSiteID: Int64?
+    var spyRetrieveSiteID: Int64?
     var spyRetrieveCouponID: Int64?
 
     var didCallDeleteCoupon = false
@@ -87,7 +87,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
 
     func retrieveCoupon(for siteID: Int64, couponID: Int64, completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallRetrieveCoupon = true
-        spyRetrieveCouponSiteID = siteID
+        spyRetrieveSiteID = siteID
         spyRetrieveCouponID = couponID
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -15,6 +15,10 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     var spySearchCouponsPageSize: Int?
     var spySearchCouponsKeyword: String?
 
+    var didCallRetrieveCoupon = false
+    var spyRetrieveCouponSiteID: Int64?
+    var spyRetrieveCouponID: Int64?
+
     var didCallDeleteCoupon = false
     var spyDeleteCouponSiteID: Int64?
     var spyDeleteCouponWithID: Int64?
@@ -79,5 +83,11 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
         didCallLoadCouponReport = true
         spyLoadCouponReportSiteID = siteID
         spyLoadCouponReportCouponID = couponID
+    }
+
+    func retrieveCoupon(for siteID: Int64, couponID: Int64, completion: @escaping (Result<Coupon, Error>) -> Void) {
+        didCallRetrieveCoupon = true
+        spyRetrieveCouponSiteID = siteID
+        spyRetrieveCouponID = couponID
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5765 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates Networking and Yosemite to enable retrieving a single coupon by ID. Changes:
- Add a new endpoint in CouponRemote for retrieving a coupon by ID
- Update CouponAction to retrieve coupon by ID
- Update CouponStore to handle retrieving a coupon.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This endpoint hasn't been integrated yet so just CI passing is sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
