### PR TITLE
Order Creation: Adds OrderSynchronizer Protocol

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -13,7 +13,13 @@ enum OrderSyncState {
 /// Product input for an `OrderSynchronizer` type.
 ///
 struct OrderSyncProductInput {
-    let product: Product
+    /// Types of products the synchronizer supports
+    ///
+    enum ProductType {
+        case product(Product)
+        case variation(ProductVariation)
+    }
+    let product: ProductType
     let quantity: Int
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -1,1 +1,72 @@
 import Foundation
+import Yosemite
+import Combine
+
+/// Possible states of an `OrderSynchronizer` type.
+///
+enum OrderSyncState {
+    case syncing
+    case synced
+    case error(Error)
+}
+
+/// Product input for an `OrderSynchronizer` type.
+///
+struct OrderSyncProductInput {
+    let product: Product
+    let quantity: Int
+}
+
+/// Addresses input for an `OrderSynchronizer` type.
+///
+struct OrderSyncAddressesInput {
+    let billing: Address
+    let shipping: Address
+}
+
+/// A type that  receives "supported" order properties and keeps it synced against another source.
+///
+protocol OrderSynchronizer {
+
+    // MARK: Outputs
+
+    /// Defines the current sync state of the synchronizer.
+    ///
+    var state: Published<OrderSyncState> { get }
+
+    /// Defines the latest order to be synced or that is synced.
+    ///
+    var order: Published<Order> { get }
+
+    // MARK: Inputs
+
+    /// Changes the underlaying order status.
+    /// This property is not synched remotely until `commitAllChanges` method is invoked.
+    ///
+    var setStatus: PassthroughSubject<OrderStatusEnum, Never> { get }
+
+    /// Sets a product with it's quantity.
+    /// Set a `zero` quantity to remove a product.
+    ///
+    var setProduct: PassthroughSubject<OrderSyncProductInput, Never> { get }
+
+    /// Sets or removes the order shipping & billing addresses.
+    ///
+    var setAddresses: PassthroughSubject<OrderSyncAddressesInput?, Never> { get }
+
+    /// Sets or removes a shipping line.
+    ///
+    var setShipping: PassthroughSubject<ShippingLine?, Never> { get }
+
+    /// Sets or removes an order fee.
+    ///
+    var setFee: PassthroughSubject<OrderFeeLine?, Never> { get }
+
+    /// Retires the order sync. State needs to be in `.error` to initiate work.
+    ///
+    func retrySync()
+
+    /// Commits all order changes to the remote source. State needs to be in `.synced` to initiate work.
+    ///
+    func commitAllChanges(onCompletion: (Result<Order, Error>) -> Void)
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -494,6 +494,7 @@
 		26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */; };
 		26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */; };
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
+		26C6439327B5DBE900DD00D1 /* OrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */; };
 		26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */; };
 		26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */; };
 		26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */; };
@@ -2115,6 +2116,7 @@
 		26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelProtocol.swift; sourceTree = "<group>"; };
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
+		26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSynchronizer.swift; sourceTree = "<group>"; };
 		26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModel.swift; sourceTree = "<group>"; };
 		26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModelTests.swift; sourceTree = "<group>"; };
 		26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorViewModel.swift; sourceTree = "<group>"; };
@@ -4474,6 +4476,14 @@
 			path = Summary;
 			sourceTree = "<group>";
 		};
+		26C6439127B5DBE900DD00D1 /* Synchronizer */ = {
+			isa = PBXGroup;
+			children = (
+				26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */,
+			);
+			path = Synchronizer;
+			sourceTree = "<group>";
+		};
 		26C6E8E126E2D85300C7BB0F /* Addresses */ = {
 			isa = PBXGroup;
 			children = (
@@ -6484,6 +6494,7 @@
 			children = (
 				CCFC50542743BC0D001E505F /* NewOrder.swift */,
 				CCFC50582743E021001E505F /* NewOrderViewModel.swift */,
+				26C6439127B5DBE900DD00D1 /* Synchronizer */,
 				AE264C05275A495E00B52996 /* FlowCoordinator */,
 				CC200BAF27847D9300EC5884 /* PaymentSection */,
 				CC53FB3627551A8700C4CA4F /* ProductsSection */,
@@ -8241,6 +8252,7 @@
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,
+				26C6439327B5DBE900DD00D1 /* OrderSynchronizer.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
 				E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */,
 				CC13C0CB278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift in Sources */,


### PR DESCRIPTION
Closes: #6127 

# Why

This PR adds an `OrderSynchronizer` protocol. 

The idea behind this protocol is for us to quickly provide a simple `LocalOrderSynchronizer` so the `NewOrderViewModel` can continue its development with a real interface while the real order synchronizer is built.

# Testing Steps

- Make sure the interface looks correct and we are not missing any inputs or outputs.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
