### PR TITLE
Order Creation: Disables view while creating an order.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -70,6 +70,7 @@ struct NewOrder: View {
         }
         .wooNavigationBarStyle()
         .notice($viewModel.notice)
+        .disabled(viewModel.disabled)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -127,6 +127,13 @@ final class NewOrderViewModel: ObservableObject {
         orderDetails.items.isNotEmpty
     }
 
+    /// Defines if the view should be disabled.
+    /// Currently `true` while performing a network request.
+    ///
+    var disabled: Bool {
+        performingNetworkRequest
+    }
+
     /// Representation of payment data display properties
     ///
     @Published private(set) var paymentDataViewModel = PaymentDataViewModel()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -54,6 +54,28 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(navigationItem, .loading)
     }
 
+    func test_view_is_disabled_during_network_request() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let isViewDisabled: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder:
+                    promise(viewModel.disabled)
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+            viewModel.createOrder()
+        }
+
+        // Then
+        XCTAssertTrue(isViewDisabled)
+    }
+
     func test_create_button_is_enabled_after_the_network_operation_completes() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
# Why 

While I was testing the feature I realized that the merchants can modify the UI while the order creation request is being made.

This PR disables the view to properly reflect the fact that any change, while the order is being updated, is not committed.

PS: This will have to be updated once we add the tax-calculation logic.

# Demo

https://user-images.githubusercontent.com/562080/152721334-41b027e0-9ffd-4c60-b373-189863039a18.mov

# Testing Steps

- Create an order
- While the order is being created see that no button is actionable

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
