### PR TITLE
[Mobile Payments] Add experimental flag for In-Person Payments in Canada

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -11,6 +11,7 @@ extension GeneralAppSettings {
         isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy,
         isOrderCreationSwitchEnabled: CopiableProp<Bool> = .copy,
         isStripeInPersonPaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
+        isCanadaInPersonPaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
         isProductSKUInputScannerSwitchEnabled: CopiableProp<Bool> = .copy,
         knownCardReaders: CopiableProp<[String]> = .copy,
         lastEligibilityErrorInfo: NullableCopiableProp<EligibilityErrorInfo> = .copy,
@@ -21,6 +22,7 @@ extension GeneralAppSettings {
         let isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled ?? self.isViewAddOnsSwitchEnabled
         let isOrderCreationSwitchEnabled = isOrderCreationSwitchEnabled ?? self.isOrderCreationSwitchEnabled
         let isStripeInPersonPaymentsSwitchEnabled = isStripeInPersonPaymentsSwitchEnabled ?? self.isStripeInPersonPaymentsSwitchEnabled
+        let isCanadaInPersonPaymentsSwitchEnabled = isCanadaInPersonPaymentsSwitchEnabled ?? self.isCanadaInPersonPaymentsSwitchEnabled
         let isProductSKUInputScannerSwitchEnabled = isProductSKUInputScannerSwitchEnabled ?? self.isProductSKUInputScannerSwitchEnabled
         let knownCardReaders = knownCardReaders ?? self.knownCardReaders
         let lastEligibilityErrorInfo = lastEligibilityErrorInfo ?? self.lastEligibilityErrorInfo
@@ -32,6 +34,7 @@ extension GeneralAppSettings {
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
             isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
             isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
+            isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
             isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -32,6 +32,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isStripeInPersonPaymentsSwitchEnabled: Bool
 
+    /// The state for the In-Person Payments in Canada feature switch
+    ///
+    public let isCanadaInPersonPaymentsSwitchEnabled: Bool
+
     /// The state(`true` or `false`) for the Product SKU Input Scanner feature switch.
     ///
     public let isProductSKUInputScannerSwitchEnabled: Bool
@@ -53,6 +57,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
                 isViewAddOnsSwitchEnabled: Bool,
                 isOrderCreationSwitchEnabled: Bool,
                 isStripeInPersonPaymentsSwitchEnabled: Bool,
+                isCanadaInPersonPaymentsSwitchEnabled: Bool,
                 isProductSKUInputScannerSwitchEnabled: Bool,
                 knownCardReaders: [String],
                 lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
@@ -62,6 +67,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
         self.isOrderCreationSwitchEnabled = isOrderCreationSwitchEnabled
         self.isStripeInPersonPaymentsSwitchEnabled = isStripeInPersonPaymentsSwitchEnabled
+        self.isCanadaInPersonPaymentsSwitchEnabled = isCanadaInPersonPaymentsSwitchEnabled
         self.isProductSKUInputScannerSwitchEnabled = isProductSKUInputScannerSwitchEnabled
         self.knownCardReaders = knownCardReaders
         self.lastEligibilityErrorInfo = lastEligibilityErrorInfo
@@ -91,6 +97,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
             isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
             isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
+            isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
             isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
@@ -110,6 +117,7 @@ extension GeneralAppSettings {
         self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
         self.isOrderCreationSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isOrderCreationSwitchEnabled) ?? false
         self.isStripeInPersonPaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isStripeInPersonPaymentsSwitchEnabled) ?? false
+        self.isCanadaInPersonPaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isCanadaInPersonPaymentsSwitchEnabled) ?? false
         self.isProductSKUInputScannerSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isProductSKUInputScannerSwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
         self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -63,6 +63,7 @@ final class GeneralAppSettingsTests: XCTestCase {
                                                   isViewAddOnsSwitchEnabled: true,
                                                   isOrderCreationSwitchEnabled: true,
                                                   isStripeInPersonPaymentsSwitchEnabled: true,
+                                                  isCanadaInPersonPaymentsSwitchEnabled: true,
                                                   isProductSKUInputScannerSwitchEnabled: true,
                                                   knownCardReaders: readers,
                                                   lastEligibilityErrorInfo: eligibilityInfo,
@@ -84,6 +85,7 @@ final class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
         assertEqual(newSettings.isOrderCreationSwitchEnabled, true)
         assertEqual(newSettings.isStripeInPersonPaymentsSwitchEnabled, true)
+        assertEqual(newSettings.isCanadaInPersonPaymentsSwitchEnabled, true)
         assertEqual(newSettings.isProductSKUInputScannerSwitchEnabled, true)
         assertEqual(newSettings.lastJetpackBenefitsBannerDismissedTime, jetpackBannerDismissedDate)
     }
@@ -95,6 +97,7 @@ private extension GeneralAppSettingsTests {
                                   isViewAddOnsSwitchEnabled: Bool = false,
                                   isOrderCreationSwitchEnabled: Bool = false,
                                   isStripeInPersonPaymentsSwitchEnabled: Bool = false,
+                                  isCanadaInPersonPaymentsSwitchEnabled: Bool = false,
                                   isProductSKUInputScannerSwitchEnabled: Bool = false,
                                   knownCardReaders: [String] = [],
                                   lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
@@ -104,6 +107,7 @@ private extension GeneralAppSettingsTests {
                            isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
                            isOrderCreationSwitchEnabled: isOrderCreationSwitchEnabled,
                            isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
+                           isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
                            isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
                            knownCardReaders: knownCardReaders,
                            lastEligibilityErrorInfo: lastEligibilityErrorInfo,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -95,12 +95,21 @@ private extension BetaFeaturesViewController {
     }
 
     func inPersonPaymentsSection() -> Section? {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.stripeExtensionInPersonPayments) else {
+        var rows: [Row] = []
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.stripeExtensionInPersonPayments) {
+            rows += [.stripeExtensionInPersonPayments, .stripeExtensionInPersonPaymentsDescription]
+        }
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.canadaInPersonPayments) {
+            rows += [.canadaInPersonPayments, .canadaInPersonPaymentsDescription]
+        }
+
+        guard rows.isNotEmpty else {
             return nil
         }
 
-        return Section(rows: [.stripeExtensionInPersonPayments,
-                              .stripeExtensionInPersonPaymentsDescription])
+        return Section(rows: rows)
     }
 
     func productSKUInputScannerSection() -> Section? {
@@ -144,6 +153,11 @@ private extension BetaFeaturesViewController {
             configureStripeExtensionInPersonPaymentsSwitch(cell: cell)
         case let cell as BasicTableViewCell where row == .stripeExtensionInPersonPaymentsDescription:
             configureStripeExtensionInPersonPaymentsDescription(cell: cell)
+        // In-Person Payments in Canada
+        case let cell as SwitchTableViewCell where row == .canadaInPersonPayments:
+            configureCanadaInPersonPaymentsSwitch(cell: cell)
+        case let cell as BasicTableViewCell where row == .canadaInPersonPaymentsDescription:
+            configureCanadaInPersonPaymentsDescription(cell: cell)
         // Product SKU Input Scanner
         case let cell as SwitchTableViewCell where row == .productSKUInputScanner:
             configureProductSKUInputScannerSwitch(cell: cell)
@@ -251,6 +265,37 @@ private extension BetaFeaturesViewController {
         cell.textLabel?.text = Localization.stripeExtensionInPersonPaymentsDescription
     }
 
+    func configureCanadaInPersonPaymentsSwitch(cell: SwitchTableViewCell) {
+        configureCommonStylesForSwitchCell(cell)
+        cell.title = Localization.canadaExtensionInPersonPaymentsTitle
+
+        // Fetch switch's state stored value.
+        let action = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState { result in
+            guard let isEnabled = try? result.get() else {
+                return cell.isOn = false
+            }
+            cell.isOn = isEnabled
+        }
+        ServiceLocator.stores.dispatch(action)
+
+        // Change switch's state stored value
+        cell.onChange = { isSwitchOn in
+            let action = AppSettingsAction.setCanadaInPersonPaymentsSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
+                // Roll back toggle if an error occurred
+                if result.isFailure {
+                    cell.isOn.toggle()
+                }
+            })
+            ServiceLocator.stores.dispatch(action)
+        }
+        cell.accessibilityIdentifier = "beta-features-canada-in-person-payments-cell"
+    }
+
+    func configureCanadaInPersonPaymentsDescription(cell: BasicTableViewCell) {
+        configureCommonStylesForDescriptionCell(cell)
+        cell.textLabel?.text = Localization.canadaExtensionInPersonPaymentsDescription
+    }
+
     func configureProductSKUInputScannerSwitch(cell: SwitchTableViewCell) {
         configureCommonStylesForSwitchCell(cell)
         cell.title = Localization.productSKUInputScannerTitle
@@ -353,15 +398,19 @@ private enum Row: CaseIterable {
     case stripeExtensionInPersonPayments
     case stripeExtensionInPersonPaymentsDescription
 
+    // In-Person Payments in Canada
+    case canadaInPersonPayments
+    case canadaInPersonPaymentsDescription
+
     // Product SKU Input Scanner
     case productSKUInputScanner
     case productSKUInputScannerDescription
 
     var type: UITableViewCell.Type {
         switch self {
-        case .orderAddOns, .orderCreation, .stripeExtensionInPersonPayments, .productSKUInputScanner:
+        case .orderAddOns, .orderCreation, .stripeExtensionInPersonPayments, .canadaInPersonPayments, .productSKUInputScanner:
             return SwitchTableViewCell.self
-        case .orderAddOnsDescription, .orderCreationDescription, .stripeExtensionInPersonPaymentsDescription, .productSKUInputScannerDescription:
+        case .orderAddOnsDescription, .orderCreationDescription, .stripeExtensionInPersonPaymentsDescription, .canadaInPersonPaymentsDescription, .productSKUInputScannerDescription:
             return BasicTableViewCell.self
         }
     }
@@ -395,6 +444,13 @@ private extension BetaFeaturesViewController {
             "Test out In-Person Payments with the Stripe Payment Gateway extension",
             comment: "Cell description on beta features screen to enable accepting in-person payments for stores with " +
             "the WooCommerce Stripe Payment Gateway extension")
+
+        static let canadaExtensionInPersonPaymentsTitle = NSLocalizedString(
+            "In-Person Payments in Canada",
+            comment: "Cell title on beta features screen to enable accepting in-person payments for stores in Canada ")
+        static let canadaExtensionInPersonPaymentsDescription = NSLocalizedString(
+            "Test out In-Person Payments in Canada",
+            comment: "Cell description on beta features screen to enable accepting in-person payments for stores in Canada")
 
         static let productSKUInputScannerTitle = NSLocalizedString(
             "Product SKU Scanner",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -410,7 +410,8 @@ private enum Row: CaseIterable {
         switch self {
         case .orderAddOns, .orderCreation, .stripeExtensionInPersonPayments, .canadaInPersonPayments, .productSKUInputScanner:
             return SwitchTableViewCell.self
-        case .orderAddOnsDescription, .orderCreationDescription, .stripeExtensionInPersonPaymentsDescription, .canadaInPersonPaymentsDescription, .productSKUInputScannerDescription:
+        case .orderAddOnsDescription, .orderCreationDescription, .stripeExtensionInPersonPaymentsDescription, .canadaInPersonPaymentsDescription,
+                .productSKUInputScannerDescription:
             return BasicTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -31,6 +31,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     let storageManager: StorageManagerType
     let stores: StoresManager
     private var stripeGatewayIPPEnabled: Bool?
+    private var canadaIPPEnabled: Bool?
 
     @Published var state: CardPresentPaymentOnboardingState = .loading
 
@@ -44,16 +45,31 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     ) {
         self.storageManager = storageManager
         self.stores = stores
-        let action = AppSettingsAction.loadStripeInPersonPaymentsSwitchState(onCompletion: { [weak self] result in
+
+        let stripeAction = AppSettingsAction.loadStripeInPersonPaymentsSwitchState(onCompletion: { [weak self] result in
             switch result {
             case .success(let stripeGatewayIPPEnabled):
                 self?.stripeGatewayIPPEnabled = stripeGatewayIPPEnabled
             default:
                 break
             }
-            self?.updateState()
         })
-        stores.dispatch(action)
+        stores.dispatch(stripeAction)
+
+        let canadaAction = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState(onCompletion: { [weak self]  result in
+            switch result {
+            case .success(let canadaIPPEnabled):
+                self?.canadaIPPEnabled = canadaIPPEnabled
+            default:
+                break
+            }
+        })
+        stores.dispatch(canadaAction)
+
+        // At the time of writing, actions are dispatched and processed synchronously, so the completion blocks for
+        // loadStripeInPersonPaymentsSwitchState and loadCanadaInPersonPaymentsSwitchState should have been called already.
+        // We defer updating the state until all settings are read to prevent unnecessary checks.
+        updateState()
     }
 
     func refresh() {
@@ -256,7 +272,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isCountrySupported(plugin: CardPresentPaymentsPlugins, countryCode: String) -> Bool {
-        return plugin.supportedCountryCodes.contains(countryCode)
+        return supportedCountryCodes(plugin: plugin).contains(countryCode)
     }
 
     func getWCPayPlugin() -> SystemPlugin? {
@@ -362,13 +378,13 @@ private extension PaymentGatewayAccount {
     }
 }
 
-private extension CardPresentPaymentsPlugins {
+private extension CardPresentPaymentsOnboardingUseCase {
     // This was moved from Yosemite so it can check the feature flag
-    // In a future iteration, we might want to store all the configuration in the WooCommerce layer
-    var supportedCountryCodes: [String] {
-        switch self {
+    // In a future iteration, we might want to store all the configuration in a better place
+    func supportedCountryCodes(plugin: CardPresentPaymentsPlugins) -> [String] {
+        switch plugin {
         case .wcPay:
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.canadaInPersonPayments) {
+            if canadaIPPEnabled == true {
                 return ["US", "CA"]
             } else {
                 return ["US"]

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -24,6 +24,8 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
             switch action {
             case .loadStripeInPersonPaymentsSwitchState(let completion):
                 completion(.success(true))
+            case .loadCanadaInPersonPaymentsSwitchState(let completion):
+                completion(.success(true))
             default:
                 break
             }
@@ -323,7 +325,11 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         _ = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
 
         // Then
-        XCTAssertEqual(stores.receivedActions.count, 2)
+
+        // AppSettingsAction.loadStripeInPersonPaymentsSwitchState
+        // + AppSettingsAction.loadCanadaInPersonPaymentsSwitchState
+        // + CardPresentPaymentAction.use
+        XCTAssertEqual(stores.receivedActions.count, 3)
         let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
 
         switch action {
@@ -369,7 +375,11 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         _ = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
 
         // Then
-        XCTAssertEqual(stores.receivedActions.count, 2)
+
+        // AppSettingsAction.loadStripeInPersonPaymentsSwitchState
+        // + AppSettingsAction.loadCanadaInPersonPaymentsSwitchState
+        // + CardPresentPaymentAction.use
+        XCTAssertEqual(stores.receivedActions.count, 3)
         let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
 
         switch action {

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -136,6 +136,14 @@ public enum AppSettingsAction: Action {
     ///
     case setStripeInPersonPaymentsSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
 
+    /// Loads the most recent state for the In-Person Payments in Canada beta feature switch
+    ///
+    case loadCanadaInPersonPaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Sets the state for the In-Person Payments in Canada beta feature switch
+    ///
+    case setCanadaInPersonPaymentsSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
+
     /// Sets the state for the Product SKU Input Scanner beta feature switch.
     ///
     case setProductSKUInputScannerFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -197,6 +197,10 @@ public class AppSettingsStore: Store {
             loadStripeInPersonPaymentsSwitchState(onCompletion: onCompletion)
         case .setStripeInPersonPaymentsSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
             setStripeInPersonPaymentsSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
+        case .loadCanadaInPersonPaymentsSwitchState(onCompletion: let onCompletion):
+            loadCanadaInPersonPaymentsSwitchState(onCompletion: onCompletion)
+        case .setCanadaInPersonPaymentsSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
+            setCanadaInPersonPaymentsSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .setProductSKUInputScannerFeatureSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
             setProductSKUInputScannerFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .loadProductSKUInputScannerFeatureSwitchState(onCompletion: let onCompletion):
@@ -315,6 +319,25 @@ private extension AppSettingsStore {
         }
     }
 
+    /// Loads the current In-Person Payments in Canada beta feature switch state from `GeneralAppSettings`
+    ///
+    func loadCanadaInPersonPaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
+        let settings = loadOrCreateGeneralAppSettings()
+        onCompletion(.success(settings.isCanadaInPersonPaymentsSwitchEnabled))
+    }
+
+    /// Sets the provided In-Person Payments in Canada beta feature switch state into `GeneralAppSettings`
+    ///
+    func setCanadaInPersonPaymentsSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            let settings = loadOrCreateGeneralAppSettings().copy(isCanadaInPersonPaymentsSwitchEnabled: isEnabled)
+            try saveGeneralAppSettings(settings)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+    }
+
     /// Sets the state for the Product SKU Input Scanner beta feature switch into `GeneralAppSettings`.
     ///
     func setProductSKUInputScannerFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
@@ -392,6 +415,7 @@ private extension AppSettingsStore {
                                       isViewAddOnsSwitchEnabled: false,
                                       isOrderCreationSwitchEnabled: false,
                                       isStripeInPersonPaymentsSwitchEnabled: false,
+                                      isCanadaInPersonPaymentsSwitchEnabled: false,
                                       isProductSKUInputScannerSwitchEnabled: false,
                                       knownCardReaders: [],
                                       lastEligibilityErrorInfo: nil)

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -161,6 +161,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
                                           feedbacks: [:], isViewAddOnsSwitchEnabled: false,
                                           isOrderCreationSwitchEnabled: false,
                                           isStripeInPersonPaymentsSwitchEnabled: false,
+                                          isCanadaInPersonPaymentsSwitchEnabled: false,
                                           isProductSKUInputScannerSwitchEnabled: false,
                                           knownCardReaders: [])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
@@ -228,6 +229,7 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             isViewAddOnsSwitchEnabled: false,
             isOrderCreationSwitchEnabled: false,
             isStripeInPersonPaymentsSwitchEnabled: false,
+            isCanadaInPersonPaymentsSwitchEnabled: false,
             isProductSKUInputScannerSwitchEnabled: false,
             knownCardReaders: []
         )

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -643,6 +643,42 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(isEnabled)
     }
 
+    func test_loadCanadaInPersonPaymentsSwitchState_returns_false_on_new_generalAppSettings() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_loadCanadaInPersonPaymentsSwitchState_returns_true_after_updating_switch_state_to_true() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.setCanadaInPersonPaymentsSwitchState(isEnabled: true, onCompletion: { _ in })
+        subject?.onAction(updateAction)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertTrue(isEnabled)
+    }
+
     // MARK: - General Store Settings
 
     func test_saving_isTelemetryAvailable_works_correctly() throws {
@@ -839,6 +875,7 @@ private extension AppSettingsStoreTests {
             isViewAddOnsSwitchEnabled: false,
             isOrderCreationSwitchEnabled: false,
             isStripeInPersonPaymentsSwitchEnabled: false,
+            isCanadaInPersonPaymentsSwitchEnabled: false,
             isProductSKUInputScannerSwitchEnabled: false,
             knownCardReaders: []
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6034 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a new Experimental Feature flag for In-Person Payments in Canada.

The PR got a little large because all the boilerplate required to manage App Settings, but it's mostly copied from the Stripe Extension case. The only thing a bit different is the initialization of `CardPresentPaymentsOnboardingUseCase` now needs to check for two features, so I had to refactor that a little bit.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

By default, the feature should be off, so switch to a store with WCPay set up in Canada:

1. Go to Settings -> In-Person Payments, it should say country not supported
1. Go to Settings -> Experimental Features, turn on In-Person Payments in Canada
1. Go to Settings -> In-Person Payments, it should show options to order/manage readers
1. Go to Settings -> Experimental Features, turn off In-Person Payments in Canada
1. Go to Settings -> In-Person Payments, it should say country not supported

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
