### PR TITLE
Add Canada to supported countries for WCPay

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -361,3 +361,20 @@ private extension PaymentGatewayAccount {
         .init(rawValue: status)
     }
 }
+
+private extension CardPresentPaymentsPlugins {
+    // This was moved from Yosemite so it can check the feature flag
+    // In a future iteration, we might want to store all the configuration in the WooCommerce layer
+    var supportedCountryCodes: [String] {
+        switch self {
+        case .wcPay:
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.canadaInPersonPayments) {
+                return ["US", "CA"]
+            } else {
+                return ["US"]
+            }
+        case .stripe:
+            return ["US"]
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -62,9 +62,21 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .countryNotSupported(countryCode: "ES"))
     }
 
+    func test_onboarding_does_not_return_country_unsupported_with_canada_when_neither_wcpay_nor_stripe_plugin_installed() {
+        // Given
+        setupCountry(country: .ca)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
+    }
+
     func test_onboarding_does_not_return_country_unsupported_with_canada_for_wcpay() {
         // Given
-        setupCountry(country: .es)
+        setupCountry(country: .ca)
         setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
 
         // When
@@ -580,6 +592,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
 
     enum Country: String {
         case us = "US:CA"
+        case ca = "CA:NS"
         case es = "ES"
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -62,6 +62,19 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .countryNotSupported(countryCode: "ES"))
     }
 
+    func test_onboarding_does_not_return_country_unsupported_with_canada() {
+        // Given
+        setupCountry(country: .es)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
+    }
+
+
     // MARK: - Plugin checks
 
     func test_onboarding_returns_plugin_not_installed_when_neither_wcpay_nor_stripe_plugin_installed() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -62,9 +62,23 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .countryNotSupported(countryCode: "ES"))
     }
 
-    func test_onboarding_does_not_return_country_unsupported_with_canada() {
+    func test_onboarding_does_not_return_country_unsupported_with_canada_for_wcpay() {
         // Given
         setupCountry(country: .es)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
+    }
+
+    func test_onboarding_returns_country_unsupported_with_canada_for_stripe() {
+        // Given
+        setupCountry(country: .es)
+        setupStripePlugin(status: .active, version: .minimumSupportedVersion)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -124,13 +124,4 @@ public enum CardPresentPaymentsPlugins: Equatable {
             return "5.9.0"
         }
     }
-
-    public var supportedCountryCodes: [String] {
-        switch self {
-        case .wcPay:
-            return ["US", "CA"]
-        case .stripe:
-            return ["US"]
-        }
-    }
 }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -128,7 +128,7 @@ public enum CardPresentPaymentsPlugins: Equatable {
     public var supportedCountryCodes: [String] {
         switch self {
         case .wcPay:
-            return ["US"]
+            return ["US", "CA"]
         case .stripe:
             return ["US"]
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5973 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds Canada to the list of supported countries for In-Person Payments (WCPay only for now)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

While testing this, I discovered we weren't checking correctly whether WCPay was active to determine when to use the Stripe extension (see #6020). I cherry-picked the changes from #6021 to test sites with Stripe. That said, go to Settings -> In-Person Payments and you should see (depending on configuration):

- WCPay 🇺🇸: options to order/manage card reader
- WCPay 🇨🇦: options to order/manage card reader
- WCPay 🇪🇸: country unsupported
- Stripe 🇺🇸: options to order/manage card reader
- Stripe 🇨🇦: country unsupported
- Stripe 🇪🇸: country unsupported


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Gateway | 🇺🇸 | 🇨🇦 | 🇪🇸 
-|-|-|-
WCPay |![wcpayus](https://user-images.githubusercontent.com/8739/151820818-df2624d2-f6aa-4cc4-a7e4-5a6ca471ab77.png)|![wcpayca](https://user-images.githubusercontent.com/8739/151820827-e8b9cabc-c925-4563-a519-57a641804188.png)|![wcpayes](https://user-images.githubusercontent.com/8739/151820829-cf7a305f-580e-4c68-a413-ac6bffd44991.png)
Stripe |![stripeus](https://user-images.githubusercontent.com/8739/151820832-a852f9b9-3204-4975-8d57-02394efab34d.png)|![stripeca](https://user-images.githubusercontent.com/8739/151820835-ec308463-0c52-4255-ad92-0be759e47e5b.png)|![stripees](https://user-images.githubusercontent.com/8739/151820838-4f776325-a503-456d-92af-f1be3dfecc6b.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
