### PR TITLE
Coupons: Add Performance section to coupon details

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -30,6 +30,7 @@ public protocol CouponsRemoteProtocol {
 
     func loadCouponReport(for siteID: Int64,
                           couponID: Int64,
+                          from startDate: Date,
                           completion: @escaping (Result<CouponReport, Error>) -> Void)
 }
 
@@ -183,15 +184,15 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     /// - Parameters:
     ///     - siteID: The site from which we'll fetch the analytics report.
     ///     - couponID: The coupon for which we'll fetch the analytics report.
+    ///     - startDate: The start of the date range for which we'll fetch the analytics report.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadCouponReport(for siteID: Int64,
                                  couponID: Int64,
+                                 from startDate: Date,
                                  completion: @escaping (Result<CouponReport, Error>) -> Void) {
-        // Get an "ancient" date to fetch all possible reports
-        let startTime = Date(timeIntervalSince1970: 1)
         let dateFormatter = ISO8601DateFormatter()
-        let formattedTime = dateFormatter.string(from: startTime)
+        let formattedTime = dateFormatter.string(from: startDate)
 
         let parameters: [String: Any] = [
             ParameterKey.coupons: [couponID],

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -188,8 +188,14 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     public func loadCouponReport(for siteID: Int64,
                                  couponID: Int64,
                                  completion: @escaping (Result<CouponReport, Error>) -> Void) {
-        let parameters = [
-            ParameterKey.coupons: [couponID]
+        // Get an "ancient" date to fetch all possible reports
+        let startTime = Date(timeIntervalSince1970: 1)
+        let dateFormatter = ISO8601DateFormatter()
+        let formattedTime = dateFormatter.string(from: startTime)
+
+        let parameters: [String: Any] = [
+            ParameterKey.coupons: [couponID],
+            ParameterKey.after: formattedTime
         ]
 
         let request = JetpackRequest(wooApiVersion: .wcAnalytics,
@@ -238,5 +244,6 @@ public extension CouponsRemote {
         static let force = "force"
         static let coupons = "coupons"
         static let keyword = "search"
+        static let after = "after"
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -273,7 +273,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571) { (result) in
+            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { (result) in
                 promise(result)
             }
         }
@@ -296,7 +296,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571) { (result) in
+            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { (result) in
                 promise(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -63,6 +63,9 @@ private extension CouponDetails {
         static let discount = NSLocalizedString("Discount", comment: "Title of the Discount row in Coupon Details screen")
         static let applyTo = NSLocalizedString("Apply To", comment: "Title of the Apply To row in Coupon Details screen")
         static let expiryDate = NSLocalizedString("Coupon Expiry Date", comment: "Title of the Coupon Expiry Date row in Coupon Details screen")
+        static let performance = NSLocalizedString("Performance", comment: "Title of the Performance section on Coupons Details screen")
+        static let discountedOrders = NSLocalizedString("Discounted Orders", comment: "Title of the Discounted Orders label on Coupon Details screen")
+        static let amount = NSLocalizedString("Amount", comment: "Title of the Amount label on Coupon Details screen")
     }
 
     struct DetailRow: Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -7,6 +7,7 @@ struct CouponDetails: View {
     init(viewModel: CouponDetailsViewModel) {
         self.viewModel = viewModel
         viewModel.syncCoupon()
+        viewModel.loadCouponReport()
     }
 
     private var detailRows: [DetailRow] {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -22,6 +22,35 @@ struct CouponDetails: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
+                    Text(Localization.performance)
+                        .bold()
+                        .padding(Constants.margin)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                    HStack(spacing: 0) {
+                        VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                            Text(Localization.discountedOrders)
+                                .secondaryBodyStyle()
+                            Text(viewModel.discountedOrdersCount)
+                                .font(.title)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                            Text(Localization.amount)
+                                .secondaryBodyStyle()
+                            Text(viewModel.discountedAmount)
+                                .font(.title)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding([.horizontal, .bottom], Constants.margin)
+                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                }
+                .background(Color(.listForeground))
+
+                Spacer().frame(height: Constants.margin)
+
+                VStack(alignment: .leading, spacing: 0) {
                     Text(Localization.detailSectionTitle)
                         .bold()
                         .padding(Constants.margin)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -41,6 +41,7 @@ struct CouponDetails: View {
                             Text(viewModel.discountedAmount)
                                 .font(.title)
                         }
+                        .padding(.leading, Constants.margin)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .padding([.horizontal, .bottom], Constants.margin)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -25,6 +25,14 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var expiryDate: String = ""
 
+    /// Total number of orders that applied the coupon
+    ///
+    @Published private(set) var discountedOrdersCount: Int = 0
+
+    /// Total amount deducted from orders that applied the coupon
+    ///
+    @Published private(set) var discountedAmount: String = ""
+
     /// The current coupon
     ///
     @Published private var coupon: Coupon

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -27,7 +27,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     /// Total number of orders that applied the coupon
     ///
-    @Published private(set) var discountedOrdersCount: String = ""
+    @Published private(set) var discountedOrdersCount: String = "0"
 
     /// Total amount deducted from orders that applied the coupon
     ///
@@ -47,6 +47,7 @@ final class CouponDetailsViewModel: ObservableObject {
         self.coupon = coupon
         self.stores = stores
         self.currencySettings = currencySettings
+        self.discountedAmount = formatStringAmount("0")
         observeCoupon()
         syncCoupon()
         loadCouponReport()
@@ -76,8 +77,7 @@ private extension CouponDetailsViewModel {
                 amount = percentFormatter.string(from: amountNumber) ?? ""
             }
         case .fixedCart, .fixedProduct:
-            let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-            amount = currencyFormatter.formatAmount(coupon.amount) ?? ""
+            amount = formatStringAmount(coupon.amount)
         case .other:
             amount = coupon.amount
         }
@@ -109,13 +109,17 @@ private extension CouponDetailsViewModel {
             switch result {
             case .success(let report):
                 self.discountedOrdersCount = "\(report.ordersCount)"
-                let currencyFormatter = CurrencyFormatter(currencySettings: self.currencySettings)
-                self.discountedAmount = currencyFormatter.formatAmount("\(report.amount)") ?? ""
+                self.discountedAmount = self.formatStringAmount("\(report.amount)")
             case .failure(let error):
                 DDLogError("⛔️ Error loading coupon report: \(error)")
             }
         }
         stores.dispatch(action)
+    }
+
+    func formatStringAmount(_ amount: String) -> String {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        return currencyFormatter.formatAmount(amount) ?? ""
     }
 
     func localizeApplyRules(productsCount: Int, excludedProductsCount: Int, categoriesCount: Int, excludedCategoriesCount: Int) -> String {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -67,7 +67,9 @@ final class CouponDetailsViewModel: ObservableObject {
     }
 
     func loadCouponReport() {
-        let action = CouponAction.loadCouponReport(siteID: coupon.siteID, couponID: coupon.couponID) { [weak self] result in
+        // Get "ancient" date to fetch all possible reports
+        let startDate = Date(timeIntervalSince1970: 1)
+        let action = CouponAction.loadCouponReport(siteID: coupon.siteID, couponID: coupon.couponID, startDate: startDate) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let report):

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -27,7 +27,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     /// Total number of orders that applied the coupon
     ///
-    @Published private(set) var discountedOrdersCount: Int64 = 0
+    @Published private(set) var discountedOrdersCount: String = ""
 
     /// Total amount deducted from orders that applied the coupon
     ///
@@ -108,7 +108,7 @@ private extension CouponDetailsViewModel {
             guard let self = self else { return }
             switch result {
             case .success(let report):
-                self.discountedOrdersCount = report.ordersCount
+                self.discountedOrdersCount = "\(report.ordersCount)"
                 let currencyFormatter = CurrencyFormatter(currencySettings: self.currencySettings)
                 self.discountedAmount = currencyFormatter.formatAmount("\(report.amount)") ?? ""
             case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -65,6 +65,20 @@ final class CouponDetailsViewModel: ObservableObject {
         }
         stores.dispatch(action)
     }
+
+    func loadCouponReport() {
+        let action = CouponAction.loadCouponReport(siteID: coupon.siteID, couponID: coupon.couponID) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let report):
+                self.discountedOrdersCount = "\(report.ordersCount)"
+                self.discountedAmount = self.formatStringAmount("\(report.amount)")
+            case .failure(let error):
+                DDLogError("⛔️ Error loading coupon report: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
 }
 
 // MARK: - Private helpers
@@ -95,20 +109,6 @@ private extension CouponDetailsViewModel {
                                                excludedCategoriesCount: coupon.excludedProductCategories.count)
 
         expiryDate = coupon.dateExpires?.toString(dateStyle: .long, timeStyle: .none) ?? ""
-    }
-
-    func loadCouponReport() {
-        let action = CouponAction.loadCouponReport(siteID: coupon.siteID, couponID: coupon.couponID) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let report):
-                self.discountedOrdersCount = "\(report.ordersCount)"
-                self.discountedAmount = self.formatStringAmount("\(report.amount)")
-            case .failure(let error):
-                DDLogError("⛔️ Error loading coupon report: \(error)")
-            }
-        }
-        stores.dispatch(action)
     }
 
     func formatStringAmount(_ amount: String) -> String {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -143,4 +143,29 @@ final class CouponDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.amount, "10%")
     }
+
+    func test_coupon_performance_is_correct() {
+        // Given
+        let sampleCoupon = Coupon.fake()
+        let sampleReport = CouponReport.fake().copy(amount: 220.0, ordersCount: 10)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon, stores: stores, currencySettings: CurrencySettings())
+        XCTAssertEqual(viewModel.discountedOrdersCount, "0")
+        XCTAssertEqual(viewModel.discountedAmount, "$0.00")
+
+        // When
+        stores.whenReceivingAction(ofType: CouponAction.self) { action in
+            switch action {
+            case let .loadCouponReport(_, _, onCompletion):
+                onCompletion(.success(sampleReport))
+            default:
+                break
+            }
+        }
+        viewModel.loadCouponReport()
+
+        // Then
+        XCTAssertEqual(viewModel.discountedOrdersCount, "10")
+        XCTAssertEqual(viewModel.discountedAmount, "$220.00")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -156,7 +156,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: CouponAction.self) { action in
             switch action {
-            case let .loadCouponReport(_, _, onCompletion):
+            case let .loadCouponReport(_, _, _, onCompletion):
                 onCompletion(.success(sampleReport))
             default:
                 break

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -48,10 +48,12 @@ public enum CouponAction: Action {
     ///
     /// - `siteID`: ID of the site that the coupon belongs to.
     /// - `couponID`: ID of the coupon to load analytics report for.
+    /// - `startDate`: the start of the date range to fetch report for.
     /// - `onCompletion`: invoked when the creation finishes.
     ///
     case loadCouponReport(siteID: Int64,
                           couponID: Int64,
+                          startDate: Date,
                           onCompletion: (Result<CouponReport, Error>) -> Void)
 
     /// Search Coupons matching a given keyword for a site

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -64,8 +64,8 @@ public final class CouponStore: Store {
             updateCoupon(coupon, onCompletion: onCompletion)
         case .createCoupon(let coupon, let onCompletion):
             createCoupon(coupon, onCompletion: onCompletion)
-        case .loadCouponReport(let siteID, let couponID, let onCompletion):
-            loadCouponReport(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
+        case .loadCouponReport(let siteID, let couponID, let startDate, let onCompletion):
+            loadCouponReport(siteID: siteID, couponID: couponID, startDate: startDate, onCompletion: onCompletion)
         case .searchCoupons(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
             searchCoupons(siteID: siteID,
                           keyword: keyword,
@@ -192,11 +192,12 @@ private extension CouponStore {
     ///
     /// - Parameters:
     ///     - siteID: ID of the site that the coupon belongs to.
-    ///     - couponID: ID of the coupon to load analytics report for.
+    ///     - couponID: ID of the coupon to load the analytics report for.
+    ///     - startDate: the start of the date range to load the analytics report for.
     ///     - onCompletion: invoked when the creation finishes.
     ///
-    func loadCouponReport(siteID: Int64, couponID: Int64, onCompletion: @escaping (Result<CouponReport, Error>) -> Void) {
-        remote.loadCouponReport(for: siteID, couponID: couponID, completion: onCompletion)
+    func loadCouponReport(siteID: Int64, couponID: Int64, startDate: Date, onCompletion: @escaping (Result<CouponReport, Error>) -> Void) {
+        remote.loadCouponReport(for: siteID, couponID: couponID, from: startDate, completion: onCompletion)
     }
 
     /// Search coupons from a Site that match a specified keyword.

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -30,6 +30,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     var spyCreateCoupon: Coupon?
 
     var didCallLoadCouponReport = false
+    var spyLoadCouponReportDate: Date?
     var spyLoadCouponReportSiteID: Int64?
     var spyLoadCouponReportCouponID: Int64?
 
@@ -79,8 +80,9 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
         spyCreateCoupon = coupon
     }
 
-    func loadCouponReport(for siteID: Int64, couponID: Int64, completion: @escaping (Result<CouponReport, Error>) -> Void) {
+    func loadCouponReport(for siteID: Int64, couponID: Int64, from startDate: Date, completion: @escaping (Result<CouponReport, Error>) -> Void) {
         didCallLoadCouponReport = true
+        spyLoadCouponReportDate = startDate
         spyLoadCouponReportSiteID = siteID
         spyLoadCouponReportCouponID = couponID
     }

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -422,7 +422,8 @@ final class CouponStoreTests: XCTestCase {
         setUpUsingSpyRemote()
         // Given
         let sampleCouponID: Int64 = 571
-        let action = CouponAction.loadCouponReport(siteID: sampleSiteID, couponID: sampleCouponID) { _ in }
+        let sampleDate = Date(timeIntervalSince1970: 1)
+        let action = CouponAction.loadCouponReport(siteID: sampleSiteID, couponID: sampleCouponID, startDate: sampleDate) { _ in }
 
         // When
         store.onAction(action)
@@ -431,18 +432,19 @@ final class CouponStoreTests: XCTestCase {
         XCTAssertTrue(remote.didCallLoadCouponReport)
         XCTAssertEqual(remote.spyLoadCouponReportSiteID, sampleSiteID)
         XCTAssertEqual(remote.spyLoadCouponReportCouponID, sampleCouponID)
+        XCTAssertEqual(remote.spyLoadCouponReportDate, sampleDate)
     }
 
     func test_loadCouponReport_returns_network_error_on_failure() {
         // Given
         let sampleCouponID: Int64 = 571
-
+        let sampleDate = Date(timeIntervalSince1970: 1)
         let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
         network.simulateError(requestUrlSuffix: "coupons", error: expectedError)
 
         // When
         let result: Result<Networking.CouponReport, Error> = waitFor { promise in
-            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID, startDate: sampleDate) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -455,12 +457,13 @@ final class CouponStoreTests: XCTestCase {
     func test_loadCouponReport_returns_expected_details_upon_success() throws {
         // Given
         let sampleCouponID: Int64 = 571
+        let sampleDate = Date(timeIntervalSince1970: 1)
         let expectedReport = CouponReport(couponID: sampleCouponID, amount: 12, ordersCount: 1)
         network.simulateResponse(requestUrlSuffix: "reports/coupons", filename: "coupon-reports")
 
         // When
         let result: Result<Networking.CouponReport, Error> = waitFor { promise in
-            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID, startDate: sampleDate) { result in
                 promise(result)
             }
             self.store.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5765 
⚠️ Please make sure that #6105 is reviewed and merged first ⚠️

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Coupon Details screen with a new section for the performance of the coupon:
- Adds a new method to coupon details view model to load coupon reports.
- Updates Coupon Details screen with Performance section.
- Fixes issue loading coupon reports for all time with a new parameter `after` with an ancient date as the value for the API request.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- On WP Admin: navigate to Marketing > Coupons > Add a new coupon to your test store if none already exists.
- Place at least one order in the store with the created coupon.
- On the app: navigate to Menu tab > Coupons > Select the created coupon. Notice that the performance section reflects the correct number of orders and amount.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/152973074-2eb3a092-686b-4d2a-93ca-89aa46797368.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
