### PR TITLE
Coupons: Add action sheet to copy and share coupon code from details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -44,6 +44,16 @@ struct CouponDetails: View {
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
         .navigationTitle(Localization.navigationTitle)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(action: {
+                    showingActionSheet = true
+                }, label: {
+                    Image(uiImage: .moreImage)
+                })
+            }
+        }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
+    @State private var showingActionSheet: Bool = false
 
     init(viewModel: CouponDetailsViewModel) {
         self.viewModel = viewModel
@@ -50,7 +51,13 @@ struct CouponDetails: View {
                     showingActionSheet = true
                 }, label: {
                     Image(uiImage: .moreImage)
-                })
+                }).actionSheet(isPresented: $showingActionSheet) {
+                    ActionSheet(
+                        title: Text(Localization.manageCoupon),
+                        buttons: [
+                        ]
+                    )
+                }
             }
         }
         .wooNavigationBarStyle()
@@ -73,6 +80,7 @@ private extension CouponDetails {
         static let discount = NSLocalizedString("Discount", comment: "Title of the Discount row in Coupon Details screen")
         static let applyTo = NSLocalizedString("Apply To", comment: "Title of the Apply To row in Coupon Details screen")
         static let expiryDate = NSLocalizedString("Coupon Expiry Date", comment: "Title of the Coupon Expiry Date row in Coupon Details screen")
+        static let manageCoupon = NSLocalizedString("Manage Coupon", comment: "Title of the action sheet displayed from the Coupon Details screen")
     }
 
     struct DetailRow: Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -52,7 +52,6 @@ struct CouponDetails: View {
                 VStack(alignment: .leading, spacing: 0) {
                     // Anchor the action sheet at the top to be able to show the popover on iPad in the most appropriate position
                     Divider()
-                        .foregroundColor(.clear)
                         .actionSheet(isPresented: $showingActionSheet) {
                             ActionSheet(
                                 title: Text(Localization.manageCoupon),
@@ -72,6 +71,7 @@ struct CouponDetails: View {
                         .shareSheet(isPresented: $showingShareSheet) {
                             ShareSheet(activityItems: [viewModel.shareMessage])
                         }
+
                     VStack(alignment: .leading, spacing: 0) {
                         Text(Localization.performance)
                             .bold()
@@ -100,7 +100,9 @@ struct CouponDetails: View {
                     }
                     .background(Color(.listForeground))
 
+                    Divider()
                     Spacer().frame(height: Constants.margin)
+                    Divider()
 
                     VStack(alignment: .leading, spacing: 0) {
                         Text(Localization.detailSectionTitle)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -81,6 +81,9 @@ private extension CouponDetails {
         static let applyTo = NSLocalizedString("Apply To", comment: "Title of the Apply To row in Coupon Details screen")
         static let expiryDate = NSLocalizedString("Coupon Expiry Date", comment: "Title of the Coupon Expiry Date row in Coupon Details screen")
         static let manageCoupon = NSLocalizedString("Manage Coupon", comment: "Title of the action sheet displayed from the Coupon Details screen")
+        static let copyCode = NSLocalizedString("Copy Code", comment: "Action title for copying coupon code from the Coupon Details screen")
+        static let couponCopied = NSLocalizedString("Coupon copied", comment: "Notice message displayed when a coupon code is copied from the Coupon Details screen")
+        static let shareCoupon = NSLocalizedString("Share Coupon", comment: "Action title for sharing coupon from the Coupon Details screen")
     }
 
     struct DetailRow: Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -13,13 +13,6 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 
         // Set presenting view controller to show the notice presenter here
         rootView.noticePresenter.presentingViewController = self
-
-        // Set action to display the share modal from this controller
-        rootView.shareAction = { [weak self] message in
-            let controller = UIActivityViewController(
-                activityItems: [message], applicationActivities: nil)
-            self?.present(controller, animated: true, completion: nil)
-        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -30,12 +23,11 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
     @State private var showingActionSheet: Bool = false
+    @State private var showingShareSheet: Bool = false
 
     /// The presenter to display notice when the coupon code is copied.
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
     let noticePresenter: DefaultNoticePresenter
-
-    var shareAction: (String) -> Void = { _ in }
 
     init(viewModel: CouponDetailsViewModel) {
         self.viewModel = viewModel
@@ -69,11 +61,14 @@ struct CouponDetails: View {
                                         noticePresenter.enqueue(notice: notice)
                                     }),
                                     .default(Text(Localization.shareCoupon), action: {
-                                        shareAction(viewModel.shareMessage)
+                                        showingShareSheet = true
                                     }),
                                     .cancel()
                                 ]
                             )
+                        }
+                        .shareSheet(isPresented: $showingShareSheet) {
+                            ShareSheet(activityItems: [viewModel.shareMessage])
                         }
 
                     VStack(alignment: .leading, spacing: 0) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -1,11 +1,32 @@
 import SwiftUI
 import Yosemite
 
+/// Hosting controller wrapper for `CouponDetails`
+///
+final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
+
+    init(viewModel: CouponDetailsViewModel) {
+        super.init(rootView: CouponDetails(viewModel: viewModel))
+        // The navigation title is set here instead of the SwiftUI view's `navigationTitle`
+        // to avoid the blinking of the title label when pushed from UIKit view.
+        title = NSLocalizedString("Coupon", comment: "Title of Coupon Details screen")
+
+        // Set presenting view controller to show the notice presenter here
+        rootView.noticePresenter.presentingViewController = self
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
     @State private var showingActionSheet: Bool = false
 
-    private let noticePresenter: DefaultNoticePresenter
+    /// The presenter to display notice when the coupon code is copied.
+    /// It is kept internal so that the hosting controller can update its presenting controller to itself.
+    let noticePresenter: DefaultNoticePresenter
 
     init(viewModel: CouponDetailsViewModel) {
         self.viewModel = viewModel
@@ -47,7 +68,6 @@ struct CouponDetails: View {
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
-        .navigationTitle(Localization.navigationTitle)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action: {
@@ -84,7 +104,6 @@ private extension CouponDetails {
     }
 
     enum Localization {
-        static let navigationTitle = NSLocalizedString("Coupon", comment: "Title of Coupon Details screen")
         static let detailSectionTitle = NSLocalizedString("Coupon Details", comment: "Title of Details section in Coupon Details screen")
         static let couponCode = NSLocalizedString("Coupon Code", comment: "Title of the Coupon Code row in Coupon Details screen")
         static let description = NSLocalizedString("Description", comment: "Title of the Description row in Coupon Details screen")

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -85,7 +85,8 @@ struct CouponDetails: View {
                             }),
                             .default(Text(Localization.shareCoupon), action: {
                                 // TODO:
-                            })
+                            }),
+                            .cancel()
                         ]
                     )
                 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -13,6 +13,13 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 
         // Set presenting view controller to show the notice presenter here
         rootView.noticePresenter.presentingViewController = self
+
+        // Set action to display the share modal from this controller
+        rootView.shareAction = { [weak self] message in
+            let controller = UIActivityViewController(
+                activityItems: [message], applicationActivities: nil)
+            self?.present(controller, animated: true, completion: nil)
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -23,11 +30,12 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
     @State private var showingActionSheet: Bool = false
-    @State private var showingShareSheet: Bool = false
 
     /// The presenter to display notice when the coupon code is copied.
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
     let noticePresenter: DefaultNoticePresenter
+
+    var shareAction: (String) -> Void = { _ in }
 
     init(viewModel: CouponDetailsViewModel) {
         self.viewModel = viewModel
@@ -75,7 +83,8 @@ struct CouponDetails: View {
                     showingActionSheet = true
                 }, label: {
                     Image(uiImage: .moreImage)
-                }).actionSheet(isPresented: $showingActionSheet) {
+                })
+                .actionSheet(isPresented: $showingActionSheet) {
                     ActionSheet(
                         title: Text(Localization.manageCoupon),
                         buttons: [
@@ -85,13 +94,11 @@ struct CouponDetails: View {
                                 noticePresenter.enqueue(notice: notice)
                             }),
                             .default(Text(Localization.shareCoupon), action: {
-                                showingShareSheet = true
+                                shareAction(viewModel.shareMessage)
                             }),
                             .cancel()
                         ]
                     )
-                }.shareSheet(isPresented: $showingShareSheet) {
-                    ShareSheet(activityItems: [viewModel.shareMessage])
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -95,11 +95,12 @@ struct CouponDetails: View {
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
         .toolbar {
-            ToolbarItem(placement: .confirmationAction) {
+            ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
                     showingActionSheet = true
                 }, label: {
                     Image(uiImage: .moreImage)
+                        .renderingMode(.template)
                 })
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -5,8 +5,11 @@ struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
     @State private var showingActionSheet: Bool = false
 
+    private let noticePresenter: DefaultNoticePresenter
+
     init(viewModel: CouponDetailsViewModel) {
         self.viewModel = viewModel
+        self.noticePresenter = DefaultNoticePresenter()
     }
 
     private var detailRows: [DetailRow] {
@@ -56,7 +59,9 @@ struct CouponDetails: View {
                         title: Text(Localization.manageCoupon),
                         buttons: [
                             .default(Text(Localization.copyCode), action: {
-                                // TODO:
+                                UIPasteboard.general.string = viewModel.couponCode
+                                let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
+                                noticePresenter.enqueue(notice: notice)
                             }),
                             .default(Text(Localization.shareCoupon), action: {
                                 // TODO:
@@ -88,7 +93,8 @@ private extension CouponDetails {
         static let expiryDate = NSLocalizedString("Coupon Expiry Date", comment: "Title of the Coupon Expiry Date row in Coupon Details screen")
         static let manageCoupon = NSLocalizedString("Manage Coupon", comment: "Title of the action sheet displayed from the Coupon Details screen")
         static let copyCode = NSLocalizedString("Copy Code", comment: "Action title for copying coupon code from the Coupon Details screen")
-        static let couponCopied = NSLocalizedString("Coupon copied", comment: "Notice message displayed when a coupon code is copied from the Coupon Details screen")
+        static let couponCopied = NSLocalizedString("Coupon copied", comment: "Notice message displayed when a coupon code is " +
+                                                    "copied from the Coupon Details screen")
         static let shareCoupon = NSLocalizedString("Share Coupon", comment: "Action title for sharing coupon from the Coupon Details screen")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -55,6 +55,12 @@ struct CouponDetails: View {
                     ActionSheet(
                         title: Text(Localization.manageCoupon),
                         buttons: [
+                            .default(Text(Localization.copyCode), action: {
+                                // TODO:
+                            }),
+                            .default(Text(Localization.shareCoupon), action: {
+                                // TODO:
+                            })
                         ]
                     )
                 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -23,6 +23,7 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
     @State private var showingActionSheet: Bool = false
+    @State private var showingShareSheet: Bool = false
 
     /// The presenter to display notice when the coupon code is copied.
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
@@ -84,16 +85,19 @@ struct CouponDetails: View {
                                 noticePresenter.enqueue(notice: notice)
                             }),
                             .default(Text(Localization.shareCoupon), action: {
-                                // TODO:
+                                showingShareSheet = true
                             }),
                             .cancel()
                         ]
                     )
+                }.shareSheet(isPresented: $showingShareSheet) {
+                    ShareSheet(activityItems: [viewModel.shareMessage])
                 }
             }
         }
         .wooNavigationBarStyle()
     }
+
 }
 
 // MARK: - Subtypes

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -56,23 +56,45 @@ struct CouponDetails: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(Localization.detailSectionTitle)
-                        .bold()
-                        .padding(Constants.margin)
-                        .padding(.horizontal, insets: geometry.safeAreaInsets)
-                    ForEach(detailRows) { row in
-                        TitleAndValueRow(title: row.title,
-                                         value: .content(row.content),
-                                         selectable: true,
-                                         action: row.action)
-                            .padding(.vertical, Constants.verticalSpacing)
+                    // Anchor the action sheet at the top to be able to show the popover on iPad in the most appropriate position
+                    Divider()
+                        .foregroundColor(.clear)
+                        .actionSheet(isPresented: $showingActionSheet) {
+                            ActionSheet(
+                                title: Text(Localization.manageCoupon),
+                                buttons: [
+                                    .default(Text(Localization.copyCode), action: {
+                                        UIPasteboard.general.string = viewModel.couponCode
+                                        let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
+                                        noticePresenter.enqueue(notice: notice)
+                                    }),
+                                    .default(Text(Localization.shareCoupon), action: {
+                                        shareAction(viewModel.shareMessage)
+                                    }),
+                                    .cancel()
+                                ]
+                            )
+                        }
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(Localization.detailSectionTitle)
+                            .bold()
+                            .padding(Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
-                        Divider()
-                            .padding(.leading, Constants.margin)
-                            .padding(.leading, insets: geometry.safeAreaInsets)
+                        ForEach(detailRows) { row in
+                            TitleAndValueRow(title: row.title,
+                                             value: .content(row.content),
+                                             selectable: true,
+                                             action: row.action)
+                                .padding(.vertical, Constants.verticalSpacing)
+                                .padding(.horizontal, insets: geometry.safeAreaInsets)
+                            Divider()
+                                .padding(.leading, Constants.margin)
+                                .padding(.leading, insets: geometry.safeAreaInsets)
+                        }
                     }
+                    .background(Color(.listForeground))
                 }
-                .background(Color(.listForeground))
             }
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
@@ -84,22 +106,6 @@ struct CouponDetails: View {
                 }, label: {
                     Image(uiImage: .moreImage)
                 })
-                .actionSheet(isPresented: $showingActionSheet) {
-                    ActionSheet(
-                        title: Text(Localization.manageCoupon),
-                        buttons: [
-                            .default(Text(Localization.copyCode), action: {
-                                UIPasteboard.general.string = viewModel.couponCode
-                                let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
-                                noticePresenter.enqueue(notice: notice)
-                            }),
-                            .default(Text(Localization.shareCoupon), action: {
-                                shareAction(viewModel.shareMessage)
-                            }),
-                            .cancel()
-                        ]
-                    )
-                }
             }
         }
         .wooNavigationBarStyle()

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -24,6 +24,16 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var expiryDate: String = ""
 
+    var shareMessage: String {
+        if coupon.productIds.isNotEmpty ||
+            coupon.productCategories.isNotEmpty ||
+            coupon.excludedProductIds.isNotEmpty ||
+            coupon.excludedProductCategories.isNotEmpty {
+            return String.localizedStringWithFormat(Localization.shareMessageSomeProducts, amount, couponCode)
+        }
+        return String.localizedStringWithFormat(Localization.shareMessageAllProducts, amount, couponCode)
+    }
+
     /// The current coupon
     ///
     private let coupon: Coupon
@@ -73,6 +83,14 @@ private extension CouponDetailsViewModel {
 //
 private extension CouponDetailsViewModel {
     enum Localization {
+        static let shareMessageAllProducts = NSLocalizedString(
+            "Apply %1$@ off to all products with the promo code “%2$@”.",
+            comment: "Message to share the coupon code if it is applicable to all products. " +
+            "Reads like: Apply 10% off to all products with the promo code “20OFF”.")
+        static let shareMessageSomeProducts = NSLocalizedString(
+            "Apply %1$@ off to some products with the promo code “%2$@”.",
+            comment: "Message to share the coupon code if it is applicable to some products. " +
+            "Reads like: Apply 10% off to some products with the promo code “20OFF”.")
         static let allProducts = NSLocalizedString("All Products", comment: "The text to be displayed in when the coupon is not limit to any specific product")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -137,8 +137,7 @@ extension CouponListViewController: UITableViewDelegate {
             return
         }
         let detailsViewModel = CouponDetailsViewModel(coupon: coupon)
-        let couponDetails = CouponDetails(viewModel: detailsViewModel)
-        let hostingController = UIHostingController(rootView: couponDetails)
+        let hostingController = CouponDetailsHostingController(viewModel: detailsViewModel)
         navigationController?.pushViewController(hostingController, animated: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -179,7 +179,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shareMessage, shareMessage)
     }
 
-    func test_coupon_share_message_is_correct_if_there_is_some_restriction() {
+    func test_coupon_share_message_is_correct_if_there_is_product_restriction() {
         // Given
         let sampleCoupon = Coupon.fake().copy(code: "TEST", amount: "10.00", discountType: .percent, productIds: [12, 23])
         let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -168,4 +168,24 @@ final class CouponDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.discountedOrdersCount, "10")
         XCTAssertEqual(viewModel.discountedAmount, "$220.00")
     }
+
+    func test_coupon_share_message_is_correct_if_there_is_no_restriction() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(code: "TEST", amount: "10.00", discountType: .percent)
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        let shareMessage = String(format: NSLocalizedString("Apply %@ off to all products with the promo code “%@”.", comment: ""), "10%", "TEST")
+        XCTAssertEqual(viewModel.shareMessage, shareMessage)
+    }
+
+    func test_coupon_share_message_is_correct_if_there_is_some_restriction() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(code: "TEST", amount: "10.00", discountType: .percent, productIds: [12, 23])
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        let shareMessage = String(format: NSLocalizedString("Apply %@ off to some products with the promo code “%@”.", comment: ""), "10%", "TEST")
+        XCTAssertEqual(viewModel.shareMessage, shareMessage)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5765 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues to update the coupon details screen with the action sheet to copy and share the coupon code. Changes include:
- Add a new navigation button that triggers the action sheet.
- Add the action sheet - which is anchored just below the navigation bar as a workaround for the bug of showing the action sheet as a popover from the trailing navigation bar item on iPad.
- Add a new class for the hosting controller of the coupon details view. This is necessary to update the presenting controller for the view's notice presenter.
- Implement copying and sharing the coupon code.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that your test store already has at least one coupon. Otherwise, create one on WP Admin > Marketing > Coupons.
- On the app, navigate to Menu > Coupons > Select the created coupon. 
- Tap the More menu button on the navigation bar. Notice that an action sheet is displayed as expected.
- Tap Copy Code / Share Coupon on the action sheet. Notice that the features work as expected.
- Feel free to test on an iPad to verify that the action sheet is displayed properly in form of a popover.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
iPhone:
| Action sheet | Coupon copied | Share sheet |
| ----- | ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/153165539-80aa13cd-0b03-4230-aba6-8c4a9010de13.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/153165632-3e3da335-b795-4e50-8b3e-a36076274b1b.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/153165716-1fa7fcc4-f187-4cb1-aafb-9da1cb9f22c0.png" width=320 /> |

iPad:
| Action sheet | Share sheet | 
| ----- | ----- |
| ![IMG_0073](https://user-images.githubusercontent.com/5533851/153165972-a5e8dcde-b8e1-496c-9de7-97a98e11a8d6.PNG) | ![IMG_0072](https://user-images.githubusercontent.com/5533851/153174421-d613a031-a71d-4326-b6fa-efcccc462e7d.PNG) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
