### PR TITLE
[Mobile Payments] Add WCPayCharge model

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1644,11 +1644,103 @@ extension WCPayAccountStatusEnum {
         .complete
     }
 }
+extension WCPayCardBrand {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayCardBrand {
+        .amex
+    }
+}
+extension WCPayCardFunding {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayCardFunding {
+        .credit
+    }
+}
+extension WCPayCardPaymentDetails {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayCardPaymentDetails {
+        .init(
+            brand: .fake(),
+            last4: .fake(),
+            funding: .fake()
+        )
+    }
+}
+extension WCPayCardPresentPaymentDetails {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayCardPresentPaymentDetails {
+        .init(
+            brand: .fake(),
+            last4: .fake(),
+            funding: .fake(),
+            receipt: .fake()
+        )
+    }
+}
+extension WCPayCardPresentReceiptDetails {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayCardPresentReceiptDetails {
+        .init(
+            accountType: .fake(),
+            applicationPreferredName: .fake(),
+            dedicatedFileName: .fake()
+        )
+    }
+}
+extension WCPayCharge {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayCharge {
+        .init(
+            siteID: .fake(),
+            id: .fake(),
+            amount: .fake(),
+            amountCaptured: .fake(),
+            amountRefunded: .fake(),
+            authorizationCode: .fake(),
+            captured: .fake(),
+            created: .fake(),
+            currency: .fake(),
+            paid: .fake(),
+            paymentIntentID: .fake(),
+            paymentMethodID: .fake(),
+            paymentMethodDetails: .fake(),
+            refunded: .fake(),
+            status: .fake()
+        )
+    }
+}
+extension WCPayChargeStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayChargeStatus {
+        .succeeded
+    }
+}
 extension WCPayPaymentIntentStatusEnum {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> WCPayPaymentIntentStatusEnum {
         .requiresPaymentMethod
+    }
+}
+extension WCPayPaymentMethodDetails {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayPaymentMethodDetails {
+        .card
+    }
+}
+extension WCPayPaymentMethodType {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayPaymentMethodType {
+        .card
     }
 }
 extension WordPressMedia {

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1733,7 +1733,7 @@ extension WCPayPaymentMethodDetails {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> WCPayPaymentMethodDetails {
-        .card
+        .unknown
     }
 }
 extension WCPayPaymentMethodType {

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */; };
 		02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */ = {isa = PBXBuildFile; fileRef = 02E7FFCE25621C7900C53030 /* shipping-label-print.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
+		0329CF9B27A82E19008AFF91 /* WCPayCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */; };
 		034480C327A42F9100DFACD2 /* order-with-charge.json in Resources */ = {isa = PBXBuildFile; fileRef = 034480C227A42F9100DFACD2 /* order-with-charge.json */; };
 		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
@@ -730,6 +731,7 @@
 		02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemoteTests.swift; sourceTree = "<group>"; };
 		02E7FFCE25621C7900C53030 /* shipping-label-print.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-print.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
+		0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCharge.swift; sourceTree = "<group>"; };
 		034480C227A42F9100DFACD2 /* order-with-charge.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-charge.json"; sourceTree = "<group>"; };
 		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
@@ -1742,12 +1744,13 @@
 				3148976F27232982007A86BD /* SystemStatus.swift */,
 				DEC51AE527684717009F3DF4 /* SystemStatusDetails */,
 				450106842399A7CB00E24722 /* TaxClass.swift */,
-				3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */,
 				31799AF7270508C600D78179 /* RemoteReaderLocation.swift */,
-				3192F223260D34C40067FEF9 /* WCPayAccountStatusEnum.swift */,
 				D8EDFE2125EE88C9003D2213 /* ReaderConnectionToken.swift */,
 				318E8FD426C31F9500F519D7 /* Customer.swift */,
 				31054705262E278100C5C02B /* RemotePaymentIntent.swift */,
+				3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */,
+				3192F223260D34C40067FEF9 /* WCPayAccountStatusEnum.swift */,
+				0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */,
 				3105470B262E27F000C5C02B /* WCPayPaymentIntentStatusEnum.swift */,
 				FE28F6E126840DED004465C7 /* User.swift */,
 			);
@@ -2844,6 +2847,7 @@
 				77CE40602514CB3E003FF69D /* ProductDownloadDragAndDrop.swift in Sources */,
 				2685C0FE263B5D8900D9EE97 /* AddOnGroupRemote.swift in Sources */,
 				450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */,
+				0329CF9B27A82E19008AFF91 /* WCPayCharge.swift in Sources */,
 				74749B97224134FF005C4CF2 /* ProductMapper.swift in Sources */,
 				26455E2A25F669F0008A1D32 /* ProductAttributeTermMapper.swift in Sources */,
 				026CF61A237D607A009563D4 /* ProductVariationAttribute.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -78,6 +78,14 @@
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
 		0329CF9B27A82E19008AFF91 /* WCPayCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */; };
 		034480C327A42F9100DFACD2 /* order-with-charge.json in Resources */ = {isa = PBXBuildFile; fileRef = 034480C227A42F9100DFACD2 /* order-with-charge.json */; };
+		0359EA0D27AAC5F80048DE2D /* WCPayChargeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA0C27AAC5F80048DE2D /* WCPayChargeStatus.swift */; };
+		0359EA0F27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA0E27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift */; };
+		0359EA1127AAC6740048DE2D /* WCPayPaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1027AAC6740048DE2D /* WCPayPaymentMethodType.swift */; };
+		0359EA1327AAC6D00048DE2D /* WCPayCardPaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1227AAC6D00048DE2D /* WCPayCardPaymentDetails.swift */; };
+		0359EA1527AAC7460048DE2D /* WCPayCardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1427AAC7460048DE2D /* WCPayCardBrand.swift */; };
+		0359EA1727AAC7740048DE2D /* WCPayAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1627AAC7740048DE2D /* WCPayAccountType.swift */; };
+		0359EA1927AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1827AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift */; };
+		0359EA1B27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1A27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift */; };
 		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
