### PR TITLE
Fetch Inbox Notes from `GET /wc-analytics/admin/notes` -  Networking layer

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
 		451274A625276C82009911FF /* product-variation.json in Resources */ = {isa = PBXBuildFile; fileRef = 451274A525276C82009911FF /* product-variation.json */; };
 		4513382027A8227F00AE5E78 /* InboxNotesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */; };
+		4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */; };
 		45150A9A268340D2006922EA /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A99268340D2006922EA /* Country.swift */; };
 		45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9B2683417A006922EA /* StateOfACountry.swift */; };
 		45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9D26836A57006922EA /* CountryListMapper.swift */; };
@@ -869,6 +870,7 @@
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
 		451274A525276C82009911FF /* product-variation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation.json"; sourceTree = "<group>"; };
 		4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNotesRemote.swift; sourceTree = "<group>"; };
+		4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNotesRemoteTests.swift; sourceTree = "<group>"; };
 		45150A99268340D2006922EA /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
 		45150A9B2683417A006922EA /* StateOfACountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateOfACountry.swift; sourceTree = "<group>"; };
 		45150A9D26836A57006922EA /* CountryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryListMapper.swift; sourceTree = "<group>"; };
@@ -1497,6 +1499,7 @@
 				45E461BD26837DB900011BF2 /* DataRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
+				4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
 				020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */,
 				B554FA8A2180B1D500C54DFF /* NotificationsRemoteTests.swift */,
@@ -2943,6 +2946,7 @@
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,
 				311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */,
 				2661547B242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift in Sources */,
+				4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */,
 				45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
 				24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
 		451274A625276C82009911FF /* product-variation.json in Resources */ = {isa = PBXBuildFile; fileRef = 451274A525276C82009911FF /* product-variation.json */; };
+		4513382027A8227F00AE5E78 /* InboxNotesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */; };
 		45150A9A268340D2006922EA /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A99268340D2006922EA /* Country.swift */; };
 		45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9B2683417A006922EA /* StateOfACountry.swift */; };
 		45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9D26836A57006922EA /* CountryListMapper.swift */; };
@@ -867,6 +868,7 @@
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
 		451274A525276C82009911FF /* product-variation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation.json"; sourceTree = "<group>"; };
+		4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNotesRemote.swift; sourceTree = "<group>"; };
 		45150A99268340D2006922EA /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
 		45150A9B2683417A006922EA /* StateOfACountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateOfACountry.swift; sourceTree = "<group>"; };
 		45150A9D26836A57006922EA /* CountryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryListMapper.swift; sourceTree = "<group>"; };
@@ -1622,6 +1624,7 @@
 				45E461BB26837CC500011BF2 /* DataRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
+				4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
 				B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */,
 				B557DA0120975500005962F4 /* OrdersRemote.swift */,
@@ -2797,6 +2800,7 @@
 				7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */,
 				D87F6151226591E10031A13B /* NullNetwork.swift in Sources */,
 				CE43A8F9229F463000A4FF29 /* ProductDownload.swift in Sources */,
