### PR TITLE
Update editing order status events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -344,6 +344,7 @@ extension WooAnalyticsEvent {
             static let errorDescription = "error_description"
             static let to = "to"
             static let from = "from"
+            static let orderID = "id"
         }
 
         static func orderAddNew() -> WooAnalyticsEvent {
@@ -361,12 +362,14 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderStatusChange(flow: Flow, from oldStatus: OrderStatusEnum, to newStatus: OrderStatusEnum) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderStatusChange, properties: [
+        static func orderStatusChange(flow: Flow, orderID: Int64? = nil, from oldStatus: OrderStatusEnum, to newStatus: OrderStatusEnum) -> WooAnalyticsEvent {
+            let properties: [String: WooAnalyticsEventPropertyType?] = [
                 Keys.flow: flow.rawValue,
+                Keys.orderID: orderID,
                 Keys.from: oldStatus.rawValue,
                 Keys.to: newStatus.rawValue
-            ])
+            ]
+            return WooAnalyticsEvent(statName: .orderStatusChange, properties: properties.compactMapValues { $0 })
         }
 
         static func orderCreateButtonTapped(status: OrderStatusEnum,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -362,7 +362,7 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderStatusChange(flow: Flow, orderID: Int64? = nil, from oldStatus: OrderStatusEnum, to newStatus: OrderStatusEnum) -> WooAnalyticsEvent {
+        static func orderStatusChange(flow: Flow, orderID: Int64?, from oldStatus: OrderStatusEnum, to newStatus: OrderStatusEnum) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [
                 Keys.flow: flow.rawValue,
                 Keys.orderID: orderID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -238,7 +238,7 @@ final class NewOrderViewModel: ObservableObject {
     func updateOrderStatus(newStatus: OrderStatusEnum) {
         let oldStatus = orderDetails.status
         orderDetails.status = newStatus
-        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .creation, from: oldStatus, to: newStatus))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .creation, orderID: nil, from: oldStatus, to: newStatus))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -842,18 +842,11 @@ private extension OrderDetailsViewController {
         let undo = updateOrderStatusAction(siteID: viewModel.order.siteID, orderID: viewModel.order.orderID, status: undoStatus)
 
         ServiceLocator.stores.dispatch(done)
-
-        ServiceLocator.analytics.track(.orderStatusChange,
-                                       withProperties: ["id": orderID,
-                                                        "from": undoStatus.rawValue,
-                                                        "to": newStatus.rawValue])
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, from: undoStatus, to: newStatus))
 
         displayOrderStatusUpdatedNotice {
             ServiceLocator.stores.dispatch(undo)
-            ServiceLocator.analytics.track(.orderStatusChange,
-                                           withProperties: ["id": orderID,
-                                                            "from": newStatus.rawValue,
-                                                            "to": undoStatus.rawValue])
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, from: newStatus, to: undoStatus))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -842,11 +842,11 @@ private extension OrderDetailsViewController {
         let undo = updateOrderStatusAction(siteID: viewModel.order.siteID, orderID: viewModel.order.orderID, status: undoStatus)
 
         ServiceLocator.stores.dispatch(done)
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, from: undoStatus, to: newStatus))
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, orderID: orderID, from: undoStatus, to: newStatus))
 
         displayOrderStatusUpdatedNotice {
             ServiceLocator.stores.dispatch(undo)
-            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, from: newStatus, to: undoStatus))
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, orderID: orderID, from: newStatus, to: undoStatus))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
@@ -61,9 +61,7 @@ final class OrderFulfillmentUseCase {
     private func dispatchStatusUpdateAction(order: Order,
                                             status targetStatus: OrderStatusEnum,
                                             activity: Activity) -> FulfillmentProcess {
-        analytics.track(.orderStatusChange, withProperties: ["id": order.orderID,
-                                                             "from": order.status.rawValue,
-                                                             "to": targetStatus.rawValue])
+        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, orderID: order.orderID, from: order.status, to: targetStatus))
 
         let result: Future<Void, FulfillmentError> = Future { promise in
             let action = OrderAction.updateOrderStatus(siteID: order.siteID, orderID: order.orderID, status: targetStatus) { error in


### PR DESCRIPTION
closes #5717 

# Why

As we updated the `order_status_change` event for order creation, we need to reflect those changes in the editing flows.

# How
- Use the `WooAnalyticsEvent.Orders.orderStatusChange` method when changing the status of an existing order.
- Use the `WooAnalyticsEvent.Orders.orderStatusChange` when marking an order as complete as part of the fulfillment use case.

# Testing 

- Change the status of an existing order & see that the `order_status_change` event now contains the `flow = editing` property.
- Mark an order as complete  & see that the `order_status_change` event now contains the `flow = editing` 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
