### PR TITLE
Remove unnecessary `project.env` `cp` to project folder from Buildkite automation

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -12,7 +12,6 @@ echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
 echo "--- :writing_hand: Copy Files"
-cp -v fastlane/env/project.env.example .configure-files/project.env
 mkdir -pv ~/.configure/woocommerce-ios/secrets
 cp -v fastlane/env/project.env.example ~/.configure/woocommerce-ios/secrets/project.env
 


### PR DESCRIPTION
This is a followup to the suggestion I left at https://github.com/woocommerce/woocommerce-ios/pull/6044#discussion_r800697581. 

If the Buildkite CI is green, my suggestion can be considered correct.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
