### PR TITLE
Order Creation: Connect shipping address data to secondary form

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+AddingDividers.swift
+++ b/WooCommerce/Classes/View Modifiers/View+AddingDividers.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Custom view modifer for adding dividers on top and bottom of a view.
+struct TopAndBottomDividers: ViewModifier {
+
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            Divider()
+            content
+            Divider()
+        }
+    }
+}
+
+extension View {
+    /// Adds dividers on top and bottom of a view.
+    func addingTopAndBottomDividers() -> some View {
+        self.modifier(TopAndBottomDividers())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -27,6 +27,10 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
                    storageManager: storageManager,
                    stores: stores,
                    analytics: analytics)
+
+        if addressData.billingAddress != addressData.shippingAddress {
+            showDifferentAddressForm = true
+        }
     }
 
     // MARK: - Protocol conformance

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -23,6 +23,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
 
         super.init(siteID: siteID,
                    address: addressData.billingAddress ?? .empty,
+                   secondaryAddress: addressData.shippingAddress ?? .empty,
                    storageManager: storageManager,
                    stores: stores,
                    analytics: analytics)
@@ -63,8 +64,13 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
-        onAddressUpdate?(.init(billingAddress: updatedAddress,
-                               shippingAddress: updatedAddress))
+        if showDifferentAddressForm {
+            onAddressUpdate?(.init(billingAddress: fields.toAddress(),
+                                   shippingAddress: secondaryFields.toAddress()))
+        } else {
+            onAddressUpdate?(.init(billingAddress: fields.toAddress(),
+                                   shippingAddress: fields.toAddress()))
+        }
         onFinish(true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -47,6 +47,10 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
         }
     }
 
