### PR TITLE
Order Creation: Release Order Creation M1 (Products and Customers) as Experimental Feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] In-Person Payments: Inform the user when a card reader battery is so low that it needs to be charged before the reader can be connected. [https://github.com/woocommerce/woocommerce-ios/pull/5998]
 - [***] The My store tab is having a new look with new conversion stats and shows up to 5 top performing products now (used to be 3). [https://github.com/woocommerce/woocommerce-ios/pull/5991]
 - [**] Fixed a crash at the startup of the app, related to Gridicons. [https://github.com/woocommerce/woocommerce-ios/pull/6005]
+- [***] Experimental Feature: It's now possible to create Orders in the app by enabling it in Settings > Experimental Features. For now you can change the order status, add products, and add customer details (billing and shipping addresses). [https://github.com/woocommerce/woocommerce-ios/pull/6060]
 
 8.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -86,10 +86,6 @@ private extension BetaFeaturesViewController {
     }
 
     func orderCreationSection() -> Section? {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) else {
-            return nil
-        }
-
         return Section(rows: [.orderCreation,
                               .orderCreationDescription])
     }


### PR DESCRIPTION
Part of: #5719

## Description

This releases Order Creation as an experimental feature (behind an Experimental Feature toggle), with the ability to:

- Change the order status.
- Add existing products to the order.
- Add billing/shipping information to the order.
- View basic payment details (product total and order total).

## Changes

Removes the feature flag check on the "Order Creation" experimental feature toggle.

I haven't removed the `.orderCreation` feature flag, so we can reuse it for in-progress M2 features. FYI @Ecarrion @ealeksandrov 

## Testing

Order Creation should now be available in release builds, by toggling on Order Creation under Settings > Experimental Features. You can test the M1 (Products and Customers) features using the full test plan:

<!-- wp:heading -->
<h3 id="testing-by-screen"><strong><span class="uppercase">Testing by screen</span></strong></h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Here's what we <strong>must </strong>verify on each affected or new screen:</p>
<!-- /wp:paragraph -->

<!-- wp:list -->
<ul><li><strong>Order List:</strong> <ul><li>Tapping "+" brings up bottom-sheet with Create Order and Simple Payment. </li><li>Choosing "Create Order" creates new order, loads New Order screen. </li><li>New Order appears in Order List after being created.</li><li>New Order appears in Order List in wp-admin after being created.</li><li>All Order details are correctly reflected in wp-admin after Order is created.</li></ul></li><li><strong>New Order:</strong> <ul><li>Edit order status, add product, and add customer appear. </li><li>Create button appears. Button can be tapped once. When tapped, Order is created and appears in Order  List. </li><li>When <code>&lt;</code>button is tapped, Order is not created, and "discard changes" confirmation dialogue appears. Order does not appear in Order List. </li><li>Each + button brings up the associated screen. After adding/editing data (product, customer, status), it appears correctly. </li><li>Once products are added, <code>+</code> and <code>-</code> buttons change product quantity. Quantity cannot be less than 1.</li><li>Once products are added, payment details (automatically calculated) appear.</li></ul><ul><li>Products total and Order total are automatically calculated and displayed.</li></ul></li><li><strong>Order Status:</strong> <ul><li>Can change order status to any status (including custom statuses). </li><li>Close button doesn't save changes. </li><li>Done button saves changes. </li></ul></li><li><strong>Add Product:</strong> <ul><li>Can add existing, non-variable products. </li><li>If variable products (nice-to-have) are displayed, product variations can be added to Order.</li><li>Can search for existing products.</li><li>Close button closes list. </li><li>When a product is added, New Order screen appears with the product listed.</li><li>Can remove products by tapping "remove".</li></ul></li><li><strong>Add Customer:</strong> <ul><li>Add customer Details, Billing Address, and Different Shipping Address toggle appear.</li></ul><ul><li>Toggle opens a second set of fields. </li><li>Country opens country list.</li><li>Customer data can be added, and appears on New Order after entering.</li><li>Customer data can be edited after it's been added.</li></ul></li></ul>
<!-- /wp:list -->

<!-- wp:heading -->
<h3 id="testing-globally">Testing globally</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Here are things we need check <strong>everywhere</strong>, in addition to some stress testing.</p>
<!-- /wp:paragraph -->

<!-- wp:list -->
<ul><li><strong>Accessibility:</strong> VoiceOver/TalkBack, Font Size<ul><li><code>+</code> button on Order List</li><li>Everything on New Order and Add Customer screens</li><li>Large font sizes, especially on a filled-out New Order screen</li></ul></li><li><strong>Device:</strong> Screen sizes, dark/light, orientation, backgrounding <ul><li>For new screens (New Order and Add Customer, I believe)</li><li>UI should align with designs on both large and small screens</li><li>Dark and Light mode, switching between dark and light mode mid-flow</li><li>Try the flow in each screen orientation, as well as switching orientation mid-flow</li><li>Background the screen mid-flow in several places. Switch apps, go to the home screen, pull down settings, turn off the screen. See how the app reacts, whether data is retained, and whether our place in the flow is saved.</li></ul></li><li><strong>Languages:</strong> RTL, entering extended-latin characters<ul><li>Entering non-latin and extended-latin characters is especially important in the Add Customer screen.</li><li>Try the flow in a language you're familiar with. Check that untranslated strings are being addressed.</li><li>Try the flow in an RTL language.</li><li>In any of the languages you try, make sure entering non-latin and extended-latin characters works in all fields including search fields (and gets appropriate results).</li></ul></li><li><strong>Try to break it:</strong> Large orders, long addresses, long product names<ul><li>Try adding an unseemly number of individual products to an order. </li><li>Try adding an unseemly number of a particular product to an order.</li><li>In the Customer section, try out long names and addresses. Make sure the fields react appropriately, then head back to New Order to check that they are displayed correctly.</li><li>Check how especially long product names are displayed in New Order as well as the Product List in Add Product.</li></ul></li><li><strong>User roles:</strong> Shop Manager<ul><li>Shop Manager can use <code>+</code> to Create order, Add Products, Add Customer. </li><li>Confirm that other roles (Customer, non-Admin WP roles like Editor) cannot interact with Order Creation.</li></ul></li></ul>
<!-- /wp:list -->

## Screenshots

https://user-images.githubusercontent.com/8658164/152381094-646b3f83-de37-445e-b1d0-9d7289d65102.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
