### PR TITLE
Coupons: Add coupon management to experimental features 

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -13,6 +13,7 @@ extension GeneralAppSettings {
         isStripeInPersonPaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
         isCanadaInPersonPaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
         isProductSKUInputScannerSwitchEnabled: CopiableProp<Bool> = .copy,
+        isCouponManagementSwitchEnabled: CopiableProp<Bool> = .copy,
         knownCardReaders: CopiableProp<[String]> = .copy,
         lastEligibilityErrorInfo: NullableCopiableProp<EligibilityErrorInfo> = .copy,
         lastJetpackBenefitsBannerDismissedTime: NullableCopiableProp<Date> = .copy
@@ -24,6 +25,7 @@ extension GeneralAppSettings {
         let isStripeInPersonPaymentsSwitchEnabled = isStripeInPersonPaymentsSwitchEnabled ?? self.isStripeInPersonPaymentsSwitchEnabled
         let isCanadaInPersonPaymentsSwitchEnabled = isCanadaInPersonPaymentsSwitchEnabled ?? self.isCanadaInPersonPaymentsSwitchEnabled
         let isProductSKUInputScannerSwitchEnabled = isProductSKUInputScannerSwitchEnabled ?? self.isProductSKUInputScannerSwitchEnabled
+        let isCouponManagementSwitchEnabled = isCouponManagementSwitchEnabled ?? self.isCouponManagementSwitchEnabled
         let knownCardReaders = knownCardReaders ?? self.knownCardReaders
         let lastEligibilityErrorInfo = lastEligibilityErrorInfo ?? self.lastEligibilityErrorInfo
         let lastJetpackBenefitsBannerDismissedTime = lastJetpackBenefitsBannerDismissedTime ?? self.lastJetpackBenefitsBannerDismissedTime
@@ -36,6 +38,7 @@ extension GeneralAppSettings {
             isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
             isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
             isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
+            isCouponManagementSwitchEnabled: isCouponManagementSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -40,6 +40,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isProductSKUInputScannerSwitchEnabled: Bool
 
+    /// The state for the Coupon Management feature switch.
+    ///
+    public let isCouponManagementSwitchEnabled: Bool
+
     /// A list (possibly empty) of known card reader IDs - i.e. IDs of card readers that should be reconnected to automatically
     /// e.g. ["CHB204909005931"]
     ///
@@ -59,6 +63,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
                 isStripeInPersonPaymentsSwitchEnabled: Bool,
                 isCanadaInPersonPaymentsSwitchEnabled: Bool,
                 isProductSKUInputScannerSwitchEnabled: Bool,
+                isCouponManagementSwitchEnabled: Bool,
                 knownCardReaders: [String],
                 lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
                 lastJetpackBenefitsBannerDismissedTime: Date? = nil) {
@@ -69,6 +74,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         self.isStripeInPersonPaymentsSwitchEnabled = isStripeInPersonPaymentsSwitchEnabled
         self.isCanadaInPersonPaymentsSwitchEnabled = isCanadaInPersonPaymentsSwitchEnabled
         self.isProductSKUInputScannerSwitchEnabled = isProductSKUInputScannerSwitchEnabled
+        self.isCouponManagementSwitchEnabled = isCouponManagementSwitchEnabled
         self.knownCardReaders = knownCardReaders
         self.lastEligibilityErrorInfo = lastEligibilityErrorInfo
         self.lastJetpackBenefitsBannerDismissedTime = lastJetpackBenefitsBannerDismissedTime
@@ -99,6 +105,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
             isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
             isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
+            isCouponManagementSwitchEnabled: isCouponManagementSwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )
@@ -119,6 +126,7 @@ extension GeneralAppSettings {
         self.isStripeInPersonPaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isStripeInPersonPaymentsSwitchEnabled) ?? false
         self.isCanadaInPersonPaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isCanadaInPersonPaymentsSwitchEnabled) ?? false
         self.isProductSKUInputScannerSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isProductSKUInputScannerSwitchEnabled) ?? false
+        self.isCouponManagementSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isCouponManagementSwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
         self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)
         self.lastJetpackBenefitsBannerDismissedTime = try container.decodeIfPresent(Date.self, forKey: .lastJetpackBenefitsBannerDismissedTime)

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -65,6 +65,7 @@ final class GeneralAppSettingsTests: XCTestCase {
                                                   isStripeInPersonPaymentsSwitchEnabled: true,
                                                   isCanadaInPersonPaymentsSwitchEnabled: true,
                                                   isProductSKUInputScannerSwitchEnabled: true,
+                                                  isCouponManagementSwitchEnabled: true,
                                                   knownCardReaders: readers,
                                                   lastEligibilityErrorInfo: eligibilityInfo,
                                                   lastJetpackBenefitsBannerDismissedTime: jetpackBannerDismissedDate)