+				4513382027A8227F00AE5E78 /* InboxNotesRemote.swift in Sources */,
 				B53EF5322180F21C003E146F /* Dictionary+Woo.swift in Sources */,
 				24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */,
 				74A1D26D21189DFF00931DFA /* SiteVisitStatsMapper.swift in Sources */,

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -62,14 +62,7 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
 
         let mapper = InboxNoteListMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: { result in
-            switch result {
-            case .success(let inboxNotes):
-                completion(.success(inboxNotes))
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        })
+        enqueue(request, mapper: mapper, completion: completion)
     }
 }
 

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -33,8 +33,8 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllInboxNotes(for siteID: Int64,
-                                  pageNumber: Int,
-                                  pageSize: Int,
+                                  pageNumber: Int = Default.pageNumber,
+                                  pageSize: Int = Default.pageSize,
                                   orderBy: InboxNotesRemote.OrderBy = .date,
                                   type: [InboxNotesRemote.NoteType]? = nil,
                                   status: [InboxNotesRemote.Status]? = nil,

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -82,10 +82,10 @@ public extension InboxNotesRemote {
 
     private enum ParameterKey {
         static let orderBy = "order_by"
-        static let page
+        static let page = "page"
         static let pageSize = "per_page"
-        static let type
-        static let status
+        static let type = "type"
+        static let status = "status"
     }
 
     /// Order By parameter

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -24,7 +24,7 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
     /// Retrieves all of the `InboxNote`s from the API.
     ///
     /// - Parameters:
-    ///     - siteID: The site for which we'll fetch coupons.
+    ///     - siteID: The site for which we'll fetch InboxNotes.
     ///     - pageNumber: The page number of the Inbox Notes list to be fetched.
     ///     - pageSize: The maximum number of Inbox Notes to be fetched for the current page.
     ///     - orderBy: The type of sorting that the Inbox Notes list will follow.

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -89,10 +89,10 @@ public extension InboxNotesRemote {
 
     private enum ParameterKey {
         static let orderBy = "order_by"
-        static let page = "page"
+        static let page
         static let pageSize = "per_page"
-        static let type = "type"
-        static let status = "status"
+        static let type
+        static let status
     }
 
     /// Order By parameter

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Protocol for `InboxNotesRemote` mainly used for mocking.
+///
+/// The required methods are intentionally incomplete. Feel free to add the other ones.
+///
+public protocol InboxNotesRemoteProtocol {
+    func loadAllInboxNotes(for siteID: Int64,
+                           pageNumber: Int,
+                           pageSize: Int,
+                           orderBy: InboxNotesRemote.OrderBy,
+                           type: [InboxNotesRemote.NoteType]?,
+                           status: [InboxNotesRemote.Status]?,
+                           completion: @escaping (Result<[InboxNote], Error>) -> ())
+}
+
+
+/// Inbox Notes: Remote endpoints
+///
+public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
+
+    // MARK: - Get Inbox Notes
+
+    /// Retrieves all of the `InboxNote`s from the API.
+    ///
+    /// - Parameters:
+    ///     - siteID: The site for which we'll fetch coupons.
+    ///     - pageNumber: The page number of the Inbox Notes list to be fetched.
+    ///     - pageSize: The maximum number of Inbox Notes to be fetched for the current page.
+    ///     - orderBy: The type of sorting that the Inbox Notes list will follow.
+    ///     - type: The array of Inbox Notes Types.
+    ///     - status: The array of Inbox Notes with a specific array of status that will be fetched.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadAllInboxNotes(for siteID: Int64,
+                                  pageNumber: Int,
+                                  pageSize: Int,
+                                  orderBy: InboxNotesRemote.OrderBy = .date,
+                                  type: [InboxNotesRemote.NoteType]? = nil,
+                                  status: [InboxNotesRemote.Status]? = nil,
+                                  completion: @escaping (Result<[InboxNote], Error>) -> ()) {
+        var parameters = [
+            ParameterKey.orderBy: orderBy.rawValue,
+            ParameterKey.page: pageNumber,
+            ParameterKey.pageSize: pageSize
+        ] as [String: Any]
+
+        if let type = type {
+            let stringOfTypes = type.map { $0.rawValue }
+            parameters[ParameterKey.type] = stringOfTypes.joined(separator: ",")
+        }
+        if let status = status {
+            let stringOfStatuses = status.map { $0.rawValue }
+            parameters[ParameterKey.status] = stringOfStatuses.joined(separator: ",")
+        }
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.notes,
+                                     parameters: parameters)
+
+        let mapper = InboxNoteListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: { result in
+            switch result {
+            case .success(let inboxNotes):
+                completion(.success(inboxNotes))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        })
+    }
+}
+
+// MARK: - Constants
+//
+public extension InboxNotesRemote {
+
+    enum Default {
+        public static let pageSize = 25
+        public static let pageNumber = 1
+    }
+
+    private enum Path {
+        static let notes = "admin/notes"
+        static let deleteNote = "admin/notes/delete"
+    }
+
+    private enum ParameterKey {
+        static let orderBy = "order_by"
+        static let page = "page"
+        static let pageSize = "per_page"
+        static let type = "type"
+        static let status = "status"
+    }
+
+    /// Order By parameter
+    ///
+    enum OrderBy: String {
+        case noteID = "note_id"
+        case date = "date"
+        case type = "type"
+        case title = "title"
+        case status = "status"
+    }
+
+    /// Type parameter
+    ///
+    enum NoteType: String {
+        case info = "info"
+        case marketing = "marketing"
+        case survey = "survey"
+        case update = "update"
+        case error = "error"
+        case warning = "warning"
+        case email = "email"
+    }
+
+    /// Status parameter
+    ///
+    enum Status: String {
+        case pending = "pending"
+        case unactioned = "unactioned"
+        case actioned = "actioned"
+        case snoozed = "snoozed"
+        case sent = "sent"
+    }
+}

