### PR TITLE
Removed unused track event `orders_list_menu_filter_tapped`

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -175,7 +175,6 @@ public enum WooAnalyticsStat: String {
     case ordersSelected = "main_tab_orders_selected"
     case ordersReselected = "main_tab_orders_reselected"
     case ordersListPulledToRefresh = "orders_list_pulled_to_refresh"
-    case ordersListFilterTapped = "orders_list_menu_filter_tapped"
     case ordersListSearchTapped = "orders_list_menu_search_tapped"
     case filterOrdersOptionSelected = "filter_orders_by_status_dialog_option_selected"
     case orderDetailAddNoteButtonTapped = "order_detail_add_note_button_tapped"


### PR DESCRIPTION
### Description
In a conversation with @JorgeMucientes yesterday, we noticed that the event `orders_list_menu_filter_tapped` is no more used and no more implemented inside our app. So, I removed the event.

### Testing instructions
Just CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