+    var secondarySectionTitle: String {
+        Localization.shippingAddressSection
+    }
+
     var showAlternativeUsageToggle: Bool {
         false
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -36,8 +36,6 @@ private struct OrderCustomerSectionContent: View {
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
     var body: some View {
-        Divider()
-
         VStack(alignment: .leading, spacing: .zero) {
             HStack(alignment: .top) {
                 Text(Localization.customer)
@@ -66,8 +64,7 @@ private struct OrderCustomerSectionContent: View {
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.listForeground))
-
-        Divider()
+        .addingTopAndBottomDividers()
     }
 
     private var createCustomerView: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -51,6 +51,10 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     ///
     var sectionTitle: String { get }
 
+    /// Defines address section title for second set of fields
+    ///
+    var secondarySectionTitle: String { get }
+
     /// Defines if "use as billing/shipping" toggle should be displayed.
     ///
     var showAlternativeUsageToggle: Bool { get }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -10,6 +10,10 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     ///
     var fields: AddressFormFields { get set }
 
+    /// Secondary address form fields
+    ///
+    var secondaryFields: AddressFormFields { get set }
+
     /// Define if address form should be expanded (show second set of fields for different address)
     ///
     var showDifferentAddressForm: Bool { get set }
@@ -30,6 +34,10 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     /// Defines if the state field should be defined as a list selector.
     ///
     var showStateFieldAsSelector: Bool { get }
+
+    /// Defines if secondary state field should be defined as a list selector.
+    ///
+    var showSecondaryStateFieldAsSelector: Bool { get }
 
     /// Defines if the email field should be shown
     ///
@@ -67,13 +75,21 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     ///
     func userDidCancelFlow()
 
-    /// Creates a view model to be used when selecting a country
+    /// Creates a view model to be used when selecting a country for primary fields
     ///
     func createCountryViewModel() -> CountrySelectorViewModel
 
-    /// Creates a view model to be used when selecting a state
+    /// Creates a view model to be used when selecting a state for primary fields
     ///
     func createStateViewModel() -> StateSelectorViewModel
+
+    /// Creates a view model to be used when selecting a country for secondary fields
+    ///
+    func createSecondaryCountryViewModel() -> CountrySelectorViewModel
+
+    /// Creates a view model to be used when selecting a state for secondary fields
+    ///
+    func createSecondaryStateViewModel() -> StateSelectorViewModel
 }
 
 /// Type to hold values from all the form fields
@@ -92,10 +108,8 @@ struct AddressFormFields {
     var city: String = ""
     var postcode: String = ""
 
-    var countryName: String = ""
-    var countryCode: String = ""
-    var stateName: String = ""
-    var stateCode: String = ""
+    var country: String = ""
+    var state: String = ""
 
     var useAsToggle: Bool = false
 
@@ -113,8 +127,8 @@ struct AddressFormFields {
         city = address.city
         postcode = address.postcode
 
-        countryCode = address.country
-        stateCode = address.state
+        country = address.country
+        state = address.state
     }
 
     func toAddress() -> Yosemite.Address {
@@ -124,11 +138,51 @@ struct AddressFormFields {
                 address1: address1,
                 address2: address2,
                 city: city,
-                state: stateCode.isNotEmpty ? stateCode : stateName, // stateCode can be empty when name entered manually
+                state: selectedState?.code ?? state,
                 postcode: postcode,
-                country: countryCode,
+                country: selectedCountry?.code ?? country,
                 phone: phone,
                 email: email)
+    }
+
+    // MARK: Country & state
+
+    /// Current selected country.
+    ///
+    var selectedCountry: Yosemite.Country? {
+        didSet {
+            self.country = selectedCountry?.name ?? ""
+
+            // When a country is selected, check if the new country has a state list.
+            // If it has, clear the selected state and its name in fields.
+            // If it doesn't only clear the selected state.
+            if selectedCountry?.states.isEmpty == false, selectedState != nil {
+                self.state = ""
+            }
+            self.selectedState = nil
+        }
+    }
+
+    /// Current selected state.
+    ///
+    var selectedState: Yosemite.StateOfACountry? {
+        didSet {
+            if let selectedState = selectedState {
+                self.state = selectedState.name
+            }
+        }
+    }
+
+    /// Set initial values from Address using the stored countries to compute the current selected country & state.
+    ///
+    mutating func refreshCountryAndStateObjects(with allCountries: [Country]) {
+        // Do not overwrite any prefilled/selected items
+        guard selectedCountry == nil, selectedState == nil else {
+            return
+        }
+
+        selectedCountry = allCountries.first { $0.code == country }
+        selectedState = selectedCountry?.states.first { $0.code == state }
     }
 }
 
@@ -149,6 +203,12 @@ open class AddressFormViewModel: ObservableObject {
         let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
         return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
     }()
+
+    /// Array for all stored countries.
+    ///
+    private var allCountries: [Country] {
+        countriesResultsController.fetchedObjects
+    }
 
     /// Trigger to sync countries.
     ///
@@ -172,11 +232,17 @@ open class AddressFormViewModel: ObservableObject {
 
     init(siteID: Int64,
          address: Address,
+         secondaryAddress: Address? = nil,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
+
         self.originalAddress = address
+        self.fields = .init(with: originalAddress)
+
+        self.secondaryOriginalAddress = secondaryAddress ?? .empty
+        self.secondaryFields = .init(with: secondaryOriginalAddress)
 
         self.storageManager = storageManager
         self.stores = stores
@@ -189,7 +255,7 @@ open class AddressFormViewModel: ObservableObject {
             self.bindNavigationTrailingItemPublisher()
 
             self.fetchStoredCountriesAndTriggerSyncIfNeeded()
-            self.setFieldsInitialValues()
+            self.refreshCountryAndStateObjects()
 
             self.trackOnLoad()
         }.store(in: &subscriptions)
@@ -201,27 +267,17 @@ open class AddressFormViewModel: ObservableObject {
     ///
     private let originalAddress: Address
 
-    /// Updated `Address`, constructed from `fields`,  `selectedCountry`, `selectedState`.
+    /// Secondary original `Address` model.
     ///
-    var updatedAddress: Address {
-        fields.toAddress()
-    }
-
-    /// Current selected country.
-    ///
-    private var selectedCountry: Yosemite.Country? {
-        countriesResultsController.fetchedObjects.first { $0.code == fields.countryCode }
-    }
-
-    /// Current selected state.
-    ///
-    private var selectedState: Yosemite.StateOfACountry? {
-        selectedCountry?.states.first { $0.code == fields.stateCode }
-    }
+    private let secondaryOriginalAddress: Address
 
     /// Address form fields
     ///
-    @Published var fields = AddressFormFields()
+    @Published var fields: AddressFormFields
+
+    /// Secondary address form fields
+    ///
+    @Published var secondaryFields: AddressFormFields = .init()
 
     /// Define if address form should be expanded (show second set of fields for different address)
     ///
@@ -252,45 +308,58 @@ open class AddressFormViewModel: ObservableObject {
     /// Defines if the state field should be defined as a list selector.
     ///
     var showStateFieldAsSelector: Bool {
-        selectedCountry?.states.isNotEmpty ?? false
+        fields.selectedCountry?.states.isNotEmpty ?? false
     }
 
-    /// Creates a view model to be used when selecting a country
+    /// Defines if the state field should be defined as a list selector.
+    ///
+    var showSecondaryStateFieldAsSelector: Bool {
+        secondaryFields.selectedCountry?.states.isNotEmpty ?? false
+    }
+
+    /// Creates a view model to be used when selecting a country for primary fields
     ///
     func createCountryViewModel() -> CountrySelectorViewModel {
         let selectedCountryBinding = Binding(
-            get: { self.selectedCountry },
-            set: {
-                self.fields.countryCode = $0?.code ?? ""
-                self.fields.countryName = $0?.name ?? ""
-
-                // When a country is selected, check if the new country has a state list.
-                // If it has, clear the selected state name and code.
-                // If it doesn't only clear the selected state code.
-                if $0?.states.isEmpty == false {
-                    self.fields.stateCode = ""
-                    self.fields.stateName = ""
-                } else {
-                    self.fields.stateCode = ""
-                }
-            }
+            get: { self.fields.selectedCountry },
+            set: { self.fields.selectedCountry = $0 }
         )
-        return CountrySelectorViewModel(countries: countriesResultsController.fetchedObjects, selected: selectedCountryBinding)
+        return CountrySelectorViewModel(countries: allCountries, selected: selectedCountryBinding)
     }
 
-    /// Creates a view model to be used when selecting a state
+    /// Creates a view model to be used when selecting a state for primary fields
     ///
     func createStateViewModel() -> StateSelectorViewModel {
         let selectedStateBinding = Binding(
-            get: { self.selectedState },
-            set: {
-                self.fields.stateCode = $0?.code ?? ""
-                self.fields.stateName = $0?.name ?? ""
-            }
+            get: { self.fields.selectedState },
+            set: { self.fields.selectedState = $0 }
         )
 
         // Sort states from the selected country
-        let states = selectedCountry?.states.sorted { $0.name < $1.name } ?? []
+        let states = fields.selectedCountry?.states.sorted { $0.name < $1.name } ?? []
+        return StateSelectorViewModel(states: states, selected: selectedStateBinding)
+    }
+
+    /// Creates a view model to be used when selecting a country for secondary fields
+    ///
+    func createSecondaryCountryViewModel() -> CountrySelectorViewModel {
+        let selectedCountryBinding = Binding(
+            get: { self.secondaryFields.selectedCountry },
+            set: { self.secondaryFields.selectedCountry = $0 }
+        )
+        return CountrySelectorViewModel(countries: allCountries, selected: selectedCountryBinding)
+    }
+
+    /// Creates a view model to be used when selecting a state for secondary fields
+    ///
+    func createSecondaryStateViewModel() -> StateSelectorViewModel {
+        let selectedStateBinding = Binding(
+            get: { self.secondaryFields.selectedState },
+            set: { self.secondaryFields.selectedState = $0 }
+        )
+
+        // Sort states from the selected country
+        let states = secondaryFields.selectedCountry?.states.sorted { $0.name < $1.name } ?? []
         return StateSelectorViewModel(states: states, selected: selectedStateBinding)
     }
 
@@ -338,31 +407,19 @@ extension AddressFormViewModel {
 }
 
 private extension AddressFormViewModel {
-    /// Set initial values from `originalAddress` using the stored countries to compute the current selected country & state.
-    ///
-    func setFieldsInitialValues() {
-        fields = .init(with: originalAddress)
-        updateCountryStateNamesFromCodes()
-    }
 
-    func updateCountryStateNamesFromCodes() {
-        if let selectedCountry = selectedCountry {
-            fields.countryName = selectedCountry.name
-        } else {
-            fields.countryName = fields.countryCode
-        }
-        if let selectedState = selectedState {
-            fields.stateName = selectedState.name
-        } else {
-            fields.stateName = fields.stateCode
-        }
+    /// Set initial values from Address using the stored countries to compute the current selected country & state.
+    ///
+    func refreshCountryAndStateObjects() {
+        fields.refreshCountryAndStateObjects(with: allCountries)
+        secondaryFields.refreshCountryAndStateObjects(with: allCountries)
     }
 
     /// Calculates what navigation trailing item should be shown depending on our internal state.
     ///
     func bindNavigationTrailingItemPublisher() {
-        Publishers.CombineLatest($fields, performingNetworkRequest)
-            .map { [originalAddress] fields, performingNetworkRequest -> AddressFormNavigationItem in
+        Publishers.CombineLatest3($fields, $secondaryFields, performingNetworkRequest)
+            .map { [originalAddress, secondaryOriginalAddress] fields, secondaryFields, performingNetworkRequest -> AddressFormNavigationItem in
                 guard !performingNetworkRequest else {
                     return .loading
                 }
@@ -371,7 +428,7 @@ private extension AddressFormViewModel {
                     return .done(enabled: true)
                 }
 
-                return .done(enabled: originalAddress != fields.toAddress())
+                return .done(enabled: originalAddress != fields.toAddress() || secondaryOriginalAddress != secondaryFields.toAddress())
             }
             .assign(to: &$navigationTrailingItem)
     }
@@ -384,7 +441,9 @@ private extension AddressFormViewModel {
 
         // Updates the initial fields when/if the data store changes(after sync).
         countriesResultsController.onDidChangeContent = { [weak self] in
-            self?.updateCountryStateNamesFromCodes()
+            guard let self = self else { return }
+
+            self.refreshCountryAndStateObjects()
         }
 
         // Trigger a sync request if there are no countries.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -142,12 +142,12 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                 }
 
                 if viewModel.showDifferentAddressForm {
-                    SingleAddressForm(fields: $viewModel.fields,
-                                      countryViewModelClosure: viewModel.createCountryViewModel,
-                                      stateViewModelClosure: viewModel.createStateViewModel,
+                    SingleAddressForm(fields: $viewModel.secondaryFields,
+                                      countryViewModelClosure: viewModel.createSecondaryCountryViewModel,
+                                      stateViewModelClosure: viewModel.createSecondaryStateViewModel,
                                       sectionTitle: viewModel.sectionTitle,
                                       showEmailField: false,
-                                      showStateFieldAsSelector: viewModel.showStateFieldAsSelector)
+                                      showStateFieldAsSelector: viewModel.showSecondaryStateFieldAsSelector)
                 }
             }
             .disableAutocorrection(true)
@@ -308,7 +308,7 @@ struct SingleAddressForm: View {
                 }
 
                 TitleAndValueRow(title: Localization.countryField,
-                                 value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.countryName),
+                                 value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.country),
                                  selectable: true) {
                     showCountrySelector = true
                 }
@@ -326,14 +326,14 @@ struct SingleAddressForm: View {
     @ViewBuilder private func stateRow() -> some View {
         if showStateFieldAsSelector {
             TitleAndValueRow(title: Localization.stateField,
-                             value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.stateName),
+                             value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.state),
                              selectable: true) {
                 showStateSelector = true
             }
         } else {
             TitleAndTextFieldRow(title: Localization.stateField,
                                  placeholder: "",
-                                 text: $fields.stateName,
+                                 text: $fields.state,
                                  symbol: nil,
                                  keyboardType: .default)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -145,7 +145,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                     SingleAddressForm(fields: $viewModel.secondaryFields,
                                       countryViewModelClosure: viewModel.createSecondaryCountryViewModel,
                                       stateViewModelClosure: viewModel.createSecondaryStateViewModel,
-                                      sectionTitle: viewModel.sectionTitle,
+                                      sectionTitle: viewModel.secondarySectionTitle,
                                       showEmailField: false,
                                       showStateFieldAsSelector: viewModel.showSecondaryStateFieldAsSelector)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -149,6 +149,8 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                                       showEmailField: false,
                                       showStateFieldAsSelector: viewModel.showSecondaryStateFieldAsSelector)
                 }
+
+                Spacer(minLength: safeAreaInsets.bottom)
             }
             .disableAutocorrection(true)
             .background(Color(.listBackground))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -312,6 +312,17 @@ struct SingleAddressForm: View {
                     EmptyView()
                 }
 
+                ///
+                /// iOS 14.5 has a bug where
+                /// Pushing a view while having "exactly two" navigation links makes the pushed view to be popped when the initial view changes its state.
+                /// EG: AddressForm -> CountrySelector -> Country is selected -> AddressForm updates country -> CountrySelector is popped automatically.
+                /// Adding an extra and useless navigation link fixes the problem but throws a warning in the console.
+                /// Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279
+                ///
+                NavigationLink(destination: EmptyView()) {
+                    EmptyView()
+                }
+
                 TitleAndValueRow(title: Localization.countryField,
                                  value: .init(placeHolder: Localization.placeholderSelectOption, content: fields.country),
                                  selectable: true) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -131,6 +131,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                         .padding(.vertical, Constants.verticalPadding)
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground))
+                        .addingTopAndBottomDividers()
                 }
 
                 if viewModel.showDifferentAddressToggle, let differentAddressToggleTitle = viewModel.differentAddressToggleTitle {
@@ -139,6 +140,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                         .padding(.vertical, Constants.verticalPadding)
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground))
+                        .addingTopAndBottomDividers()
                 }
 
                 if viewModel.showDifferentAddressForm {
@@ -256,6 +258,7 @@ struct SingleAddressForm: View {
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.systemBackground))
+        .addingTopAndBottomDividers()
 
         ListHeaderView(text: sectionTitle, alignment: .left)
             .padding(.horizontal, insets: safeAreaInsets)
