### PR TITLE
Enabled "view product in store" option for variable products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [***] The My store tab is having a new look with new conversion stats and shows up to 5 top performing products now (used to be 3). [https://github.com/woocommerce/woocommerce-ios/pull/5991]
 - [**] Fixed a crash at the startup of the app, related to Gridicons. [https://github.com/woocommerce/woocommerce-ios/pull/6005]
 - [***] Experimental Feature: It's now possible to create Orders in the app by enabling it in Settings > Experimental Features. For now you can change the order status, add products, and add customer details (billing and shipping addresses). [https://github.com/woocommerce/woocommerce-ios/pull/6060]
+- [*] Enabled "view product in store" and "share product" options for variable products when accessing them through the order details screen. [https://github.com/woocommerce/woocommerce-ios/pull/6091]
 
 8.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -153,7 +153,7 @@ extension ProductVariationFormViewModel {
     }
 
     func canShareProduct() -> Bool {
-        false
+        formType != .add
     }
 
     func canDeleteProduct() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -149,7 +149,7 @@ extension ProductVariationFormViewModel {
     }
 
     func canViewProductInStore() -> Bool {
-        false
+        originalProductVariation.productVariation.status == .publish && formType != .add
     }
 
     func canShareProduct() -> Bool {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
 		03FBDAFD263EE4E800ACE257 /* CouponListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */; };
+		094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */; };
 		098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
@@ -2024,6 +2025,7 @@
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
 		03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModelTests.swift; sourceTree = "<group>"; };
+		094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModelTests.swift; sourceTree = "<group>"; };
 		098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSourceTests.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
@@ -3334,6 +3336,7 @@
 				023EC2E524DAB1270021DA91 /* EditableProductVariationModelTests.swift */,
 				0236BCA325087B660043EB43 /* ProductFormRemoteActionUseCaseTests.swift */,
 				0271E1632509C66200633F7A /* DefaultProductFormTableViewModelTests.swift */,
+				094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */,
 				0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */,
 				0215C6FB2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift */,
 				2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */,
@@ -9291,6 +9294,7 @@
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
 				578195FC25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift in Sources */,
+				094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */,
 				CECC759923D6160000486676 /* AggregateDataHelperTests.swift in Sources */,
 				454453C82755171E00464AC5 /* HubMenuCoordinatorTests.swift in Sources */,
 				5767E940256D9A4A00CFA652 /* OrderListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -54,6 +54,57 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(canViewProductInStore)
     }
+
+    // MARK: `canShareProduct`
+
+    func test_edit_product_variation_form_with_published_status_can_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.publish)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertTrue(canShareProduct)
+    }
+
+    func test_add_product_variation_form_with_published_status_cannot_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.publish)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertFalse(canShareProduct)
+    }
+
+    func test_edit_product_variation_form_with_non_published_status_can_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.pending)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertTrue(canShareProduct)
+    }
+
+    func test_add_product_form_with_non_published_status_cannot_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.pending)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertFalse(canShareProduct)
+    }
+
 }
 
 private extension ProductVariationFormViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+import TestKit
+
+final class ProductVariationFormViewModelTests: XCTestCase {
+    // MARK: `canViewProductInStore`
+
+    func test_edit_product_variation_form_with_published_status_can_view_product_in_store() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.publish)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let canViewProductInStore = viewModel.canViewProductInStore()
+
+        // Then
+        XCTAssertTrue(canViewProductInStore)
+    }
+
+    func test_add_product_variation_form_with_published_status_cannot_view_product_in_store() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.publish)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let canViewProductInStore = viewModel.canViewProductInStore()
+
+        // Then
+        XCTAssertFalse(canViewProductInStore)
+    }
+
+    func test_edit_product_variation_form_with_non_published_status_cannot_view_product_in_store() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.pending)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let canViewProductInStore = viewModel.canViewProductInStore()
+
+        // Then
+        XCTAssertFalse(canViewProductInStore)
+    }
+
+    func test_add_product_variation_form_with_non_published_status_cannot_view_product_in_store() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.pending)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let canViewProductInStore = viewModel.canViewProductInStore()
+
+        // Then
+        XCTAssertFalse(canViewProductInStore)
+    }
+}
+
+private extension ProductVariationFormViewModelTests {
+    func createViewModel(product: ProductVariation, formType: ProductFormType, stores: StoresManager = ServiceLocator.stores) -> ProductVariationFormViewModel {
+        let model = EditableProductVariationModel(productVariation: product)
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
+        return ProductVariationFormViewModel(productVariation: model,
+                                             formType: formType,
+                                             productImageActionHandler: productImageActionHandler,
+                                             storesManager: stores)
+    }
+}


### PR DESCRIPTION
Closes: #4609

### Description
When we display the product form of a variable product the 3 dots in the top right are missing, so the User that not view the product in store. This is because it is hardcoded that most of the actions are not allowed (return false) in [ProductVariationFormViewModel](https://github.com/woocommerce/woocommerce-ios/blob/1b3ed8344509823f0f78f2c06b94872142b0c0d6/WooCommerce/Classes/ViewRelated/Products/Edit%20Product/ProductVariationFormViewModel.swift#L136):

    func canViewProductInStore() -> Bool {
        false
    }

### Testing instructions
1. Go to Orders
2. Select an order that has a variable product
3. Tap on that variable product
4. On the top right of the navigation bar it should display a "3 dots" button
5. Tap that "3 dots" button
6. An button to view the product in the store should be displayed
7. Taping the button we should be redirected to the web to view the item

### Screenshots
 
Now a variable product supports the "view the product in the store" button:

https://user-images.githubusercontent.com/96764631/152700343-50fccbfd-38c8-4113-942a-3c0798dc16c8.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
