### PR TITLE
Dismiss optimistic order update/complete notification right away if an error occur

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/NoticePresenter.swift
+++ b/WooCommerce/Classes/ServiceLocator/NoticePresenter.swift
@@ -8,6 +8,10 @@ protocol NoticePresenter {
     ///
     func enqueue(notice: Notice)
 
+    /// It dismisses the provided `Notice` if it is currenly presented in the foreground, or removes it from the queue
+    ///
+    func cancel(notice: Notice)
+
     /// UIViewController to be used as Notice(s) Presenter
     ///
     var presentingViewController: UIViewController? { get set }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsNotices.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsNotices.swift
@@ -2,6 +2,10 @@ import Foundation
 import Yosemite
 
 final class OrderDetailsNotices {
+
+    /// Contains the latest  order update notice
+    var orderUpdateNotice: Notice?
+
     /// Displays the `Unable to delete tracking` Notice.
     ///
     func displayDeleteErrorNotice(order: Order, tracking: ShipmentTracking, onAction: @escaping () -> Void) {
@@ -18,6 +22,10 @@ final class OrderDetailsNotices {
                             feedbackType: .error,
                             actionTitle: actionTitle) {
                                 onAction()
+        }
+
+        if let orderUpdateNotice = orderUpdateNotice {
+            ServiceLocator.noticePresenter.cancel(notice: orderUpdateNotice)
         }
 
         ServiceLocator.noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentNoticePresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentNoticePresenter.swift
@@ -16,6 +16,7 @@ final class OrderFulfillmentNoticePresenter {
     private let analytics: Analytics = ServiceLocator.analytics
 
     private var cancellables = Set<AnyCancellable>()
+    private var optimisticFulfillmentNotice: Notice?
 
     /// Start presenting notices for the given fulfillment process.
     ///
@@ -50,13 +51,16 @@ final class OrderFulfillmentNoticePresenter {
     private func displayOptimisticFulfillmentNotice(_ fulfillmentProcess: OrderFulfillmentUseCase.FulfillmentProcess) {
         let message = NSLocalizedString("🎉 Order Completed", comment: "Success notice when tapping Mark Order Complete on Review Order screen")
         let actionTitle = NSLocalizedString("Undo", comment: "Undo Action")
-        let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle) {
+        let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle) { [weak self] in
+            guard let self = self else { return }
             self.analytics.track(.orderMarkedCompleteUndoButtonTapped)
 
             self.observe(fulfillmentProcess: fulfillmentProcess.undo())
+            self.optimisticFulfillmentNotice = nil
         }
 
         noticePresenter.enqueue(notice: notice)
+        optimisticFulfillmentNotice = notice
     }
 
     private func displayFulfillmentErrorNotice(error: OrderFulfillmentUseCase.FulfillmentError) {
@@ -65,6 +69,10 @@ final class OrderFulfillmentNoticePresenter {
             self.observe(fulfillmentProcess: error.retry())
         }
 
+        // Cancel the optimistic fulfillment notice (if any) in order to display immediately the most relevant error message
+        if let optimisticFulfillmentNotice = optimisticFulfillmentNotice {
+            noticePresenter.cancel(notice: optimisticFulfillmentNotice)
+        }
         noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockNoticePresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockNoticePresenter.swift
@@ -14,4 +14,8 @@ final class MockNoticePresenter: NoticePresenter {
     func enqueue(notice: Notice) {
         queuedNotices.append(notice)
     }
+
+    func cancel(notice: Notice) {
+        queuedNotices.removeAll(where: {$0 == notice})
+    }
 }


### PR DESCRIPTION
Closes: #3817

### Description
When `DefaultNoticePresenter` displays a `Notice` there is a dismissDelay of 5 seconds, so any other `Notice` that is enqueued afterwards it will have to wait at most 5 seconds to be displayed.
When we mark an order as complete(or update its status) in `OrderDetailsViewController`  we optimistically display a success message but if the API update fails immediately the user will have to wait about 5 seconds to get notified.

This PR fixes the problem, by add the capability to the `DefaultNoticePresenter` to cancel a `Notice` that is presented or in the queue to be presented.

### Testing instructions

Marking Order complete flow:

1. Navigate to a processing order.
2. Go offline.
3. Tap on Mark Order Complete. 
4. You should see the optimistic message, “Order completed” that is immediately dismissed
4. Then a fulfillment failure message should be displayed 

Updating the Order's status flow:

1. Navigate to an order.
2. Go offline.
3. Tap on change the Order's status. 
4. You should see the optimistic message, “Order status update” that is immediately dismissed
4. Then a failure message should be displayed 

### Screenshots

Order Complete message is immediately dismissed when the error occurs

https://user-images.githubusercontent.com/96764631/152586349-ddecd67c-541f-4d8b-a4bc-81cc865cc821.mp4

Similarly the order update message is immediately dismissed when the error occurs

https://user-images.githubusercontent.com/96764631/152586449-1e6211f1-65f7-4b29-8144-5346f64be2d1.mp4




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
