### PR TITLE
Preselect the current day in custom date filters

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
@@ -135,7 +135,7 @@ extension DateRangeFilterViewController: UITableViewDelegate {
         } else {
             startDate = today
         }
-        self.onCompletion(self.startDate, self.endDate)
+       onCompletion(self.startDate, self.endDate)
     }
 
     /// If we do not have a endDate then preselect the current (or startDate) day

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
@@ -139,7 +139,8 @@ extension DateRangeFilterViewController: UITableViewDelegate {
     }
 
     /// If we do not have a endDate then preselect the current (or startDate) day
-    /// to be in synch with the datapicker element that starts with a preselect date
+    /// to be in synch with the datepicker element that starts with a preselect date
+    ///
     private func preselectedEndDateIfNeeded() {
         guard endDateExpanded, endDate == nil else { return }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
@@ -150,7 +150,7 @@ extension DateRangeFilterViewController: UITableViewDelegate {
         } else {
             endDate = today
         }
-        self.onCompletion(self.startDate, self.endDate)
+        onCompletion(self.startDate, self.endDate)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
@@ -110,15 +110,45 @@ extension DateRangeFilterViewController: UITableViewDelegate {
         switch rows[indexPath.row] {
         case .startDateTitle:
             startDateExpanded.toggle()
+            preselectedStartDateIfNeeded()
             updateRows()
             tableView.reloadData()
         case .endDateTitle:
             endDateExpanded.toggle()
+            preselectedEndDateIfNeeded()
             updateRows()
             tableView.reloadData()
         default:
             return
         }
+    }
+
+    /// If we do not have a startDate then preselect the current (or endDate) day
+    /// to be in synch with the datapicker element that starts with a preselect date
+    private func preselectedStartDateIfNeeded() {
+        guard startDateExpanded, startDate == nil else { return }
+
+        let today = Date()
+        if let endDate = endDate {
+            startDate = today <= endDate ? today : endDate
+        } else {
+            startDate = today
+        }
+        self.onCompletion(self.startDate, self.endDate)
+    }
+
+    /// If we do not have a endDate then preselect the current (or startDate) day
+    /// to be in synch with the datapicker element that starts with a preselect date
+    private func preselectedEndDateIfNeeded() {
+        guard endDateExpanded, endDate == nil else { return }
+
+        let today = Date()
+        if let startDate = startDate {
+            endDate = today >= startDate ? today : startDate
+        } else {
+            endDate = today
+        }
+        self.onCompletion(self.startDate, self.endDate)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
@@ -124,7 +124,8 @@ extension DateRangeFilterViewController: UITableViewDelegate {
     }
 
     /// If we do not have a startDate then preselect the current (or endDate) day
-    /// to be in synch with the datapicker element that starts with a preselect date
+    /// to be in synch with the datepicker element that starts with a preselect date
+    ///
     private func preselectedStartDateIfNeeded() {
         guard startDateExpanded, startDate == nil else { return }
 


### PR DESCRIPTION
Closes: #5646

### Description
When the user is at the select custom date range for the orders filter, and she taps to select the start (or end) date, a date picker appears but if the user taps on the current date it is not selected. 

### Analysis
The problem lies in that the `UIDatePicker`(by default) has a starting initial date (defaults to current date), but the selected  `startDate` in `DateRangeFilterViewController` does not have initial value. Then we are listening for the value change event of the picker in `DatePickerTableViewCell`, so when the user taps the initial selected date, it does not trigger a value change event(since it is already the selected value).
The underlying problem here is that the `UIDatePicker` has a starting value that is not in synch with the `startDate` in `DateRangeFilterViewController`. 
This fix sets the `startDate`/`endDate` in `DateRangeFilterViewController` automatically when we tap to display the picker (if we do not have already a selected starting/ending date). This way the initial value that is displayed by the picker will match the `startDate` in `DateRangeFilterViewController`.

### Testing instructions

- [ ] Test the happy path for selecting start date:

1. Go to Orders screen
2. Tap on Filter 
3. Select Date Range and then Custom Range
3. Tap on Start Date field
4. The today's date is selected (previously it did not)

- [ ] Test the happy path for selecting end date:

1. Go to Orders screen
2. Tap on Filter 
3. Select Date Range and then Custom Range
3. Tap on End Date field
4. The today's date is selected (previously it did not)

- [ ] Test the path for selecting start date with a previous selected end date:

1. Go to Orders screen
2. Tap on Filter 
3. Select Date Range and then Custom Range
3. Tap on End Date field and a select any end date that is before today
4. Tap on Start Date field
5. The End Date should be selected for the Start Date field

- [ ] Test the path for selecting start date with a previous selected start date:

1. Go to Orders screen
2. Tap on Filter 
3. Select Date Range and then Custom Range
3. Tap on Start Date field and a select any end date that is after today
4. Tap on End Date field
5. The Start Date should be selected for the End Date field

### Screenshots
You can see that the default value the picker has is automatically selected, when the picker appears:

https://user-images.githubusercontent.com/96764631/151696716-16ac3bb0-4075-40bf-bb97-4b80d0255ac5.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

