### PR TITLE
[Mobile Payments] Weak self for IPPVC root view closures please

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -3,10 +3,12 @@ import SwiftUI
 final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView> {
     init(viewModel: InPersonPaymentsViewModel) {
         super.init(rootView: InPersonPaymentsView(viewModel: viewModel))
-        rootView.showSupport = {
+        rootView.showSupport = { [weak self] in
+            guard let self = self else { return }
             ZendeskProvider.shared.showNewWCPayRequestIfPossible(from: self)
         }
-        rootView.showURL = { url in
+        rootView.showURL = { [weak self] url in
+            guard let self = self else { return }
             WebviewHelper.launch(url, with: self)
         }
     }


### PR DESCRIPTION
Closes: #6154

### Description
- Props @ctarda for finding these two references to self that were causing the VC to never deinit

### Testing instructions
- On a store with the Stripe extension installed and active
- Configure your run scheme to gather memory logs. See #6154 for instructions if needed
- Repeatedly enter and exit In-Person Payments in settings
- Pause execution and examine the memory graph. Ensure NO IPPVC and IPPVM are present
- Ensure that tapping on the learn more link on a IPP view opens the web view (e.g. on the Activate WooCommerce Stripe Gateway view, which presents when Stripe is installed but not active)
- Ensure that tapping on the support button on an IPP view opens support (e.g. on the Conflicting payment plugins detected view, which presents to administrators when both WCPay and Stripe are active)

### Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