@@ -87,6 +88,7 @@ final class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.isStripeInPersonPaymentsSwitchEnabled, true)
         assertEqual(newSettings.isCanadaInPersonPaymentsSwitchEnabled, true)
         assertEqual(newSettings.isProductSKUInputScannerSwitchEnabled, true)
+        assertEqual(newSettings.isCouponManagementSwitchEnabled, true)
         assertEqual(newSettings.lastJetpackBenefitsBannerDismissedTime, jetpackBannerDismissedDate)
     }
 }
@@ -99,6 +101,7 @@ private extension GeneralAppSettingsTests {
                                   isStripeInPersonPaymentsSwitchEnabled: Bool = false,
                                   isCanadaInPersonPaymentsSwitchEnabled: Bool = false,
                                   isProductSKUInputScannerSwitchEnabled: Bool = false,
+                                  isCouponManagementSwitchEnabled: Bool = false,
                                   knownCardReaders: [String] = [],
                                   lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
                                   lastJetpackBenefitsBannerDismissedTime: Date? = nil) -> GeneralAppSettings {
@@ -109,6 +112,7 @@ private extension GeneralAppSettingsTests {
                            isStripeInPersonPaymentsSwitchEnabled: isStripeInPersonPaymentsSwitchEnabled,
                            isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
                            isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
+                           isCouponManagementSwitchEnabled: isCouponManagementSwitchEnabled,
                            knownCardReaders: knownCardReaders,
                            lastEligibilityErrorInfo: lastEligibilityErrorInfo,
                            lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -506,7 +506,7 @@ private extension BetaFeaturesViewController {
 
         static let couponManagementTitle = NSLocalizedString("Coupon Management", comment: "Cell title on beta features screen to enable coupon management")
         static let couponManagementDescription = NSLocalizedString(
-            "Test out coupon management as we get ready to launch",
+            "Test out managing coupons as we get ready to launch",
             comment: "Cell description on beta features screen to enable coupon management"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -455,5 +455,11 @@ private extension BetaFeaturesViewController {
         static let productSKUInputScannerDescription = NSLocalizedString(
             "Test out scanning a barcode for a product SKU in the product inventory settings",
             comment: "Cell description on beta features screen to enable product SKU input scanner in inventory settings.")
+
+        static let couponManagementTitle = NSLocalizedString("Coupon Management", comment: "Cell title on beta features screen to enable coupon management")
+        static let couponManagementDescription = NSLocalizedString(
+            "Test out coupon management as we get ready to launch",
+            comment: "Cell description on beta features screen to enable coupon management"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -80,6 +80,9 @@ struct HubMenu: View {
         }
         .navigationBarHidden(true)
         .background(Color(.listBackground).edgesIgnoringSafeArea(.all))
+        .onAppear {
+            viewModel.setupMenuElements()
+        }
     }
 
     func pushReviewDetailsView(using parcel: ProductReviewFromNoteParcel) {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -86,7 +86,7 @@ final class HubMenuViewModel: ObservableObject {
                 self.menuElements.append(.coupons)
             }
         }
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 
     /// Present the `StorePickerViewController` using the `StorePickerCoordinator`, passing the navigation controller from the entry point.

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -16,22 +16,25 @@ final class HubMenuViewModel: ObservableObject {
     private(set) unowned var navigationController: UINavigationController?
 
     var avatarURL: URL? {
-        guard let urlString = ServiceLocator.stores.sessionManager.defaultAccount?.gravatarUrl, let url = URL(string: urlString) else {
+        guard let urlString = stores.sessionManager.defaultAccount?.gravatarUrl, let url = URL(string: urlString) else {
             return nil
         }
         return url
     }
+
     var storeTitle: String {
-        ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.myStore
+        stores.sessionManager.defaultSite?.name ?? Localization.myStore
     }
+
     var storeURL: URL {
-        guard let urlString = ServiceLocator.stores.sessionManager.defaultSite?.url, let url = URL(string: urlString) else {
+        guard let urlString = stores.sessionManager.defaultSite?.url, let url = URL(string: urlString) else {
             return WooConstants.URLs.blog.asURL()
         }
         return url
     }
+
     var woocommerceAdminURL: URL {
-        guard let urlString = ServiceLocator.stores.sessionManager.defaultSite?.adminURL, let url = URL(string: urlString) else {
+        guard let urlString = stores.sessionManager.defaultSite?.adminURL, let url = URL(string: urlString) else {
             return WooConstants.URLs.blog.asURL()
         }
         return url
@@ -43,15 +46,21 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published var showingReviewDetail = false
 
+    private let stores: StoresManager
+
     private var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
 
     private var storePickerCoordinator: StorePickerCoordinator?
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(siteID: Int64, navigationController: UINavigationController? = nil, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(siteID: Int64,
+         navigationController: UINavigationController? = nil,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.navigationController = navigationController
+        self.stores = stores
         menuElements = [.woocommerceAdmin, .viewStore]
         if featureFlagService.isFeatureFlagEnabled(.inbox) {
             menuElements.append(.inbox)
@@ -87,7 +96,7 @@ final class HubMenuViewModel: ObservableObject {
     }
 
     private func observeSiteForUIUpdates() {
-        ServiceLocator.stores.site.sink { site in
+        stores.site.sink { site in
             // This will be useful in the future for updating some info of the screen depending on the store site info
         }.store(in: &cancellables)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -50,7 +50,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .coupons, .reviews])
     }
 
-    func test_menuElements_does_not_include_coupons_when_couponManagement_is_not_enabled_in_app_settings() {
+    func test_menuElements_do_not_include_coupons_when_couponManagement_is_not_enabled_in_app_settings() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let featureFlagService = MockFeatureFlagService(isInboxOn: false)

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 
 @testable import WooCommerce
+@testable import Yosemite
 
 final class HubMenuViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 606
@@ -22,8 +23,51 @@ final class HubMenuViewModelTests: XCTestCase {
 
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService)
+        viewModel.setupMenuElements()
 
         // Then
         XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .reviews])
+    }
+
+    func test_menuElements_include_coupons_when_couponManagement_is_enabled_in_app_settings() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+
+        // When
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadCouponManagementFeatureSwitchState(let onCompletion):
+                onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
+        viewModel.setupMenuElements()
+
+        // Then
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .coupons, .reviews])
+    }
+
+    func test_menuElements_does_not_include_coupons_when_couponManagement_is_not_enabled_in_app_settings() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let featureFlagService = MockFeatureFlagService(isInboxOn: false)
+
+        // When
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadCouponManagementFeatureSwitchState(let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
+        viewModel.setupMenuElements()
+
+        // Then
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
     }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -152,6 +152,14 @@ public enum AppSettingsAction: Action {
     ///
     case loadProductSKUInputScannerFeatureSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
 
+    /// Sets the state for the Coupon Management beta feature switch.
+    ///
+    case setCouponManagementFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Loads the most recent state for the Coupon Management beta feature switch
+    ///
+    case loadCouponManagementFeatureSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
+
     /// Remember the given card reader (to support automatic reconnection)
     /// where `cardReaderID` is a String e.g. "CHB204909005931"
     ///

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -205,6 +205,10 @@ public class AppSettingsStore: Store {
             setProductSKUInputScannerFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .loadProductSKUInputScannerFeatureSwitchState(onCompletion: let onCompletion):
             loadProductSKUInputScannerFeatureSwitchState(onCompletion: onCompletion)
+        case .setCouponManagementFeatureSwitchState(let isEnabled, let onCompletion):
+            setCouponManagementFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
+        case .loadCouponManagementFeatureSwitchState(let onCompletion):
+            loadCouponManagementFeatureSwitchState(onCompletion: onCompletion)
         }
     }
 }
@@ -357,6 +361,25 @@ private extension AppSettingsStore {
         onCompletion(.success(settings.isProductSKUInputScannerSwitchEnabled))
     }
 
+    /// Sets the state for the Coupon Mangagement beta feature switch into `GeneralAppSettings`.
+    ///
+    func setCouponManagementFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            let settings = loadOrCreateGeneralAppSettings().copy(isCouponManagementSwitchEnabled: isEnabled)
+            try saveGeneralAppSettings(settings)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+    }
+
+    /// Loads the most recent state for the Coupon Management beta feature switch from `GeneralAppSettings`.
+    ///
+    func loadCouponManagementFeatureSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
+        let settings = loadOrCreateGeneralAppSettings()
+        onCompletion(.success(settings.isCouponManagementSwitchEnabled))
+    }
+
     /// Loads the last persisted eligibility error information from `GeneralAppSettings`
     ///
     func loadEligibilityErrorInfo(onCompletion: (Result<EligibilityErrorInfo, Error>) -> Void) {
@@ -417,6 +440,7 @@ private extension AppSettingsStore {
                                       isStripeInPersonPaymentsSwitchEnabled: false,
                                       isCanadaInPersonPaymentsSwitchEnabled: false,
                                       isProductSKUInputScannerSwitchEnabled: false,
+                                      isCouponManagementSwitchEnabled: false,
                                       knownCardReaders: [],
                                       lastEligibilityErrorInfo: nil)
         }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -37,7 +37,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .pending)
+        let settings = createAppSetting(installationDate: installationDate, feedbackType: .general, feedbackStatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -54,7 +54,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .pending)
+        let settings = createAppSetting(installationDate: installationDate, feedbackType: .general, feedbackStatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -72,7 +72,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .given(lastFeedbackDate))
+        let settings = createAppSetting(installationDate: installationDate, feedbackType: .general, feedbackStatus: .given(lastFeedbackDate))
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -90,7 +90,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .given(lastFeedbackDate))
+        let settings = createAppSetting(installationDate: installationDate, feedbackType: .general, feedbackStatus: .given(lastFeedbackDate))
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -108,7 +108,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .general, feedbackSatus: .pending)
+        let settings = createAppSetting(installationDate: nil, feedbackType: .general, feedbackStatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -128,7 +128,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .pending)
+        let settings = createAppSetting(installationDate: installationDate, feedbackType: .general, feedbackStatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -142,7 +142,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         // Given
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .general, feedbackSatus: .pending)
+        let settings = createAppSetting(installationDate: nil, feedbackType: .general, feedbackStatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -163,6 +163,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
                                           isStripeInPersonPaymentsSwitchEnabled: false,
                                           isCanadaInPersonPaymentsSwitchEnabled: false,
                                           isProductSKUInputScannerSwitchEnabled: false,
+                                          isCouponManagementSwitchEnabled: false,
                                           knownCardReaders: [])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
@@ -175,7 +176,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_true_if_feedback_has_pending_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsVariations, feedbackSatus: .pending)
+        let settings = createAppSetting(installationDate: nil, feedbackType: .productsVariations, feedbackStatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
@@ -187,7 +188,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_false_if_feedback_has_dismissed_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsVariations, feedbackSatus: .dismissed)
+        let settings = createAppSetting(installationDate: nil, feedbackType: .productsVariations, feedbackStatus: .dismissed)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
@@ -199,7 +200,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_false_if_feedback_has_given_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsVariations, feedbackSatus: .given(Date()))
+        let settings = createAppSetting(installationDate: nil, feedbackType: .productsVariations, feedbackStatus: .given(Date()))
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
@@ -221,16 +222,17 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
         try XCTUnwrap(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last)
     }
 