@@ -733,6 +741,14 @@
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
 		0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCharge.swift; sourceTree = "<group>"; };
 		034480C227A42F9100DFACD2 /* order-with-charge.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-charge.json"; sourceTree = "<group>"; };
+		0359EA0C27AAC5F80048DE2D /* WCPayChargeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayChargeStatus.swift; sourceTree = "<group>"; };
+		0359EA0E27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayPaymentMethodDetails.swift; sourceTree = "<group>"; };
+		0359EA1027AAC6740048DE2D /* WCPayPaymentMethodType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayPaymentMethodType.swift; sourceTree = "<group>"; };
+		0359EA1227AAC6D00048DE2D /* WCPayCardPaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardPaymentDetails.swift; sourceTree = "<group>"; };
+		0359EA1427AAC7460048DE2D /* WCPayCardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardBrand.swift; sourceTree = "<group>"; };
+		0359EA1627AAC7740048DE2D /* WCPayAccountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayAccountType.swift; sourceTree = "<group>"; };
+		0359EA1827AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardPresentPaymentDetails.swift; sourceTree = "<group>"; };
+		0359EA1A27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardPresentReceiptDetails.swift; sourceTree = "<group>"; };
 		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
@@ -1750,8 +1766,16 @@
 				31054705262E278100C5C02B /* RemotePaymentIntent.swift */,
 				3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */,
 				3192F223260D34C40067FEF9 /* WCPayAccountStatusEnum.swift */,
+				0359EA1627AAC7740048DE2D /* WCPayAccountType.swift */,
+				0359EA1827AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift */,
+				0359EA1A27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift */,
+				0359EA1427AAC7460048DE2D /* WCPayCardBrand.swift */,
+				0359EA1227AAC6D00048DE2D /* WCPayCardPaymentDetails.swift */,
 				0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */,
+				0359EA0C27AAC5F80048DE2D /* WCPayChargeStatus.swift */,
 				3105470B262E27F000C5C02B /* WCPayPaymentIntentStatusEnum.swift */,
+				0359EA0E27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift */,
+				0359EA1027AAC6740048DE2D /* WCPayPaymentMethodType.swift */,
 				FE28F6E126840DED004465C7 /* User.swift */,
 			);
 			path = Model;
@@ -2674,6 +2698,7 @@
 				D89A01D426D3F8D9008195BE /* ReaderLocation.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
 				02C254AC2563781800A04423 /* ShippingLabelStatus.swift in Sources */,
+				0359EA1B27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift in Sources */,
 				74ABA1D3213F25AE00FFAD30 /* TopEarnerStatsMapper.swift in Sources */,
 				020D07B823D852BB00FD9580 /* Media.swift in Sources */,
 				B5BB1D0C20A2050300112D92 /* DateFormatter+Woo.swift in Sources */,
@@ -2716,6 +2741,7 @@
 				456930AB264EB85A009ED69D /* ShippingLabelCarriersAndRatesMapper.swift in Sources */,
 				CCF48AD4262864CB0034EA83 /* ShippingLabelAccountSettings.swift in Sources */,
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,
+				0359EA0F27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift in Sources */,
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
 				57E8FED3246616AC0057CD68 /* Result+Extensions.swift in Sources */,
 				020D07BC23D856BF00FD9580 /* MediaRemote.swift in Sources */,
@@ -2850,6 +2876,7 @@
 				0329CF9B27A82E19008AFF91 /* WCPayCharge.swift in Sources */,
 				74749B97224134FF005C4CF2 /* ProductMapper.swift in Sources */,
 				26455E2A25F669F0008A1D32 /* ProductAttributeTermMapper.swift in Sources */,
+				0359EA1127AAC6740048DE2D /* WCPayPaymentMethodType.swift in Sources */,
 				026CF61A237D607A009563D4 /* ProductVariationAttribute.swift in Sources */,
 				D8FBFF1A22D4DF7A006E3336 /* OrderStatsV4.swift in Sources */,
 				74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */,
@@ -2858,10 +2885,12 @@
 				314703082670222500EF253A /* PaymentGatewayAccount.swift in Sources */,
 				CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */,
 				B5BB1D1220A255EC00112D92 /* OrderStatusEnum.swift in Sources */,
+				0359EA1727AAC7740048DE2D /* WCPayAccountType.swift in Sources */,
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,
 				2665032A261F41510079A159 /* ProductAddOn.swift in Sources */,
 				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,
+				0359EA1327AAC6D00048DE2D /* WCPayCardPaymentDetails.swift in Sources */,
 				CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */,
 				74C8F06820EEB7BD00B6EDC9 /* OrderNotesMapper.swift in Sources */,
 				24F98C582502EA8800F49B68 /* FeatureFlagMapper.swift in Sources */,
@@ -2913,14 +2942,17 @@
 				B59325D5217E4206000B0E8E /* NoteRange.swift in Sources */,
 				26B2F74324C545D50065CCC8 /* Leaderboard.swift in Sources */,
 				458C6DE425AC72A1009B300D /* StoredProductSettings.swift in Sources */,
+				0359EA1927AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift in Sources */,
 				45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */,
 				AEF9458B27297FF6001DCCFB /* IgnoringResponseMapper.swift in Sources */,
 				B59325C7217E22FC000B0E8E /* Note.swift in Sources */,
 				CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */,
 				D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */,
 				029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */,
+				0359EA0D27AAC5F80048DE2D /* WCPayChargeStatus.swift in Sources */,
 				CE430674234BA6AD0073CBFF /* RefundMapper.swift in Sources */,
 				CE0A0F1B223989670075ED8D /* ProductsRemote.swift in Sources */,
+				0359EA1527AAC7460048DE2D /* WCPayCardBrand.swift in Sources */,
 				2665032E261F4FBF0079A159 /* ProductAddOnOption.swift in Sources */,
 				028296F7237D588700E84012 /* ProductVariation.swift in Sources */,
 				DEC51AEF2768A628009F3DF4 /* SystemStatus+Database.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -83,7 +83,7 @@
 		0359EA1127AAC6740048DE2D /* WCPayPaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1027AAC6740048DE2D /* WCPayPaymentMethodType.swift */; };
 		0359EA1327AAC6D00048DE2D /* WCPayCardPaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1227AAC6D00048DE2D /* WCPayCardPaymentDetails.swift */; };
 		0359EA1527AAC7460048DE2D /* WCPayCardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1427AAC7460048DE2D /* WCPayCardBrand.swift */; };
-		0359EA1727AAC7740048DE2D /* WCPayAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1627AAC7740048DE2D /* WCPayAccountType.swift */; };
+		0359EA1727AAC7740048DE2D /* WCPayCardFunding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1627AAC7740048DE2D /* WCPayCardFunding.swift */; };
 		0359EA1927AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1827AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift */; };
 		0359EA1B27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1A27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift */; };
 		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
