### PR TITLE
[Mobile Payments] Remove bullets from list of conflicting plugins

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsPluginChoicesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsPluginChoicesView.swift
@@ -13,10 +13,10 @@ struct InPersonPaymentsPluginChoicesView: View {
     var body: some View {
         VStack {
             ForEach(CardPresentPaymentsPlugins.allCases, id: \.self) { plugin in
-                HStack {
-                    Text("\u{2022}")
-                    Text(plugin.pluginName).font(.callout).bold()
-                }.padding(.bottom, 1)
+                Text(plugin.pluginName)
+                    .font(.callout)
+                    .bold()
+                    .padding(.bottom, 1)
             }
         }.padding(.bottom, isCompact ? 12 : 24)
     }


### PR DESCRIPTION
Follow on from #6078 

### Description
- Remove the bullets from the plugin list per @adamzelinski 's request

### Testing instructions
- This just removes the bullets. Probably sufficient to just review the code and ensure the unit tests pass.

### Screenshots
- Looks like this now:

<img width="349" alt="Screen Shot 2022-02-08 at 1 08 44 PM" src="https://user-images.githubusercontent.com/1595739/153075941-6249edf0-2448-444b-a422-f49d31cdd9cd.png">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
