### PR TITLE
Inbox view part 2: inbox note row UI - title, HTML content, actions

### DIFF
--- a/WooCommerce/Classes/Extensions/NSAttributedString+Attributes.swift
+++ b/WooCommerce/Classes/Extensions/NSAttributedString+Attributes.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension NSAttributedString {
+    /// Returns an `NSAttributedString` with attributes applied to the whole string.
+    func addingAttributes(_ attributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
+        let attributedHTMLString = NSMutableAttributedString(attributedString: self)
+
+        let range = NSRange(location: 0, length: attributedHTMLString.length)
+        attributedHTMLString.addAttributes(attributes, range: range)
+        return attributedHTMLString
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -15,11 +15,16 @@ struct Inbox: View {
         Group {
             switch viewModel.syncState {
             case .results:
-                // TODO: 5954 - update results state
                 InfiniteScrollList(isLoading: viewModel.shouldShowBottomActivityIndicator,
                                    loadAction: viewModel.onLoadNextPageAction) {
-                    ForEach(viewModel.notes, id: \.id) { note in
-                        TitleAndSubtitleRow(title: note.title, subtitle: note.content)
+                    ForEach(viewModel.noteRowViewModels) { rowViewModel in
+                        if #available(iOS 15.0, *) {
+                            // In order to show full-width separator, the default list separator is hidden and a `Divider` is shown inside the row.
+                            InboxNoteRow(viewModel: rowViewModel)
+                                .listRowSeparator(.hidden)
+                        } else {
+                            InboxNoteRow(viewModel: rowViewModel)
+                        }
                     }
                 }
             case .empty:
@@ -29,8 +34,14 @@ struct Inbox: View {
                            image: .emptyProductsTabImage)
                     .frame(maxHeight: .infinity)
             case .syncingFirstPage:
-                // TODO: 5954 - update placeholder state
-                EmptyView()
+                List {
+                    ForEach(viewModel.placeholderRowViewModels) { rowViewModel in
+                        InboxNoteRow(viewModel: rowViewModel)
+                            .redacted(reason: .placeholder)
+                            .shimmering()
+                    }
+                }
+                .listStyle(PlainListStyle())
             }
         }
         .background(Color(.listBackground).ignoresSafeArea())

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -18,7 +18,8 @@ struct InboxNoteRow: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 // Content.
-                // TODO: 5954 - HTML content
+                AttributedText(viewModel.attributedContent)
+                    .attributedTextLinkColor(Color(.accent))
 
                 // HStack with actions and dismiss action.
                 HStack(spacing: Constants.spacingBetweenActions) {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import Yosemite
+
+/// Shows information about an inbox note with actions and a CTA to dismiss the note.
+struct InboxNoteRow: View {
+    let viewModel: InboxNoteRowViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading,
+                   spacing: Constants.verticalSpacing) {
+                // HStack with type icon and relative date.
+                // TODO: 5954 - type icon and relative date
+
+                // Title.
+                Text(viewModel.title)
+                    .bodyStyle()
+                    .fixedSize(horizontal: false, vertical: true)
+
+                // Content.
+                // TODO: 5954 - HTML content
+
+                // HStack with actions and dismiss action.
+                HStack(spacing: Constants.spacingBetweenActions) {
+                    ForEach(viewModel.actions) { action in
+                        if let url = action.url {
+                            Button(action.title) {
+                                // TODO: 5955 - handle action
+                                print("Handling action with URL: \(url)")
+                            }
+                            .foregroundColor(Color(.accent))
+                            .font(.body)
+                            .buttonStyle(PlainButtonStyle())
+                        } else {
+                            Text(action.title)
+                        }
+                    }
+                    Button(Localization.dismiss) {
+                        // TODO: 5955 - handle dismiss action
+                        print("Handling dismiss action")
+                    }
+                    .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
+                    .font(.body)
+                    .buttonStyle(PlainButtonStyle())
+
+                    Spacer()
+                }
+            }
+                   .padding(Constants.defaultPadding)
+
+            if #available(iOS 15.0, *) {
+                // In order to show full-width separator, the default list separator is hidden and a `Divider` is shown inside the row.
+                Divider()
+                    .frame(height: Constants.dividerHeight)
+            }
+        }
+        .listRowInsets(.zero)
+    }
+}
+
+private extension InboxNoteRow {
+    enum Localization {
+        static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss button in inbox note row.")
+    }
+
+    enum Constants {
+        static let spacingBetweenActions: CGFloat = 16
+        static let verticalSpacing: CGFloat = 14
+        static let defaultPadding: CGFloat = 16
+        static let dividerHeight: CGFloat = 1
+    }
+}
+
+struct InboxNoteRow_Previews: PreviewProvider {
+    static var previews: some View {
+        let note = InboxNote(siteID: 2,
+                             id: 6,
+                             name: "",
+                             type: "",
+                             status: "",
+                             actions: [.init(id: 2, name: "", label: "Let your customers know about Apple Pay", status: "", url: "https://wordpress.org"),
+                                       .init(id: 6, name: "", label: "No URL", status: "", url: "")],
+                             title: "Boost sales this holiday season with Apple Pay!",
+                             content: """
+  Increase your conversion rate by letting your customers know that you accept Apple Pay.
+  It’s seamless to <a href=\"https://docs.woocommerce.com/document/payments/apple-pay/\">
+  enable Apple Pay with WooCommerce Payments</a> and easy to communicate it with
+  this <a href=\"https://developer.apple.com/apple-pay/marketing/\">marketing guide</a>.
+""",
+                             isRemoved: false,
+                             isRead: false,
+                             dateCreated: .init())
+        let viewModel = InboxNoteRowViewModel(note: note)
+        Group {
+            InboxNoteRow(viewModel: viewModel)
+                .preferredColorScheme(.dark)
+            InboxNoteRow(viewModel: viewModel)
+                .preferredColorScheme(.light)
+            InboxNoteRow(viewModel: viewModel)
+                .preferredColorScheme(.light)
+                .environment(\.sizeCategory, .extraExtraExtraLarge)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -1,0 +1,40 @@
+import Yosemite
+
+/// View model for `InboxNoteRow`.
+struct InboxNoteRowViewModel: Identifiable {
+    let id: Int64
+    let title: String
+
+    let actions: [InboxNoteRowActionViewModel]
+
+    init(note: InboxNote) {
+        let actions = note.actions.map { InboxNoteRowActionViewModel(action: $0) }
+        self.init(id: note.id,
+                  title: note.title,
+                  actions: actions)
+    }
+
+    init(id: Int64, title: String, actions: [InboxNoteRowActionViewModel]) {
+        self.id = id
+        self.title = title
+        self.actions = actions
+    }
+}
+
+/// View model for an action in `InboxNoteRow`.
+struct InboxNoteRowActionViewModel: Identifiable {
+    let id: Int64
+    let title: String
+    let url: URL?
+
+    init(action: InboxAction) {
+        let url = URL(string: action.url)
+        self.init(id: action.id, title: action.label, url: url)
+    }
+
+    init(id: Int64, title: String, url: URL?) {
+        self.id = id
+        self.title = title
+        self.url = url
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -1,28 +1,38 @@
 import Yosemite
 
 /// View model for `InboxNoteRow`.
-struct InboxNoteRowViewModel: Identifiable {
+struct InboxNoteRowViewModel: Identifiable, Equatable {
     let id: Int64
     let title: String
+
+    /// HTML note content.
+    let attributedContent: NSAttributedString
 
     let actions: [InboxNoteRowActionViewModel]
 
     init(note: InboxNote) {
+        let attributedContent = note.content.htmlToAttributedString
+            .addingAttributes([
+                .font: UIFont.body,
+                .foregroundColor: UIColor.secondaryLabel
+            ])
         let actions = note.actions.map { InboxNoteRowActionViewModel(action: $0) }
         self.init(id: note.id,
                   title: note.title,
+                  attributedContent: attributedContent,
                   actions: actions)
     }
 
-    init(id: Int64, title: String, actions: [InboxNoteRowActionViewModel]) {
+    init(id: Int64, title: String, attributedContent: NSAttributedString, actions: [InboxNoteRowActionViewModel]) {
         self.id = id
         self.title = title
+        self.attributedContent = attributedContent
         self.actions = actions
     }
 }
 
 /// View model for an action in `InboxNoteRow`.
-struct InboxNoteRowActionViewModel: Identifiable {
+struct InboxNoteRowActionViewModel: Identifiable, Equatable {
     let id: Int64
     let title: String
     let url: URL?

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -8,7 +8,17 @@ final class InboxViewModel: ObservableObject {
     let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
 
     /// All inbox notes.
-    @Published private(set) var notes: [InboxNote] = []
+    @Published private var notes: [InboxNote] = []
+
+    /// View models for inbox note rows.
+    @Published private(set) var noteRowViewModels: [InboxNoteRowViewModel] = []
+
+    /// View models for placeholder rows.
+    let placeholderRowViewModels: [InboxNoteRowViewModel] = [Int64](0..<3).map {
+        // The content does not matter because the text in placeholder rows is redacted.
+        InboxNoteRowViewModel(id: $0, title: "            ",
+                              actions: [.init(id: 0, title: "Placeholder", url: nil)])
+    }
 
     // MARK: Sync
 
@@ -35,6 +45,8 @@ final class InboxViewModel: ObservableObject {
         self.stores = stores
         self.syncState = syncState
         self.paginationTracker = PaginationTracker(pageSize: pageSize)
+
+        $notes.map { $0.map { InboxNoteRowViewModel(note: $0) } }.assign(to: &$noteRowViewModels)
 
         configurePaginationTracker()
         configureFirstPageLoad()

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -17,6 +17,7 @@ final class InboxViewModel: ObservableObject {
     let placeholderRowViewModels: [InboxNoteRowViewModel] = [Int64](0..<3).map {
         // The content does not matter because the text in placeholder rows is redacted.
         InboxNoteRowViewModel(id: $0, title: "            ",
+                              attributedContent: .init(string: "\n\n\n"),
                               actions: [.init(id: 0, title: "Placeholder", url: nil)])
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
@@ -25,6 +25,9 @@ import SwiftUI
  SOFTWARE.
  */
 
+/// Note: the font and foreground color of the text have to be set in `NSAttributedString`'s attributes.
+/// `font` and `attributedTextForegroundColor` functions do not take effect.
+/// The link color can be set with `attributedTextLinkColor`.
 struct AttributedText: View {
     @StateObject private var textViewStore = TextViewStore()
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -213,6 +213,9 @@
 		02645D8227BA20A30065DC68 /* InboxViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */; };
 		02645D8527BA2DB40065DC68 /* InboxNoteRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8327BA2DB30065DC68 /* InboxNoteRowViewModel.swift */; };
 		02645D8627BA2DB40065DC68 /* InboxNoteRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8427BA2DB40065DC68 /* InboxNoteRow.swift */; };
+		02645D8827BA2E820065DC68 /* NSAttributedString+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8727BA2E820065DC68 /* NSAttributedString+Attributes.swift */; };
+		02645D8A27BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8927BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift */; };
+		02645D8C27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8B27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */; };
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
@@ -1841,6 +1844,9 @@
 		02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxViewModelTests.swift; sourceTree = "<group>"; };
 		02645D8327BA2DB30065DC68 /* InboxNoteRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxNoteRowViewModel.swift; sourceTree = "<group>"; };
 		02645D8427BA2DB40065DC68 /* InboxNoteRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxNoteRow.swift; sourceTree = "<group>"; };
+		02645D8727BA2E820065DC68 /* NSAttributedString+Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Attributes.swift"; sourceTree = "<group>"; };
+		02645D8927BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+AttributesTests.swift"; sourceTree = "<group>"; };
+		02645D8B27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNoteRowViewModelTests.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
@@ -3770,6 +3776,7 @@
 			isa = PBXGroup;
 			children = (
 				02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */,
+				02645D8B27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift */,
 			);
 			path = Inbox;
 			sourceTree = "<group>";
@@ -6041,6 +6048,7 @@
 				DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */,
 				DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */,
 				02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */,
+				02645D8927BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -6656,6 +6664,7 @@
 				DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */,
 				DEC51B05276B3F3C009F3DF4 /* Int64+Helpers.swift */,
 				02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */,
+				02645D8727BA2E820065DC68 /* NSAttributedString+Attributes.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -8222,6 +8231,7 @@
 				57896D6625362B0C000E8C4D /* TitleAndEditableValueTableViewCellViewModel.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
 				DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */,
+				02645D8827BA2E820065DC68 /* NSAttributedString+Attributes.swift in Sources */,
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,
 				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */,
@@ -9320,6 +9330,7 @@
 				26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
 				D8025496265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift in Sources */,
+				02645D8C27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,
 				D89C009A25B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift in Sources */,
@@ -9442,6 +9453,7 @@
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
 				02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */,
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
+				02645D8A27BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift in Sources */,
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 				023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -211,6 +211,8 @@
 		02645D7D27BA027B0065DC68 /* Inbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D7927BA027B0065DC68 /* Inbox.swift */; };
 		02645D7E27BA027B0065DC68 /* InboxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D7A27BA027B0065DC68 /* InboxViewModel.swift */; };
 		02645D8227BA20A30065DC68 /* InboxViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */; };
+		02645D8527BA2DB40065DC68 /* InboxNoteRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8327BA2DB30065DC68 /* InboxNoteRowViewModel.swift */; };
+		02645D8627BA2DB40065DC68 /* InboxNoteRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8427BA2DB40065DC68 /* InboxNoteRow.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */; };
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
@@ -1837,6 +1839,8 @@
 		02645D7927BA027B0065DC68 /* Inbox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Inbox.swift; sourceTree = "<group>"; };
 		02645D7A27BA027B0065DC68 /* InboxViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxViewModel.swift; sourceTree = "<group>"; };
 		02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxViewModelTests.swift; sourceTree = "<group>"; };
+		02645D8327BA2DB30065DC68 /* InboxNoteRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxNoteRowViewModel.swift; sourceTree = "<group>"; };
+		02645D8427BA2DB40065DC68 /* InboxNoteRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxNoteRow.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
@@ -3756,6 +3760,8 @@
 			children = (
 				02645D7927BA027B0065DC68 /* Inbox.swift */,
 				02645D7A27BA027B0065DC68 /* InboxViewModel.swift */,
+				02645D8427BA2DB40065DC68 /* InboxNoteRow.swift */,
+				02645D8327BA2DB30065DC68 /* InboxNoteRowViewModel.swift */,
 			);
 			path = Inbox;
 			sourceTree = "<group>";
