### PR TITLE
Fixed retain cycle in NoticeView & NoticeContainerView

### DIFF
--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -136,7 +136,10 @@ private extension DefaultNoticePresenter {
             makeBottomConstraintForNoticeContainer(noticeContainerView)
         ])
 
-        let offScreenState = {
+        let offScreenState = { [weak noticeView, weak self] in
+            guard let noticeView = noticeView, let self = self else {
+                return
+            }
             noticeView.alpha = UIKitConstants.alphaZero
             noticeContainerView.noticeBottomConstraint.constant = self.offscreenBottomOffset
 
@@ -150,12 +153,15 @@ private extension DefaultNoticePresenter {
             noticeContainerView.layoutIfNeeded()
         }
 
-        let hiddenState = {
+        let hiddenState = { [weak noticeView] in
+            guard let noticeView = noticeView else {
+                return
+            }
             noticeView.alpha = UIKitConstants.alphaZero
         }
 
-        let dismiss = {
-            guard noticeContainerView.superview != nil else {
+        let dismiss = { [weak noticeContainerView] in
+            guard let noticeContainerView = noticeContainerView, noticeContainerView.superview != nil else {
                 return
             }
 


### PR DESCRIPTION
Closes: #6016

### Description
There is a memory leak that causes NoticeView & NoticeContainerView instances to remain in memory after a Notice is displayed after calling the `DefaultNoticePresenter.enqueue(notice: notice)`.
In the `presentNoticeInForeground` method the `DefaultNoticePresenter` there are closure that hold strong references and cause the retain cycle. The  [dismiss closure](https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift#L157) holds a strong reference to noticeContainerView then noticeContainerView holds a strong reference [to the noticeView](https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift#L263) and noticeView to the initial [dismiss closure](https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift#L168).

### Testing instructions
Steps to reproduce the behaviour:

You can replace the steps 1 to 4 with any steps that produce a notification

1. Go to Orders
2. Select a Processing Order
3. Tap Mark Order Complete
4. Tap Mark Order Complete
5. Wait for the notification to disappear
6. After the on screen Notification disappears open the memory graph debugger and you will see NoticeView & NoticeContainerView instances are not allocated in memory


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
