### PR TITLE
Dismiss an Inbox Note from `DELETE /wc-analytics/admin/notes/delete/{{id}}` - Networking layer

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		451274A625276C82009911FF /* product-variation.json in Resources */ = {isa = PBXBuildFile; fileRef = 451274A525276C82009911FF /* product-variation.json */; };
 		4513382027A8227F00AE5E78 /* InboxNotesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */; };
 		4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */; };
+		4513382427A951B300AE5E78 /* InboxNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513382327A951B300AE5E78 /* InboxNoteMapper.swift */; };
 		45150A9A268340D2006922EA /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A99268340D2006922EA /* Country.swift */; };
 		45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9B2683417A006922EA /* StateOfACountry.swift */; };
 		45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9D26836A57006922EA /* CountryListMapper.swift */; };
@@ -871,6 +872,7 @@
 		451274A525276C82009911FF /* product-variation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation.json"; sourceTree = "<group>"; };
 		4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNotesRemote.swift; sourceTree = "<group>"; };
 		4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNotesRemoteTests.swift; sourceTree = "<group>"; };
+		4513382327A951B300AE5E78 /* InboxNoteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNoteMapper.swift; sourceTree = "<group>"; };
 		45150A99268340D2006922EA /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
 		45150A9B2683417A006922EA /* StateOfACountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateOfACountry.swift; sourceTree = "<group>"; };
 		45150A9D26836A57006922EA /* CountryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryListMapper.swift; sourceTree = "<group>"; };
@@ -1991,6 +1993,7 @@
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
 				AEF9458A27297FF6001DCCFB /* IgnoringResponseMapper.swift */,
+				4513382327A951B300AE5E78 /* InboxNoteMapper.swift */,
 				45CCFCE527A2E3710012E8CB /* InboxNoteListMapper.swift */,
 				26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */,
 				020D07BD23D8570800FD9580 /* MediaListMapper.swift */,
@@ -2767,6 +2770,7 @@
 				74A1D26821189A7100931DFA /* SiteVisitStats.swift in Sources */,
 				02C254B0256378D000A04423 /* ShippingLabelRefundStatus.swift in Sources */,
 				4568E2242459D3230007E478 /* Post.swift in Sources */,
+				4513382427A951B300AE5E78 /* InboxNoteMapper.swift in Sources */,
 				DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */,
 				B557DA0320975500005962F4 /* Remote.swift in Sources */,
 				B53EF53C21814900003E146F /* SuccessResultMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		4513382027A8227F00AE5E78 /* InboxNotesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */; };
 		4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */; };
 		4513382427A951B300AE5E78 /* InboxNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513382327A951B300AE5E78 /* InboxNoteMapper.swift */; };
+		4513382627A96DB700AE5E78 /* InboxNoteMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513382527A96DB700AE5E78 /* InboxNoteMapperTests.swift */; };
+		4513382827A96DE700AE5E78 /* inbox-note.json in Resources */ = {isa = PBXBuildFile; fileRef = 4513382727A96DE700AE5E78 /* inbox-note.json */; };
 		45150A9A268340D2006922EA /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A99268340D2006922EA /* Country.swift */; };
 		45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9B2683417A006922EA /* StateOfACountry.swift */; };
 		45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9D26836A57006922EA /* CountryListMapper.swift */; };
@@ -873,6 +875,8 @@
 		4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNotesRemote.swift; sourceTree = "<group>"; };
 		4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNotesRemoteTests.swift; sourceTree = "<group>"; };
 		4513382327A951B300AE5E78 /* InboxNoteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNoteMapper.swift; sourceTree = "<group>"; };
+		4513382527A96DB700AE5E78 /* InboxNoteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNoteMapperTests.swift; sourceTree = "<group>"; };
+		4513382727A96DE700AE5E78 /* inbox-note.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "inbox-note.json"; sourceTree = "<group>"; };
 		45150A99268340D2006922EA /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
 		45150A9B2683417A006922EA /* StateOfACountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateOfACountry.swift; sourceTree = "<group>"; };
 		45150A9D26836A57006922EA /* CountryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryListMapper.swift; sourceTree = "<group>"; };
@@ -1974,6 +1978,7 @@
 				DEC51AEC2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json */,
 				077F39D726A58EB600ABEADC /* systemStatus.json */,
 				45CCFCE927A2E59B0012E8CB /* inbox-note-list.json */,
+				4513382727A96DE700AE5E78 /* inbox-note.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -2136,6 +2141,7 @@
 				45150A9F26837357006922EA /* CountryListMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				AED8AEBB272A997500663FCC /* IgnoringResponseMapperTests.swift */,
+				4513382527A96DB700AE5E78 /* InboxNoteMapperTests.swift */,
 				45CCFCE727A2E5020012E8CB /* InboxNoteListMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
 				B5C151BF217EE3FB00C7BDC1 /* NoteListMapperTests.swift */,
@@ -2471,6 +2477,7 @@
 				02C254D72563999300A04423 /* order-shipping-labels.json in Resources */,
 				45B204BC24890B1200FE6526 /* category.json in Resources */,
 				022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */,
