### PR TITLE
Order Creation: Address form improvements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -164,7 +164,7 @@ struct AddressFormFields {
             // When a country is selected, check if the new country has a state list.
             // If it has, clear the selected state and its name in fields.
             // If it doesn't only clear the selected state.
-            if selectedCountry?.states.isEmpty == false, selectedState != nil {
+            if selectedCountry?.states.isEmpty == false {
                 self.state = ""
             }
             self.selectedState = nil
@@ -189,8 +189,9 @@ struct AddressFormFields {
             return
         }
 
+        let initialStateValue = state // storing initial state value because it will be cleared by selectedCountry setter
         selectedCountry = allCountries.first { $0.code == country }
-        selectedState = selectedCountry?.states.first { $0.code == state }
+        selectedState = selectedCountry?.states.first { $0.code == initialStateValue }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -430,8 +430,9 @@ private extension AddressFormViewModel {
     /// Calculates what navigation trailing item should be shown depending on our internal state.
     ///
     func bindNavigationTrailingItemPublisher() {
-        Publishers.CombineLatest3($fields, $secondaryFields, performingNetworkRequest)
-            .map { [originalAddress, secondaryOriginalAddress] fields, secondaryFields, performingNetworkRequest -> AddressFormNavigationItem in
+        Publishers.CombineLatest4($fields, $secondaryFields, $showDifferentAddressForm, performingNetworkRequest)
+            .map { [originalAddress, secondaryOriginalAddress]
+                fields, secondaryFields, showDifferentAddressForm, performingNetworkRequest -> AddressFormNavigationItem in
                 guard !performingNetworkRequest else {
                     return .loading
                 }
@@ -440,7 +441,13 @@ private extension AddressFormViewModel {
                     return .done(enabled: true)
                 }
 
-                return .done(enabled: originalAddress != fields.toAddress() || secondaryOriginalAddress != secondaryFields.toAddress())
+                let addressesAreDifferentButSecondAddressSwitchIsDisabled = secondaryOriginalAddress != .empty &&
+                originalAddress != secondaryOriginalAddress &&
+                !showDifferentAddressForm
+
+                return .done(enabled: addressesAreDifferentButSecondAddressSwitchIsDisabled ||
+                             originalAddress != fields.toAddress() ||
+                             secondaryOriginalAddress != secondaryFields.toAddress())
             }
             .assign(to: &$navigationTrailingItem)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -986,6 +986,7 @@
 		AE457813275644590092F687 /* OrderStatusSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE457812275644590092F687 /* OrderStatusSection.swift */; };
 		AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */; };
 		AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */; };
+		AE90475C27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */; };
 		AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9E04742776213E003FA09E /* OrderCustomerSection.swift */; };
 		AEA622B2274669D3002A9B57 /* AddOrderCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA622B1274669D3002A9B57 /* AddOrderCoordinator.swift */; };
 		AEA622B427466B78002A9B57 /* BottomSheetOrderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA622B327466B78002A9B57 /* BottomSheetOrderType.swift */; };
@@ -2573,6 +2574,7 @@
 		AE457812275644590092F687 /* OrderStatusSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusSection.swift; sourceTree = "<group>"; };
 		AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveStack.swift; sourceTree = "<group>"; };
 		AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AddingDividers.swift"; sourceTree = "<group>"; };
+		AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrderAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		AE9E04742776213E003FA09E /* OrderCustomerSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerSection.swift; sourceTree = "<group>"; };
 		AEA622B1274669D3002A9B57 /* AddOrderCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOrderCoordinator.swift; sourceTree = "<group>"; };
 		AEA622B327466B78002A9B57 /* BottomSheetOrderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetOrderType.swift; sourceTree = "<group>"; };
@@ -6211,6 +6213,7 @@
 				CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */,
 				CC53FB3F2759042600C4CA4F /* AddProductToOrderViewModelTests.swift */,
 				CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */,