@@ -746,7 +746,7 @@
 		0359EA1027AAC6740048DE2D /* WCPayPaymentMethodType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayPaymentMethodType.swift; sourceTree = "<group>"; };
 		0359EA1227AAC6D00048DE2D /* WCPayCardPaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardPaymentDetails.swift; sourceTree = "<group>"; };
 		0359EA1427AAC7460048DE2D /* WCPayCardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardBrand.swift; sourceTree = "<group>"; };
-		0359EA1627AAC7740048DE2D /* WCPayAccountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayAccountType.swift; sourceTree = "<group>"; };
+		0359EA1627AAC7740048DE2D /* WCPayCardFunding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardFunding.swift; sourceTree = "<group>"; };
 		0359EA1827AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardPresentPaymentDetails.swift; sourceTree = "<group>"; };
 		0359EA1A27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCardPresentReceiptDetails.swift; sourceTree = "<group>"; };
 		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
@@ -1766,7 +1766,7 @@
 				31054705262E278100C5C02B /* RemotePaymentIntent.swift */,
 				3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */,
 				3192F223260D34C40067FEF9 /* WCPayAccountStatusEnum.swift */,
-				0359EA1627AAC7740048DE2D /* WCPayAccountType.swift */,
+				0359EA1627AAC7740048DE2D /* WCPayCardFunding.swift */,
 				0359EA1827AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift */,
 				0359EA1A27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift */,
 				0359EA1427AAC7460048DE2D /* WCPayCardBrand.swift */,
@@ -2885,7 +2885,7 @@
 				314703082670222500EF253A /* PaymentGatewayAccount.swift in Sources */,
 				CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */,
 				B5BB1D1220A255EC00112D92 /* OrderStatusEnum.swift in Sources */,
