### PR TITLE
Order Creation & Editing: Validate email locally

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -76,7 +76,8 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
 
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
         guard validateEmail() else {
-            return notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
+            notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
+            return onFinish(false)
         }
 
         if showDifferentAddressForm {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -75,6 +75,10 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     }
 
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
+        guard validateEmail() else {
+            return notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
+        }
+
         if showDifferentAddressForm {
             onAddressUpdate?(.init(billingAddress: fields.toAddress(),
                                    shippingAddress: secondaryFields.toAddress()))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -382,7 +382,9 @@ open class AddressFormViewModel: ObservableObject {
     /// Returns `true` if the fields contains a valid email or if there is no email to validate. `False` otherwise.
     ///
     func validateEmail() -> Bool {
-        EmailFormatValidator.validate(string: fields.email)
+        let primaryEmailIsValid = fields.email.isEmpty || EmailFormatValidator.validate(string: fields.email)
+        let secondaryEmailIsValid = secondaryFields.email.isEmpty || EmailFormatValidator.validate(string: fields.email)
+        return primaryEmailIsValid && secondaryEmailIsValid
     }
 }
 
@@ -415,6 +417,10 @@ extension AddressFormViewModel {
         }
     }
 
+    enum Localization {
+        static let invalidEmail = NSLocalizedString("Please enter a valid email address.", comment: "Notice text when the merchant enters an invalid email")
+    }
+
     /// Creates address form general notices.
     ///
     enum NoticeFactory {
@@ -422,6 +428,12 @@ extension AddressFormViewModel {
         ///
         static func createErrorNotice(from error: EditAddressError) -> Notice {
             Notice(title: error.errorDescription ?? "", message: error.recoverySuggestion, feedbackType: .error)
+        }
+
+        /// Creates an error notice indicating that the email address is invalid.
+        ///
+        static func createInvalidEmailNotice() -> Notice {
+            .init(title: Localization.invalidEmail, feedbackType: .error)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -1,5 +1,6 @@
 import Combine
 import Yosemite
+import class WordPressShared.EmailFormatValidator
 import protocol Storage.StorageManagerType
 
 /// Protocol to describe viewmodel of editable address
@@ -376,6 +377,12 @@ open class AddressFormViewModel: ObservableObject {
     ///
     func trackOnLoad() {
         // override in subclass
+    }
+
+    /// Returns `true` if the fields contains a valid email or if there is no email to validate. `False` otherwise.
+    ///
+    func validateEmail() -> Bool {
+        EmailFormatValidator.validate(string: fields.email)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -110,7 +110,8 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
     ///
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
         guard validateEmail() else {
-            return notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
+            notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
+            return onFinish(false)
         }
 
         let updatedAddress = fields.toAddress()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -109,6 +109,10 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
     /// Update the address remotely and invoke a completion block when finished
     ///
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
+        guard validateEmail() else {
+            return notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
+        }
+
         let updatedAddress = fields.toAddress()
         let orderFields: [OrderUpdateField]
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
@@ -380,6 +380,24 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.showEmailField)
     }
+
+    func test_view_model_fires_error_notice_when_providing_an_invalid_email() {
+        // Given
+        let address1 = sampleAddress().copy(email: "invalid")
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: address1, shippingAddress: nil),
+                                                        onAddressUpdate: { _ in })
+
+        // When
+        let notice: Notice? = waitFor { promise in
+            viewModel.saveAddress { _ in
+                promise(viewModel.notice)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(notice, AddressFormViewModel.NoticeFactory.createInvalidEmailNotice())
+    }
 }
 
 private extension CreateOrderAddressFormViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -687,6 +687,22 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         assertEqual(analyticsProvider.receivedEvents, [WooAnalyticsStat.orderDetailEditFlowStarted.rawValue])
         assertEqual(analyticsProvider.receivedProperties.first?["subject"] as? String, "billing_address")
     }
+
+    func test_view_model_fires_error_notice_when_providing_an_invalid_email() {
+        // Given
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .billing)
+        viewModel.fields.email = "invalid"
+
+        // When
+        let notice: Notice? = waitFor { promise in
+            viewModel.saveAddress { _ in
+                promise(viewModel.notice)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(notice, AddressFormViewModel.NoticeFactory.createInvalidEmailNotice())
+    }
 }
 
 private extension EditOrderAddressFormViewModelTests {


### PR DESCRIPTION
fix #6100 

# Why

As we will use the ORDER API to calculate taxes while the user modifies an order, we need to make sure we have as few failure points as possible to make that experience usable.

One of those failure points is that the API needs a valid email when updating the customer details.

This PR provides a local email validation to prevent API failures due to invalid emails.

# Demo

https://user-images.githubusercontent.com/562080/152879485-cc094cbc-3f7f-4e70-b0cd-ab1eef284ee0.mov

https://user-images.githubusercontent.com/562080/152879498-f5cbafe9-e3d5-4af6-b421-f235873f4cfa.mov


# Testing Steps

- Go to the create order feature
- Add an invalid email in customer details and tap done
- See that an error notice is being presented
- Enter a valid or empty email
- See that you can proceed with the flow.


- Go to the edit order feature
- Add an invalid email in the billing address section
- See that an error notice is being presented
- Enter a valid or empty email
- See that you can proceed with the flow.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
