### PR TITLE
Order Creation: Rename "Customer" to "Customer Details"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -43,7 +43,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     var viewTitle: String {
-        Localization.newCustomerTitle
+        Localization.customerDetailsTitle
     }
 
     var sectionTitle: String {
@@ -94,7 +94,7 @@ private extension CreateOrderAddressFormViewModel {
 
     // MARK: Constants
     enum Localization {
-        static let newCustomerTitle = NSLocalizedString("New Customer", comment: "Title for the Shipping Address Form for New Customer")
+        static let customerDetailsTitle = NSLocalizedString("Customer Details", comment: "Title for the Shipping Address Form for Customer Details")
 
         static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address Form")
         static let billingTitle = NSLocalizedString("Billing Address", comment: "Title for the Edit Billing Address Form")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -68,7 +68,7 @@ private struct OrderCustomerSectionContent: View {
     }
 
     private var createCustomerView: some View {
-        Button(Localization.addCustomer) {
+        Button(Localization.addCustomerDetails) {
             showAddressForm.toggle()
         }
         .buttonStyle(PlusButtonStyle())
@@ -112,7 +112,8 @@ private extension OrderCustomerSectionContent {
 
     enum Localization {
         static let customer = NSLocalizedString("Customer", comment: "Title text of the section that shows Customer details when creating a new order")
-        static let addCustomer = NSLocalizedString("Add customer", comment: "Title text of the button that adds a customer when creating a new order")
+        static let addCustomerDetails = NSLocalizedString("Add Customer Details",
+                                                          comment: "Title text of the button that adds customer data when creating a new order")
         static let editButton = NSLocalizedString("Edit", comment: "Button to edit a customer on the New Order screen")
 
         static let billingTitle = NSLocalizedString("Billing Address", comment: "Title for the Billing Address section in order customer data")


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6086.

## Description

This PR renames "new customer" to "customer details" in 2 places since we're not creating actual customers in WC.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Observe "+ Add Customer Details" button (1st fix).
5. Tap it to display the address form.
6. Confirm that the address form shows "Customer Details" title (2nd fix).

## Screenshots

customer section | address form
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/152801712-d3381e69-410a-4c55-a2cb-84c7a69c3194.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/152801722-e2790928-30a2-4f49-9039-61acc915e9d3.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
