### PR TITLE
Maintenance: Enlarge notice view's action button tap area

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 8.6
 -----
+- [*] Enlarged the tap area for the action button on the notice view. [https://github.com/woocommerce/woocommerce-ios/pull/6146]
 
 
 8.5

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -206,7 +206,7 @@ private extension NoticeView {
     enum Metrics {
         static let cornerRadius: CGFloat = 13.0
         static let layoutMargins = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
-        static let actionButtonContentInsets = UIEdgeInsets(top: 24.0, left: 16.0, bottom: 24.0, right: 16.0)
+        static let actionButtonContentInsets = UIEdgeInsets(top: 22.0, left: 16.0, bottom: 22.0, right: 16.0)
         static let labelLineSpacing: CGFloat = 18.0
     }
 

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -156,7 +156,7 @@ private extension NoticeView {
         actionButton.setTitleColor(Appearance.actionColor, for: .normal)
         actionButton.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
         actionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
-        actionButton.contentEdgeInsets = Metrics.layoutMargins
+        actionButton.contentEdgeInsets = Metrics.actionButtonContentInsets
         actionButton.backgroundColor = Appearance.actionBackgroundColor
     }
 
@@ -213,6 +213,7 @@ private extension NoticeView {
     enum Metrics {
         static let cornerRadius: CGFloat = 13.0
         static let layoutMargins = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
+        static let actionButtonContentInsets = UIEdgeInsets(top: 24.0, left: 16.0, bottom: 24.0, right: 16.0)
         static let labelLineSpacing: CGFloat = 18.0
     }
 

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -141,9 +141,7 @@ private extension NoticeView {
         contentStackView.addArrangedSubview(actionBackgroundView)
         actionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
 
-        actionBackgroundView.layoutMargins = Metrics.layoutMargins
-        actionBackgroundView.backgroundColor = Appearance.actionBackgroundColor
-
+        actionBackgroundView.layoutMargins = .zero
         actionBackgroundView.addSubview(actionButton)
         actionButton.translatesAutoresizingMaskIntoConstraints = false
 
@@ -158,6 +156,8 @@ private extension NoticeView {
         actionButton.setTitleColor(Appearance.actionColor, for: .normal)
         actionButton.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
         actionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        actionButton.contentEdgeInsets = Metrics.layoutMargins
+        actionButton.backgroundColor = Appearance.actionBackgroundColor
     }
 
     func configureDismissRecognizer() {

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -8,7 +8,6 @@ class NoticeView: UIView {
 
     private let backgroundContainerView = UIView()
     private let backgroundView: UIVisualEffectView
-    private let actionBackgroundView = UIView()
     private let shadowLayer = CAShapeLayer()
     private let shadowMaskLayer = CAShapeLayer()
 
@@ -138,19 +137,12 @@ private extension NoticeView {
     }
 
     func configureActionButton() {
-        contentStackView.addArrangedSubview(actionBackgroundView)
-        actionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
-
-        actionBackgroundView.layoutMargins = .zero
-        actionBackgroundView.addSubview(actionButton)
-        actionButton.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.addArrangedSubview(actionButton)
 
         NSLayoutConstraint.activate([
-            actionBackgroundView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
-            actionBackgroundView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor),
+            actionButton.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
+            actionButton.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor),
             ])
-
-        actionBackgroundView.pinSubviewToAllEdgeMargins(actionButton)
 
         actionButton.titleLabel?.font = Fonts.actionButtonFont
         actionButton.setTitleColor(Appearance.actionColor, for: .normal)
@@ -184,8 +176,9 @@ private extension NoticeView {
 
         if let actionTitle = notice.actionTitle {
             actionButton.setTitle(actionTitle, for: .normal)
+            actionButton.isHidden = false
         } else {
-            actionBackgroundView.isHidden = true
+            actionButton.isHidden = true
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5899 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR aims to make it easier to tap the action button on the notice view.
The solution is to remove the background view for the action button entirely and adjust the content insets for the action button to be larger (matching the old size). This will update the intrinsic size for the button and force the notice view to size itself to fit the button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The notice view can be tested in different flows like order status change or marking reviews as spam.
Notice that you can tap on the edges of the button and the button still works as expected.
Feel free to test the case when the notice view doesn't have the action button (e.g when marking an order complete while offline). 

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/153541063-d8fa6f2b-b1f9-4f86-ade3-1b258d830acd.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
