### PR TITLE
Order Creation: Update price label when product quantity changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -51,7 +51,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Label showing product details: stock status, price, and variations (if any).
     ///
-    lazy var productDetailsLabel: String = {
+    var productDetailsLabel: String {
         let stockLabel = createStockText()
         let priceLabel = createPriceText()
         let variationsLabel = createVariationsText()
@@ -59,7 +59,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         return [stockLabel, priceLabel, variationsLabel]
             .compactMap({ $0 })
             .joined(separator: " • ")
-    }()
+    }
 
     /// Label showing product SKU
     ///
@@ -191,14 +191,14 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         }
     }
 
-    /// Create the price text based on a product's price.
+    /// Create the price text based on a product's price and quantity.
     ///
     private func createPriceText() -> String? {
         guard let price = price else {
             return nil
         }
-        let unformattedPrice = price.isNotEmpty ? price : "0"
-        return currencyFormatter.formatAmount(unformattedPrice)
+        let productSubtotal = quantity * (currencyFormatter.convertToDecimal(from: price)?.decimalValue ?? Decimal.zero)
+        return currencyFormatter.formatAmount(productSubtotal)
     }
 
     /// Create the variations text for a variable product.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -129,6 +129,21 @@ class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
+    func test_view_model_updates_price_label_when_quantity_changes() {
+        // Given
+        let product = Product.fake().copy(price: "2.50")
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+        viewModel.incrementQuantity()
+
+        // Then
+        let expectedPriceLabel = "$5.00"
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedPriceLabel),
+                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
+    }
+
     func test_view_model_creates_expected_product_details_label_for_variable_product() {
         // Given
         let product = Product.fake().copy(productTypeKey: "variable", stockStatusKey: "instock", variations: [0, 1])


### PR DESCRIPTION
Closes: #5946

## Description

During order creation, we currently display the price for each item added to an order. This PR updates the iOS behavior to match Android, so when an item is added to a new order, the product row displays the item's subtotal (price x quantity) rather than the price for a single item.

<img src="https://user-images.githubusercontent.com/8658164/150788319-a7318f92-e049-4228-95fa-68ebf03a1fae.png" width="300px">

Note: Currently we are calculating the subtotal on our end, but once we support auto-drafts for new orders (#6023) we can update this behavior to display the subtotal provided by the backend.

## Changes

* Updates the price label in `ProductRowViewModel` to be the subtotal (price x quantity) rather than just the price.
* `productDetailsLabel` is no longer a lazy var, so it is updated as the quantity changes.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, select a product.
6. Back on the New Order screen, tap the +/- buttons in the stepper to change the product quantity in the order. Confirm the price label for that item changes to reflect the quantity changes.

## Screenshots

https://user-images.githubusercontent.com/8658164/152218593-bee45ef9-e469-477d-a134-38523008c2e0.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
