### PR TITLE
Fix: now the the icons “search” and “plus” have the same order between Products and Orders screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -161,8 +161,8 @@ private extension OrdersRootViewController {
     ///
     func configureNavigationButtons(isOrderCreationExperimentalToggleEnabled: Bool) {
         let buttons: [UIBarButtonItem] = [
-            createSearchBarButtonItem(),
-            createAddOrderItem(isOrderCreationEnabled: isOrderCreationExperimentalToggleEnabled)
+            createAddOrderItem(isOrderCreationEnabled: isOrderCreationExperimentalToggleEnabled),
+            createSearchBarButtonItem()
         ]
         navigationItem.rightBarButtonItems = buttons
     }


### PR DESCRIPTION
Closes: #6081 

### Description
@hichamboushaba noted during the last beta testing that the icons “search” and “plus” have different ordering between the Products and Orders screens. I aligned the Orders screen to Products (so, search button on the left, plus button on the right).

### Testing instructions
Just notice that the buttons in the navigation bar between Orders and Products list now follow the same order.

### Screenshots
| Products             |  Orders |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-02-07 at 11 58 30](https://user-images.githubusercontent.com/495617/152776079-214ab105-083f-40f4-b689-9084e3093c72.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-02-07 at 11 58 26](https://user-images.githubusercontent.com/495617/152776095-b3268b99-596d-4db2-b906-089f408698b3.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
