### PR TITLE
Use `sentry_check_cli_installed` to verify Sentry's CLI requirements

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -937,5 +937,8 @@ end
   # Raises an error if Sentry is not installed
   # -----------------------------------------------------------------------------------
   def ensure_sentry_installed
-      UI.user_error!('sentry-cli not installed') unless sh('command -v sentry-cli')
+    # This is an action provided by the Sentry Fastlane plugin that verifies the
+    # CLI is installed and its version is compatible with the plugin's
+    # expectation.
+    sentry_check_cli_installed
   end


### PR DESCRIPTION
This is an action [provided by the Sentry Fastlane plugin](https://github.com/getsentry/sentry-fastlane-plugin/tree/3dff83c640a4ebb92beb74e6122cccd5e5e77429#checking-the-sentry-cli-is-installed) that verifies the CLI is installed and its version is compatible with the plugin's expectation.

## Extra context

I recently had to deploy some builds locally. The first time I tried, the process failed because my `sentry-cli` version was too old. We already had a custom check to ensure that the CLI is installed at the start of the lane, but that didn't cover the version. It was an annoying failure because it occurred after my machine was busy building and uploading... This should make us fail ASAP if the version is not the expected one, avoiding work that's doomed to be thrown away.

I went in search for this after bumping into a Sentry-related change here: https://github.com/woocommerce/woocommerce-ios/pull/6044#discussion_r800702937.

## Testing

This is the action output in the happy path:

![image](https://user-images.githubusercontent.com/1218433/152956848-975534bd-daad-4fba-b857-3aed2224630b.png)

If the CLI is missing, the lane will fail with the following output:

![image](https://user-images.githubusercontent.com/1218433/152957168-fbe484e6-5fa3-4d5b-bc62-2777149869ab.png)

I started looking into how to install an older version of the CLI to verify that path, too, but it proved to be a fiddly process. I gave up in the interest of not getting sidetracked, trusting that the plugin does what it's supposed to.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
