### PR TITLE
Changed the order of statuses in filters to match the Order's lifecycle

### DIFF
--- a/Networking/Networking/Model/OrderStatusEnum.swift
+++ b/Networking/Networking/Model/OrderStatusEnum.swift
@@ -3,17 +3,19 @@ import Codegen
 
 /// Represents all of the possible Order Statuses in enum form
 ///
-public enum OrderStatusEnum: Codable, Hashable, GeneratedFakeable {
+/// The order of the statuses declaration is according to the Order's lifecycle
+/// and it is used to determine the user facing display order
+///
+public enum OrderStatusEnum: Codable, Hashable, Comparable, GeneratedFakeable {
     case pending
     case processing
     case onHold
-    case failed
-    case cancelled
     case completed
+    case cancelled
     case refunded
+    case failed
     case custom(String)
 }
-
 
 /// RawRepresentable Conformance
 ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListDataSource.swift
@@ -1,21 +1,25 @@
 import Foundation
 import UIKit
 import Yosemite
+import protocol Storage.StorageManagerType
 
 final class OrderStatusListDataSource {
+
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
-        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld && slug != %@",
                                     siteID,
                                     OrderStatusEnum.refunded.rawValue)
-        let descriptor = NSSortDescriptor(key: "slug", ascending: true)
-        return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [])
     }()
 
     private let siteID: Int64
 
-    init(siteID: Int64) {
+    /// Used to inject as a dependency to `ResultsController`.
+    private let storageManager: StorageManagerType
+
+    init(siteID: Int64, storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
+        self.storageManager = storageManager
     }
 
     func performFetch() throws {
@@ -27,7 +31,7 @@ final class OrderStatusListDataSource {
     }
 
     func statuses() -> [OrderStatus] {
-        statusResultsController.fetchedObjects
+        statusResultsController.fetchedObjects.sorted(by: { $1.status > $0.status })
     }
 
     func startForwardingEvents(to tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -67,7 +67,7 @@ private extension OrderStatusFilterViewController {
     }
 
     func configureRows() {
-        rows = [.any, .pending, .processing, .onHold, .failed, .cancelled, .completed, .refunded]
+        rows = Row.allCases
     }
 
     func selectOrDelesectRow(_ row: Row) {
@@ -125,14 +125,16 @@ extension OrderStatusFilterViewController: UITableViewDelegate {
 //
 private extension OrderStatusFilterViewController {
     enum Row: CaseIterable {
+        // The order of the statuses declaration is according to the Order's lifecycle
+        // and it is used to determine the user facing display order using the synthesized allCases
         case any
         case pending
         case processing
         case onHold
-        case failed
-        case cancelled
         case completed
+        case cancelled
         case refunded
+        case failed
 
         var status: OrderStatusEnum? {
             switch self {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
 		03FBDAFD263EE4E800ACE257 /* CouponListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */; };
+		098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -2023,6 +2024,7 @@
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
 		03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModelTests.swift; sourceTree = "<group>"; };
+		098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSourceTests.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
@@ -4224,6 +4226,14 @@
 			path = Coupons;
 			sourceTree = "<group>";
 		};
+		098FFA1527AD7F40002EBEE4 /* Edit Order Status */ = {
+			isa = PBXGroup;
+			children = (
+				098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */,
+			);
+			path = "Edit Order Status";
+			sourceTree = "<group>";
+		};
 		2611EE57243A46C500A74490 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -5206,6 +5216,7 @@
 		57F2C6CA246DEBBF0074063B /* Order Summary Section */ = {
 			isa = PBXGroup;
 			children = (
+				098FFA1527AD7F40002EBEE4 /* Edit Order Status */,
 				57F2C6CB246DEBCA0074063B /* SummaryTableViewCell */,
 			);
 			path = "Order Summary Section";
@@ -9037,6 +9048,7 @@
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
 				4552085B25829091001CF873 /* AddAttributeViewModelTests.swift in Sources */,
+				098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */,
 				DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */,
 				D449C52C26E02F2F00D75B02 /* WhatsNewFactoryTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListDataSourceTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+import Yosemite
+
+import protocol Storage.StorageManagerType
+import protocol Storage.StorageType
+
+@testable import WooCommerce
+
+class OrderStatusListDataSourceTests: XCTestCase {
+
+    private var storageManager: MockOrderStatusesStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockOrderStatusesStoresManager()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_order_of_statuses_matches_the_orders_lifecycle() throws {
+        // Given
+        let expectedStatusesOrder: [OrderStatusEnum] = [.pending, .processing, .onHold, .completed, .cancelled, .failed, .custom("aCustomStatus")]
+        // refunded status is not shown
+        let storedStatuses: [OrderStatusEnum] = [.cancelled, .completed, .failed, .onHold, .pending, .processing, .refunded, .custom("aCustomStatus")]
+        storedStatuses.forEach { status in
+            storageManager.insertOrderStatus(name: status.rawValue)
+        }
+        storageManager.viewStorage.saveIfNeeded()
+
+        let orderStatusListDataSource = OrderStatusListDataSource(siteID: MockOrderStatusesStoresManager.siteID, storageManager: storageManager)
+
+        // When
+        try orderStatusListDataSource.performFetch()
+        let statuses = orderStatusListDataSource.statuses()
+
+        // Then
+        let actualStatusesOrder = statuses.map({ $0.status })
+        XCTAssertEqual(actualStatusesOrder, expectedStatusesOrder)
+    }
+}
+
+/// Mock Order Statuses Store Manager
+///
+private final class MockOrderStatusesStoresManager: MockStorageManager {
+    fileprivate static let siteID: Int64 = 1
+
+    /// Inserts an order status
+    ///
+    @discardableResult
+    func insertOrderStatus(name: String) -> StorageOrderStatus {
+        let orderStatus = viewStorage.insertNewObject(ofType: StorageOrderStatus.self)
+        orderStatus.name = name
+        orderStatus.slug = name
+        orderStatus.siteID = MockOrderStatusesStoresManager.siteID
+        return orderStatus
+    }
+}


### PR DESCRIPTION
Closes: #4457 

### Description
Currently the order that the list of statuses appear, in the select `Order Status` filters screen, is different from what Android displays. Android follows the more natural order that matches the Order's lifecycle. So this PR fixes the order in iOS to match what Android uses i.e. pending, processing, on hold, completed, cancelled, refunded, failed. Tested with the [latest version](https://github.com/woocommerce/woocommerce-android/commit/d675e7ef66a8085c1c872caf4f495df99fff5c5d) of the Android client. 
Currently the order of the statuses in iOS is pending, processing, on hold, failed, cancelled, completed, refunded.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the iOS client
2. Navigate to the `Orders` tab
3. Tap the `filter` button
4. Select the Order Status
5. Observe the order of the statuses. It should match the Order's lifecycle i.e. pending, processing, onHold, completed, cancelled, refunded, failed.

### Screenshots

After applying the fix the order of the status in the iOS client is the same as in the Android client, and follows the Order lifecycle:

<img src="https://user-images.githubusercontent.com/96764631/151608907-0343c48c-4889-4632-a62b-f4e70cfa0df1.png" width=35% height=35%> <img src="https://user-images.githubusercontent.com/96764631/151608901-42c4428d-85f9-41f4-a5f2-0cb656771e37.png" width=30% height=30%>

There are some other discrepancies in the statuses names between the iOS and Android in the latest trunk version. Like the Any/All and the Pending/Pending Payment:
Since the actual translations are handled by GlotPress during the release build phase, I am not updating any translations here. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
