### PR TITLE
[Mobile Payments] Support WCPay being installed but disabled to use Stripe

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -165,7 +165,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // If only the Stripe extension is installed, skip to checking Stripe activation and version
         if let stripe = stripe,
-            onlyStripeIsInstalled(wcPay: wcPay, stripe: stripe) {
+            onlyStripeIsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
             return stripeGatewayOnlyOnboardingState(plugin: stripe)
         } else {
             return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -277,13 +277,13 @@ private extension CardPresentPaymentsOnboardingUseCase {
         return wcPay.active && stripe.active
     }
 
-    func onlyStripeIsInstalled(wcPay: SystemPlugin?, stripe: SystemPlugin) -> Bool {
+    func onlyStripeIsInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin) -> Bool {
         // If the WCPay plugin is installed, immediately return false
-        guard wcPay == nil else {
-            return false
+        guard let wcPay = wcPay else {
+            return true
         }
 
-        return true
+        return wcPay.active == false
     }
 
     func isWCPayVersionSupported(plugin: SystemPlugin) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -165,7 +165,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // If only the Stripe extension is installed, skip to checking Stripe activation and version
         if let stripe = stripe,
-            onlyStripeIsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
+            wcPayInstalledAndActive(wcPay: wcPay, stripe: stripe) == false {
             return stripeGatewayOnlyOnboardingState(plugin: stripe)
         } else {
             return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -277,13 +277,13 @@ private extension CardPresentPaymentsOnboardingUseCase {
         return wcPay.active && stripe.active
     }
 
-    func onlyStripeIsInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin) -> Bool {
-        // If the WCPay plugin is installed, immediately return false
+    func wcPayInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin) -> Bool {
+        // If the WCPay plugin is not installed, immediately return false
         guard let wcPay = wcPay else {
-            return true
+            return false
         }
 
-        return wcPay.active == false
+        return wcPay.active
     }
 
     func isWCPayVersionSupported(plugin: SystemPlugin) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -226,6 +226,21 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .completed)
     }
 
+    func test_onboarding_returns_complete_when_stripe_active_and_wcpay_plugin_installed_but_not_active() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .inactive, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed)
+    }
+
     func test_onboarding_returns_complete_when_wcpay_plugin_active() {
         // Given
         setupCountry(country: .us)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6020 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Instead of just checking whether WCPay, this also checks if it's active to decide whether we can use Stripe for payments.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Either rely on the new unit tests, or:

1. Have a site that has WCPay installed but not activated, and Stripe active and set up correctly
2. Go to Settings -> In-Person Payments
3. Check that you see the option to manage your card reader

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
