### PR TITLE
Dashboard: fix redacted view color for JCP sites before Home Screen M2 changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsEmptyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsEmptyView.swift
@@ -1,3 +1,4 @@
+import Experiments
 import UIKit
 
 final class StoreStatsEmptyView: UIView {
@@ -27,7 +28,8 @@ final class StoreStatsEmptyView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
 
         let emptyView = UIView(frame: .zero)
-        emptyView.backgroundColor = .systemColor(.secondarySystemBackground)
+        emptyView.backgroundColor = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.myStoreTabUpdates) ?
+            .systemColor(.secondarySystemBackground): .systemColor(.systemGroupedBackground)
         emptyView.layer.cornerRadius = 2.0
         emptyView.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6001 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The color of the site visitor redacted view was updated as part of M2 redesign https://github.com/woocommerce/woocommerce-ios/pull/5780 without the check on `myStoreTabUpdates` feature flag, and isn't visible anymore with the new color. This PR adds a feature flag check to show the color before the redesign, and targets release 8.4 branch (cc @jkmassel). The feature flag is enabled for all in the upcoming release 8.5.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the account is connected to at least a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23)

- In `DefaultFeatureFlagService`, return `false` for `myStoreTabUpdates` to disable Home Screen M2 changes for release 8.4
- Launch the app --> in the site visit stats, the redacted view next to the Jetpack logo should be visible in Dark mode

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screen Shot - iPhone 12 - 2022-01-28 at 15 24 36](https://user-images.githubusercontent.com/1945542/151505561-be1344de-2a2f-404d-903a-9923e4a6182f.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-28 at 15 15 54](https://user-images.githubusercontent.com/1945542/151505568-30648780-ecaa-49f4-b56c-8ae3a638289a.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