-    func createAppSetting(instalationDate: Date?, feedbackType: FeedbackType, feedbackSatus: FeedbackSettings.Status) -> GeneralAppSettings {
-        let feedback = FeedbackSettings(name: feedbackType, status: feedbackSatus)
+    func createAppSetting(installationDate: Date?, feedbackType: FeedbackType, feedbackStatus: FeedbackSettings.Status) -> GeneralAppSettings {
+        let feedback = FeedbackSettings(name: feedbackType, status: feedbackStatus)
         let settings = GeneralAppSettings(
-            installationDate: instalationDate,
+            installationDate: installationDate,
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
             isOrderCreationSwitchEnabled: false,
             isStripeInPersonPaymentsSwitchEnabled: false,
             isCanadaInPersonPaymentsSwitchEnabled: false,
             isProductSKUInputScannerSwitchEnabled: false,
+            isCouponManagementSwitchEnabled: false,
             knownCardReaders: []
         )
         return settings

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -679,6 +679,42 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(isEnabled)
     }
 
+    func test_loadCouponManagementFeatureSwitchState_returns_false_on_new_generalAppSettings() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadCouponManagementFeatureSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_loadCouponManagementFeatureSwitchState_returns_true_after_updating_switch_state_to_true() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.setCouponManagementFeatureSwitchState(isEnabled: true, onCompletion: { _ in })
+        subject?.onAction(updateAction)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadCouponManagementFeatureSwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertTrue(isEnabled)
+    }
+
     // MARK: - General Store Settings
 
     func test_saving_isTelemetryAvailable_works_correctly() throws {
@@ -877,6 +913,7 @@ private extension AppSettingsStoreTests {
             isStripeInPersonPaymentsSwitchEnabled: false,
             isCanadaInPersonPaymentsSwitchEnabled: false,
             isProductSKUInputScannerSwitchEnabled: false,
+            isCouponManagementSwitchEnabled: false,
             knownCardReaders: []
         )
         return (settings, feedback)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6149 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR aims to enable coupon management feature based on the beta feature switch instead of the feature flag. That way, we can launch each milestone of the feature gradually and merchants can experience the feature as we develop it.
Changes:
- Storage: Add coupon management feature switch to GeneralAppSettings.
- Yosemite: Update AppSettingsAction and AppSettingsStore to handle loading and updating the setting for coupon management feature switch.
- Beta switch screen: Add a new section for toggling coupon management feature.
- Hub menu: 
  - Inject stores manager to the view model for easy testing
  - Make setting up menu an internal method for reloading menus when the view appears and for easy testing.
  - Update the logic to make the Coupons menu available based on app settings instead of the feature flag.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu tab > Settings > Experimental Features and toggle off the Coupon Management switch. Navigate back to the Menu tab, notice that the Coupons menu is not present.
- Repeat the same steps, this time turn on the Coupon Management switch. Notice that the Coupons menu is present on the Menu tab.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/153568458-2f652b3b-bba0-4520-b9b3-aaacbe00ea45.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