@@ -321,6 +324,7 @@ struct SingleAddressForm: View {
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.systemBackground))
+        .addingTopAndBottomDividers()
     }
 
     /// Decides if the state row should be rendered as a list selector field or as a text input field.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -81,6 +81,10 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
         }
     }
 
+    var secondarySectionTitle: String {
+        ""
+    }
+
     var showAlternativeUsageToggle: Bool {
         true
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -105,6 +105,7 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
     /// Update the address remotely and invoke a completion block when finished
     ///
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
+        let updatedAddress = fields.toAddress()
         let orderFields: [OrderUpdateField]
 
         let modifiedOrder: Yosemite.Order
@@ -137,7 +138,7 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
 
             case .failure(let error):
                 DDLogError("⛔️ Error updating order: \(error)")
-                if self.type == .billing, self.updatedAddress.hasEmailAddress == false {
+                if self.type == .billing, updatedAddress.hasEmailAddress == false {
                     DDLogError("⛔️ Email is nil in address. It won't work in WC < 5.9.0 (https://git.io/J68Gl)")
                 }
                 self.presentNotice = .error(.unableToUpdateAddress)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -984,6 +984,7 @@
 		ABC35F18E744C5576B986CB3 /* InPersonPaymentsUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC35055F8AC8C8EB649F421 /* InPersonPaymentsUnavailableView.swift */; };
 		AE457813275644590092F687 /* OrderStatusSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE457812275644590092F687 /* OrderStatusSection.swift */; };
 		AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */; };
