### PR TITLE
Remove unused imports of `Observables` framework

### DIFF
--- a/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
+++ b/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
@@ -1,7 +1,6 @@
 import Combine
 import KeychainAccess
 import WordPressAuthenticator
-import Observables
 import Yosemite
 
 /// Checks and listens for observations when the Apple ID credential is revoked when the user previously signed in with Apple.

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -2,9 +2,6 @@ import Combine
 import Foundation
 import Yosemite
 import KeychainAccess
-import Observables
-
-
 
 // MARK: - SessionManager Notifications
 //

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -1,7 +1,6 @@
 import Combine
 import Foundation
 import Yosemite
-import Observables
 import enum Networking.DotcomError
 import class Networking.UserAgent
 

--- a/Yosemite/Yosemite/Base/StoresManager.swift
+++ b/Yosemite/Yosemite/Base/StoresManager.swift
@@ -1,6 +1,5 @@
 import Combine
 import Foundation
-import Observables
 
 /// Abstracts the Stores coordination
 ///

--- a/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
@@ -1,6 +1,5 @@
 import Combine
 import Foundation
-import Observables
 
 public struct MockSessionManager: SessionManagerProtocol {
 
@@ -8,7 +7,6 @@ public struct MockSessionManager: SessionManagerProtocol {
 
     init(objectGraph: MockObjectGraph) {
         self.objectGraph = objectGraph
-        self.storeIDSubject = BehaviorSubject<Int64?>(objectGraph.defaultSite.siteID)
         defaultAccount = objectGraph.defaultAccount
         defaultSite = objectGraph.defaultSite
         defaultStoreID = objectGraph.defaultSite.siteID
@@ -35,14 +33,6 @@ public struct MockSessionManager: SessionManagerProtocol {
     public var defaultCredentials: Credentials?
 
     public var anonymousUserID: String? = nil
-
-    /// Observable site ID
-    ///
-    public var siteID: Observable<Int64?> {
-        storeIDSubject
-    }
-
-    private let storeIDSubject: BehaviorSubject<Int64?>
 
     public func reset() {
         // Do nothing

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -1,5 +1,4 @@
 import Combine
-import Observables
 import Storage
 
 public class MockStoresManager: StoresManager {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #4379
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When I was going to migrate the last few classes that used to use our temporary Observables framework, I realized that the usage was already replaced so this PR just removed the imports 😄 I will remove the Observables framework in a separate PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to launch the app and see that everything works like before!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