-				0359EA1727AAC7740048DE2D /* WCPayAccountType.swift in Sources */,
+				0359EA1727AAC7740048DE2D /* WCPayCardFunding.swift in Sources */,
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,
 				2665032A261F41510079A159 /* ProductAddOn.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1763,7 +1763,7 @@ extension WCPayCharge {
         amount: CopiableProp<Int64> = .copy,
         amountCaptured: CopiableProp<Int64> = .copy,
         amountRefunded: CopiableProp<Int64> = .copy,
-        authorizationCode: CopiableProp<String> = .copy,
+        authorizationCode: NullableCopiableProp<String> = .copy,
         captured: CopiableProp<Bool> = .copy,
         created: CopiableProp<Date> = .copy,
         currency: CopiableProp<String> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1701,27 +1701,57 @@ extension TopEarnerStatsItem {
 
 extension WCPayCardPaymentDetails {
     public func copy(
+        brand: CopiableProp<WCPayCardBrand> = .copy,
+        last4: CopiableProp<String> = .copy,
+        funding: CopiableProp<WCPayCardFunding> = .copy
     ) -> WCPayCardPaymentDetails {
+        let brand = brand ?? self.brand
+        let last4 = last4 ?? self.last4
+        let funding = funding ?? self.funding
 
         return WCPayCardPaymentDetails(
+            brand: brand,
+            last4: last4,
+            funding: funding
         )
     }
 }
 
 extension WCPayCardPresentPaymentDetails {
     public func copy(
+        brand: CopiableProp<WCPayCardBrand> = .copy,
+        last4: CopiableProp<String> = .copy,
+        funding: CopiableProp<WCPayCardFunding> = .copy,
+        receipt: CopiableProp<WCPayCardPresentReceiptDetails> = .copy
     ) -> WCPayCardPresentPaymentDetails {
+        let brand = brand ?? self.brand
+        let last4 = last4 ?? self.last4
+        let funding = funding ?? self.funding
+        let receipt = receipt ?? self.receipt
 
         return WCPayCardPresentPaymentDetails(
+            brand: brand,
+            last4: last4,
+            funding: funding,
+            receipt: receipt
         )
     }
 }
 
 extension WCPayCardPresentReceiptDetails {
     public func copy(
+        accountType: CopiableProp<WCPayCardFunding> = .copy,
+        applicationPreferredName: CopiableProp<String> = .copy,
+        dedicatedFileName: CopiableProp<String> = .copy
     ) -> WCPayCardPresentReceiptDetails {
+        let accountType = accountType ?? self.accountType
+        let applicationPreferredName = applicationPreferredName ?? self.applicationPreferredName
+        let dedicatedFileName = dedicatedFileName ?? self.dedicatedFileName
 
         return WCPayCardPresentReceiptDetails(
+            accountType: accountType,
+            applicationPreferredName: applicationPreferredName,
+            dedicatedFileName: dedicatedFileName
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1699,6 +1699,87 @@ extension TopEarnerStatsItem {
     }
 }
 
+extension WCPayCardPaymentDetails {
+    public func copy(
+    ) -> WCPayCardPaymentDetails {
+
+        return WCPayCardPaymentDetails(
+        )
+    }
+}
+
+extension WCPayCardPresentPaymentDetails {
+    public func copy(
+    ) -> WCPayCardPresentPaymentDetails {
+
+        return WCPayCardPresentPaymentDetails(
+        )
+    }
+}
+
+extension WCPayCardPresentReceiptDetails {
+    public func copy(
+    ) -> WCPayCardPresentReceiptDetails {
+
+        return WCPayCardPresentReceiptDetails(
+        )
+    }
+}
+
+extension WCPayCharge {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        id: CopiableProp<String> = .copy,
+        amount: CopiableProp<Int64> = .copy,
+        amountCaptured: CopiableProp<Int64> = .copy,
+        amountRefunded: CopiableProp<Int64> = .copy,
+        authorizationCode: CopiableProp<String> = .copy,
+        captured: CopiableProp<Bool> = .copy,
+        created: CopiableProp<Date> = .copy,
+        currency: CopiableProp<String> = .copy,
+        paid: CopiableProp<Bool> = .copy,
+        paymentIntentID: NullableCopiableProp<String> = .copy,
+        paymentMethodID: CopiableProp<String> = .copy,
+        paymentMethodDetails: CopiableProp<WCPayPaymentMethodDetails> = .copy,
+        refunded: CopiableProp<Bool> = .copy,
+        status: CopiableProp<WCPayChargeStatus> = .copy
+    ) -> WCPayCharge {
+        let siteID = siteID ?? self.siteID
+        let id = id ?? self.id
+        let amount = amount ?? self.amount
+        let amountCaptured = amountCaptured ?? self.amountCaptured
+        let amountRefunded = amountRefunded ?? self.amountRefunded
+        let authorizationCode = authorizationCode ?? self.authorizationCode
+        let captured = captured ?? self.captured
+        let created = created ?? self.created
+        let currency = currency ?? self.currency
+        let paid = paid ?? self.paid
+        let paymentIntentID = paymentIntentID ?? self.paymentIntentID
+        let paymentMethodID = paymentMethodID ?? self.paymentMethodID
+        let paymentMethodDetails = paymentMethodDetails ?? self.paymentMethodDetails
+        let refunded = refunded ?? self.refunded
+        let status = status ?? self.status
+
+        return WCPayCharge(
+            siteID: siteID,
+            id: id,
+            amount: amount,
+            amountCaptured: amountCaptured,
+            amountRefunded: amountRefunded,
+            authorizationCode: authorizationCode,
+            captured: captured,
+            created: created,
+            currency: currency,
+            paid: paid,
+            paymentIntentID: paymentIntentID,
+            paymentMethodID: paymentMethodID,
+            paymentMethodDetails: paymentMethodDetails,
+            refunded: refunded,
+            status: status
+        )
+    }
+}
+
 extension WordPressMedia {
     public func copy(
         mediaID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/WCPayAccountType.swift
+++ b/Networking/Networking/Model/WCPayAccountType.swift
@@ -1,9 +1,0 @@
-import Foundation
-import Codegen
-
-public enum WCPayAccountType: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
-    case credit
-    case debit
-    case prepaid
-    case unknown
-}

--- a/Networking/Networking/Model/WCPayAccountType.swift
+++ b/Networking/Networking/Model/WCPayAccountType.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Codegen
+
+public enum WCPayAccountType: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    case credit
+    case debit
+    case prepaid
+    case unknown
+}

--- a/Networking/Networking/Model/WCPayCardBrand.swift
+++ b/Networking/Networking/Model/WCPayCardBrand.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Codegen
+
+// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-brand
+public enum WCPayCardBrand: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    case amex
+    case diners
+    case discover
+    case jcb
+    case mastercard
+    case unionpay
+    case visa
+    case unknown
+}

--- a/Networking/Networking/Model/WCPayCardBrand.swift
+++ b/Networking/Networking/Model/WCPayCardBrand.swift
@@ -1,7 +1,12 @@
 import Foundation
 import Codegen
 
-// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-brand
+/// Model for card brands as returned from WCPay.
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-brand)
+///
 public enum WCPayCardBrand: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case amex
     case diners

--- a/Networking/Networking/Model/WCPayCardFunding.swift
+++ b/Networking/Networking/Model/WCPayCardFunding.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Codegen
+
+/// Model containing information about how a card is funded
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-funding)
+///
+/// e.g. `credit`, `debit`, `prepaid`
+///
+public enum WCPayCardFunding: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    case credit
+    case debit
+    case prepaid
+    case unknown
+}

--- a/Networking/Networking/Model/WCPayCardPaymentDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPaymentDetails.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Codegen
+
+// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card
+public struct WCPayCardPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    let brand: WCPayCardBrand
+    let last4: String
+    let funding: WCPayAccountType
+
+    public init(brand: WCPayCardBrand,
+                last4: String,
+                funding: WCPayAccountType) {
+        self.brand = brand
+        self.last4 = last4
+        self.funding = funding
+    }
+}

--- a/Networking/Networking/Model/WCPayCardPaymentDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPaymentDetails.swift
@@ -1,15 +1,25 @@
 import Foundation
 import Codegen
 
-// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card
+/// Model containing information about a WCPay card payment.
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card)
+///
 public struct WCPayCardPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    /// The brand of the card used to pay, e.g. `amex`, `mastercard`, `visa`
     let brand: WCPayCardBrand
+
+    /// The last 4 digits of the card number
     let last4: String
-    let funding: WCPayAccountType
+
+    /// The way the card is funded, e.g. `credit`, `debit`, `prepaid`
+    let funding: WCPayCardFunding
 
     public init(brand: WCPayCardBrand,
                 last4: String,
-                funding: WCPayAccountType) {
+                funding: WCPayCardFunding) {
         self.brand = brand
         self.last4 = last4
         self.funding = funding

--- a/Networking/Networking/Model/WCPayCardPaymentDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPaymentDetails.swift
@@ -9,13 +9,13 @@ import Codegen
 ///
 public struct WCPayCardPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The brand of the card used to pay, e.g. `amex`, `mastercard`, `visa`
-    let brand: WCPayCardBrand
+    public let brand: WCPayCardBrand
 
     /// The last 4 digits of the card number
-    let last4: String
+    public let last4: String
 
     /// The way the card is funded, e.g. `credit`, `debit`, `prepaid`
-    let funding: WCPayCardFunding
+    public let funding: WCPayCardFunding
 
     public init(brand: WCPayCardBrand,
                 last4: String,

--- a/Networking/Networking/Model/WCPayCardPresentPaymentDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentPaymentDetails.swift
@@ -1,16 +1,28 @@
 import Foundation
 import Codegen
 
-// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present
+/// Model containing information about a card present payment.
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present)
+///
 public struct WCPayCardPresentPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    /// The brand of the card, e.g. `amex`, `mastercard`, `visa`, etc
     let brand: WCPayCardBrand
+    
+    /// The last 4 digits of the card number
     let last4: String
-    let funding: WCPayAccountType
+
+    /// The way the card is funded, e.g. `credit`, `debit`, `prepaid`
+    let funding: WCPayCardFunding
+
+    /// Required receipt details (some mandatory for EMV receipts)
     let receipt: WCPayCardPresentReceiptDetails
 
     public init(brand: WCPayCardBrand,
                 last4: String,
-                funding: WCPayAccountType,
+                funding: WCPayCardFunding,
                 receipt: WCPayCardPresentReceiptDetails) {
         self.brand = brand
         self.last4 = last4

--- a/Networking/Networking/Model/WCPayCardPresentPaymentDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentPaymentDetails.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Codegen
+
+// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present
+public struct WCPayCardPresentPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    let brand: WCPayCardBrand
+    let last4: String
+    let funding: WCPayAccountType
+    let receipt: WCPayCardPresentReceiptDetails
+
+    public init(brand: WCPayCardBrand,
+                last4: String,
+                funding: WCPayAccountType,
+                receipt: WCPayCardPresentReceiptDetails) {
+        self.brand = brand
+        self.last4 = last4
+        self.funding = funding
+        self.receipt = receipt
+    }
+}

--- a/Networking/Networking/Model/WCPayCardPresentPaymentDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentPaymentDetails.swift
@@ -9,16 +9,16 @@ import Codegen
 ///
 public struct WCPayCardPresentPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The brand of the card, e.g. `amex`, `mastercard`, `visa`, etc
-    let brand: WCPayCardBrand
-    
+    public let brand: WCPayCardBrand
+
     /// The last 4 digits of the card number
-    let last4: String
+    public let last4: String
 
     /// The way the card is funded, e.g. `credit`, `debit`, `prepaid`
-    let funding: WCPayCardFunding
+    public let funding: WCPayCardFunding
 
     /// Required receipt details (some mandatory for EMV receipts)
-    let receipt: WCPayCardPresentReceiptDetails
+    public let receipt: WCPayCardPresentReceiptDetails
 
     public init(brand: WCPayCardBrand,
                 last4: String,

--- a/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Codegen
+
+// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-receipt
+public struct WCPayCardPresentReceiptDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    let accountType: WCPayAccountType
+    let applicationPreferredName: String
+    let dedicatedFileName: String
+
+    public init(accountType: WCPayAccountType,
+                applicationPreferredName: String,
+                dedicatedFileName: String) {
+        self.accountType = accountType
+        self.applicationPreferredName = applicationPreferredName
+        self.dedicatedFileName = dedicatedFileName
+    }
+}
+
+internal extension WCPayCardPresentReceiptDetails {
+    enum CodingKeys: String, CodingKey {
+        case accountType = "account_type"
+        case applicationPreferredName = "application_preferred_name"
+        case dedicatedFileName = "dedicated_file_name"
+    }
+}

--- a/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
@@ -1,13 +1,25 @@
 import Foundation
 import Codegen
 
-// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-receipt
+/// Model containing information for inclusion on a receipt for a card present payment.
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-receipt)
+///
+/// Custom receipt field details can be found in [Stripe's documentation](https://stripe.com/docs/terminal/features/receipts#custom)
+///
 public struct WCPayCardPresentReceiptDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
-    let accountType: WCPayAccountType
+    /// The funding method for the account used to pay, e.g. `credit`, `debit`, `prepaid`, `unknown`
+    let accountType: WCPayCardFunding
+
+    /// The EMV Application Identifier (AID)
     let applicationPreferredName: String
+
+    /// The EMV Dedicated File (DF) Name
     let dedicatedFileName: String
 
-    public init(accountType: WCPayAccountType,
+    public init(accountType: WCPayCardFunding,
                 applicationPreferredName: String,
                 dedicatedFileName: String) {
         self.accountType = accountType

--- a/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
@@ -11,13 +11,13 @@ import Codegen
 ///
 public struct WCPayCardPresentReceiptDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The funding method for the account used to pay, e.g. `credit`, `debit`, `prepaid`, `unknown`
-    let accountType: WCPayCardFunding
+    public let accountType: WCPayCardFunding
 
     /// The EMV Application Identifier (AID)
-    let applicationPreferredName: String
+    public let applicationPreferredName: String
 
     /// The EMV Dedicated File (DF) Name
-    let dedicatedFileName: String
+    public let dedicatedFileName: String
 
     public init(accountType: WCPayCardFunding,
                 applicationPreferredName: String,

--- a/Networking/Networking/Model/WCPayCharge.swift
+++ b/Networking/Networking/Model/WCPayCharge.swift
@@ -24,7 +24,7 @@ public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable, Equa
     public let amountRefunded: Int64
 
     /// The authorization code for the charge. This is not part of the Stripe model, but a WCPay-added field.
-    public let authorizationCode: String
+    public let authorizationCode: String?
 
     /// Whether the charge has been captured yet
     public let captured: Bool
@@ -58,7 +58,7 @@ public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable, Equa
                 amount: Int64,
                 amountCaptured: Int64,
                 amountRefunded: Int64,
-                authorizationCode: String,
+                authorizationCode: String?,
                 captured: Bool,
                 created: Date,
                 currency: String,
@@ -98,7 +98,7 @@ public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable, Equa
         let amount = try container.decode(Int64.self, forKey: .amount)
         let amountCaptured = try container.decode(Int64.self, forKey: .amountCaptured)
         let amountRefunded = try container.decode(Int64.self, forKey: .amountRefunded)
-        let authorizationCode = try container.decode(String.self, forKey: .authorizationCode)
+        let authorizationCode = try container.decodeIfPresent(String.self, forKey: .authorizationCode)
         let captured = try container.decode(Bool.self, forKey: .captured)
         let created = try container.decode(Date.self, forKey: .created)
         let currency = try container.decode(String.self, forKey: .currency)

--- a/Networking/Networking/Model/WCPayCharge.swift
+++ b/Networking/Networking/Model/WCPayCharge.swift
@@ -1,0 +1,318 @@
+import Foundation
+import Codegen
+
+/// Model for the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The API returns a thin wrapper around the Stripe object, so these docs are relevant: https://stripe.com/docs/api/charges/object
+
+public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable {
+    public let siteID: Int64
+    public let id: String
+    public let amount: Int64
+    public let amountCaptured: Int64
+    public let amountRefunded: Int64
+    public let authorizationCode: String
+    public let captured: Bool
+    public let created: Date // = 1643280767
+    public let currency: String // = "usd",
+    public let paid: Bool
+    public let paymentIntentID: String?
+    public let paymentMethodID: String
+    public let paymentMethodDetails: WCPayPaymentMethodDetails
+    public let refunded: Bool
+    public let status: WCPayChargeStatus
+
+    public init(siteID: Int64,
+                id: String,
+                amount: Int64,
+                amountCaptured: Int64,
+                amountRefunded: Int64,
+                authorizationCode: String,
+                captured: Bool,
+                created: Date,
+                currency: String,
+                paid: Bool,
+                paymentIntentID: String?,
+                paymentMethodID: String,
+                paymentMethodDetails: WCPayPaymentMethodDetails,
+                refunded: Bool,
+                status: WCPayChargeStatus) {
+        self.siteID = siteID
+        self.id = id
+        self.amount = amount
+        self.amountCaptured = amountCaptured
+        self.amountRefunded = amountRefunded
+        self.authorizationCode = authorizationCode
+        self.captured = captured
+        self.created = created
+        self.currency = currency
+        self.paid = paid
+        self.paymentIntentID = paymentIntentID
+        self.paymentMethodID = paymentMethodID
+        self.paymentMethodDetails = paymentMethodDetails
+        self.refunded = refunded
+        self.status = status
+    }
+
+    /// The public initializer for WCPayCharge.
+        ///
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw WCPayChargeDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let chargeID = try container.decode(String.self, forKey: .chargeID)
+        let amount = try container.decode(Int64.self, forKey: .amount)
+        let amountCaptured = try container.decode(Int64.self, forKey: .amountCaptured)
+        let amountRefunded = try container.decode(Int64.self, forKey: .amountRefunded)
+        let authorizationCode = try container.decode(String.self, forKey: .authorizationCode)
+        let captured = try container.decode(Bool.self, forKey: .captured)
+        let created = try container.decode(Date.self, forKey: .created)
+        let currency = try container.decode(String.self, forKey: .currency)
+        let paid = try container.decode(Bool.self, forKey: .paid)
+        let paymentIntentID = try container.decodeIfPresent(String.self, forKey: .paymentIntentID)
+        let paymentMethodID = try container.decode(String.self, forKey: .paymentMethodID)
+        let paymentMethodDetails = try container.decode(WCPayPaymentMethodDetails.self, forKey: .paymentMethodDetails)
+        let refunded = try container.decode(Bool.self, forKey: .refunded)
+        let status = try container.decode(WCPayChargeStatus.self, forKey: .status)
+
+        self.init(siteID: siteID,
+                  id: chargeID,
+                  amount: amount,
+                  amountCaptured: amountCaptured,
+                  amountRefunded: amountRefunded,
+                  authorizationCode: authorizationCode,
+                  captured: captured,
+                  created: created,
+                  currency: currency,
+                  paid: paid,
+                  paymentIntentID: paymentIntentID,
+                  paymentMethodID: paymentMethodID,
+                  paymentMethodDetails: paymentMethodDetails,
+                  refunded: refunded,
+                  status: status)
+    }
+}
+
+// MARK: WCPayChargeStatus
+public enum WCPayChargeStatus: String, Decodable {
+    case succeeded
+    case pending
+    case failed
+    case unknown
+}
+
+extension WCPayChargeStatus: RawRepresentable {
+    // Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.succeeded:
+            self = .succeeded
+        case Keys.pending:
+            self = .pending
+        case Keys.failed:
+            self = .failed
+        default:
+            self = .unknown
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .succeeded: return Keys.succeeded
+        case .pending: return Keys.pending
+        case .failed: return Keys.failed
+        case .unknown: return Keys.unknown
+        }
+    }
+}
+
+/// Enum containing the 'Known' WCPayChargeStatus Keys
+///
+private extension WCPayChargeStatus {
+    enum Keys {
+        static let succeeded = "succeeded"
+        static let pending = "pending"
+        static let failed = "failed"
+        static let unknown = "unknown"
+    }
+}
+
+// MARK: WCPayPaymentMethodDetails
+public enum WCPayPaymentMethodDetails: Decodable {
+    case card(details: CardPaymentDetails) //type = card
+    case cardPresent(details: CardPresentPaymentDetails) //type = card_present
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        guard let type = try? container.decode(PaymentMethodType.self, forKey: .type) else {
+            self = .unknown
+            return
+        }
+
+        switch type {
+        case .card:
+            guard let cardDetails = try? container.decode(CardPaymentDetails.self, forKey: .card) else {
+                throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
+            }
+            self = .card(details: cardDetails)
+        case .cardPresent:
+            guard let cardPresentDetails = try? container.decode(CardPresentPaymentDetails.self, forKey: .cardPresent) else {
+                throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
+            }
+            self = .cardPresent(details: cardPresentDetails)
+        case .unknown:
+            self = .unknown
+        }
+    }
+
+    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-type
+    public enum PaymentMethodType: String, Decodable {
+        case card
+        case cardPresent
+        case unknown
+    }
+
+    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card
+    public struct CardPaymentDetails: Decodable, GeneratedCopiable, GeneratedFakeable {
+        let brand: CardBrand
+        let last4: String
+        let funding: AccountType
+
+        public init(brand: CardBrand,
+                    last4: String,
+                    funding: AccountType) {
+            self.brand = brand
+            self.last4 = last4
+            self.funding = funding
+        }
+    }
+
+    public enum CardBrand: String, Decodable {
+        case amex
+        case diners
+        case discover
+        case jcb
+        case mastercard
+        case unionpay
+        case visa
+        case unknown
+    }
+
+    public enum AccountType: String, Decodable {
+        case credit
+        case debit
+        case prepaid
+        case unknown
+    }
+
+    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present
+    public struct CardPresentPaymentDetails: Decodable, GeneratedCopiable, GeneratedFakeable {
+        let brand: CardBrand
+        let last4: String
+        let funding: AccountType
+        let receipt: CardPresentReceiptDetails
+
+        public init(brand: CardBrand,
+                    last4: String,
+                    funding: AccountType,
+                    receipt: CardPresentReceiptDetails) {
+            self.brand = brand
+            self.last4 = last4
+            self.funding = funding
+            self.receipt = receipt
+        }
+    }
+
+    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-receipt
+    public struct CardPresentReceiptDetails: Decodable, GeneratedCopiable, GeneratedFakeable {
+        let accountType: AccountType
+        let applicationPreferredName: String
+        let dedicatedFileName: String
+
+        public init(accountType: AccountType,
+                    applicationPreferredName: String,
+                    dedicatedFileName: String) {
+            self.accountType = accountType
+            self.applicationPreferredName = applicationPreferredName
+            self.dedicatedFileName = dedicatedFileName
+        }
+    }
+}
+
+
+// MARK: CodingKeys
+internal extension WCPayCharge {
+    enum CodingKeys: String, CodingKey {
+        case chargeID = "id"
+        case amount
+        case amountCaptured = "amount_captured"
+        case amountRefunded = "amount_refunded"
+        case authorizationCode = "authorization_code"
+        case captured
+        case created
+        case currency
+        case paid
+        case paymentIntentID = "payment_intent"
+        case paymentMethodID = "payment_method"
+        case paymentMethodDetails = "payment_method_details"
+        case refunded
+        case status
+    }
+}
+
+internal extension WCPayPaymentMethodDetails {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case card
+        case cardPresent = "card_present"
+    }
+}
+
+internal extension WCPayPaymentMethodDetails.PaymentMethodType {
+    enum CodingKeys: String, CodingKey {
+        case card
+        case cardPresent = "card_present"
+    }
+}
+
+internal extension WCPayPaymentMethodDetails.CardPaymentDetails {
+    enum CodingKeys: String, CodingKey {
+        case brand
+        case last4
+        case funding
+    }
+}
+
+internal extension WCPayPaymentMethodDetails.CardPresentPaymentDetails {
+    enum CodingKeys: String, CodingKey {
+        case brand
+        case last4
+        case funding
+        case receipt
+    }
+}
+
+internal extension WCPayPaymentMethodDetails.CardPresentReceiptDetails {
+    enum CodingKeys: String, CodingKey {
+        case accountType = "account_type"
+        case applicationPreferredName = "application_preferred_name"
+        case dedicatedFileName = "dedicated_file_name"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum WCPayChargeDecodingError: Error {
+    case missingSiteID
+}
+
+enum WCPayPaymentMethodDetailsDecodingError: Error {
+    case noDetailsPresentForPaymentType
+}

--- a/Networking/Networking/Model/WCPayCharge.swift
+++ b/Networking/Networking/Model/WCPayCharge.swift
@@ -1,25 +1,56 @@
 import Foundation
 import Codegen
 
-/// Model for the `/payments/charges/<charge_id>` WCPay endpoint.
+/// Model containing information about a WCPay Charge.
 ///
-/// The endpoint returns a thin wrapper around the Stripe object, so these docs are relevant: https://stripe.com/docs/api/charges/object
+/// This is returned as the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object)
 ///
 public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    /// The siteID of the site that the charge relates to
     public let siteID: Int64
+
+    /// The chargeID – matches Stripe's charge ID, e.g. `ch_3KMVap2EdyGr1FMV1uKJEWtg`
     public let id: String
+
+    /// The amount charged, in the smallest units of the relevant currency
     public let amount: Int64
+
+    /// The amount captured, i.e. taken from the card, in the smallest units of the relevant currency
     public let amountCaptured: Int64
+
+    /// The amount refunded, in the smallest units of the relevant currency. 0 if no refunds.
     public let amountRefunded: Int64
+
+    /// The authorization code for the charge. This is not part of the Stripe model, but a WCPay-added field.
     public let authorizationCode: String
+
+    /// Whether the charge has been captured yet
     public let captured: Bool
+
+    /// The date the charge was created
     public let created: Date // = 1643280767
-    public let currency: String // = "usd",
+
+    /// The currency for the charge, as a 3-letter code e.g. `usd`
+    public let currency: String
+
+    /// Whether the charge succeeded
     public let paid: Bool
+
+    /// The ID for the payment intent associated with this charge, e.g. `pi_3KMVap2EdyGr1FMV16atNgK9`
     public let paymentIntentID: String?
+
+    /// The ID for the payment method for this charge, e.g. `pm_1KMVas2EdyGr1FMVnleuPovE`
     public let paymentMethodID: String
+
+    /// The details of the payment method used, including the type of payment, and associated details about that type.
     public let paymentMethodDetails: WCPayPaymentMethodDetails
+
+    /// Whether the charge has been *fully* refunded or not. Will be `false` for partial refunds.
     public let refunded: Bool
+
+    /// The charge's success status
     public let status: WCPayChargeStatus
 
     public init(siteID: Int64,

--- a/Networking/Networking/Model/WCPayCharge.swift
+++ b/Networking/Networking/Model/WCPayCharge.swift
@@ -2,9 +2,10 @@ import Foundation
 import Codegen
 
 /// Model for the `/payments/charges/<charge_id>` WCPay endpoint.
-/// The API returns a thin wrapper around the Stripe object, so these docs are relevant: https://stripe.com/docs/api/charges/object
-
-public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable {
+///
+/// The endpoint returns a thin wrapper around the Stripe object, so these docs are relevant: https://stripe.com/docs/api/charges/object
+///
+public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
     public let siteID: Int64
     public let id: String
     public let amount: Int64
@@ -54,7 +55,7 @@ public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable {
     }
 
     /// The public initializer for WCPayCharge.
-        ///
+    ///
     public init(from decoder: Decoder) throws {
         guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw WCPayChargeDecodingError.missingSiteID
@@ -95,158 +96,6 @@ public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable {
     }
 }
 
-// MARK: WCPayChargeStatus
-public enum WCPayChargeStatus: String, Decodable {
-    case succeeded
-    case pending
-    case failed
-    case unknown
-}
-
-extension WCPayChargeStatus: RawRepresentable {
-    // Designated Initializer.
-    ///
-    public init(rawValue: String) {
-        switch rawValue {
-        case Keys.succeeded:
-            self = .succeeded
-        case Keys.pending:
-            self = .pending
-        case Keys.failed:
-            self = .failed
-        default:
-            self = .unknown
-        }
-    }
-
-    /// Returns the current Enum Case's Raw Value
-    ///
-    public var rawValue: String {
-        switch self {
-        case .succeeded: return Keys.succeeded
-        case .pending: return Keys.pending
-        case .failed: return Keys.failed
-        case .unknown: return Keys.unknown
-        }
-    }
-}
-
-/// Enum containing the 'Known' WCPayChargeStatus Keys
-///
-private extension WCPayChargeStatus {
-    enum Keys {
-        static let succeeded = "succeeded"
-        static let pending = "pending"
-        static let failed = "failed"
-        static let unknown = "unknown"
-    }
-}
-
-// MARK: WCPayPaymentMethodDetails
-public enum WCPayPaymentMethodDetails: Decodable {
-    case card(details: CardPaymentDetails) //type = card
-    case cardPresent(details: CardPresentPaymentDetails) //type = card_present
-    case unknown
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        guard let type = try? container.decode(PaymentMethodType.self, forKey: .type) else {
-            self = .unknown
-            return
-        }
-
-        switch type {
-        case .card:
-            guard let cardDetails = try? container.decode(CardPaymentDetails.self, forKey: .card) else {
-                throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
-            }
-            self = .card(details: cardDetails)
-        case .cardPresent:
-            guard let cardPresentDetails = try? container.decode(CardPresentPaymentDetails.self, forKey: .cardPresent) else {
-                throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
-            }
-            self = .cardPresent(details: cardPresentDetails)
-        case .unknown:
-            self = .unknown
-        }
-    }
-
-    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-type
-    public enum PaymentMethodType: String, Decodable {
-        case card
-        case cardPresent
-        case unknown
-    }
-
-    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card
-    public struct CardPaymentDetails: Decodable, GeneratedCopiable, GeneratedFakeable {
-        let brand: CardBrand
-        let last4: String
-        let funding: AccountType
-
-        public init(brand: CardBrand,
-                    last4: String,
-                    funding: AccountType) {
-            self.brand = brand
-            self.last4 = last4
-            self.funding = funding
-        }
-    }
-
-    public enum CardBrand: String, Decodable {
-        case amex
-        case diners
-        case discover
-        case jcb
-        case mastercard
-        case unionpay
-        case visa
-        case unknown
-    }
-
-    public enum AccountType: String, Decodable {
-        case credit
-        case debit
-        case prepaid
-        case unknown
-    }
-
-    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present
-    public struct CardPresentPaymentDetails: Decodable, GeneratedCopiable, GeneratedFakeable {
-        let brand: CardBrand
-        let last4: String
-        let funding: AccountType
-        let receipt: CardPresentReceiptDetails
-
-        public init(brand: CardBrand,
-                    last4: String,
-                    funding: AccountType,
-                    receipt: CardPresentReceiptDetails) {
-            self.brand = brand
-            self.last4 = last4
-            self.funding = funding
-            self.receipt = receipt
-        }
-    }
-
-    // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-receipt
-    public struct CardPresentReceiptDetails: Decodable, GeneratedCopiable, GeneratedFakeable {
-        let accountType: AccountType
-        let applicationPreferredName: String
-        let dedicatedFileName: String
-
-        public init(accountType: AccountType,
-                    applicationPreferredName: String,
-                    dedicatedFileName: String) {
-            self.accountType = accountType
-            self.applicationPreferredName = applicationPreferredName
-            self.dedicatedFileName = dedicatedFileName
-        }
-    }
-}
-
-
 // MARK: CodingKeys
 internal extension WCPayCharge {
     enum CodingKeys: String, CodingKey {
@@ -267,52 +116,7 @@ internal extension WCPayCharge {
     }
 }
 
-internal extension WCPayPaymentMethodDetails {
-    enum CodingKeys: String, CodingKey {
-        case type
-        case card
-        case cardPresent = "card_present"
-    }
-}
-
-internal extension WCPayPaymentMethodDetails.PaymentMethodType {
-    enum CodingKeys: String, CodingKey {
-        case card
-        case cardPresent = "card_present"
-    }
-}
-
-internal extension WCPayPaymentMethodDetails.CardPaymentDetails {
-    enum CodingKeys: String, CodingKey {
-        case brand
-        case last4
-        case funding
-    }
-}
-
-internal extension WCPayPaymentMethodDetails.CardPresentPaymentDetails {
-    enum CodingKeys: String, CodingKey {
-        case brand
-        case last4
-        case funding
-        case receipt
-    }
-}
-
-internal extension WCPayPaymentMethodDetails.CardPresentReceiptDetails {
-    enum CodingKeys: String, CodingKey {
-        case accountType = "account_type"
-        case applicationPreferredName = "application_preferred_name"
-        case dedicatedFileName = "dedicated_file_name"
-    }
-}
-
 // MARK: - Decoding Errors
-//
 enum WCPayChargeDecodingError: Error {
     case missingSiteID
-}
-
-enum WCPayPaymentMethodDetailsDecodingError: Error {
-    case noDetailsPresentForPaymentType
 }

--- a/Networking/Networking/Model/WCPayChargeStatus.swift
+++ b/Networking/Networking/Model/WCPayChargeStatus.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Codegen
+
+// https://stripe.com/docs/api/charges/object#charge_object-status
+public enum WCPayChargeStatus: String, Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    case succeeded
+    case pending
+    case failed
+}

--- a/Networking/Networking/Model/WCPayChargeStatus.swift
+++ b/Networking/Networking/Model/WCPayChargeStatus.swift
@@ -1,7 +1,12 @@
 import Foundation
 import Codegen
 
-// https://stripe.com/docs/api/charges/object#charge_object-status
+/// Model containing information about the status of a WCPayCharge
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-status)
+///
 public enum WCPayChargeStatus: String, Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case succeeded
     case pending

--- a/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
@@ -1,9 +1,17 @@
 import Foundation
 import Codegen
 
-// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details
+/// Model containing the details of a payment method from WCPay.
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details)
+///
 public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    /// A card payment, with `details`. This represents a payment made online, rather than in-person
     case card(details: WCPayCardPaymentDetails)
+
+    /// A card present payment, with `details`. This represents an In-Person Payment.
     case cardPresent(details: WCPayCardPresentPaymentDetails)
     case unknown
 

--- a/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
@@ -8,12 +8,13 @@ import Codegen
 /// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details)
 ///
 public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    case unknown
+
     /// A card payment, with `details`. This represents a payment made online, rather than in-person
     case card(details: WCPayCardPaymentDetails)
 
     /// A card present payment, with `details`. This represents an In-Person Payment.
     case cardPresent(details: WCPayCardPresentPaymentDetails)
-    case unknown
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Codegen
+
+// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details
+public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    case card(details: WCPayCardPaymentDetails)
+    case cardPresent(details: WCPayCardPresentPaymentDetails)
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        guard let type = try? container.decode(WCPayPaymentMethodType.self, forKey: .type) else {
+            self = .unknown
+            return
+        }
+
+        switch type {
+        case .card:
+            guard let cardDetails = try? container.decode(WCPayCardPaymentDetails.self, forKey: .card) else {
+                throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
+            }
+            self = .card(details: cardDetails)
+        case .cardPresent:
+            guard let cardPresentDetails = try? container.decode(WCPayCardPresentPaymentDetails.self, forKey: .cardPresent) else {
+                throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
+            }
+            self = .cardPresent(details: cardPresentDetails)
+        case .unknown:
+            self = .unknown
+        }
+    }
+}
+
+internal extension WCPayPaymentMethodDetails {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case card
+        case cardPresent = "card_present"
+    }
+}
+
+enum WCPayPaymentMethodDetailsDecodingError: Error {
+    case noDetailsPresentForPaymentType
+}

--- a/Networking/Networking/Model/WCPayPaymentMethodType.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodType.swift
@@ -9,13 +9,6 @@ import Codegen
 ///
 public enum WCPayPaymentMethodType: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case card
-    case cardPresent
+    case cardPresent = "card_present"
     case unknown
-}
-
-internal extension WCPayPaymentMethodType {
-    enum CodingKeys: String, CodingKey {
-        case card
-        case cardPresent = "card_present"
-    }
 }

--- a/Networking/Networking/Model/WCPayPaymentMethodType.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodType.swift
@@ -1,7 +1,12 @@
 import Foundation
 import Codegen
 
-// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-type
+/// Model for a WCPay payment method type
+///
+/// This is returned as part of the response from the `/payments/charges/<charge_id>` WCPay endpoint.
+/// The endpoint returns a thin wrapper around the Stripe object, so
+/// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-type)
+///
 public enum WCPayPaymentMethodType: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case card
     case cardPresent

--- a/Networking/Networking/Model/WCPayPaymentMethodType.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodType.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Codegen
+
+// https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-type
+public enum WCPayPaymentMethodType: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+    case card
+    case cardPresent
+    case unknown
+}
+
+internal extension WCPayPaymentMethodType {
+    enum CodingKeys: String, CodingKey {
+        case card
+        case cardPresent = "card_present"
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #5976 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a model matching the fields from /payments/charges/<charge_id> that are likely to be useful in the project in the near future. In particular, the `brand` and `last4` will be used for identifying the correct card for IPP refunds, and the `receipt` field contains the data we need to view/print/email a receipt from a different device than the one which payment was taken on.

Apologies for the length, but I thought it important to include the documentation comments and it didn't make sense to split it down further.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
There's no visible changes, this GR just adds a model – unit tests are sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
