### PR TITLE
Order Creation: Add support for adding shipping lines on orders in Networking layer

### DIFF
--- a/Networking/Networking/Model/ShippingLine.swift
+++ b/Networking/Networking/Model/ShippingLine.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Shipping Line Entity.
 ///
-public struct ShippingLine: Decodable, Equatable, GeneratedFakeable {
+public struct ShippingLine: Codable, Equatable, GeneratedFakeable {
     public let shippingID: Int64
     public let methodTitle: String
     public let methodID: String
@@ -26,6 +26,21 @@ public struct ShippingLine: Decodable, Equatable, GeneratedFakeable {
         self.total = total
         self.totalTax = totalTax
         self.taxes = taxes
+    }
+}
+
+// MARK: Codable
+extension ShippingLine {
+
+    /// Encodes ShippingLine writable fields.
+    ///
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(shippingID, forKey: .shippingID)
+        try container.encode(methodTitle, forKey: .methodTitle)
+        try container.encode(methodID, forKey: .methodID)
+        try container.encode(total, forKey: .total)
     }
 }
 

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -147,6 +147,8 @@ public class OrdersRemote: Remote {
                         if let shippingAddress = order.shippingAddress {
                             params[Order.CodingKeys.shippingAddress.rawValue] = try shippingAddress.toDictionary()
                         }
+                    case .shippingLines:
+                        params[Order.CodingKeys.shippingLines.rawValue] = try order.shippingLines.compactMap { try $0.toDictionary() }
                     }
                 }
             }()
@@ -201,6 +203,9 @@ public class OrdersRemote: Remote {
                     case .fees:
                         let feesEncoded = try order.fees.map { try $0.toDictionary() }
                         params[Order.CodingKeys.feeLines.rawValue] = feesEncoded
+                    case .shippingLines:
+                        let shippingEncoded = try order.shippingLines.map { try $0.toDictionary() }
+                        params[Order.CodingKeys.shippingLines.rawValue] = shippingEncoded
                     }
                 }
             }()
@@ -283,6 +288,7 @@ public extension OrdersRemote {
         case shippingAddress
         case billingAddress
         case fees
+        case shippingLines
     }
 
     /// Order fields supported for create
@@ -293,5 +299,6 @@ public extension OrdersRemote {
         case items
         case billingAddress
         case shippingAddress
+        case shippingLines
     }
 }

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -264,6 +264,8 @@ final class OrdersRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    // MARK: - Create Order Tests
+
     func test_create_order_properly_encodes_fee_lines() throws {
         // Given
         let remote = OrdersRemote(network: network)
@@ -375,6 +377,27 @@ final class OrdersRemoteTests: XCTestCase {
             "country": address2.country
         ]
         assertEqual(received2, expected2)
+    }
+
+    func test_create_order_properly_encodes_shipping_lines() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let shipping = ShippingLine(shippingID: 333, methodTitle: "Shipping", methodID: "other", total: "1.23", totalTax: "", taxes: [])
+        let order = Order.fake().copy(shippingLines: [shipping])
+
+        // When
+        remote.createOrder(siteID: 123, order: order, fields: [.shippingLines]) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["shipping_lines"] as? [[String: AnyHashable]]).first
+        let expected: [String: AnyHashable] = [
+            "id": shipping.shippingID,
+            "method_title": shipping.methodTitle,
+            "method_id": shipping.methodID,
+            "total": shipping.total
+        ]
+        assertEqual(received, expected)
     }
 }
 


### PR DESCRIPTION
Part of: #6026

## Description

Adds support in the Networking layer for encoding/adding shipping lines (shipping fees) when creating or updating an order.

Note: To remove shipping lines from an order that already exists remotely (including draft orders), we need to be able to send a null `method_id` to remote. Support for this will be added in a separate PR.

## Changes

* Adds a public encoder to `ShippingLine`, including all writable shipping fields.
* Encodes the order's shipping lines in remote requests to create or update an order.
* Adds a unit test.

## Testing

We don't yet support adding shipping to a new order or updating the shipping on an existing order in the app. For now, you can confirm tests pass in CI. You can also confirm the encoded shipping lines match the writable "Shipping lines properties" for orders in the [REST API docs](https://woocommerce.github.io/woocommerce-rest-api-docs/#order-properties).

Additional testing will be done when support is added in the Yosemite layer in #6162.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