+				AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -9227,6 +9230,7 @@
 				023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */,
 				AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */,
 				02DE5CAB279F8754007CBEF3 /* Double+RoundingTests.swift in Sources */,
+				AE90475C27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift in Sources */,
 				B56C721421B5BBC000E5E85B /* MockStoresManager.swift in Sources */,
 				26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
@@ -1,0 +1,388 @@
+import XCTest
+import Yosemite
+import TestKit
+import Combine
+@testable import WooCommerce
+
+final class CreateOrderAddressFormViewModelTests: XCTestCase {
+
+    let sampleSiteID: Int64 = 123
+
+    let testingStorage = MockStorageManager()
+
+    let testingStores = MockStoresManager(sessionManager: .testingInstance)
+
+    var subscriptions = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+
+        testingStorage.reset()
+        testingStorage.insertSampleCountries(readOnlyCountries: Self.sampleCountries)
+
+        testingStores.reset()
+        subscriptions.removeAll()
+    }
+
+    func test_input_of_identical_addresses_disables_different_address_toggle() {
+        // Given
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+
+        // Then
+        XCTAssertFalse(viewModel.showDifferentAddressForm)
+    }
+
+    func test_input_of_different_addresses_enables_different_address_toggle() {
+        // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+
+        // Then
+        XCTAssertTrue(viewModel.showDifferentAddressForm)
+    }
+
+    func test_creating_with_second_address_prefills_fields_with_correct_data() {
+        // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryFields.firstName, address2.firstName)
+        XCTAssertEqual(viewModel.secondaryFields.lastName, address2.lastName)
+        XCTAssertEqual(viewModel.secondaryFields.email, address2.email ?? "")
+        XCTAssertEqual(viewModel.secondaryFields.phone, address2.phone ?? "")
+
+        XCTAssertEqual(viewModel.secondaryFields.company, address2.company ?? "")
+        XCTAssertEqual(viewModel.secondaryFields.address1, address2.address1)
+        XCTAssertEqual(viewModel.secondaryFields.address2, address2.address2 ?? "")
+        XCTAssertEqual(viewModel.secondaryFields.city, address2.city)
+        XCTAssertEqual(viewModel.secondaryFields.postcode, address2.postcode)
+
+        let country = Self.sampleCountries.first { $0.code == address2.country }
+        XCTAssertEqual(viewModel.secondaryFields.country, country?.name)
+        XCTAssertEqual(viewModel.secondaryFields.state, country?.states.first?.name) // Only one state supported in tests
+
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+    }
+
+    func test_selecting_country_updates_country_field() {
+        // Given
+        let newCountry = Self.sampleCountries[0]
+
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        viewModel.onLoadTrigger.send()
+
+        // When
+        let countryViewModel = viewModel.createSecondaryCountryViewModel()
+        let viewController = ListSelectorViewController(command: countryViewModel.command, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        countryViewModel.command.handleSelectedChange(selected: newCountry, viewController: viewController)
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryFields.country, newCountry.name)
+    }
+
+    func test_country_and_state_names_are_converted_from_codes_when_available() {
+        // Given
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        XCTAssertEqual(viewModel.secondaryFields.country, "US")
+        XCTAssertNil(viewModel.secondaryFields.selectedCountry)
+        XCTAssertEqual(viewModel.secondaryFields.state, "NY")
+        XCTAssertNil(viewModel.secondaryFields.selectedState)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryFields.country, "United States")
+        XCTAssertNotNil(viewModel.secondaryFields.selectedCountry)
+        XCTAssertEqual(viewModel.secondaryFields.state, "New York")
+        XCTAssertNotNil(viewModel.secondaryFields.selectedState)
+    }
+
+    func test_state_name_is_displayed_as_string_when_mapping_is_not_available() {
+        // Given
+        let addressWithUnknownCountryAndState = sampleAddress().copy(state: "Bavaria", country: "Germany")
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: addressWithUnknownCountryAndState,
+                                                                           shippingAddress: addressWithUnknownCountryAndState),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryFields.state, "Bavaria")
+        XCTAssertNil(viewModel.secondaryFields.selectedState)
+    }
+
+    func test_selecting_country_without_states_nullifies_selectedState_property_but_keeps_state_field() {
+        // Given
+        let newCountry = Country(code: "GB", name: "United Kingdom", states: [])
+
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        viewModel.onLoadTrigger.send()
+        XCTAssertEqual(viewModel.secondaryFields.state, "New York")
+        XCTAssertNotNil(viewModel.secondaryFields.selectedState)
+
+        // When
+        let countryViewModel = viewModel.createSecondaryCountryViewModel()
+        let viewController = ListSelectorViewController(command: countryViewModel.command, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        countryViewModel.command.handleSelectedChange(selected: newCountry, viewController: viewController)
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryFields.state, "New York")
+        XCTAssertNil(viewModel.secondaryFields.selectedState)
+    }
+
+    func test_selecting_country_with_states_nullifies_selectedState_property_and_state_field() {
+        // Given
+        let newCountry = Country(code: "AU", name: "Australia", states: [.init(code: "VIC", name: "Victoria")])
+
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        viewModel.onLoadTrigger.send()
+        XCTAssertEqual(viewModel.secondaryFields.state, "New York")
+        XCTAssertNotNil(viewModel.secondaryFields.selectedState)
+
+        // When
+        let countryViewModel = viewModel.createSecondaryCountryViewModel()
+        let viewController = ListSelectorViewController(command: countryViewModel.command, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        countryViewModel.command.handleSelectedChange(selected: newCountry, viewController: viewController)
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryFields.state, "")
+        XCTAssertNil(viewModel.secondaryFields.selectedState)
+    }
+
+    func test_selecting_state_updates_state_field() {
+        // Given
+        let newState = StateOfACountry(code: "CA", name: "California")
+
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        viewModel.onLoadTrigger.send()
+
+        // When
+        let stateViewModel = viewModel.createSecondaryStateViewModel()
+        let viewController = ListSelectorViewController(command: stateViewModel.command, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        stateViewModel.command.handleSelectedChange(selected: newState, viewController: viewController)
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryFields.state, newState.name)
+    }
+
+    func test_updating_second_fields_enables_done_button() {
+        // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+
+        // When
+        viewModel.onLoadTrigger.send()
+        viewModel.secondaryFields.firstName = "Johnny"
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: true))
+    }
+
+    func test_updating_second_fields_back_to_original_values_disables_done_button() {
+        // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+
+        // When
+        viewModel.onLoadTrigger.send()
+        viewModel.secondaryFields.firstName = "Johnny"
+        viewModel.secondaryFields.lastName = "Ipsum"
+        viewModel.secondaryFields.firstName = "John"
+        viewModel.secondaryFields.lastName = "Appleseed"
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+    }
+
+    func test_turning_off_different_address_toggle_for_different_input_addresses_enables_done_button() {
+        // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+
+        // When
+        viewModel.onLoadTrigger.send()
+        viewModel.showDifferentAddressForm = false
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: true))
+    }
+
+    func test_switching_different_address_toggle_for_same_input_addresses_does_not_enable_done_button() {
+        // Given
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+
+        // When
+        viewModel.onLoadTrigger.send()
+        viewModel.showDifferentAddressForm = true
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+
+        // When
+        viewModel.showDifferentAddressForm = false
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
+    }
+
+    func test_view_model_returns_duplicated_billing_address_when_toggle_is_disabled() {
+        // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
+        var updatedAddressData: CreateOrderAddressFormViewModel.NewOrderAddressData?
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
+                                                        onAddressUpdate: { updatedData in
+            updatedAddressData = updatedData
+        },
+                                                        storageManager: testingStorage)
+
+        // When
+        viewModel.showDifferentAddressForm = false
+        viewModel.fields.firstName = "Tester"
+        viewModel.saveAddress { _ in }
+
+        // Then
+        assertEqual(updatedAddressData?.billingAddress?.firstName, "Tester")
+        assertEqual(updatedAddressData?.billingAddress, updatedAddressData?.shippingAddress)
+    }
+
+    func test_view_model_returns_different_billing_and_shipping_addresses_when_toggle_is_enabled() {
+        // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
+        var updatedAddressData: CreateOrderAddressFormViewModel.NewOrderAddressData?
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
+                                                        onAddressUpdate: { updatedData in
+            updatedAddressData = updatedData
+        },
+                                                        storageManager: testingStorage)
+
+        // When
+        XCTAssertTrue(viewModel.showDifferentAddressForm)
+        viewModel.fields.firstName = "Tester"
+        viewModel.saveAddress { _ in }
+
+        // Then
+        assertEqual(updatedAddressData?.billingAddress?.firstName, "Tester")
+        assertEqual(updatedAddressData?.shippingAddress?.firstName, "John")
+        XCTAssertNotEqual(updatedAddressData?.billingAddress, updatedAddressData?.shippingAddress)
+    }
+
+    func test_view_model_fires_error_notice_after_failing_to_fetch_countries() {
+        // Given
+        testingStorage.reset()
+        testingStores.whenReceivingAction(ofType: DataAction.self) { action in
+            switch action {
+            case .synchronizeCountries(_, let completion):
+                completion(.failure(NSError(domain: "", code: 0)))
+            }
+        }
+
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage,
+                                                        stores: testingStores)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        assertEqual(viewModel.notice, AddressFormViewModel.NoticeFactory.createErrorNotice(from: .unableToLoadCountries))
+    }
+
+    func test_view_model_shows_email_field() {
+        // Given
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+
+        // Then
+        XCTAssertTrue(viewModel.showEmailField)
+    }
+}
+
+private extension CreateOrderAddressFormViewModelTests {
+    func sampleAddress() -> Address {
+        return Address(firstName: "Johnny",
+                       lastName: "Appleseed",
+                       company: nil,
+                       address1: "234 70th Street",
+                       address2: nil,
+                       city: "Niagara Falls",
+                       state: "NY",
+                       postcode: "14304",
+                       country: "US",
+                       phone: "333-333-3333",
+                       email: "scrambled@scrambled.com")
+    }
+}
+
+private extension CreateOrderAddressFormViewModelTests {
+    static let sampleCountries: [Country] = {
+        return Locale.isoRegionCodes.map { regionCode in
+            let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
+            let states = regionCode == "US" ? [StateOfACountry(code: "NY", name: "New York")] : []
+            return Country(code: regionCode, name: name, states: states)
+        }.sorted { a, b in
+            a.name <= b.name
+        }
+    }()
+}


### PR DESCRIPTION
## Description

This PR fixes couple of bugs noticed in https://github.com/woocommerce/woocommerce-ios/pull/6012 and adds unit tests.

## Changes

- Adds `showDifferentAddressForm` observation to `bindNavigationTrailingItemPublisher()`.
- Updates `state` field nullifying logic.
- Adds tests for `CreateOrderAddressFormViewModel`.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "+ Add customer" button to display the address form.

First bugfix:
1. Enter some data.
2. Enable "Add a different shipping address" toggle.
3. Enter different data for shipping address in expanded form.
4. Tap "Done" to save and close the address form.
5. Tap "Edit" in the customer section.
6. Tap on a switch to collapse address form.
7. Confirm that "Done" button is enabled and tap it.
8. Confirm that the shipping address is updated in the customer section to be the same as billing.

Second bugfix:
1. Tap "Edit" in the customer section.
2. Select a country with no states. Enter state name manually.
3. Select a country with states.
4. Observe that the state field is cleared.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
