### PR TITLE
Add fakes for InboxAction and InboxNote

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -187,6 +187,38 @@ extension DotcomError {
         .empty
     }
 }
+extension InboxAction {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> InboxAction {
+        .init(
+            id: .fake(),
+            name: .fake(),
+            label: .fake(),
+            status: .fake(),
+            url: .fake()
+        )
+    }
+}
+extension InboxNote {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> InboxNote {
+        .init(
+            siteID: .fake(),
+            id: .fake(),
+            name: .fake(),
+            type: .fake(),
+            status: .fake(),
+            actions: .fake(),
+            title: .fake(),
+            content: .fake(),
+            isDeleted: .fake(),
+            isRead: .fake(),
+            dateCreated: .fake()
+        )
+    }
+}
 extension Leaderboard {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Model/InboxAction.swift
+++ b/Networking/Networking/Model/InboxAction.swift
@@ -25,6 +25,19 @@ public struct InboxAction: GeneratedCopiable, GeneratedFakeable, Equatable {
     /// URL where the action points.
     ///
     public let url: String
+
+
+    public init(id: Int64,
+                name: String,
+                label: String,
+                status: String,
+                url: String) {
+        self.id = id
+        self.name = name
+        self.label = label
+        self.status = status
+        self.url = url
+    }
 }
 
 

--- a/Networking/Networking/Model/InboxNote.swift
+++ b/Networking/Networking/Model/InboxNote.swift
@@ -50,6 +50,31 @@ public struct InboxNote: GeneratedCopiable, GeneratedFakeable, Equatable {
     /// Date the note was created (GMT).
     ///
     public let dateCreated: Date
+
+
+    public init(siteID: Int64,
+                id: Int64,
+                name: String,
+                type: String,
+                status: String,
+                actions: [InboxAction],
+                title: String,
+                content: String,
+                isDeleted: Bool,
+                isRead: Bool,
+                dateCreated: Date) {
+        self.siteID = siteID
+        self.id = id
+        self.name = name
+        self.type = type
+        self.status = status
+        self.actions = actions
+        self.title = title
+        self.content = content
+        self.isDeleted = isDeleted
+        self.isRead = isRead
+        self.dateCreated = dateCreated
+    }
 }
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


### Description
I couldn't generate the fakes after making changes to `Order` on some other work, as `bundle exec rake generate` failed on `InboxAction` and `InboxNotes`

```
error: woocommerce-ios/CodeGeneration/Sourcery/Fakes/Fakes.swifttemplate: SwiftTemplate/main.swift:70: Fatal error: Couldn't find initializer for type: InboxAction
```

This adds the missing initializers for these models.

### Testing instructions
Run `bundle exec rake generate` - should succeed and make no changes.
Run unit tests

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
