### PR TITLE
Hot fix: name of two tracking events for the hub menu

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -554,8 +554,8 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Hub Menu
     //
-    case hubMenuTabSelected = "hub_menu_tab_selected"
-    case hubMenuTabReselected = "hub_menu_tab_reselected"
+    case hubMenuTabSelected = "main_tab_hub_menu_selected"
+    case hubMenuTabReselected = "main_tab_hub_menu_reselected"
     case hubMenuSwitchStoreTapped = "hub_menu_switch_store_tapped"
     case hubMenuOptionTapped = "hub_menu_option_tapped"
     case hubMenuSettingsTapped = "hub_menu_settings_tapped"


### PR DESCRIPTION
### Description
@JorgeMucientes encountered a discordant pattern problem in two events we implemented for the menu hub and planned to be released in the next release 8.4. So, it's important to merge this PR today.
Discussion here: p91TBi-7aB#comment-8331

### Testing instructions
I changed just the name of two events, so just look at the code.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
