### PR TITLE
[Mobile Payments] Configuration store for different countries/features

### DIFF
--- a/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
@@ -35,7 +35,7 @@ public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFa
                 throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
             }
             self = .cardPresent(details: cardPresentDetails)
-        case .unknown:
+        case .interacPresent, .unknown:
             self = .unknown
         }
     }

--- a/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
@@ -35,7 +35,10 @@ public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFa
                 throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
             }
             self = .cardPresent(details: cardPresentDetails)
-        case .interacPresent, .unknown:
+        case .interacPresent:
+            // Unsupported for now, coming up in https://github.com/woocommerce/woocommerce-ios/issues/5979
+            self = .unknown
+        case .unknown:
             self = .unknown
         }
     }

--- a/Networking/Networking/Model/WCPayPaymentMethodType.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodType.swift
@@ -10,5 +10,6 @@ import Codegen
 public enum WCPayPaymentMethodType: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case card
     case cardPresent = "card_present"
+    case interacPresent = "interac_present"
     case unknown
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
 		E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */; };
+		E1BD4D0027ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */; };
 		FE28F6EE268440B1004465C7 /* UserAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6ED268440B1004465C7 /* UserAction.swift */; };
 		FE28F6F026844231004465C7 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6EF26844231004465C7 /* UserStore.swift */; };
 		FE28F6F2268462A6004465C7 /* UserStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6F1268462A6004465C7 /* UserStoreTests.swift */; };
@@ -745,6 +746,7 @@
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingState.swift; sourceTree = "<group>"; };
+		E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsConfiguration.swift; sourceTree = "<group>"; };
 		FE28F6ED268440B1004465C7 /* UserAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAction.swift; sourceTree = "<group>"; };
 		FE28F6EF26844231004465C7 /* UserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStore.swift; sourceTree = "<group>"; };
 		FE28F6F1268462A6004465C7 /* UserStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStoreTests.swift; sourceTree = "<group>"; };
@@ -1562,6 +1564,7 @@
 				31A89EE5278CC38F002A588E /* StripeAccount+PaymentGatewayAccount.swift */,
 				3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */,
 				31799AF927050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift */,
+				E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */,
 			);
 			path = Payments;
 			sourceTree = "<group>";
@@ -1843,6 +1846,7 @@
 				261F94E6242EFF8700762B58 /* ProductCategoryStore.swift in Sources */,
 				57DFCC7925003C4000251E0C /* FetchResultSnapshotsProvider.swift in Sources */,
 				7492FAD9217FAD1000ED2C69 /* SiteSetting+ReadOnlyConvertible.swift in Sources */,
+				E1BD4D0027ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift in Sources */,
 				CE3B7AD52225EBF10050FE4B /* OrderStatusAction.swift in Sources */,
 				7493750C224987D9007D85D1 /* ProductAttribute+ReadOnlyConvertible.swift in Sources */,
 				744A3219216D55F80051439B /* SiteVisitStatsItem+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
 		E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */; };
 		E1BD4D0027ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */; };
+		E1F54D0427AD4DAF00012983 /* CardPresentConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F54D0327AD4DAF00012983 /* CardPresentConfigurationTests.swift */; };
 		FE28F6EE268440B1004465C7 /* UserAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6ED268440B1004465C7 /* UserAction.swift */; };
 		FE28F6F026844231004465C7 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6EF26844231004465C7 /* UserStore.swift */; };
 		FE28F6F2268462A6004465C7 /* UserStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6F1268462A6004465C7 /* UserStoreTests.swift */; };
@@ -747,6 +748,7 @@
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingState.swift; sourceTree = "<group>"; };
 		E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsConfiguration.swift; sourceTree = "<group>"; };
+		E1F54D0327AD4DAF00012983 /* CardPresentConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationTests.swift; sourceTree = "<group>"; };
 		FE28F6ED268440B1004465C7 /* UserAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAction.swift; sourceTree = "<group>"; };
 		FE28F6EF26844231004465C7 /* UserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStore.swift; sourceTree = "<group>"; };
 		FE28F6F1268462A6004465C7 /* UserStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStoreTests.swift; sourceTree = "<group>"; };
@@ -840,6 +842,7 @@
 			children = (
 				029B00A5230D64CD00B0AE66 /* Enums */,
 				0225512322FC310E00D98613 /* Extensions */,
