### PR TITLE
Fix: Gridicons crash on startup

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ target 'WooCommerce' do
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/build-configuration'
   pod 'Automattic-Tracks-iOS', '~> 0.9.1'
 
-  pod 'Gridicons', '~> 1.0'
+  pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   pod 'WordPressAuthenticator', '~> 1.42.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
     - AppAuth (~> 1.4)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - Gridicons (1.0)
+  - Gridicons (1.2.0)
   - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
@@ -96,7 +96,7 @@ DEPENDENCIES:
   - Charts (~> 3.6.0)
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
-  - Gridicons (~> 1.0)
+  - Gridicons (~> 1.2.0)
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 6.0.0)
   - Sourcery (~> 1.0.3)
@@ -164,7 +164,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
-  Gridicons: f032dbc3350f8648e0fabe3e531b72cf97d428a9
+  Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
   KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
@@ -197,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 16b1ff41117e33746b502037c890c8799fc18c21
+PODFILE CHECKSUM: b5364cc82ccfcea6d4ee524c9a7b817bdc327562
 
 COCOAPODS: 1.11.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 8.5
 -----
 - [***] The My store tab is having a new look with new conversion stats and shows up to 5 top performing products now (used to be 3). [https://github.com/woocommerce/woocommerce-ios/pull/5991]
+- [**] Fixed a crash at the startup of the app, related to Gridicons. [https://github.com/woocommerce/woocommerce-ios/pull/6005]
 
 
 8.4


### PR DESCRIPTION
Fixes #2454 
I'm tagging for the PR review, the people that have investigated previously this issue.

### Description
In 2020, we started encountering from Sentry a lot of crashes coming from our external library [Gridicons](https://github.com/Automattic/Gridicons-iOS).
So far, we encountered more than 1K crashes during the last 2 years in different Sentry issues, and I believe many have not been properly tracked by Sentry, therefore the number of crashes could be significantly higher (potentially affecting all users who have installed the app for the first time on the device, at the first launch).
After some investigations, I managed to come to the origin of the problem, also managing to replicate it in a systematic way (see the test instructions).
It appears that the problem is caused by the way we import `xcassets` resources into the podspec file of Gridicons. [Here](https://github.com/Automattic/Gridicons-iOS/pull/66) you can read more about the problem and the fix.

### Testing instructions
1. Make sure to be on `trunk` branch.
2. Launch the simulator where you want to run the app.
3. Go on the `Device` menu, and click `Erase All content and settings...`.
4. Run the app on that simulator.
5. Try to log in, adding your credentials.
6. After adding your email, you will encounter a crash on the Gridicons library.
7. Now move to this branch, run `rake dependencies` and repeat the steps starting from `step 2`.
8. The crash will never happen again.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
