### PR TITLE
[Mobile Payments] Add initial support for WisePad 3

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderType.swift
+++ b/Hardware/Hardware/CardReader/CardReaderType.swift
@@ -5,6 +5,8 @@ public enum CardReaderType {
     case chipper
     /// Stripe M2
     case stripeM2
+    /// BBPOS WisePad 3
+    case wisepad3
     /// Other
     case other
 }
@@ -22,6 +24,8 @@ extension CardReaderType {
             return "CHIPPER_2X"
         case .stripeM2:
             return "STRIPE_M2"
+        case .wisepad3:
+            return "WISEPAD_3"
         default:
             return "UNKNOWN"
         }

--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderType+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderType+Stripe.swift
@@ -11,6 +11,8 @@ extension CardReaderType {
             return .chipper
         case .stripeM2:
             return .stripeM2
+        case .wisePad3:
+            return .wisepad3
         default:
             return .other
         }

--- a/Hardware/HardwareTests/CardReaderTests.swift
+++ b/Hardware/HardwareTests/CardReaderTests.swift
@@ -59,6 +59,13 @@ final class CardReaderTests: XCTestCase {
         XCTAssertEqual(cardReader.readerType, .stripeM2)
     }
 
+    func test_card_reader_maps_reader_type_for_wisepad3() {
+        let mockReader = MockStripeCardReader.wisepad3()
+        let cardReader = CardReader(reader: mockReader)
+
+        XCTAssertEqual(cardReader.readerType, .wisepad3)
+    }
+
     func test_card_reader_maps_reader_type_for_verifone() {
         let mockReader = MockStripeCardReader.verifoneP400()
         let cardReader = CardReader(reader: mockReader)

--- a/Hardware/HardwareTests/Mocks/MockStripeCardReader.swift
+++ b/Hardware/HardwareTests/Mocks/MockStripeCardReader.swift
@@ -53,4 +53,15 @@ extension MockStripeCardReader {
                              batteryLevel: NSNumber(floatLiteral: 0.5),
                              locationId: "st_simulated")
     }
+
+    static func wisepad3() -> Self {
+        MockStripeCardReader(serialNumber: "W3E-SIMULATOR-1",
+                             stripeId: "SIMULATOR",
+                             label: "Simulated WisePad 3",
+                             status: .online,
+                             deviceSoftwareVersion: "0.0.0.1",
+                             deviceType: .wisePad3,
+                             batteryLevel: NSNumber(floatLiteral: 0.5),
+                             locationId: "st_simulated")
+    }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -154,7 +154,7 @@ private extension CardPresentPaymentStore {
                     }
                 },
                 receiveValue: { readers in
-                    let supportedReaders = readers.filter({$0.readerType == .chipper || $0.readerType == .stripeM2})
+                    let supportedReaders = readers.filter({$0.readerType == .chipper || $0.readerType == .stripeM2 || $0.readerType == .wisepad3})
                     onReaderDiscovered(supportedReaders)
                 }
             ))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5977 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds WisePad 3 to the list of supported readers. This doesn't prevent a connection if used in the wrong country, and payments still not work (need some backend support first), but it should be able to connect. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Use a store with an address in Canada, and try to connect to a WisePad 3 reader.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="450" src="https://user-images.githubusercontent.com/8739/153227808-d802b0b9-f092-48a2-8d26-2f3c162ce06e.png">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