+				E1F54D0327AD4DAF00012983 /* CardPresentConfigurationTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2036,6 +2039,7 @@
 				D87F27DB25E7E8EA006EC8C9 /* MockCardReader.swift in Sources */,
 				02A26F1E2744FE97008E4EDB /* MockAccountRemote.swift in Sources */,
 				02124DAC24318D6B00980D74 /* Media+MediaTypeTests.swift in Sources */,
+				E1F54D0427AD4DAF00012983 /* CardPresentConfigurationTests.swift in Sources */,
 				025CA2D0238F54E800B05C81 /* ProductShippingClassStoreTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				D8652E322630741000350F37 /* PaymentIntent+ReceiptParametersTests.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -141,6 +141,7 @@ public typealias StripeAccount = Networking.StripeAccount
 public typealias WCPayAccount = Networking.WCPayAccount
 public typealias WCPayAccountStatusEnum = Networking.WCPayAccountStatusEnum
 public typealias WCPayCustomer = Networking.Customer
+public typealias WCPayPaymentMethodType = Networking.WCPayPaymentMethodType
 
 // MARK: - Exported Storage Symbols
 

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-struct CardPresentPaymentsConfiguration {
-    let paymentMethods: [WCPayPaymentMethodType]
-    let currencies: [String]
-    let paymentGateways: [String]
+public struct CardPresentPaymentsConfiguration {
+    public let paymentMethods: [WCPayPaymentMethodType]
+    public let currencies: [String]
+    public let paymentGateways: [String]
 
     init(paymentMethods: [WCPayPaymentMethodType], currencies: [String], paymentGateways: [String]) {
         self.paymentMethods = paymentMethods
@@ -11,7 +11,7 @@ struct CardPresentPaymentsConfiguration {
         self.paymentGateways = paymentGateways
     }
 
-    init(country: String, stripeEnabled: Bool, canadaEnabled: Bool) throws {
+    public init(country: String, stripeEnabled: Bool, canadaEnabled: Bool) throws {
         switch country {
         case "US" where stripeEnabled == true:
             self.init(
@@ -37,4 +37,4 @@ struct CardPresentPaymentsConfiguration {
     }
 }
 
-struct CardPresentPaymentsConfigurationMissingError: Error {}
+public struct CardPresentPaymentsConfigurationMissingError: Error {}

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -11,27 +11,30 @@ struct CardPresentPaymentsConfiguration {
         self.paymentGateways = paymentGateways
     }
 
-    init(country: String) throws {
-        guard let configuration = Self.countryConfigurations[country] else {
+    init(country: String, stripeEnabled: Bool, canadaEnabled: Bool) throws {
+        switch country {
+        case "US" where stripeEnabled == true:
+            self.init(
+                paymentMethods: [.cardPresent],
+                currencies: ["USD"],
+                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID]
+            )
+        case "US" where stripeEnabled == false:
+            self.init(
+                paymentMethods: [.cardPresent],
+                currencies: ["USD"],
+                paymentGateways: [WCPayAccount.gatewayID]
+            )
+        case "CA" where canadaEnabled == true:
+            self.init(
+                paymentMethods: [.cardPresent, .interacPresent],
+                currencies: ["CAD"],
+                paymentGateways: [WCPayAccount.gatewayID]
+            )
+        default:
             throw CardPresentPaymentsConfigurationMissingError()
         }
-        self = configuration
     }
-}
-
-private extension CardPresentPaymentsConfiguration {
-    static let countryConfigurations: [String: CardPresentPaymentsConfiguration] = [
-        "US": .init(
-            paymentMethods: [.cardPresent],
-            currencies: ["USD"],
-            paymentGateways: [WCPayAccount.gatewayID]
-        ),
-        "CA": .init(
-            paymentMethods: [.cardPresent, .interacPresent],
-            currencies: ["CAD"],
-            paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID]
-        ),
-    ]
 }
 
 struct CardPresentPaymentsConfigurationMissingError: Error {}

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct CardPresentPaymentsConfiguration {
+    let paymentMethods: [WCPayPaymentMethodType]
+    let currencies: [String]
+    let paymentGateways: [String]
+
+    init(paymentMethods: [WCPayPaymentMethodType], currencies: [String], paymentGateways: [String]) {
+        self.paymentMethods = paymentMethods
+        self.currencies = currencies
+        self.paymentGateways = paymentGateways
+    }
+
+    init(country: String) throws {
+        guard let configuration = Self.countryConfigurations[country] else {
+            throw CardPresentPaymentsConfigurationMissingError()
+        }
+        self = configuration
+    }
+}
+
+private extension CardPresentPaymentsConfiguration {
+    static let countryConfigurations: [String: CardPresentPaymentsConfiguration] = [
+        "US": .init(
+            paymentMethods: [.cardPresent],
+            currencies: ["USD"],
+            paymentGateways: [WCPayAccount.gatewayID]
+        ),
+        "CA": .init(
+            paymentMethods: [.cardPresent, .interacPresent],
+            currencies: ["CAD"],
+            paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID]
+        ),
+    ]
+}
+
+struct CardPresentPaymentsConfigurationMissingError: Error {}

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -4,28 +4,28 @@ import XCTest
 
 class CardPresentConfigurationTests: XCTestCase {
     // MARK: - US Tests
-    func testConfigurationForUsWithStripeEnabledCanadaEnabled() throws {
+    func test_configuration_for_US_with_Stripe_enabled_Canada_enabled() throws {
         let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: true)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
     }
 
-    func testConfigurationForUsWithStripeEnabledCanadaDisabled() throws {
+    func test_configuration_for_US_with_Stripe_enabled_Canada_disabled() throws {
         let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: false)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
     }
 
-    func testConfigurationForUsWithStripeDisabledCanadaEnabled() throws {
+    func test_configuration_for_US_with_Stripe_disabled_Canada_enabled() throws {
         let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: true)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
     }
 
-    func testConfigurationForUsWithStripeDisabledCanadaDisabled() throws {
+    func test_configuration_for_US_with_Stripe_disabled_Canada_disabled() throws {
         let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: false)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
@@ -33,25 +33,25 @@ class CardPresentConfigurationTests: XCTestCase {
     }
 
     // MARK: - Canada Tests
-    func testConfigurationForCanadaWithStripeEnabledCanadaEnabled() throws {
+    func test_configuration_for_Canada_with_Stripe_enabled_Canada_enabled() throws {
         let configuration = try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: true)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
     }
 
-    func testConfigurationForCanadaWithStripeEnabledCanadaDisabled() {
+    func test_configuration_for_Canada_with_Stripe_enabled_Canada_disabled() {
         XCTAssertThrowsError(try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: false))
     }
 
-    func testConfigurationForCanadaWithStripeDisabledCanadaEnabled() throws {
+    func test_configuration_for_Canada_with_Stripe_disabled_Canada_enabled() throws {
         let configuration = try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: true)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
     }
 
-    func testConfigurationForCanadaWithStripeDisabledCanadaDisabled() throws {
+    func test_configuration_for_Canada_with_Stripe_disabled_Canada_disabled() throws {
         XCTAssertThrowsError(try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: false))
     }
 

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import XCTest
+@testable import Yosemite
+
+class CardPresentConfigurationTests: XCTestCase {
+    // MARK: - US Tests
+    func testConfigurationForUsWithStripeEnabledCanadaEnabled() throws {
+        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: true)
+        XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+    }
+
+    func testConfigurationForUsWithStripeEnabledCanadaDisabled() throws {
+        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: false)
+        XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+    }
+
+    func testConfigurationForUsWithStripeDisabledCanadaEnabled() throws {
+        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: true)
+        XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+    }
+
+    func testConfigurationForUsWithStripeDisabledCanadaDisabled() throws {
+        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: false)
+        XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+    }
+
+    // MARK: - Canada Tests
+    func testConfigurationForCanadaWithStripeEnabledCanadaEnabled() throws {
+        let configuration = try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: true)
+        XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
+    }
+
+    func testConfigurationForCanadaWithStripeEnabledCanadaDisabled() {
+        XCTAssertThrowsError(try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: false))
+    }
+
+    func testConfigurationForCanadaWithStripeDisabledCanadaEnabled() throws {
+        let configuration = try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: true)
+        XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
+    }
+
+    func testConfigurationForCanadaWithStripeDisabledCanadaDisabled() throws {
+        XCTAssertThrowsError(try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: false))
+    }
+
+    private enum Constants {
+        enum Currency {
+            static let usd = "USD"
+            static let cad = "CAD"
+        }
+
+        enum PaymentGateway {
+            static let wcpay = "woocommerce-payments"
+            static let stripe = "woocommerce-stripe"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5974 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a new `CardPresentPaymentsConfiguration` type to encapsulate all the country-specific configuration for payments. Right now that includes:
- Currencies supported
- Payment gateways (WCPay/Stripe)
- Payment methods (not yet used)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Unit tests should be enough, but I've also tested the steps in #6004 to double check

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