+		AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */; };
 		AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9E04742776213E003FA09E /* OrderCustomerSection.swift */; };
 		AEA622B2274669D3002A9B57 /* AddOrderCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA622B1274669D3002A9B57 /* AddOrderCoordinator.swift */; };
 		AEA622B427466B78002A9B57 /* BottomSheetOrderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA622B327466B78002A9B57 /* BottomSheetOrderType.swift */; };
@@ -2566,6 +2567,7 @@
 		ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingError.swift; sourceTree = "<group>"; };
 		AE457812275644590092F687 /* OrderStatusSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusSection.swift; sourceTree = "<group>"; };
 		AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveStack.swift; sourceTree = "<group>"; };
+		AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AddingDividers.swift"; sourceTree = "<group>"; };
 		AE9E04742776213E003FA09E /* OrderCustomerSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerSection.swift; sourceTree = "<group>"; };
 		AEA622B1274669D3002A9B57 /* AddOrderCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOrderCoordinator.swift; sourceTree = "<group>"; };
 		AEA622B327466B78002A9B57 /* BottomSheetOrderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetOrderType.swift; sourceTree = "<group>"; };
@@ -4252,6 +4254,7 @@
 				DE4B3B5526A68DD000EEF2D8 /* View+InsetPaddings.swift */,
 				581D5051274AA2480089B6AD /* View+AutofocusTextModifier.swift */,
 				26281775278F0B0100C836D3 /* View+NoticesModifier.swift */,
