### PR TITLE
Order Creation: Make entire ProductRow tappable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -44,6 +44,7 @@ struct ProductRow: View {
                     .renderedIf(viewModel.canChangeQuantity)
             }
         }
+        .contentShape(Rectangle())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -37,14 +37,13 @@ struct ProductRow: View {
                     }
                     .accessibilityElement(children: .combine)
                 }
-
-                Spacer()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
 
                 ProductStepper(viewModel: viewModel)
                     .renderedIf(viewModel.canChangeQuantity)
             }
         }
-        .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
Closes: #6061

## Description

During order creation, there was an issue in the products list where only the label area was tappable. This makes the entire product row tappable, including the empty space.

## Changes

Adds a `contentShape` modifier to `ProductRow`, to make the entire row tappable.

Note: I couldn't find a nice way to exclude the stepper from being tappable, so if you tap on the stepper (except for on the `+`/`-` buttons themselves) it will respond to the tap the same as the rest of the row. However, this is the same as current `trunk` behavior. The only difference with this change is that `Spacer()` areas also become tappable.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. On the New Order screen, tap the "Add product" button.
5. On the Add Product screen, tap anywhere on a product row and confirm the product is selected.
6. Back on the New Order screen, confirm you can still tap the +/- buttons in the stepper to change the product quantity in the order.

## Screenshots

Before|After
-|-
<img src="https://user-images.githubusercontent.com/198826/152398363-a36e4726-ee29-4152-80d3-a7088a962d39.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/152412038-6b076545-f3b3-4dd1-b3e7-11d8b5efd16f.png" width="300px">

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