+				4513382827A96DE700AE5E78 /* inbox-note.json in Resources */,
 				31A451D227863A2E00FE81AA /* stripe-account-restricted-pending.json in Resources */,
 				45CCFCEA27A2E59B0012E8CB /* inbox-note-list.json in Resources */,
 				025CA2C8238F4FF400B05C81 /* product-shipping-classes-load-all.json in Resources */,
@@ -2985,6 +2992,7 @@
 				D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */,
 				B567AF3120A0FB8F00AB6C62 /* JetpackRequestTests.swift in Sources */,
 				7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */,
+				4513382627A96DB700AE5E78 /* InboxNoteMapperTests.swift in Sources */,
 				7412A8EE21B6E335005D182A /* ReportOrderMapperTests.swift in Sources */,
 				AED8AEBC272A997500663FCC /* IgnoringResponseMapperTests.swift in Sources */,
 				74CF0A8C22414D7800DB993F /* ProductMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/InboxNoteMapper.swift
+++ b/Networking/Networking/Mapper/InboxNoteMapper.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Mapper: Inbox Note
+///
+struct InboxNoteMapper: Mapper {
+
+    /// Site we're parsing `InboxNote`s for
+    /// We're injecting this field by copying it in after parsing response, because `siteID` is not returned in any of the Inbox Note endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into an Inbox Note.
+    ///
+    func map(response: Data) throws -> InboxNote {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+        return try decoder.decode(InboxNote.self, from: response)
+    }
+}

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -98,14 +98,7 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
 
         let mapper = InboxNoteMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: { result in
-            switch result {
-            case .success(let inboxNote):
-                completion(.success(inboxNote))
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        })
+        enqueue(request, mapper: mapper, completion: completion)
     }
 }
 

--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -12,6 +12,10 @@ public protocol InboxNotesRemoteProtocol {
                            type: [InboxNotesRemote.NoteType]?,
                            status: [InboxNotesRemote.Status]?,
                            completion: @escaping (Result<[InboxNote], Error>) -> ())
+
+    func dismissInboxNote(for siteID: Int64,
+                          noteID: Int64,
+                          completion: @escaping (Result<InboxNote, Error>) -> ())
 }
 
 
@@ -66,6 +70,38 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
             switch result {
             case .success(let inboxNotes):
                 completion(.success(inboxNotes))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        })
+    }
+
+    // MARK: - DISMISS Inbox Note
+
+    /// Dismiss one `InboxNote`.
+    /// This internally marks a notification’s is_deleted field to true and such notifications do not show in the results anymore.
+    ///
+    /// - Parameters:
+    ///     - siteID: The site for which we'll fetch InboxNotes.
+    ///     - noteID: The ID of the note that should be marked as dismissed.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func dismissInboxNote(for siteID: Int64,
+                                 noteID: Int64,
+                                 completion: @escaping (Result<InboxNote, Error>) -> ()) {
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics,
+                                     method: .delete,
+                                     siteID: siteID,
+                                     path: Path.notes + "/\(noteID)",
+                                     parameters: nil)
+
+        let mapper = InboxNoteMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: { result in
+            switch result {
+            case .success(let inboxNote):
+                completion(.success(inboxNote))
             case .failure(let error):
                 completion(.failure(error))
             }

--- a/Networking/NetworkingTests/Mapper/InboxNoteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InboxNoteListMapperTests.swift
@@ -62,7 +62,7 @@ final class InboxNoteListMapperTests: XCTestCase {
 ///
 private extension InboxNoteListMapperTests {
 
-    /// Returns the CouponListMapper output upon receiving `filename` (Data Encoded)
+    /// Returns the InboxNoteListMapper output upon receiving `filename` (Data Encoded)
     ///
     func mapInboxNoteList(from filename: String) throws -> [InboxNote] {
         guard let response = Loader.contentsOf(filename) else {

--- a/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
@@ -29,23 +29,23 @@ final class InboxNoteMapperTests: XCTestCase {
 
         // When
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-        let url = "https://woocommerce.com/posts/pre-launch-checklist-the-essentials/?utm_source=inbox&utm_medium=product"
-        let content = "To make sure you never get that sinking \"what did I forget\" feeling, we've put together the essential pre-launch checklist."
+        let url = "https://woocommerce.com/products/woocommerce-bookings/"
+        let content = "Your subscription expired on October 22nd. Get a new subscription to continue receiving updates and access to support."
         let expectedInboxNote = InboxNote(siteID: dummySiteID,
-                                          id: 291,
-                                          name: "wc-admin-launch-checklist",
-                                          type: "info",
+                                          id: 296,
+                                          name: "wc-admin-wc-helper-subscription",
+                                          type: "warning",
                                           status: "unactioned",
-                                          actions: [InboxAction(id: 13225,
-                                                                name: "learn-more",
-                                                                label: "Learn more",
+                                          actions: [InboxAction(id: 13329,
+                                                                name: "renew-subscription",
+                                                                label: "Renew Subscription",
                                                                 status: "actioned",
                                                                 url: url)],
-                                          title: "Ready to launch your store?",
+                                          title: "WooCommerce Bookings subscription expired",
                                           content: content,
-                                          isDeleted: false,
+                                          isDeleted: true,
                                           isRead: false,
-                                          dateCreated: dateFormatter.date(from: "2022-01-26T14:32:08")!)
+                                          dateCreated: dateFormatter.date(from: "2022-01-31T14:25:32")!)
 
         // Then
         XCTAssertEqual(inboxNote, expectedInboxNote)

--- a/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Networking
+
+final class InboxNoteMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 12983476
+
+    /// Verifies that the whole list is parsed.
+    ///
+    func test_InboxNoteMapper_parses_the_InboxNote_in_response() throws {
+        let inboxNote = try mapLoadInboxNoteResponse()
+        XCTAssertNotNil(inboxNote)
+    }
+
+    /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint.
+    ///
+    func test_InboxNoteMapper_includes_siteID_in_parsed_result() throws {
+        let inboxNote = try mapLoadInboxNoteResponse()
+        XCTAssertEqual(inboxNote?.siteID, dummySiteID)
+    }
+
+    /// Verifies that the fields are all parsed correctly.
+    ///
+    func test_InboxNoteMapper_parses_all_fields_in_result() throws {
+        // Given
+        let inboxNote = try mapLoadInboxNoteResponse()
+
+        // When
+        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+        let url = "https://woocommerce.com/posts/pre-launch-checklist-the-essentials/?utm_source=inbox&utm_medium=product"
+        let content = "To make sure you never get that sinking \"what did I forget\" feeling, we've put together the essential pre-launch checklist."
+        let expectedInboxNote = InboxNote(siteID: dummySiteID,
+                                          id: 291,
+                                          name: "wc-admin-launch-checklist",
+                                          type: "info",
+                                          status: "unactioned",
+                                          actions: [InboxAction(id: 13225,
+                                                                name: "learn-more",
+                                                                label: "Learn more",
+                                                                status: "actioned",
+                                                                url: url)],
+                                          title: "Ready to launch your store?",
+                                          content: content,
+                                          isDeleted: false,
+                                          isRead: false,
+                                          dateCreated: dateFormatter.date(from: "2022-01-26T14:32:08")!)
+
+        // Then
+        XCTAssertEqual(inboxNote, expectedInboxNote)
+    }
+}
+
+
+// MARK: - Test Helpers
+///
+private extension InboxNoteMapperTests {
+
+    /// Returns the InboxNoteMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapInboxNote(from filename: String) throws -> InboxNote? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try InboxNoteMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the InboxNoteMapper output from `inbox-note.json`
+    ///
+    func mapLoadInboxNoteResponse() throws -> InboxNote? {
+        return try mapInboxNote(from: "inbox-note")
+    }
+}

--- a/Networking/NetworkingTests/Responses/inbox-note.json
+++ b/Networking/NetworkingTests/Responses/inbox-note.json
@@ -1,0 +1,52 @@
+{
+    "id": 296,
+    "name": "wc-admin-wc-helper-subscription",
+    "type": "warning",
+    "locale": "en_US",
+    "title": "WooCommerce Bookings subscription expired",
+    "content": "Your subscription expired on October 22nd. Get a new subscription to continue receiving updates and access to support.",
+    "content_data": {
+        "product_id": 390890,
+        "product_name": "WooCommerce Bookings",
+        "expired": true,
+        "expires": 1634860800,
+        "expires_date": "October 22nd"
+    },
+    "status": "unactioned",
+    "source": "woocommerce-admin",
+    "date_created": "2022-01-31T08:55:32",
+    "date_reminder": null,
+    "is_snoozable": false,
+    "actions": [
+        {
+            "id": 13329,
+            "name": "renew-subscription",
+            "label": "Renew Subscription",
+            "query": "https://woocommerce.com/products/woocommerce-bookings/",
+            "status": "actioned",
+            "primary": false,
+            "actioned_text": "",
+            "nonce_action": null,
+            "nonce_name": null,
+            "url": "https://woocommerce.com/products/woocommerce-bookings/"
+        }
+    ],
+    "layout": "plain",
+    "image": "",
+    "is_deleted": true,
+    "is_read": false,
+    "date_created_gmt": "2022-01-31T14:25:32",
+    "date_reminder_gmt": null,
+    "_links": {
+        "self": [
+            {
+                "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc-analytics/admin/notes/296"
+            }
+        ],
+        "collection": [
+            {
+                "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc-analytics/admin/notes"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Part of #5952

### Description
As part of the Home Screen Updates Milestone 3 (Inbox) project, in this PR I added the networking layer and the unit tests for dismissing an Inbox Note from `DELETE /wc-analytics/admin/notes/delete/{{id}}`. Plus, I added the new `InboxNoteMapper` and the unit tests.

### Testing instructions
Just CI, the code is still not used in the codebase.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
