### PR TITLE
Simple Payments: Mark Sharing Payment Link as BETA

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -40,7 +40,7 @@ struct SimplePaymentsMethod: View {
             Divider()
 
             Group {
-                MethodRow(icon: .priceImage, title: Localization.cash) {
+                MethodRow(icon: .priceImage, title: Localization.cash, showBetaAnnotation: false) {
                     showingCashAlert = true
                     viewModel.trackCollectByCash()
                 }
@@ -48,7 +48,7 @@ struct SimplePaymentsMethod: View {
                 if viewModel.showPayWithCardRow {
                     Divider()
 
-                    MethodRow(icon: .creditCardImage, title: Localization.card) {
+                    MethodRow(icon: .creditCardImage, title: Localization.card, showBetaAnnotation: false) {
                         viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
                     }
                 }
@@ -56,7 +56,7 @@ struct SimplePaymentsMethod: View {
                 if viewModel.showPaymentLinkRow {
                     Divider()
 
-                    MethodRow(icon: .linkImage, title: Localization.link) {
+                    MethodRow(icon: .linkImage, title: Localization.link, showBetaAnnotation: true) {
                         sharingPaymentLink = true
                         viewModel.trackCollectByPaymentLink()
                     }
@@ -114,6 +114,10 @@ private struct MethodRow: View {
     ///
     let title: String
 
+    /// Defines if the beta tag should be shown.
+    ///
+    let showBetaAnnotation: Bool
+
     /// Action when the row is selected
     ///
     let action: () -> ()
@@ -137,9 +141,14 @@ private struct MethodRow: View {
                     .foregroundColor(Color(.systemGray))
                     .accessibility(hidden: true)
 
-                Text(title)
-                    .bodyStyle()
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                HStack {
+                    Text(title)
+                        .bodyStyle()
+
+                    BetaTag()
+                        .renderedIf(showBetaAnnotation)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 Image(uiImage: .chevronImage)
                     .resizable()
@@ -152,6 +161,30 @@ private struct MethodRow: View {
             .padding(.vertical, SimplePaymentsMethod.Layout.verticalPadding)
             .padding(.horizontal, insets: safeAreaInsets)
         }
+    }
+}
+
+/// Represents a Beta annotation tag
+///
+private struct BetaTag: View {
+    /// Constants
+    ///
+    enum Localization {
+        static let beta = NSLocalizedString("Beta", comment: "Beta annotation for sharing a payment link")
+    }
+
+    enum Layout {
+        static let padding: CGFloat = 5
+        static let cornerRadius: CGFloat = 7
+    }
+
+    var body: some View {
+        Text(Localization.beta)
+            .font(.caption)
+            .foregroundColor(Color(.textInverted))
+            .padding(Layout.padding)
+            .background(Color(.accent))
+            .cornerRadius(Layout.cornerRadius)
     }
 }
 


### PR DESCRIPTION
# Why 

We recently identified that the "share payment link" option of the Simple Payments feature is not working correctly for all stores. 

To not disable the feature, as it has been proven useful for many merchants, we have decided to tag the option as a `beta` while we properly make a fix it.

# Changes

- Add a new `BetaTag` view that will be used inside the `MethodRow` view, which is inside the `SimplePaymentsMethod` view.

- Mark the Payment Link Row, to display the beta tag.

# Screenshot

Dark | Light
---- | ----
<img width="491" alt="dark" src="https://user-images.githubusercontent.com/562080/152416831-aa8b8e80-eecb-422f-b143-ac2cfe336e0c.png"> | <img width="483" alt="light" src="https://user-images.githubusercontent.com/562080/152416835-936a70cf-e597-45ec-95fc-f7ab864a5c42.png">

# Testing Steps

- Start a simple payments flow
- Go all the way until the payment methods screen
- See the beta tag besides the "Share Payment Link" option.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
