### PR TITLE
Order Creation: Add support for shipping lines on orders in Yosemite layer

### DIFF
--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -315,7 +315,7 @@ private extension OrderStore {
     /// Creates a manual order with the provided order details.
     ///
     func createOrder(siteID: Int64, order: Order, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        remote.createOrder(siteID: siteID, order: order, fields: [.status, .items, .billingAddress, .shippingAddress]) { [weak self] result in
+        remote.createOrder(siteID: siteID, order: order, fields: [.status, .items, .billingAddress, .shippingAddress, .shippingLines]) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -768,6 +768,28 @@ final class OrderStoreTests: XCTestCase {
         let receivedNote = try XCTUnwrap(request.parameters["customer_note"] as? String)
         assertEqual(receivedNote, note)
     }
+
+    func test_create_order_sends_expected_fields() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
+
+        // When
+        let action = OrderAction.createOrder(siteID: sampleSiteID, order: sampleOrder()) { _ in }
+        store.onAction(action)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let receivedKeys = Array(request.parameters.keys).sorted()
+        let expectedKeys = [
+            "billing",
+            "line_items",
+            "shipping",
+            "shipping_lines",
+            "status"
+        ]
+        assertEqual(expectedKeys, receivedKeys)
+    }
 }
 
 


### PR DESCRIPTION
Closes: #6162
⚠️ Depends on #6163 ⚠️ 

## Description

Adds support in the Yosemite layer for creating an order with shipping lines (shipping fees).

The Yosemite action for updating an order already supports shipping lines; it passes the specified fields (which can include shipping lines) from the UI layer to the remote request.

## Changes

* Adds the `.shippingLines` field to the remote order creation request when creating a manual order.
* Adds a unit test to check that the expected fields are included when creating a manual order.

## Testing

We don't yet support adding shipping to a new order or updating the shipping on an existing order in the app. However, you can test this by firing a `createOrder()` action with a new order that includes shipping lines.

One way to do this is to modify [NewOrderViewModel.OrderDetails.toOrder()](https://github.com/woocommerce/woocommerce-ios/blob/55929e686e47f92297afb900e1c90895510ef6f8/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/NewOrderViewModel.swift#L277-L282) to include a shipping line, for example:

``` swift
func toOrder() -> Order {
            emptyOrder.copy(status: status,
                            items: items.map { $0.orderItem },
                            billingAddress: billingAddress,
                            shippingAddress: shippingAddress,
                            shippingLines: [ShippingLine(shippingID: 0, methodTitle: "App Shipping", methodID: "other", total: "2.50", totalTax: "", taxes: [])])
}
```

Then, go to the Orders tab > tap the `+` button > select `Create order` in the app. Create a new order and confirm the shipping line is added to the newly created order.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
