### PR TITLE
Order Creation: Do not prefill shipping address fields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -21,14 +21,17 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
          analytics: Analytics = ServiceLocator.analytics) {
         self.onAddressUpdate = onAddressUpdate
 
+        // don't prefill second set of fields if input addresses are identical
+        let addressesAreDifferent = addressData.billingAddress != addressData.shippingAddress
+
         super.init(siteID: siteID,
                    address: addressData.billingAddress ?? .empty,
-                   secondaryAddress: addressData.shippingAddress ?? .empty,
+                   secondaryAddress: addressesAreDifferent ? (addressData.shippingAddress ?? .empty) : .empty,
                    storageManager: storageManager,
                    stores: stores,
                    analytics: analytics)
 
-        if addressData.billingAddress != addressData.shippingAddress {
+        if addressesAreDifferent {
             showDifferentAddressForm = true
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
@@ -97,8 +97,10 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         // Given
         let newCountry = Self.sampleCountries[0]
 
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
         let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
-                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
                                                         onAddressUpdate: nil,
                                                         storageManager: testingStorage)
         viewModel.onLoadTrigger.send()
@@ -114,8 +116,10 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
 
     func test_country_and_state_names_are_converted_from_codes_when_available() {
         // Given
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
         let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
-                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
                                                         onAddressUpdate: nil,
                                                         storageManager: testingStorage)
         XCTAssertEqual(viewModel.secondaryFields.country, "US")
@@ -135,10 +139,10 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
 
     func test_state_name_is_displayed_as_string_when_mapping_is_not_available() {
         // Given
-        let addressWithUnknownCountryAndState = sampleAddress().copy(state: "Bavaria", country: "Germany")
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(state: "Bavaria", country: "Germany")
         let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
-                                                        addressData: .init(billingAddress: addressWithUnknownCountryAndState,
-                                                                           shippingAddress: addressWithUnknownCountryAndState),
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
                                                         onAddressUpdate: nil,
                                                         storageManager: testingStorage)
 
@@ -154,8 +158,10 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         // Given
         let newCountry = Country(code: "GB", name: "United Kingdom", states: [])
 
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
         let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
-                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
                                                         onAddressUpdate: nil,
                                                         storageManager: testingStorage)
         viewModel.onLoadTrigger.send()
@@ -176,8 +182,10 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         // Given
         let newCountry = Country(code: "AU", name: "Australia", states: [.init(code: "VIC", name: "Victoria")])
 
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
         let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
-                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
                                                         onAddressUpdate: nil,
                                                         storageManager: testingStorage)
         viewModel.onLoadTrigger.send()
@@ -198,8 +206,10 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         // Given
         let newState = StateOfACountry(code: "CA", name: "California")
 
+        let address1 = sampleAddress()
+        let address2 = sampleAddress().copy(firstName: "John")
         let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
-                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        addressData: .init(billingAddress: address1, shippingAddress: address2),
                                                         onAddressUpdate: nil,
                                                         storageManager: testingStorage)
         viewModel.onLoadTrigger.send()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
@@ -35,6 +35,20 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showDifferentAddressForm)
     }
 
+    func test_input_of_identical_addresses_does_not_prefill_second_set_of_fields() {
+        // Given
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: sampleAddress(), shippingAddress: sampleAddress()),
+                                                        onAddressUpdate: nil,
+                                                        storageManager: testingStorage)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        assertEqual(viewModel.secondaryFields.toAddress(), .empty)
+    }
+
     func test_input_of_different_addresses_enables_different_address_toggle() {
         // Given
         let address1 = sampleAddress()
@@ -59,7 +73,6 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         viewModel.onLoadTrigger.send()
-
 
         // Then
         XCTAssertEqual(viewModel.secondaryFields.firstName, address2.firstName)


### PR DESCRIPTION
## Description

This PR updates address form logic in order creation flow to prevent billing address prefilling in shipping address fields.
Internal discussion ref: pdcxQM-q5-p2#comment-371 

## Changes

- Adds `addressesAreDifferent` check in `CreateOrderAddressFormViewModel()` initializer.
- Updates initializer to use `.empty` second address if 2 input addresses are the same.
- Adds related test.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "+ Add customer" button to display the address form.
5. Enter some data.
6. Enable "Add a different shipping address" toggle.
7. Confirm that the second set of fields in the expanded form is empty.
8. Disable "Add a different shipping address" toggle to keep sam address for billing and shipping.
9. Tap "Done" to save and close the address form.
10. Tap "Edit" in the customer section.
11. Enable "Add a different shipping address" toggle.
12. Confirm that the second set of fields in the expanded form is empty.
13. Enter some different data in the second set of fields.
14. Tap "Done" to save and close the address form.
15. Confirm that the customer section shows 2 different correct addresses.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.