### PR TITLE
[Mobile Payments] Add WCPayChargesRemote

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		03DCB7822627394500C8953D /* CouponMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7812627394500C8953D /* CouponMapperTests.swift */; };
 		03DCB786262739D200C8953D /* CouponMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB785262739D200C8953D /* CouponMapper.swift */; };
 		03DCB796262741E000C8953D /* Coupon+Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB795262741E000C8953D /* Coupon+Decoder.swift */; };
+		03E8FEC427B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */; };
 		077F39C8269F2C7E00ABEADC /* SystemPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */; };
 		077F39D426A58DE700ABEADC /* SystemStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */; };
 		077F39D626A58E4500ABEADC /* SystemStatusRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39D526A58E4500ABEADC /* SystemStatusRemote.swift */; };
@@ -774,6 +775,7 @@
 		03DCB7812627394500C8953D /* CouponMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapperTests.swift; sourceTree = "<group>"; };
 		03DCB785262739D200C8953D /* CouponMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapper.swift; sourceTree = "<group>"; };
 		03DCB795262741E000C8953D /* Coupon+Decoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Coupon+Decoder.swift"; sourceTree = "<group>"; };
+		03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card-present-minimal.json"; sourceTree = "<group>"; };
 		077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPlugin.swift; sourceTree = "<group>"; };
 		077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapper.swift; sourceTree = "<group>"; };
 		077F39D526A58E4500ABEADC /* SystemStatusRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusRemote.swift; sourceTree = "<group>"; };
@@ -2019,6 +2021,7 @@
 				077F39D726A58EB600ABEADC /* systemStatus.json */,
 				0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */,
 				0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */,
+				03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */,
 				0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */,
 				45CCFCE927A2E59B0012E8CB /* inbox-note-list.json */,
 				4513382727A96DE700AE5E78 /* inbox-note.json */,
@@ -2528,6 +2531,7 @@
 				45CCFCEA27A2E59B0012E8CB /* inbox-note-list.json in Resources */,
 				025CA2C8238F4FF400B05C81 /* product-shipping-classes-load-all.json in Resources */,
 				74046E21217A73D0007DD7BF /* settings-general.json in Resources */,
+				03E8FEC427B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json in Resources */,
 				31054724262E2FC600C5C02B /* wcpay-payment-intent-requires-capture.json in Resources */,
 				7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */,
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		0359EA1F27AAE4680048DE2D /* WCPayChargeMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA1E27AAE4680048DE2D /* WCPayChargeMapperTests.swift */; };
 		0359EA2127AAE58C0048DE2D /* wcpay-charge-card-present.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */; };
 		0359EA2527AAF7D60048DE2D /* wcpay-charge-card.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */; };
+		0359EA2927AC2AAD0048DE2D /* wcpay-charge-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */; };
 		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
@@ -762,6 +763,7 @@
 		0359EA1E27AAE4680048DE2D /* WCPayChargeMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayChargeMapperTests.swift; sourceTree = "<group>"; };
 		0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card-present.json"; sourceTree = "<group>"; };
 		0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card.json"; sourceTree = "<group>"; };
+		0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error.json"; sourceTree = "<group>"; };
 		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
@@ -2017,6 +2019,7 @@
 				077F39D726A58EB600ABEADC /* systemStatus.json */,
 				0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */,
 				0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */,
+				0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */,
 				45CCFCE927A2E59B0012E8CB /* inbox-note-list.json */,
 				4513382727A96DE700AE5E78 /* inbox-note.json */,
 			);
@@ -2581,6 +2584,7 @@
 				B524194721AC643900D6FC0A /* device-settings.json in Resources */,
 				3158A49F2729F3F600C3CFA8 /* wcpay-account-live-live.json in Resources */,
 				318E8FD926C324D900F519D7 /* wcpay-customer-error.json in Resources */,
