### PR TITLE
[Mobile Payments] [Stripe Backend] Ensure the backend has been configured if connecting in order flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -100,6 +100,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     /// - Parameter onCollect: Closure Invoked after the collect process has finished.
     /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed, Currently after merchant has handled the receipt.
     func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
+        configureBackend()
         connectReader { [weak self] in
             self?.attemptPayment(onCompletion: { [weak self] result in
                 // Inform about the collect payment state
@@ -117,6 +118,12 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 
 // MARK: Private functions
 private extension CollectOrderPaymentUseCase {
+    /// Configure the CardPresentPaymentStore to use the appropriate backend
+    ///
+    func configureBackend() {
+        let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
+        stores.dispatch(setAccount)
+    }
 
     /// Attempts to connect to a reader.
     /// Finishes immediately if a reader is already connected.


### PR DESCRIPTION
Closes: #6042

@joshheald @ctarda - only one review needed but either of y'all are welcome

### Description
- On a store using the Stripe extension for In-Person Payments, if you don't connect your card reader through settings before collecting payment for an order the CardPresentPaymentStore attempts to use WCPay remote to connect to the reader, which fails.
- With this change, we always tell the CardPresentPaymentStore which account is in effect before we attempt collecting payment

### Testing instructions
- Set up a store with the Stripe extension (test keys are fine)
- Checkout using Cash on Delivery
- Launch the app and proceed to orders without passing through settings
- Ensure you can connect the reader and capture payment

### Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