+				AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -8833,6 +8836,7 @@
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
 				DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
+				AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */,
 				0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -45,8 +45,8 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.fields.postcode, address.postcode)
 
         let country = Self.sampleCountries.first { $0.code == address.country }
-        XCTAssertEqual(viewModel.fields.countryName, country?.name)
-        XCTAssertEqual(viewModel.fields.stateName, country?.states.first?.name) // Only one state supported in tests
+        XCTAssertEqual(viewModel.fields.country, country?.name)
+        XCTAssertEqual(viewModel.fields.state, country?.states.first?.name) // Only one state supported in tests
 
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
@@ -246,7 +246,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         countryViewModel.command.handleSelectedChange(selected: newCountry, viewController: viewController)
 
         // Then
-        XCTAssertEqual(viewModel.fields.countryName, newCountry.name)
+        XCTAssertEqual(viewModel.fields.country, newCountry.name)
     }
 
     func test_view_model_only_updates_shipping_address_field() {
@@ -337,7 +337,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         stateViewModel.command.handleSelectedChange(selected: newState, viewController: viewController)
 
         // Then
-        XCTAssertEqual(viewModel.fields.stateName, newState.name)
+        XCTAssertEqual(viewModel.fields.state, newState.name)
     }
 
     func test_view_model_updates_billing_and_shipping_address_fields_when_use_as_toggle_is_on() {


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/5412, closes https://github.com/woocommerce/woocommerce-ios/issues/5997.

## Description

This PR adds data binding for secondary form in address flow UI, used only in order creation flow. Code changes may (but shouldn't) impact the existing order editing flow.

## Changes

- Even more logic around country/state moved to `AddressFormFields` to prevent duplication.
- Adds `secondaryFields` and all related bindings, mainly to `AddressFormViewModel,` to keep country/state logic in a single place.
- Updates `CreateOrderAddressFormViewModel` to pass input and output data.
- Fixes safe area handling at the bottom of address form.
- Adds more full-width dividers to address form in line with the design.

## Testing

Check both new order and edit order flows. Pay extra attention to state/country manipulation.

Setup:
1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.

Try new order address flow:
1. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
2. Tap "+ Add customer" button to display the address form.
3. Enter some data.
4. Enable "Add a different shipping address" toggle.
5. Enter different data for shipping address in expanded form.
6. Tap "Done" to save and close the address form.
7. Confirm that the customer section is updated with new data.
8. Tap "Edit" in the customer section.
9. Confirm that the address form shows correct data.
10. Clear all fields for one of the addresses and tap "Done".
11. Confirm that the empty state for update address shows "No address specified.".
12. Tap "Create" to create an order. Confirm that the order displays the correct addresses.

Try existing order editing flow:
1. In order details, tap the pencil icon to edit the shipping address.
2. Update some data, tap "Done" to save and close the address form.
3. Confirm that the customer section is updated with new data.
4. Tap "View Billing Information".
5. Tap the pencil icon to edit the billing address.
6. Update some data, tap "Done" to save and close the address form.
7. Confirm that the billing information screen is updated with new data.

## Screenshots

updated customer section|expanded form with different addresses
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/151614362-4267e5bf-d96c-41b8-aad0-658aa47f060b.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/151614388-4873fe6f-c646-42a9-841e-12fd5c560fab.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
