### PR TITLE
Remove unnecessary checks on IPP onboarding tests

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -326,10 +326,6 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // Then
 
-        // AppSettingsAction.loadStripeInPersonPaymentsSwitchState
-        // + AppSettingsAction.loadCanadaInPersonPaymentsSwitchState
-        // + CardPresentPaymentAction.use
-        XCTAssertEqual(stores.receivedActions.count, 3)
         let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
 
         switch action {
@@ -376,10 +372,6 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // Then
 
-        // AppSettingsAction.loadStripeInPersonPaymentsSwitchState
-        // + AppSettingsAction.loadCanadaInPersonPaymentsSwitchState
-        // + CardPresentPaymentAction.use
-        XCTAssertEqual(stores.receivedActions.count, 3)
         let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
 
         switch action {


### PR DESCRIPTION
As suggested in https://github.com/woocommerce/woocommerce-ios/pull/6035/files/7f592ed183523205dba8ffdbc683bff0770643ee#r797478700, these don't really add much and just test and implementation detail that will change as we remove feature flags

<!-- Remember about a good descriptive title. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Unit tests should pass

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
