### PR TITLE
Order Creation: Use onLoadTrigger subject to trigger product/variation sync only on first page load

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -48,7 +48,7 @@ struct AddProductToOrder: View {
                 }
             }
             .onAppear {
-                viewModel.syncFirstPage()
+                viewModel.onLoadTrigger.send()
             }
         }
         .wooNavigationBarStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -57,7 +57,7 @@ struct AddProductVariationToOrder: View {
             }
         }
         .onAppear {
-            viewModel.syncFirstPage()
+            viewModel.onLoadTrigger.send()
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -127,11 +127,11 @@ class AddProductToOrderViewModelTests: XCTestCase {
     func test_onLoadTrigger_triggers_initial_product_sync() {
         // Given
         let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, stores: stores)
-        var isSyncTriggered = false
+        var timesSynced = 0
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case .synchronizeProducts:
-                isSyncTriggered = true
+                timesSynced += 1
             default:
                 XCTFail("Unsupported Action")
             }
@@ -139,9 +139,10 @@ class AddProductToOrderViewModelTests: XCTestCase {
 
         // When
         viewModel.onLoadTrigger.send()
+        viewModel.onLoadTrigger.send()
 
         // Then
-        XCTAssertTrue(isSyncTriggered)
+        XCTAssertEqual(timesSynced, 1)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -123,6 +123,26 @@ class AddProductToOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.syncStatus, .results)
     }
+
+    func test_onLoadTrigger_triggers_initial_product_sync() {
+        // Given
+        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, stores: stores)
+        var isSyncTriggered = false
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case .synchronizeProducts:
+                isSyncTriggered = true
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertTrue(isSyncTriggered)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -168,11 +168,11 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
     func test_onLoadTrigger_triggers_initial_product_variation_sync() {
         // Given
         let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: Product.fake(), storageManager: storageManager, stores: stores)
-        var isSyncTriggered = false
+        var timesSynced = 0
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case .synchronizeProductVariations:
-                isSyncTriggered = true
+                timesSynced += 1
             default:
                 XCTFail("Unsupported Action")
             }
@@ -180,9 +180,10 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
 
         // When
         viewModel.onLoadTrigger.send()
+        viewModel.onLoadTrigger.send()
 
         // Then
-        XCTAssertTrue(isSyncTriggered)
+        XCTAssertEqual(timesSynced, 1)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -164,6 +164,26 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.syncStatus, .results)
     }
+
+    func test_onLoadTrigger_triggers_initial_product_variation_sync() {
+        // Given
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: Product.fake(), storageManager: storageManager, stores: stores)
+        var isSyncTriggered = false
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case .synchronizeProductVariations:
+                isSyncTriggered = true
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertTrue(isSyncTriggered)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Closes: #5902

## Description

Previously in order creation, we were triggering the product list view (`AddProductToOrder`) and product variation list view (`AddProductVariationToOrder`) to sync the first page of products/variations any time the view appears. This could potentially corrupt the sync state e.g. if the user navigates to another app and then back or a system alert appears.

This changes the approach to only trigger the first page sync once, the first time the view appears.

## Changes

Instead of triggering the first page sync directly with `onAppear`:

```
.onAppear {
     viewModel.syncFirstPage()
}
```

We now use an `onLoadTrigger` subject (from the view model) and call it in `onAppear`. We only listen to the first event from that publisher, and use that to trigger the first page sync.

This change is implemented in the same way for `AddProductToOrder`/`AddProductToOrderViewModel` and `AddProductVariationToOrder`/`AddProductVariationToOrderViewModel`.

There are also unit tests to check that `onLoadTrigger` triggers the initial sync once (and only once).


## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, confirm the product list is synced as expected (including if you switch apps during the initial sync).
6. Select a variable product and confirm the product variation list is synced as expected (including if you switch apps during the initial sync).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
