### PR TITLE
Fixed broken path in UI-TESTS.md

### DIFF
--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -67,7 +67,7 @@ We also run the UI tests on CircleCI on every commit to the `trunk` or `release/
 When adding a new UI test, consider:
 
 * Whether you need to test a user flow (to accomplish a task or goal) or a specific feature (e.g. boundary testing).
-* What screens are being tested (defined as screen objects in the [Screens](../WooCommerce/WooCommerceUITests/Screens) directory).
+* What screens are being tested (defined as screen objects in the [Screens](../WooCommerce/UITestsFoundation/Screens) directory).
 * Whether there are actions or flows that could be shared across tests (defined in the [Utils](../WooCommerce/WooCommerceUITests/Utils) directory).
 * What network requests are made during the test (defined in the [Mocks](../WooCommerce/WooCommerceUITests/Mocks) directory).
 


### PR DESCRIPTION
The directory for the Screens objects have been moved in `WooCommerce/UITestsFoundation/Screens` from `WooCommerce/WooCommerceUITests/Screens`, the old reference exists in the UI-TESTS documentation.

### Description
Fixed broken path in documentation.

### Testing instructions
Non needed

### Screenshots
Non needed

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
