### PR TITLE
Coupons: Add row for usage details and some polishing for coupon details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -122,6 +122,19 @@ struct CouponDetails: View {
                         }
                     }
                     .background(Color(.listForeground))
+
+                    Spacer().frame(height: Constants.margin)
+                    Divider()
+                    VStack {
+                        NavigationRow(content: {
+                            Text(Localization.usageDetails)
+                                .bodyStyle()
+                        }, action: {
+                            // TODO-5766: Add usage details screen
+                        }).padding(.horizontal, insets: geometry.safeAreaInsets)
+                    }
+                    .background(Color(.listForeground))
+                    Divider()
                 }
             }
             .background(Color(.listBackground))
@@ -165,6 +178,7 @@ private extension CouponDetails {
         static let performance = NSLocalizedString("Performance", comment: "Title of the Performance section on Coupons Details screen")
         static let discountedOrders = NSLocalizedString("Discounted Orders", comment: "Title of the Discounted Orders label on Coupon Details screen")
         static let amount = NSLocalizedString("Amount", comment: "Title of the Amount label on Coupon Details screen")
+        static let usageDetails = NSLocalizedString("Usage details", comment: "Title of the Usage details row in Coupon Details screen")
     }
 
     struct DetailRow: Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -112,7 +112,7 @@ struct CouponDetails: View {
                         ForEach(detailRows) { row in
                             TitleAndValueRow(title: row.title,
                                              value: .content(row.content),
-                                             selectable: true,
+                                             selectable: false,
                                              action: row.action)
                                 .padding(.vertical, Constants.verticalSpacing)
                                 .padding(.horizontal, insets: geometry.safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -132,9 +132,9 @@ private extension CouponDetailsViewModel {
 
     /// Localize content for the "Apply to" field. This takes into consideration different cases of apply rules:
     ///    - When only specific products or categories are defined: Display "x Products" or "x Categories"
-    ///    - When specific products/categories and exceptions are defined: Display "x Products except y Categories" etc.
+    ///    - When specific products/categories and exceptions are defined: Display "x Products excl. y Categories" etc.
     ///    - When both specific products and categories are defined: Display "x Products and y Categories"
-    ///    - When only exceptions are defined: Display "All except x Products" or "All except y Categories"
+    ///    - When only exceptions are defined: Display "All excl. x Products" or "All excl. y Categories"
     ///
     func localizeApplyRules(productsCount: Int, excludedProductsCount: Int, categoriesCount: Int, excludedCategoriesCount: Int) -> String {
         let productText = String.pluralize(productsCount, singular: Localization.singleProduct, plural: Localization.multipleProducts)
@@ -198,8 +198,8 @@ private extension CouponDetailsViewModel {
             comment: "The number of category allowed for a coupon in plural form. " +
             "Reads like: 10 Categories"
         )
-        static let allWithException = NSLocalizedString("All except %1$@", comment: "Exception rule for a coupon. Reads like: All except 2 Products")
-        static let ruleWithException = NSLocalizedString("%1$@ except %2$@", comment: "Exception rule for a coupon. Reads like: 3 Products except 1 Category")
+        static let allWithException = NSLocalizedString("All excl. %1$@", comment: "Exception rule for a coupon. Reads like: All excl. 2 Products")
+        static let ruleWithException = NSLocalizedString("%1$@ excl. %2$@", comment: "Exception rule for a coupon. Reads like: 3 Products excl. 1 Category")
         static let combinedRules = NSLocalizedString("%1$@ and %2$@", comment: "Combined rule for a coupon. Reads like: 2 Products and 1 Category")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -87,7 +87,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
 
         // Then
-        let appliedTo = String(format: NSLocalizedString("%d Products except %d Category", comment: ""), 3, 1)
+        let appliedTo = String(format: NSLocalizedString("%d Products excl. %d Category", comment: ""), 3, 1)
         XCTAssertEqual(viewModel.productsAppliedTo, appliedTo)
     }
 
@@ -97,7 +97,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
 
         // Then
-        let appliedTo = String(format: NSLocalizedString("%d Categories except %d Products", comment: ""), 3, 2)
+        let appliedTo = String(format: NSLocalizedString("%d Categories excl. %d Products", comment: ""), 3, 2)
         XCTAssertEqual(viewModel.productsAppliedTo, appliedTo)
     }
 
@@ -107,7 +107,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
 
         // Then
-        let appliedTo = String(format: NSLocalizedString("All except %d Products", comment: ""), 2)
+        let appliedTo = String(format: NSLocalizedString("All excl. %d Products", comment: ""), 2)
         XCTAssertEqual(viewModel.productsAppliedTo, appliedTo)
     }
 
@@ -117,7 +117,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
         let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
 
         // Then
-        let appliedTo = String(format: NSLocalizedString("All except %d Categories", comment: ""), 2)
+        let appliedTo = String(format: NSLocalizedString("All excl. %d Categories", comment: ""), 2)
         XCTAssertEqual(viewModel.productsAppliedTo, appliedTo)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5765 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR completes the coupon details screen with a few last updates:
- Add a new row to navigate to the Usage Details screen. This screen will be added on a separate PR for #5766.
- Update wording for the product exclusion rules: replace "except" with "excl." to be grammatically correct.
- Disable selecting rows in the Details section since we're only supporting coupon viewing in milestone 1.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have at least one coupon on your test store. Otherwise, navigate to WP Admin > Marketing > Coupons to create one.
- On the app, make sure that coupon management is enabled in Menu > Settings > Experimental Features.
- On the Menu tab, select Coupons and then select a coupon in the list. Notice that: 
  - The Usage details row is present
  - The rows in the Coupon details cannot be selected and the disclosure indicator is not present.
  - If the coupon has exclusion rule for the products or categories applied, notice that the description on the Apply to row is correct.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/153850547-806fead7-bf24-4907-9309-6996df3354cc.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