@@ -8768,6 +8774,7 @@
 				934CB123224EAB150005CCB9 /* main.swift in Sources */,
 				456396AE25C81D81001F1A26 /* ShippingLabelFormViewModel.swift in Sources */,
 				02ECD1DF24FF48D000735BE5 /* PaginationTracker.swift in Sources */,
+				02645D8627BA2DB40065DC68 /* InboxNoteRow.swift in Sources */,
 				020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */,
 				262A09812628A8F40033AD20 /* WooStyleModifiers.swift in Sources */,
 				DEC2962526C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift in Sources */,
@@ -8914,6 +8921,7 @@
 				26FE09DD24D9F3F600B9BDF5 /* LoadingView.swift in Sources */,
 				457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */,
 				02F49ADA23BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift in Sources */,
+				02645D8527BA2DB40065DC68 /* InboxNoteRowViewModel.swift in Sources */,
 				740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */,
 				CE22709F2293052700C0626C /* WebviewHelper.swift in Sources */,
 				02BA12852461674B008D8325 /* Optional+String.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/NSAttributedString+AttributesTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/NSAttributedString+AttributesTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import UIKit
+@testable import WooCommerce
+
+final class NSAttributedString_AttributesTests: XCTestCase {
+    func test_adding_attributes_applies_to_the_whole_range() {
+        // Given
+        let originalString = NSAttributedString(string: "It’s seamless to <a href=\"https://docs.woocommerce.com\">enable Apple Pay with Stripe</a>")
+
+        // When
+        let string = originalString.addingAttributes([.foregroundColor: UIColor.purple])
+
+        // Then
+        var effectiveRange = NSRange()
+        XCTAssertEqual(string.attributes(at: 0, effectiveRange: &effectiveRange) as? [NSAttributedString.Key: UIColor], [
+            .foregroundColor: UIColor.purple
+        ])
+        XCTAssertEqual(effectiveRange, .init(location: 0, length: originalString.length))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class InboxNoteRowViewModelTests: XCTestCase {
+    // MARK: - `InboxNoteRowViewModel`
+
+    func test_initializing_InboxNoteRowViewModel_with_note_has_expected_properties() throws {
+        // Given
+        let action = InboxAction.fake().copy(id: 606)
+        let note = InboxNote.fake().copy(actions: [action])
+
+        // When
+        let viewModel = InboxNoteRowViewModel(note: note)
+
+        // Then
+        XCTAssertEqual(viewModel.id, note.id)
+        XCTAssertEqual(viewModel.title, note.title)
+        XCTAssertEqual(viewModel.attributedContent.string, note.content)
+
+        let actionViewModel = try XCTUnwrap(viewModel.actions.first)
+        XCTAssertEqual(actionViewModel.id, action.id)
+    }
+
+    // MARK: - `InboxNoteRowActionViewModel`
+
+    func test_initializing_InboxNoteRowActionViewModel_with_action_with_empty_URL_path_has_nil_URL() {
+        // When
+        let actionViewModel = InboxNoteRowActionViewModel(action: .init(id: 134, name: "wcpay_applepay_holiday2021",
+                                                                        label: "Accept Apple Pay",
+                                                                        status: "actioned",
+                                                                        url: ""))
+
+        // Then
+        XCTAssertEqual(actionViewModel, .init(id: 134, title: "Accept Apple Pay", url: nil))
+        XCTAssertNil(actionViewModel.url)
+    }
+
+    func test_initializing_InboxNoteRowActionViewModel_with_action_has_expected_properties() {
+        // When
+        let actionViewModel = InboxNoteRowActionViewModel(action: .init(id: 134, name: "wcpay_applepay_holiday2021",
+                                                                        label: "Accept Apple Pay",
+                                                                        status: "actioned",
+                                                                        url: "https://woocommerce.com"))
+
+        // Then
+        XCTAssertEqual(actionViewModel, .init(id: 134, title: "Accept Apple Pay", url: .init(string: "https://woocommerce.com")))
+        XCTAssertEqual(actionViewModel.id, 134)
+        XCTAssertEqual(actionViewModel.title, "Accept Apple Pay")
+        XCTAssertEqual(actionViewModel.url?.absoluteString, "https://woocommerce.com")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5954 
<!-- Id number of the GitHub issue this PR addresses. -->

- [x] Make sure https://github.com/woocommerce/woocommerce-ios/pull/6159 is reviewed & merged before emerging

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR added a SwiftUI view `InboxNoteRow` for each inbox note, including title, HTML content, and actions plus a dismiss action. There is still a horizontal stack UI with a type icon and relative date that will be worked on separately.

For the HTML content, the best solution I found so far is to use `AttributedText` which uses `UITextView` under the hood. Using `AttributedText` with `String.htmlToAttributedString` seems to work fine, with some drawbacks:

- The placeholder UI with `.redacted(reason: .placeholder).shimmering()` does not render anything (as in the empty state screenshots below)
- Similar to https://github.com/woocommerce/woocommerce-ios/pull/4527, we need to optimize when `String.htmlToAttributedString` is called when converting a `String` to `NSAttributedString` with `String.htmlToAttributedString`. I ran into a crash when the placeholder state is also using `InboxNoteRowViewModel(note: InboxNote)` for each placeholder row which calls `htmlToAttributedString`, then fixed it by calling the memberwise initializer
- The font size does not respond to dynamic type even when `AttributedText`'s ` UITextView` already has `adjustsFontForContentSizeCategory = true`
- On some simulators like iPod Touch 7gen iOS 15.2, I noticed the text view isn't at the right size until I start scrolling up or down 😞 (screenshot right below)

<img src="https://user-images.githubusercontent.com/1945542/153828341-24a96be4-dd09-4343-a2da-3d971061f3a9.png" width="300" />

Another option is to show a webview for the attributed content. I tried using a webview before, but didn't find an easy to customize font and text color. It might also be tricky to customize how we handle URL tap actions. But due to the issues above, I plan to revisit the webview option or fix the issues in a later subtask.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please note that pagination might be broken if your site only returns 24 instead of 25 notes as the page size in the API request. I'm looking into the issue separately.

- Launch the app
- Go to the Menu tab
- Tap on "Inbox" --> after syncing, a list of notes with title, HTML content, and actions are shown

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

placeholder | results | empty
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2022-02-14 at 16 03 14](https://user-images.githubusercontent.com/1945542/153827481-f57124aa-adef-4046-ab32-934d46d6b15c.png) | ![Simulator Screen Shot - iPhone 11 - 2022-02-14 at 16 03 34](https://user-images.githubusercontent.com/1945542/153827488-0a92a4be-f122-4ab2-aa25-b3d4c3e3eafa.png) | ![Simulator Screen Shot - iPhone 11 - 2022-02-14 at 16 32 30](https://user-images.githubusercontent.com/1945542/153829066-1f0e1cf8-4e69-42ab-b693-d7efd20bbf9e.png)
![Simulator Screen Shot - iPhone 11 - 2022-02-14 at 16 33 01](https://user-images.githubusercontent.com/1945542/153829192-0c4b0d28-5ba7-496e-984f-34be035b3ecd.png) | ![Simulator Screen Shot - iPhone 11 - 2022-02-14 at 16 32 09](https://user-images.githubusercontent.com/1945542/153829180-b47ceba6-80b3-489d-9952-08a9c5fbcb63.png) | ![Simulator Screen Shot - iPhone 11 - 2022-02-14 at 16 32 23](https://user-images.githubusercontent.com/1945542/153829190-6d6f57d0-e148-4392-8b7f-799a876e0485.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
