### PR TITLE
Fix: centralised icons in Hub Menu buttons

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -31,9 +31,12 @@ struct HubMenuElement: View {
                     }
                     .frame(width: imageSize, height: imageSize, alignment: .center)
                     .cornerRadius(imageSize/2)
-                    .padding(.bottom, Constants.paddingBetweenElements)
+                    .padding(.top, Constants.iconTopPadding)
+
                     Text(text)
                         .bodyStyle()
+                        .padding(.top, Constants.paddingBetweenElements)
+                    Spacer()
                 }
                 .frame(width: Constants.itemSize, height: Constants.itemSize)
                 HubMenuBadge(value: badge)
@@ -62,6 +65,7 @@ struct HubMenuElement: View {
     }
 
     enum Constants {
+        static let iconTopPadding: CGFloat = 32
         static let paddingBetweenElements: CGFloat = 8
         static let itemSize: CGFloat = 160
         static let badgeSize: CGFloat = 24
@@ -72,7 +76,7 @@ struct HubMenuElement: View {
 struct HubMenuElement_Previews: PreviewProvider {
     static var previews: some View {
         HubMenuElement(image: .starOutlineImage(),
-                       imageColor: .blue,
+                       imageColor: .brand,
                        text: "Menu",
                        badge: 1,
                        onTapGesture: {})

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -9,9 +9,6 @@ struct HubMenuElement: View {
     let badge: Int
     let onTapGesture: (() -> Void)
 
-    @ScaledMetric var imageSize: CGFloat = 58
-    @ScaledMetric var iconSize: CGFloat = 34
-
     var body: some View {
         Button {
             onTapGesture()
@@ -27,15 +24,16 @@ struct HubMenuElement: View {
                             .resizable()
                             .scaledToFit()
                             .foregroundColor(Color(imageColor))
-                            .frame(width: iconSize, height: iconSize)
+                            .frame(width: Constants.iconSize, height: Constants.iconSize)
                     }
-                    .frame(width: imageSize, height: imageSize, alignment: .center)
-                    .cornerRadius(imageSize/2)
+                    .frame(width: Constants.imageSize, height: Constants.imageSize, alignment: .center)
+                    .cornerRadius(Constants.imageSize/2)
                     .padding(.top, Constants.iconTopPadding)
 
                     Text(text)
                         .bodyStyle()
                         .padding(.top, Constants.paddingBetweenElements)
+                        .padding(.bottom, Constants.minimumBottomPadding)
                     Spacer()
                 }
                 .frame(width: Constants.itemSize, height: Constants.itemSize)
@@ -67,9 +65,12 @@ struct HubMenuElement: View {
     enum Constants {
         static let iconTopPadding: CGFloat = 32
         static let paddingBetweenElements: CGFloat = 8
+        static let minimumBottomPadding: CGFloat = 2
         static let itemSize: CGFloat = 160
         static let badgeSize: CGFloat = 24
         static let cornerRadius: CGFloat = badgeSize/2
+        static let imageSize: CGFloat = 58
+        static let iconSize: CGFloat = 34
     }
 }
 


### PR DESCRIPTION
Fixes #6080 


### Description
@hichamboushaba during his beta test, discovered that the icons in the hub menu are not centralised when the text of a button is on two lines. As said by @adamzelinski, the icons should all align.


### Testing instructions
1) Open the hub menu.
2) All the icons inside the hub menu buttons should be vertical aligned.

### Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Before](https://user-images.githubusercontent.com/495617/152823060-1e19db2b-90a7-4017-985e-d75066316b9a.png) | ![After](https://user-images.githubusercontent.com/495617/152823075-bce30c23-602e-4515-9e87-0a8b891aaa9e.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
