### PR TITLE
[Mobile Payments] Pass empty statement descriptors as nil to Stripe

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -5,7 +5,7 @@ extension Hardware.PaymentIntentParameters {
     /// Hardware.PaymentIntentParameters
     func toStripe() -> StripeTerminal.PaymentIntentParameters? {
         // Shortcircuit if we do not have a valid currency code
-        guard !self.currency.isEmpty else {
+        guard !currency.isEmpty else {
             return nil
         }
 
@@ -15,20 +15,20 @@ extension Hardware.PaymentIntentParameters {
 
         let amountForStripe = NSDecimalNumber(decimal: amountInSmallestUnit).uintValue
 
-        let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: self.currency)
-        returnValue.stripeDescription = self.receiptDescription
+        let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: currency)
+        returnValue.stripeDescription = receiptDescription
 
         /// Stripe allows the credit card statement descriptor to be nil, but not an empty string
         /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)statementDescriptor
         returnValue.statementDescriptor = nil
-        let descriptor = self.statementDescription ?? ""
+        let descriptor = statementDescription ?? ""
         if !descriptor.isEmpty {
             returnValue.statementDescriptor = descriptor
         }
 
-        returnValue.receiptEmail = self.receiptEmail
-        returnValue.customer = self.customerID
-        returnValue.metadata = self.metadata
+        returnValue.receiptEmail = receiptEmail
+        returnValue.customer = customerID
+        returnValue.metadata = metadata
 
         return returnValue
     }

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -17,7 +17,15 @@ extension Hardware.PaymentIntentParameters {
 
         let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: self.currency)
         returnValue.stripeDescription = self.receiptDescription
-        returnValue.statementDescriptor = self.statementDescription
+
+        /// Stripe allows the credit card statement descriptor to be nil, but not an empty string
+        /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)statementDescriptor
+        returnValue.statementDescriptor = nil
+        let descriptor = self.statementDescription ?? ""
+        if !descriptor.isEmpty {
+            returnValue.statementDescriptor = descriptor
+        }
+
         returnValue.receiptEmail = self.receiptEmail
         returnValue.customer = self.customerID
         returnValue.metadata = self.metadata

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -67,6 +67,14 @@ final class PaymentIntentParametersTests: XCTestCase {
         XCTAssertEqual(statementDescription, "A DESCRIPTION LONGER T")
     }
 
+    func test_statementDescription_is_passed_as_nil_when_empty() throws {
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "")
+
+        let stripeParameters = params.toStripe()
+
+        XCTAssertNil(stripeParameters?.statementDescriptor)
+    }
+
     func test_customer_id_is_passed_to_stripe() {
         let customerID = "customer_id"
         let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION", customerID: customerID)

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -75,6 +75,14 @@ final class PaymentIntentParametersTests: XCTestCase {
         XCTAssertNil(stripeParameters?.statementDescriptor)
     }
 
+    func test_statementDescription_is_passed_as_nil_when_nil() throws {
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: nil)
+
+        let stripeParameters = params.toStripe()
+
+        XCTAssertNil(stripeParameters?.statementDescriptor)
+    }
+
     func test_customer_id_is_passed_to_stripe() {
         let customerID = "customer_id"
         let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION", customerID: customerID)


### PR DESCRIPTION
Closes: #6040

@ctarda @joshheald - just one review is needed but either of y'all (or both) are welcome

fyi @brianyu28 

Related: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2303#discussion_r796885593

### Description
- If the plugin passes us an empty statement_descriptor in the account endpoint, pass that as nil to Stripe to avoid payment intent creation failure

### Testing instructions
- With Stripe extension version 6.1.0, make sure you have no statement descriptor set in the plugin settings

<img width="749" alt="no-descriptor" src="https://user-images.githubusercontent.com/1595739/152035225-b35d229d-2c66-4d47-a265-e9e8d0eae956.png">

- Check Wormholy to ensure an empty string is passed in the response body for the account request when you connect the reader:

<img width="537" alt="Screen Shot 2022-02-01 at 11 15 16 AM" src="https://user-images.githubusercontent.com/1595739/152035550-ac169698-0423-4f63-9675-596d0ceeb234.png">

- Proceed to orders and collect in-person payment for a cash on delivery order
- Ensure that payment collection (and therefore intent creation) succeeds
- For Stripe extension powered sites, you will see "Stripe" as the descriptor for that payment if a descriptor has not been configured in the Stripe dashboard for the account. Otherwise you will see whatever has been configured in the Stripe dashboard for that account.
- Also ensure new unit test passes

### Screenshots

<img width="540" alt="statement-descriptor-stripe" src="https://user-images.githubusercontent.com/1595739/152035007-acd8e5c0-caf5-45f1-9ef5-7df9a1d4f6fd.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
