### PR TITLE
Simple Payments: Adds email local validation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import Yosemite
 import Combine
 import Experiments
+import class WordPressShared.EmailFormatValidator
 
 /// `ViewModel` to drive the content of the `SimplePaymentsSummary` view.
 ///
@@ -246,10 +247,15 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     /// Updates the order remotely with the information entered by the merchant.
     ///
     func updateOrder() {
-        showLoadingIndicator = true
-
         // Clean any whitespace as it is not allowed by the remote endpoint
         email = email.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Perform local email validation
+        guard email.isEmpty || EmailFormatValidator.validate(string: email) else {
+            return presentNoticeSubject.send(.error(Localization.invalidEmail))
+        }
+
+        showLoadingIndicator = true
 
         // Don't send empty emails as older WC stores can't handle them.
         let action = OrderAction.updateSimplePaymentsOrder(siteID: siteID,
@@ -315,6 +321,7 @@ private extension SimplePaymentsSummaryViewModel {
     enum Localization {
         static let updateError = NSLocalizedString("There was an error updating the order",
                                                    comment: "Notice text after failing to update a simple payments order.")
+        static let invalidEmail = NSLocalizedString("Please enter a valid email address.", comment: "Notice text when the merchant enters an invalid email")
         static let tax = NSLocalizedString("Tax",
                                              comment: "Tax label for the tax detail row.")
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -282,6 +282,36 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         XCTAssertTrue(receivedError)
     }
 
+    func test_view_model_attempts_error_notice_presentation_when_submitting_invalid_email() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
+                                                       totalWithTaxes: "1.0",
+                                                       taxAmount: "0.0",
+                                                       taxLines: [],
+                                                       presentNoticeSubject: noticeSubject,
+                                                       stores: mockStores)
+        viewModel.email = "invalid"
+
+        // When
+        let receivedError: Bool = waitFor { promise in
+            noticeSubject.sink { intent in
+                switch intent {
+                case .error:
+                    promise(true)
+                case .completed, .created:
+                    promise(false)
+                }
+            }
+            .store(in: &self.subscriptions)
+            viewModel.updateOrder()
+        }
+
+        // Then
+        XCTAssertTrue(receivedError)
+    }
+
     func test_when_order_is_updated_navigation_to_payments_method_is_triggered() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
# Why

Similar to #6100, as the API endpoint will fail if we provide an invalid email, This PR adds an email local validation to prevent that error.

# Demo

https://user-images.githubusercontent.com/562080/153077976-c3482655-273c-4ca4-b4ee-52db80d0d4a9.mov

# Testing Steps

- Start a simple payment & enter an amount
- In the summary screen enter an invalid email & tap "take payment"
- See an error notice indicating that the email is invalid.
- Correct or delete the email & tap "take payment"
- See that you can proceed normally.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
