### PR TITLE
[Mobile Payments] 6041 code review suggestions

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -17,19 +17,20 @@ extension Hardware.PaymentIntentParameters {
 
         let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: self.currency)
         returnValue.stripeDescription = self.receiptDescription
-
-        /// Stripe allows the credit card statement descriptor to be nil, but not an empty string
-        /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)statementDescriptor
-        returnValue.statementDescriptor = nil
-        let descriptor = self.statementDescription ?? ""
-        if !descriptor.isEmpty {
-            returnValue.statementDescriptor = descriptor
-        }
-
+        returnValue.statementDescriptor = nonEmptyStatementDescription
         returnValue.receiptEmail = self.receiptEmail
         returnValue.customer = self.customerID
         returnValue.metadata = self.metadata
 
         return returnValue
+    }
+
+    /// Stripe allows the credit card statement descriptor to be nil, but not an empty string
+    ///
+    /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)statementDescriptor
+    private var nonEmptyStatementDescription: String? {
+        return statementDescription.flatMap {
+            return $0.isEmpty ? nil : $0
+        }
     }
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -5,7 +5,7 @@ extension Hardware.PaymentIntentParameters {
     /// Hardware.PaymentIntentParameters
     func toStripe() -> StripeTerminal.PaymentIntentParameters? {
         // Shortcircuit if we do not have a valid currency code
-        guard !self.currency.isEmpty else {
+        guard !currency.isEmpty else {
             return nil
         }
 
@@ -15,12 +15,12 @@ extension Hardware.PaymentIntentParameters {
 
         let amountForStripe = NSDecimalNumber(decimal: amountInSmallestUnit).uintValue
 
-        let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: self.currency)
-        returnValue.stripeDescription = self.receiptDescription
+        let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: currency)
+        returnValue.stripeDescription = receiptDescription
         returnValue.statementDescriptor = nonEmptyStatementDescription
-        returnValue.receiptEmail = self.receiptEmail
-        returnValue.customer = self.customerID
-        returnValue.metadata = self.metadata
+        returnValue.receiptEmail = receiptEmail
+        returnValue.customer = customerID
+        returnValue.metadata = metadata
 
         return returnValue
     }

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -75,6 +75,14 @@ final class PaymentIntentParametersTests: XCTestCase {
         XCTAssertNil(stripeParameters?.statementDescriptor)
     }
 
+    func test_statementDescription_is_passed_as_nil_when_nil() throws {
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: nil)
+
+        let stripeParameters = params.toStripe()
+
+        XCTAssertNil(stripeParameters?.statementDescriptor)
+    }
+
     func test_customer_id_is_passed_to_stripe() {
         let customerID = "customer_id"
         let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION", customerID: customerID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Suggestions from code review of #6041 

### Description
@allendav Totally up to you whether you take these, but I found the empty check a little difficult to read so noodled around with it for a while. `flatMap` isn't always the easiest to read either, but the short closure combined with a descriptive variable name I think overcomes that.

Ignore if you don't like it!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
I followed the same testing as in #6041
Unit tests still pass

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