--- a/Networking/NetworkingTests/Remote/InboxNotesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/InboxNotesRemoteTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Networking
+
+final class InboxNotesRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Load all Inbox Notes tests
+
+    /// Verifies that loadAllInboxNotes properly parses the `inbox-note-list` sample response.
+    ///
+    func test_loadAllInboxNotes_returns_parsed_inbox_notes() throws {
+        // Given
+        let remote = InboxNotesRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "admin/notes", filename: "inbox-note-list")
+
+        // When
+        let result = waitFor { promise in
+            remote.loadAllInboxNotes(for: self.sampleSiteID, pageNumber: 0, pageSize: 25) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssert(result.isSuccess)
+        let inboxNotes = try XCTUnwrap(result.get())
+        XCTAssertEqual(inboxNotes.count, 24)
+    }
+
+    /// Verifies that loadAllInboxNotes uses the SiteID passed in for the request.
+    ///
+    func test_loadAllInboxNotes_uses_passed_siteID_for_request() throws {
+        // Given
+        let remote = InboxNotesRemote(network: network)
+
+        // When
+        remote.loadAllInboxNotes(for: sampleSiteID) { _ in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
+        XCTAssertEqual(request.siteID, sampleSiteID)
+    }
+
+    /// Verifies that loadAllInboxNotes uses the SiteID passed in to build the models.
+    ///
+    func test_loadAllInboxNotes_uses_passed_siteID_for_model_creation() throws {
+        // Given
+        let remote = InboxNotesRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "admin/notes", filename: "inbox-note-list")
+
+        // When
+        let result = waitFor { promise in
+            remote.loadAllInboxNotes(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let inboxNotes = try result.get()
+        XCTAssertEqual(inboxNotes.first?.siteID, sampleSiteID)
+    }
+
+    /// Verifies that loadAllInboxNotes properly relays Networking Layer errors.
+    ///
+    func test_loadAllInboxNotes_properly_relays_networking_errors() throws {
+        // Given
+        let remote = InboxNotesRemote(network: network)
+
+        let error = NetworkError.unacceptableStatusCode(statusCode: 403)
+        network.simulateError(requestUrlSuffix: "admin/notes", error: error)
+
+        // When
+        let result = waitFor { promise in
+            remote.loadAllInboxNotes(for: self.sampleSiteID,
+                                  completion: { (result) in
+                                    promise(result)
+                                })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertNotNil(resultError)
+    }
+}


### PR DESCRIPTION
Part of #5951

### Description
As part of the Home Screen Updates Milestone 3 (Inbox) project, in this PR I added the networking layer and the unit tests for fetching the Inbox Notes from `GET /wc-analytics/admin/notes`.

### Testing instructions
Just CI, the code is still not implemented.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