+				0359EA2927AC2AAD0048DE2D /* wcpay-charge-error.json in Resources */,
 				CEF88DAB233E911A00BED485 /* order-fully-refunded.json in Resources */,
 				02698CFA24C188E9005337C4 /* product-variations-load-all-alternative-types.json in Resources */,
 				CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */,

--- a/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
@@ -14,14 +14,14 @@ public struct WCPayCardPresentReceiptDetails: Codable, GeneratedCopiable, Genera
     public let accountType: WCPayCardFunding
 
     /// The EMV Application Identifier (AID)
-    public let applicationPreferredName: String
+    public let applicationPreferredName: String?
 
     /// The EMV Dedicated File (DF) Name
-    public let dedicatedFileName: String
+    public let dedicatedFileName: String?
 
     public init(accountType: WCPayCardFunding,
-                applicationPreferredName: String,
-                dedicatedFileName: String) {
+                applicationPreferredName: String?,
+                dedicatedFileName: String?) {
         self.accountType = accountType
         self.applicationPreferredName = applicationPreferredName
         self.dedicatedFileName = dedicatedFileName

--- a/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
+++ b/Networking/Networking/Model/WCPayCardPresentReceiptDetails.swift
@@ -14,9 +14,13 @@ public struct WCPayCardPresentReceiptDetails: Codable, GeneratedCopiable, Genera
     public let accountType: WCPayCardFunding
 
     /// The EMV Application Identifier (AID)
+    /// Ideally these would not be optional, as they are required on the receipt. Stripe's simulated cards currently give `null` here.
+    /// p1644486564027519-slack-C01G168NFC2
     public let applicationPreferredName: String?
 
     /// The EMV Dedicated File (DF) Name
+    /// Ideally these would not be optional, as they are required on the receipt. Stripe's simulated cards currently give `null` here.
+    /// p1644486564027519-slack-C01G168NFC2 
     public let dedicatedFileName: String?
 
     public init(accountType: WCPayCardFunding,

--- a/Networking/Networking/Remote/WCPayRemote.swift
+++ b/Networking/Networking/Remote/WCPayRemote.swift
@@ -60,6 +60,24 @@ public class WCPayRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Fetches the details of a charge, if available. See https://stripe.com/docs/api/charges/object
+    /// Also note that the JSON returned by the WCPay endpoint is an abridged copy of Stripe's response.
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the charge.
+    ///   - chargeID: ID of the charge to fetch
+    ///   - completion: Closure to be run on completion.
+    public func fetchCharge(for siteID: Int64,
+                            chargeID: String,
+                            completion: @escaping (Result<WCPayCharge, Error>) -> Void) {
+        let path = "\(Path.charges)/\(chargeID)"
+
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: [:])
+
+        let mapper = WCPayChargeMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: - CardReaderCapableRemote
@@ -104,6 +122,7 @@ private extension WCPayRemote {
         static let captureTerminalPayment = "capture_terminal_payment"
         static let createCustomer = "create_customer"
         static let locations = "payments/terminal/locations/store"
+        static let charges = "payments/charges"
     }
 
     enum AccountParameterKeys {

--- a/Networking/Networking/Remote/WCPayRemote.swift
+++ b/Networking/Networking/Remote/WCPayRemote.swift
@@ -72,7 +72,7 @@ public class WCPayRemote: Remote {
                             completion: @escaping (Result<WCPayCharge, Error>) -> Void) {
         let path = "\(Path.charges)/\(chargeID)"
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: [:])
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: [:])
 
         let mapper = WCPayChargeMapper(siteID: siteID)
 

--- a/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
@@ -53,6 +53,39 @@ class WCPayChargeMapperTests: XCTestCase {
         XCTAssertEqual(wcpayCharge, expectedWcpayCharge)
     }
 
+    /// Verifies that the fields are all parsed correctly for a card present payment
+    ///
+    func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present_with_nulls() throws {
+        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .cardPresentMinimal)
+
+        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1643799478) //2022-02-02 10:57:58 UTC
+
+        let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.cardPresent(
+            details: .init(brand: .visa,
+                           last4: "4242",
+                           funding: .credit,
+                           receipt: .init(accountType: .credit,
+                                          applicationPreferredName: nil,
+                                          dedicatedFileName: nil)))
+
+        let expectedWcpayCharge = WCPayCharge(siteID: dummySiteID,
+                                              id: "ch_3KOgX62EdyGr1FMV0CSW2k48",
+                                              amount: 100,
+                                              amountCaptured: 100,
+                                              amountRefunded: 0,
+                                              authorizationCode: "123456",
+                                              captured: true,
+                                              created: expectedCreatedDate,
+                                              currency: "usd",
+                                              paid: true,
+                                              paymentIntentID: "pi_3KOgX62EdyGr1FMV0HpUJ10k",
+                                              paymentMethodID: "pm_1KOgXB2EdyGr1FMVucJRZLpC",
+                                              paymentMethodDetails: expectedPaymentMethodDetails,
+                                              refunded: false,
+                                              status: .succeeded)
+        XCTAssertEqual(wcpayCharge, expectedWcpayCharge)
+    }
+
     /// Verifies that the fields are all parsed correctly for a card payment
     ///
     func test_WCPayCharge_map_parses_all_fields_in_result_for_card() throws {
@@ -107,6 +140,7 @@ private extension WCPayChargeMapperTests {
 
     enum ChargeResponse: String {
         case cardPresent = "wcpay-charge-card-present"
+        case cardPresentMinimal = "wcpay-charge-card-present-minimal"
         case card = "wcpay-charge-card"
     }
 }

--- a/Networking/NetworkingTests/Responses/wcpay-charge-card-present-minimal.json
+++ b/Networking/NetworkingTests/Responses/wcpay-charge-card-present-minimal.json
@@ -1,0 +1,157 @@
+{
+  "data": {
+    "id": "ch_3KOgX62EdyGr1FMV0CSW2k48",
+    "object": "charge",
+    "amount": 100,
+    "amount_captured": 100,
+    "amount_refunded": 0,
+    "application": "ca_Ex84e31yMTLaNU5ozQvi5woLclpIDVpX",
+    "application_fee": "fee_1KOgXF2EdyGr1FMVtgiTktaZ",
+    "application_fee_amount": 13,
+    "authorization_code": "123456",
+    "balance_transaction": {
+      "id": "txn_3KOgX62EdyGr1FMV0EvyEIyd",
+      "object": "balance_transaction",
+      "amount": 100,
+      "available_on": 1644364800,
+      "created": 1643799481,
+      "currency": "usd",
+      "description": "In-Person Payment for Order #213 for My WordPress Site",
+      "exchange_rate": null,
+      "fee": 13,
+      "fee_details": [
+        {
+          "amount": 13,
+          "application": "ca_Ex84e31yMTLaNU5ozQvi5woLclpIDVpX",
+          "currency": "usd",
+          "description": "WooCommerce Payments application fee",
+          "type": "application_fee"
+        }
+      ],
+      "net": 87,
+      "reporting_category": "charge",
+      "source": "ch_3KOgX62EdyGr1FMV0CSW2k48",
+      "status": "available",
+      "type": "charge"
+    },
+    "billing_details": {
+      "address": {
+        "city": null,
+        "country": null,
+        "line1": null,
+        "line2": null,
+        "postal_code": null,
+        "state": null
+      },
+      "email": null,
+      "name": null,
+      "phone": null,
+      "formatted_address": ""
+    },
+    "calculated_statement_descriptor": "TAXBUGCHECK.MYSTAGINGW",
+    "captured": true,
+    "created": 1643799478,
+    "currency": "usd",
+    "customer": "cus_L4qDnGQ8DjdMrb",
+    "description": "In-Person Payment for Order #213 for My WordPress Site",
+    "destination": null,
+    "dispute": null,
+    "disputed": false,
+    "failure_code": null,
+    "failure_message": null,
+    "fraud_details": [],
+    "invoice": null,
+    "level3": {
+      "customer_reference": "213",
+      "line_items": [
+        {
+          "discount_amount": 0,
+          "product_code": "simple-payme",
+          "product_description": "Simple Payments",
+          "quantity": 1,
+          "tax_amount": 0,
+          "unit_cost": 100
+        }
+      ],
+      "merchant_reference": "213",
+      "shipping_amount": 0,
+      "shipping_from_zip": "85120"
+    },
+    "livemode": false,
+    "metadata": {
+      "order_id": "213",
+      "payment_type": "single",
+      "paymentintent.storename": "My WordPress Site",
+      "reader_ID": "CHB20SIMULATOR1",
+      "reader_model": "CHIPPER_2X",
+      "site_url": "https://store.example.com"
+    },
+    "on_behalf_of": null,
+    "order": {
+      "number": "213",
+      "url": "https://store.example.com/wp-admin/post.php?post=213&action=edit",
+      "customer_url": "admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=0",
+      "subscriptions": []
+    },
+    "outcome": {
+      "network_status": "approved_by_network",
+      "reason": null,
+      "risk_level": "not_assessed",
+      "seller_message": "Payment complete.",
+      "type": "authorized"
+    },
+    "paid": true,
+    "payment_intent": "pi_3KOgX62EdyGr1FMV0HpUJ10k",
+    "payment_method": "pm_1KOgXB2EdyGr1FMVucJRZLpC",
+    "payment_method_details": {
+      "card_present": {
+        "amount_authorized": 100,
+        "brand": "visa",
+        "cardholder_name": null,
+        "country": "US",
+        "emv_auth_data": "8A023030",
+        "exp_month": 12,
+        "exp_year": 2030,
+        "fingerprint": "0SEufZLr8JkcLcfi",
+        "funding": "credit",
+        "generated_card": "pm_1KOgXB2EdyGr1FMVZ4GOElsc",
+        "last4": "4242",
+        "network": "visa",
+        "overcapture_supported": false,
+        "read_method": "contactless_emv",
+        "receipt": {
+          "account_type": "credit",
+          "application_cryptogram": null,
+          "application_preferred_name": null,
+          "authorization_code": null,
+          "authorization_response_code": "3030",
+          "cardholder_verification_method": null,
+          "dedicated_file_name": null,
+          "terminal_verification_results": null,
+          "transaction_status_information": null
+        }
+      },
+      "type": "card_present"
+    },
+    "receipt_email": null,
+    "receipt_number": null,
+    "receipt_url": "https://pay.stripe.com/receipts/acct_1Jaefx2EdyGr1FMV/ch_3KOgX62EdyGr1FMV0CSW2k48/rcpt_L4qDOZ5aR8acdq5HxPDdO49rjeYBSgk",
+    "refunded": false,
+    "refunds": {
+      "object": "list",
+      "data": [],
+      "has_more": false,
+      "total_count": 0,
+      "url": "/v1/charges/ch_3KOgX62EdyGr1FMV0CSW2k48/refunds"
+    },
+    "review": null,
+    "shipping": null,
+    "source": null,
+    "source_transfer": null,
+    "statement_descriptor": "TAXBUGCHECK.MYSTAGINGW",
+    "statement_descriptor_suffix": null,
+    "status": "succeeded",
+    "transfer_data": null,
+    "transfer_group": null
+  }
+}

--- a/Networking/NetworkingTests/Responses/wcpay-charge-error.json
+++ b/Networking/NetworkingTests/Responses/wcpay-charge-error.json
@@ -1,0 +1,4 @@
+{
+  "error": "wcpay_get_charge",
+  "message": "Error: No such charge: 'ch_3KMVapErrorERROR'"
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #5976 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a remote to fetch a WCPayCharge by ID. This will be used to get the `last4` and `brand` of the card used to pay, where possible. Currently it is unused as it's just the networking code.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Run unit tests

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
