### PR TITLE
Order Creation: Local Synchronizer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -106,7 +106,8 @@ private struct ProductsSection: View {
                 ForEach(viewModel.productRows) { productRow in
                     ProductRow(viewModel: productRow)
                         .onTapGesture {
-                            viewModel.selectOrderItem(productRow.id)
+                            // TODO: Support selecting an order item
+                            // viewModel.selectOrderItem(productRow.id)
                         }
                         .sheet(item: $viewModel.selectedOrderItem) { item in
                             createProductInOrderView(for: item)
@@ -139,12 +140,13 @@ private struct ProductsSection: View {
     }
 
     @ViewBuilder private func createProductInOrderView(for item: NewOrderViewModel.NewOrderItem) -> some View {
-        if let productRowViewModel = viewModel.createProductRowViewModel(for: item, canChangeQuantity: false) {
-            let productInOrderViewModel = ProductInOrderViewModel(productRowViewModel: productRowViewModel) {
-                viewModel.removeItemFromOrder(item)
-            }
-            ProductInOrder(viewModel: productInOrderViewModel)
-        }
+        // TODO: Support selecting an order item
+//        if let productRowViewModel = viewModel.createProductRowViewModel(for: item, canChangeQuantity: false) {
+//            let productInOrderViewModel = ProductInOrderViewModel(productRowViewModel: productRowViewModel) {
+//                viewModel.removeItemFromOrder(item)
+//            }
+//            ProductInOrder(viewModel: productInOrderViewModel)
+//        }
         EmptyView()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -106,11 +106,10 @@ private struct ProductsSection: View {
                 ForEach(viewModel.productRows) { productRow in
                     ProductRow(viewModel: productRow)
                         .onTapGesture {
-                            // TODO: Support selecting an order item
-                            // viewModel.selectOrderItem(productRow.id)
+                            viewModel.selectOrderItem(productRow.id)
                         }
-                        .sheet(item: $viewModel.selectedOrderItem) { item in
-                            createProductInOrderView(for: item)
+                        .sheet(item: $viewModel.selectedProductViewModel) { productViewModel in
+                            ProductInOrder(viewModel: productViewModel)
                         }
 
                     Divider()
@@ -137,17 +136,6 @@ private struct ProductsSection: View {
 
             Divider()
         }
-    }
-
-    @ViewBuilder private func createProductInOrderView(for item: NewOrderViewModel.NewOrderItem) -> some View {
-        // TODO: Support selecting an order item
-//        if let productRowViewModel = viewModel.createProductRowViewModel(for: item, canChangeQuantity: false) {
-//            let productInOrderViewModel = ProductInOrderViewModel(productRowViewModel: productRowViewModel) {
-//                viewModel.removeItemFromOrder(item)
-//            }
-//            ProductInOrder(viewModel: productInOrderViewModel)
-//        }
-        EmptyView()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -225,7 +225,7 @@ final class NewOrderViewModel: ObservableObject {
     func createOrder() {
         performingNetworkRequest = true
 
-        let action = OrderAction.createOrder(siteID: siteID, order: orderDetails.toOrder()) { [weak self] result in
+        orderSynchronizer.commitAllChanges { [weak self] result in
             guard let self = self else { return }
             self.performingNetworkRequest = false
 
@@ -239,7 +239,6 @@ final class NewOrderViewModel: ObservableObject {
                 DDLogError("⛔️ Error creating new order: \(error)")
             }
         }
-        stores.dispatch(action)
         trackCreateButtonTapped()
     }
 
@@ -527,9 +526,9 @@ private extension NewOrderViewModel {
     /// or figure out a better way to get the product count.
     ///
     func trackCreateButtonTapped() {
-        let hasCustomerDetails = orderDetails.billingAddress != nil || orderDetails.shippingAddress != nil
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(status: orderDetails.status,
-                                                                                productCount: orderDetails.items.count,
+        let hasCustomerDetails = orderSynchronizer.order.billingAddress != nil || orderSynchronizer.order.shippingAddress != nil
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(status: orderSynchronizer.order.status,
+                                                                                productCount: orderSynchronizer.order.items.count,
                                                                                 hasCustomerDetails: hasCustomerDetails))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -477,7 +477,7 @@ private extension NewOrderViewModel {
     /// Updates customer data viewmodel based on order addresses.
     ///
     func configureCustomerDataViewModel() {
-        $orderDetails
+        orderSynchronizer.orderPublisher
             .map {
                 CustomerDataViewModel(billingAddress: $0.billingAddress, shippingAddress: $0.shippingAddress)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -12,10 +12,6 @@ final class NewOrderViewModel: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    /// Order details used to create the order
-    ///
-    @Published var orderDetails = OrderDetails()
-
     /// Active navigation bar trailing item.
     /// Defaults to no visible button.
     ///
@@ -272,19 +268,6 @@ extension NewOrderViewModel {
         case loading
     }
 
-    /// Type to hold all order detail values
-    ///
-    struct OrderDetails {
-        var items: [NewOrderItem] = []
-
-        func toOrder() -> Order {
-            OrderFactory.emptyNewOrder.copy(status: .pending,
-                                            items: items.map { $0.orderItem },
-                                            billingAddress: nil,
-                                            shippingAddress: nil)
-        }
-    }
-
     /// Representation of order status display properties
     ///
     struct StatusBadgeViewModel {
@@ -310,52 +293,6 @@ extension NewOrderViewModel {
         init(orderStatusEnum: OrderStatusEnum) {
             let siteOrderStatus = OrderStatus(name: nil, siteID: 0, slug: orderStatusEnum.rawValue, total: 0)
             self.init(orderStatus: siteOrderStatus)
-        }
-    }
-
-    /// Representation of new items in an order.
-    ///
-    struct NewOrderItem: Equatable, Identifiable {
-        let id: String
-        let productID: Int64
-        let variationID: Int64
-        var quantity: Decimal
-        let price: NSDecimalNumber
-        var subtotal: String {
-            String(describing: quantity * price.decimalValue)
-        }
-
-        var orderItem: OrderItem {
-            OrderItem(itemID: 0,
-                      name: "",
-                      productID: productID,
-                      variationID: variationID,
-                      quantity: quantity,
-                      price: price,
-                      sku: nil,
-                      subtotal: subtotal,
-                      subtotalTax: "",
-                      taxClass: "",
-                      taxes: [],
-                      total: "",
-                      totalTax: "",
-                      attributes: [])
-        }
-
-        init(product: Product, quantity: Decimal) {
-            self.id = UUID().uuidString
-            self.productID = product.productID
-            self.variationID = 0 // Products in an order are represented in Core with a variation ID of 0
-            self.quantity = quantity
-            self.price = NSDecimalNumber(string: product.price)
-        }
-
-        init(variation: ProductVariation, quantity: Decimal) {
-            self.id = UUID().uuidString
-            self.productID = variation.productID
-            self.variationID = variation.productVariationID
-            self.quantity = quantity
-            self.price = NSDecimalNumber(string: variation.price)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -134,6 +134,12 @@ final class NewOrderViewModel: ObservableObject {
         performingNetworkRequest
     }
 
+    /// Defines the current order status.
+    ///
+    var currentOrderStatus: OrderStatusEnum {
+        orderSynchronizer.order.status
+    }
+
     /// Representation of payment data display properties
     ///
     @Published private(set) var paymentDataViewModel = PaymentDataViewModel()
@@ -268,7 +274,6 @@ extension NewOrderViewModel {
     /// Type to hold all order detail values
     ///
     struct OrderDetails {
-        var status: OrderStatusEnum = .pending
         var items: [NewOrderItem] = []
         var billingAddress: Address?
         var shippingAddress: Address?
@@ -279,7 +284,7 @@ extension NewOrderViewModel {
         let emptyOrder = Order.empty
 
         func toOrder() -> Order {
-            emptyOrder.copy(status: status,
+            emptyOrder.copy(status: .pending,
                             items: items.map { $0.orderItem },
                             billingAddress: billingAddress,
                             shippingAddress: shippingAddress)
@@ -425,10 +430,10 @@ private extension NewOrderViewModel {
     /// Updates status badge viewmodel based on status order property.
     ///
     func configureStatusBadgeViewModel() {
-        $orderDetails
-            .map { [weak self] orderDetails in
-                guard let siteOrderStatus = self?.currentSiteStatuses.first(where: { $0.status == orderDetails.status }) else {
-                    return StatusBadgeViewModel(orderStatusEnum: orderDetails.status)
+        orderSynchronizer.orderPublisher
+            .map { [weak self] order in
+                guard let siteOrderStatus = self?.currentSiteStatuses.first(where: { $0.status == order.status }) else {
+                    return StatusBadgeViewModel(orderStatusEnum: order.status)
                 }
                 return StatusBadgeViewModel(orderStatus: siteOrderStatus)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -436,8 +436,8 @@ private extension NewOrderViewModel {
     /// Adds a selected product (from the product list) to the order.
     ///
     func addProductToOrder(_ product: Product) {
-        let newOrderItem = NewOrderItem(product: product, quantity: 1)
-        orderDetails.items.append(newOrderItem)
+        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        orderSynchronizer.setProduct.send(input)
         configureProductRowViewModels()
 
         analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: .creation))
@@ -446,8 +446,8 @@ private extension NewOrderViewModel {
     /// Adds a selected product variation (from the product list) to the order.
     ///
     func addProductVariationToOrder(_ variation: ProductVariation) {
-        let newOrderItem = NewOrderItem(variation: variation, quantity: 1)
-        orderDetails.items.append(newOrderItem)
+        let input = OrderSyncProductInput(product: .variation(variation), quantity: 1)
+        orderSynchronizer.setProduct.send(input)
         configureProductRowViewModels()
 
         analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: .creation))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -142,6 +142,10 @@ final class NewOrderViewModel: ObservableObject {
     ///
     private let analytics: Analytics
 
+    /// Order Synchronizer helper.
+    ///
+    private let orderSynchronizer: OrderSynchronizer
+
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -152,6 +156,7 @@ final class NewOrderViewModel: ObservableObject {
         self.storageManager = storageManager
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.analytics = analytics
+        self.orderSynchronizer = LocalOrderSynchronizer(siteID: siteID, stores: stores)
 
         configureNavigationTrailingItem()
         configureStatusBadgeViewModel()
@@ -245,8 +250,8 @@ final class NewOrderViewModel: ObservableObject {
     /// Updates the order status & tracks its event
     ///
     func updateOrderStatus(newStatus: OrderStatusEnum) {
-        let oldStatus = orderDetails.status
-        orderDetails.status = newStatus
+        let oldStatus = orderSynchronizer.order.status
+        orderSynchronizer.setStatus.send(newStatus)
         analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .creation, orderID: nil, from: oldStatus, to: newStatus))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -124,7 +124,7 @@ final class NewOrderViewModel: ObservableObject {
     /// Indicates if the Payment section should be shown
     ///
     var shouldShowPaymentSection: Bool {
-        orderDetails.items.isNotEmpty
+        orderSynchronizer.order.items.isNotEmpty
     }
 
     /// Defines if the view should be disabled.
@@ -488,14 +488,14 @@ private extension NewOrderViewModel {
     /// Updates payment section view model based on items in the order.
     ///
     func configurePaymentDataViewModel() {
-        $orderDetails
-            .map { [weak self] orderDetails in
+        orderSynchronizer.orderPublisher
+            .map { [weak self] order in
                 guard let self = self else {
                     return PaymentDataViewModel()
                 }
 
-                let itemsTotal = orderDetails.items
-                    .map { $0.orderItem.subtotal }
+                let itemsTotal = order.items
+                    .map { $0.subtotal }
                     .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
                     .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
                     .stringValue
@@ -520,7 +520,7 @@ private extension NewOrderViewModel {
 
     /// Tracks when the create order button is tapped.
     ///
-    /// Warning: This methods assume that `orderDetails.items.count` is equal to the product count,
+    /// Warning: This methods assume that `orderSynchronizer.order.items.count` is equal to the product count,
     /// As the module evolves to handle more types of items, we need to update the property to something like `itemsCount`
     /// or figure out a better way to get the product count.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -188,21 +188,21 @@ final class NewOrderViewModel: ObservableObject {
 
     /// Creates a view model for the `ProductRow` corresponding to an order item.
     ///
-    func createProductRowViewModel(for item: NewOrderItem, canChangeQuantity: Bool) -> ProductRowViewModel? {
+    func createProductRowViewModel(for item: OrderItem, canChangeQuantity: Bool) -> ProductRowViewModel? {
         guard let product = allProducts.first(where: { $0.productID == item.productID }) else {
             return nil
         }
 
         if item.variationID != 0, let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {
             let attributes = ProductVariationFormatter().generateAttributes(for: variation, from: product.attributes)
-            return ProductRowViewModel(id: item.id,
+            return ProductRowViewModel(id: item.itemID,
                                        productVariation: variation,
                                        name: product.name,
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
                                        displayMode: .attributes(attributes))
         } else {
-            return ProductRowViewModel(id: item.id, product: product, quantity: item.quantity, canChangeQuantity: canChangeQuantity)
+            return ProductRowViewModel(id: item.itemID, product: product, quantity: item.quantity, canChangeQuantity: canChangeQuantity)
         }
     }
 
@@ -458,7 +458,7 @@ private extension NewOrderViewModel {
     func configureProductRowViewModels() {
         updateProductsResultsController()
         updateProductVariationsResultsController()
-        productRows = orderDetails.items.enumerated().compactMap { index, item in
+        productRows = orderSynchronizer.order.items.compactMap { item in
             guard let productRowViewModel = createProductRowViewModel(for: item, canChangeQuantity: true) else {
                 return nil
             }
@@ -466,7 +466,8 @@ private extension NewOrderViewModel {
             // Observe changes to the product quantity
             productRowViewModel.$quantity
                 .sink { [weak self] newQuantity in
-                    self?.orderDetails.items[index].quantity = newQuantity
+                    // TODO: Add update quantity support
+                    // self?.orderDetails.items[index].quantity = newQuantity
                 }
                 .store(in: &cancellables)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -509,7 +509,7 @@ private extension NewOrderViewModel {
     ///
     func trackCustomerDetailsAdded() {
         let areAddressesDifferent: Bool = {
-            guard let billingAddress = orderDetails.billingAddress, let shippingAddress = orderDetails.shippingAddress else {
+            guard let billingAddress = orderSynchronizer.order.billingAddress, let shippingAddress = orderSynchronizer.order.shippingAddress else {
                 return false
             }
             return billingAddress != shippingAddress
@@ -547,7 +547,7 @@ private extension NewOrderViewModel {
     /// Expects `billing` and `shipping` addresses to exists together,
     ///
     static func createAddressesInput(from data: CreateOrderAddressFormViewModel.NewOrderAddressData) -> OrderSyncAddressesInput? {
-        guard let billingAddress = data.shippingAddress, let shippingAddress = data.shippingAddress else {
+        guard let billingAddress = data.billingAddress, let shippingAddress = data.shippingAddress else {
             return nil
         }
         return OrderSyncAddressesInput(billing: billingAddress, shipping: shippingAddress)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -278,16 +278,11 @@ extension NewOrderViewModel {
         var billingAddress: Address?
         var shippingAddress: Address?
 
-        /// Used to create `Order` and check if order details have changed from empty/default values.
-        /// Required because `Order` has `Date` properties that have to be the same to be Equatable.
-        ///
-        let emptyOrder = Order.empty
-
         func toOrder() -> Order {
-            emptyOrder.copy(status: .pending,
-                            items: items.map { $0.orderItem },
-                            billingAddress: billingAddress,
-                            shippingAddress: shippingAddress)
+            OrderFactory.emptyNewOrder.copy(status: .pending,
+                                            items: items.map { $0.orderItem },
+                                            billingAddress: billingAddress,
+                                            shippingAddress: shippingAddress)
         }
     }
 
@@ -412,13 +407,13 @@ private extension NewOrderViewModel {
     /// Calculates what navigation trailing item should be shown depending on our internal state.
     ///
     func configureNavigationTrailingItem() {
-        Publishers.CombineLatest($orderDetails, $performingNetworkRequest)
-            .map { orderDetails, performingNetworkRequest -> NavigationItem in
+        Publishers.CombineLatest(orderSynchronizer.orderPublisher, $performingNetworkRequest)
+            .map { order, performingNetworkRequest -> NavigationItem in
                 guard !performingNetworkRequest else {
                     return .loading
                 }
 
-                guard orderDetails.emptyOrder != orderDetails.toOrder() else {
+                guard OrderFactory.emptyNewOrder != order else {
                     return .none
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -275,14 +275,12 @@ extension NewOrderViewModel {
     ///
     struct OrderDetails {
         var items: [NewOrderItem] = []
-        var billingAddress: Address?
-        var shippingAddress: Address?
 
         func toOrder() -> Order {
             OrderFactory.emptyNewOrder.copy(status: .pending,
                                             items: items.map { $0.orderItem },
-                                            billingAddress: billingAddress,
-                                            shippingAddress: shippingAddress)
+                                            billingAddress: nil,
+                                            shippingAddress: nil)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -2,7 +2,13 @@ import Yosemite
 
 /// View model for `ProductInOrder`.
 ///
-final class ProductInOrderViewModel {
+final class ProductInOrderViewModel: Identifiable {
+
+    /// Underlying row ID.
+    ///
+    var ID: Int64 {
+        productRowViewModel.id
+    }
 
     /// The product being edited.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -3,13 +3,6 @@ import Yosemite
 /// View model for `ProductInOrder`.
 ///
 final class ProductInOrderViewModel: Identifiable {
-
-    /// Underlying row ID.
-    ///
-    var ID: Int64 {
-        productRowViewModel.id
-    }
-
     /// The product being edited.
     ///
     let productRowViewModel: ProductRowViewModel

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -13,7 +13,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Unique ID for the view model.
     ///
-    let id: String
+    let id: Int64
 
     // MARK: Product properties
 
@@ -93,7 +93,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     let numberOfVariations: Int
 
-    init(id: String? = nil,
+    init(id: Int64? = nil,
          productOrVariationID: Int64,
          name: String,
          sku: String?,
@@ -107,7 +107,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          numberOfVariations: Int = 0,
          variationDisplayMode: VariationDisplayMode? = nil,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
-        self.id = id ?? productOrVariationID.description
+        self.id = id ?? Int64(UUID().uuidString.hashValue)
         self.productOrVariationID = productOrVariationID
         self.name = name
         self.sku = sku
@@ -125,7 +125,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Initialize `ProductRowViewModel` with a `Product`
     ///
-    convenience init(id: String? = nil,
+    convenience init(id: Int64? = nil,
                      product: Product,
                      quantity: Decimal = 1,
                      canChangeQuantity: Bool,
@@ -155,7 +155,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Initialize `ProductRowViewModel` with a `ProductVariation`
     ///
-    convenience init(id: String? = nil,
+    convenience init(id: Int64? = nil,
                      productVariation: ProductVariation,
                      name: String,
                      quantity: Decimal = 1,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -34,7 +34,7 @@ struct OrderStatusSection: View {
                 .padding(.trailing, -Layout.linkButtonTrailingPadding) // remove trailing padding to align button title to the side
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
-                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.orderDetails.status) { newStatus in
+                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus) { newStatus in
                         viewModel.updateOrderStatus(newStatus: newStatus)
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -70,6 +70,12 @@ private extension LocalOrderSynchronizer {
                ProductInputTransformer.update(input: productInput, on: order)
             }
             .assign(to: &$order)
+
+        setAddresses.withLatestFrom(orderPublisher)
+            .map { addressesInput, order in
+                order.copy(billingAddress: addressesInput?.billing, shippingAddress: addressesInput?.shipping)
+            }
+            .assign(to: &$order)
     }
 }
 
@@ -136,4 +142,3 @@ private struct ProductInputTransformer {
                          attributes: [])
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Yosemite
+import Combine
+
+/// Local implementation that does not syncs the order with the remote server.
+///
+final class LocalOrderSynchronizer: OrderSynchronizer {
+
+    @Published private(set) var state: OrderSyncState = .synced
+
+    var statePublisher: Published<OrderSyncState>.Publisher {
+        $state
+    }
+
+    @Published private(set) var order: Order = Order.empty
+
+    var orderPublisher: Published<Order>.Publisher {
+        $order
+    }
+
+    var setStatus = PassthroughSubject<OrderStatusEnum, Never>()
+
+    var setProduct = PassthroughSubject<OrderSyncProductInput, Never>()
+
+    var setAddresses = PassthroughSubject<OrderSyncAddressesInput?, Never>()
+
+    var setShipping =  PassthroughSubject<ShippingLine?, Never>()
+
+    var setFee = PassthroughSubject<OrderFeeLine?, Never>()
+
+    func retrySync() {
+    }
+
+    func commitAllChanges(onCompletion: (Result<Order, Error>) -> Void) {
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -6,6 +6,8 @@ import Combine
 ///
 final class LocalOrderSynchronizer: OrderSynchronizer {
 
+    // MARK: Outputs
+
     @Published private(set) var state: OrderSyncState = .synced
 
     var statePublisher: Published<OrderSyncState>.Publisher {
@@ -18,6 +20,8 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
         $order
     }
 
+    // MARK: Inputs
+
     var setStatus = PassthroughSubject<OrderStatusEnum, Never>()
 
     var setProduct = PassthroughSubject<OrderSyncProductInput, Never>()
@@ -28,9 +32,26 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
 
     var setFee = PassthroughSubject<OrderFeeLine?, Never>()
 
-    func retrySync() {
+    // MARK: Private properties
+
+    private let siteID: Int64
+
+    private let stores: StoresManager
+
+    // MARK: Initializers
+
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
     }
 
-    func commitAllChanges(onCompletion: (Result<Order, Error>) -> Void) {
+    // MARK: Methods
+    func retrySync() {
+        // No op
+    }
+
+    func commitAllChanges(onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        let action = OrderAction.createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
+        stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -131,15 +131,14 @@ private struct ProductInputTransformer {
     /// Creates and order item by using the `input.id` as the `item.itemID`.
     ///
     private static func createOrderItem(using input: OrderSyncProductInput) -> OrderItem {
-        let quantity = Decimal(input.quantity)
         let parameters: OrderItemParameters = {
             switch input.product {
             case .product(let product):
                 let price = Decimal(string: product.price) ?? .zero
-                return OrderItemParameters(quantity: quantity, price: price, productID: product.productID, variationID: nil)
+                return OrderItemParameters(quantity: input.quantity, price: price, productID: product.productID, variationID: nil)
             case .variation(let variation):
                 let price = Decimal(string: variation.price) ?? .zero
-                return OrderItemParameters(quantity: quantity, price: price, productID: variation.productID, variationID: variation.productVariationID)
+                return OrderItemParameters(quantity: input.quantity, price: price, productID: variation.productID, variationID: variation.productVariationID)
             }
         }()
 
@@ -147,7 +146,7 @@ private struct ProductInputTransformer {
                          name: "",
                          productID: parameters.productID,
                          variationID: parameters.variationID ?? 0,
-                         quantity: quantity,
+                         quantity: parameters.quantity,
                          price: parameters.price as NSDecimalNumber,
                          sku: nil,
                          subtotal: parameters.subtotal,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -124,30 +124,29 @@ private struct ProductInputTransformer {
     ///
     private static func remove(input: OrderSyncProductInput, from order: Order) -> Order {
         var items = order.items
-        items.removeAll { $0.itemID == input.id.hashValue }
+        items.removeAll { $0.itemID == input.id }
         return order.copy(items: items)
     }
 
     /// Creates and order item by using the `input.id` as the `item.itemID`.
     ///
     private static func createOrderItem(using input: OrderSyncProductInput) -> OrderItem {
-        let quantity = Decimal(input.quantity)
         let parameters: OrderItemParameters = {
             switch input.product {
             case .product(let product):
                 let price = Decimal(string: product.price) ?? .zero
-                return OrderItemParameters(quantity: quantity, price: price, productID: product.productID, variationID: nil)
+                return OrderItemParameters(quantity: input.quantity, price: price, productID: product.productID, variationID: nil)
             case .variation(let variation):
                 let price = Decimal(string: variation.price) ?? .zero
-                return OrderItemParameters(quantity: quantity, price: price, productID: variation.productID, variationID: variation.productVariationID)
+                return OrderItemParameters(quantity: input.quantity, price: price, productID: variation.productID, variationID: variation.productVariationID)
             }
         }()
 
-        return OrderItem(itemID: Int64(input.id.hashValue),
+        return OrderItem(itemID: input.id,
                          name: "",
                          productID: parameters.productID,
                          variationID: parameters.variationID ?? 0,
-                         quantity: quantity,
+                         quantity: parameters.quantity,
                          price: parameters.price as NSDecimalNumber,
                          sku: nil,
                          subtotal: parameters.subtotal,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -43,6 +43,7 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.stores = stores
+        bindInputs()
     }
 
     // MARK: Methods
@@ -53,5 +54,15 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
     func commitAllChanges(onCompletion: @escaping (Result<Order, Error>) -> Void) {
         let action = OrderAction.createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
         stores.dispatch(action)
+    }
+}
+
+private extension LocalOrderSynchronizer {
+    func bindInputs() {
+        setStatus.withLatestFrom(orderPublisher)
+            .map { newStatus, order in
+                order.copy(status: newStatus)
+            }
+            .assign(to: &$order)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -14,7 +14,7 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
         $state
     }
 
-    @Published private(set) var order: Order = Order.empty
+    @Published private(set) var order: Order = OrderFactory.emptyNewOrder
 
     var orderPublisher: Published<Order>.Publisher {
         $order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -19,6 +19,7 @@ struct OrderSyncProductInput {
         case product(Product)
         case variation(ProductVariation)
     }
+    let id = UUID().uuidString
     let product: ProductType
     let quantity: Int
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -19,9 +19,9 @@ struct OrderSyncProductInput {
         case product(Product)
         case variation(ProductVariation)
     }
-    let id = UUID().uuidString
+    var id: Int64 = Int64(UUID().uuidString.hashValue)
     let product: ProductType
-    let quantity: Int
+    let quantity: Decimal
 }
 
 /// Addresses input for an `OrderSynchronizer` type.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -19,9 +19,9 @@ struct OrderSyncProductInput {
         case product(Product)
         case variation(ProductVariation)
     }
-    let id = UUID().uuidString
+    var id = Int64(UUID().uuidString.hashValue)
     let product: ProductType
-    let quantity: Int
+    let quantity: Decimal
 }
 
 /// Addresses input for an `OrderSynchronizer` type.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -36,13 +36,21 @@ protocol OrderSynchronizer {
 
     // MARK: Outputs
 
-    /// Defines the current sync state of the synchronizer.
+    /// Latest order sync state.
     ///
-    var state: Published<OrderSyncState> { get }
+    var state: OrderSyncState { get }
 
-    /// Defines the latest order to be synced or that is synced.
+    /// Order Sync State Publisher.
     ///
-    var order: Published<Order> { get }
+    var statePublisher: Published<OrderSyncState>.Publisher { get }
+
+    /// Latest order to be synced or that is synced.
+    ///
+    var order: Order { get }
+
+    /// Publisher for the order toe be synced or that is synced.
+    ///
+    var orderPublisher: Published<Order>.Publisher { get }
 
     // MARK: Inputs
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -82,5 +82,5 @@ protocol OrderSynchronizer {
 
     /// Commits all order changes to the remote source. State needs to be in `.synced` to initiate work.
     ///
-    func commitAllChanges(onCompletion: (Result<Order, Error>) -> Void)
+    func commitAllChanges(onCompletion: @escaping (Result<Order, Error>) -> Void)
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */; };
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
 		26C6439327B5DBE900DD00D1 /* OrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */; };
+		26C6439527B9A1B300DD00D1 /* LocalOrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6439427B9A1B300DD00D1 /* LocalOrderSynchronizer.swift */; };
 		26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */; };
 		26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */; };
 		26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */; };
@@ -2125,6 +2126,7 @@
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
 		26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSynchronizer.swift; sourceTree = "<group>"; };
+		26C6439427B9A1B300DD00D1 /* LocalOrderSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalOrderSynchronizer.swift; sourceTree = "<group>"; };
 		26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModel.swift; sourceTree = "<group>"; };
 		26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModelTests.swift; sourceTree = "<group>"; };
 		26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorViewModel.swift; sourceTree = "<group>"; };
@@ -4507,6 +4509,7 @@
 			isa = PBXGroup;
 			children = (
 				26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */,
+				26C6439427B9A1B300DD00D1 /* LocalOrderSynchronizer.swift */,
 			);
 			path = Synchronizer;
 			sourceTree = "<group>";
@@ -8840,6 +8843,7 @@
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
 				E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */,
 				454453CC27566FAE00464AC5 /* HubMenuElement.swift in Sources */,
+				26C6439527B9A1B300DD00D1 /* LocalOrderSynchronizer.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,
 				4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */,
 				45A4221A24ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -164,7 +164,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
     }
 
-    func test_order_details_are_updated_when_product_quantity_changes() throws {
+    func test_order_details_are_updated_when_product_quantity_changes() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -184,8 +184,6 @@ class NewOrderViewModelTests: XCTestCase {
     }
 
     func test_selectOrderItem_selects_expected_order_item() throws {
-        throw XCTSkip("Test disabled while we enable select order support on OrderSynchronizer")
-
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -194,14 +192,15 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product.productID)
 
         // When
-        let expectedOrderItem = viewModel.orderDetails.items[0]
-        viewModel.selectOrderItem(expectedOrderItem.id)
+        let expectedRow = viewModel.productRows[0]
+        viewModel.selectOrderItem(expectedRow.id)
 
         // Then
-        XCTAssertEqual(viewModel.selectedOrderItem, expectedOrderItem)
+        XCTAssertNotNil(viewModel.selectedProductViewModel)
+        XCTAssertEqual(viewModel.selectedProductViewModel?.productRowViewModel.id, expectedRow.id)
     }
 
-    func test_view_model_is_updated_when_product_is_removed_from_order() throws {
+    func test_view_model_is_updated_when_product_is_removed_from_order() {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
@@ -214,13 +213,13 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product1.productID)
 
         // When
-        throw XCTSkip("Test disabled while we enable remove item support on OrderSynchronizer")
-        let expectedRemainingItem = viewModel.orderDetails.items[1]
-        viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
+        let expectedRemainingRow = viewModel.productRows[1]
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)
+        viewModel.removeItemFromOrder(itemToRemove)
 
         // Then
         XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product0.productID }))
-        XCTAssertEqual(viewModel.orderDetails.items, [expectedRemainingItem])
+        XCTAssertEqual(viewModel.productRows.map { $0.id }, [expectedRemainingRow].map { $0.id })
     }
 
     func test_createProductRowViewModel_creates_expected_row_for_product() {
@@ -321,7 +320,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
     }
 
-    func test_payment_section_only_displayed_when_order_has_products() throws {
+    func test_payment_section_only_displayed_when_order_has_products() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -333,12 +332,13 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldShowPaymentSection)
 
         // When & Then
-        throw XCTSkip("This unit test needs to be reenabled when the remove item method is migrated")
-        viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id, productID: product.productID)
+        viewModel.removeItemFromOrder(itemToRemove)
+
         XCTAssertFalse(viewModel.shouldShowPaymentSection)
     }
 
-    func test_payment_section_is_updated_when_products_update() throws {
+    func test_payment_section_is_updated_when_products_update() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -161,7 +161,6 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product.productID)
 
         // Then
-        let expectedOrderItem = NewOrderViewModel.NewOrderItem(product: product, quantity: 1).orderItem
         XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
     }
 
@@ -180,10 +179,8 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product.productID)
 
         // Then
-        throw XCTSkip("Test disabled while we enable update quantity support on OrderSynchronizer")
-        let expectedOrderItem = NewOrderViewModel.NewOrderItem(product: product, quantity: 2).orderItem
-        XCTAssertTrue(viewModel.orderDetails.items.contains(where: { $0.orderItem == expectedOrderItem }),
-                      "Order details do not contain order item with updated quantity")
+        XCTAssertEqual(viewModel.productRows[safe: 0]?.quantity, 2)
+        XCTAssertEqual(viewModel.productRows[safe: 1]?.quantity, 1)
     }
 
     func test_selectOrderItem_selects_expected_order_item() throws {
@@ -355,7 +352,6 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
 
         // When & Then
-        throw XCTSkip("Test disabled while we enable update quantity support on OrderSynchronizer")
         viewModel.productRows[0].incrementQuantity()
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£17.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£17.00")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -26,7 +26,7 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID)
 
         // When
-        viewModel.orderDetails.status = .processing
+        viewModel.updateOrderStatus(newStatus: .processing)
 
         // Then
         XCTAssertEqual(viewModel.navigationTrailingItem, .create)
@@ -82,7 +82,7 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
 
         // When
-        viewModel.orderDetails.status = .processing
+        viewModel.updateOrderStatus(newStatus: .processing)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .createOrder(_, order, onCompletion):
@@ -144,7 +144,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "Pending payment")
 
         // When
-        viewModel.orderDetails.status = .processing
+        viewModel.updateOrderStatus(newStatus: .processing)
 
         // Then
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "Processing")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -273,10 +273,13 @@ class NewOrderViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let addressViewModel = viewModel.createOrderAddressFormViewModel()
         XCTAssertFalse(viewModel.customerDataViewModel.isDataAvailable)
 
         // When
-        viewModel.orderDetails.billingAddress = sampleAddress1()
+        addressViewModel.fields.firstName = sampleAddress1().firstName
+        addressViewModel.fields.lastName = sampleAddress1().lastName
+        addressViewModel.saveAddress(onFinish: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.customerDataViewModel.isDataAvailable)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -163,10 +163,9 @@ class NewOrderViewModelTests: XCTestCase {
         // Then
         let expectedOrderItem = NewOrderViewModel.NewOrderItem(product: product, quantity: 1).orderItem
         XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
-        XCTAssertTrue(viewModel.orderDetails.items.contains(where: { $0.orderItem == expectedOrderItem }), "Order details do not contain expected order item")
     }
 
-    func test_order_details_are_updated_when_product_quantity_changes() {
+    func test_order_details_are_updated_when_product_quantity_changes() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -181,12 +180,15 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product.productID)
 
         // Then
+        throw XCTSkip("Test disabled while we enable update quantity support on OrderSynchronizer")
         let expectedOrderItem = NewOrderViewModel.NewOrderItem(product: product, quantity: 2).orderItem
         XCTAssertTrue(viewModel.orderDetails.items.contains(where: { $0.orderItem == expectedOrderItem }),
                       "Order details do not contain order item with updated quantity")
     }
 
-    func test_selectOrderItem_selects_expected_order_item() {
+    func test_selectOrderItem_selects_expected_order_item() throws {
+        throw XCTSkip("Test disabled while we enable select order support on OrderSynchronizer")
+
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -202,7 +204,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedOrderItem, expectedOrderItem)
     }
 
-    func test_view_model_is_updated_when_product_is_removed_from_order() {
+    func test_view_model_is_updated_when_product_is_removed_from_order() throws {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
@@ -215,6 +217,7 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product1.productID)
 
         // When
+        throw XCTSkip("Test disabled while we enable remove item support on OrderSynchronizer")
         let expectedRemainingItem = viewModel.orderDetails.items[1]
         viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
 
@@ -231,8 +234,8 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // When
-        let newOrderItem = NewOrderViewModel.NewOrderItem(product: product, quantity: 1)
-        let productRow = viewModel.createProductRowViewModel(for: newOrderItem, canChangeQuantity: true)
+        let orderItem = OrderItem.fake().copy(name: product.name, productID: product.productID, quantity: 1)
+        let productRow = viewModel.createProductRowViewModel(for: orderItem, canChangeQuantity: true)
 
         // Then
         let expectedProductRow = ProductRowViewModel(product: product, canChangeQuantity: true)
@@ -254,8 +257,11 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // When
-        let newOrderItem = NewOrderViewModel.NewOrderItem(variation: productVariation, quantity: 2)
-        let productRow = viewModel.createProductRowViewModel(for: newOrderItem, canChangeQuantity: false)
+        let orderItem = OrderItem.fake().copy(name: product.name,
+                                              productID: product.productID,
+                                              variationID: productVariation.productVariationID,
+                                              quantity: 2)
+        let productRow = viewModel.createProductRowViewModel(for: orderItem, canChangeQuantity: false)
 
         // Then
         let expectedProductRow = ProductRowViewModel(productVariation: productVariation,
@@ -318,7 +324,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
     }
 
-    func test_payment_section_only_displayed_when_order_has_products() {
+    func test_payment_section_only_displayed_when_order_has_products() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -330,11 +336,12 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldShowPaymentSection)
 
         // When & Then
+        throw XCTSkip("This unit test needs to be reenabled when the remove item method is migrated")
         viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
         XCTAssertFalse(viewModel.shouldShowPaymentSection)
     }
 
-    func test_payment_section_is_updated_when_products_update() {
+    func test_payment_section_is_updated_when_products_update() throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
@@ -348,6 +355,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
 
         // When & Then
+        throw XCTSkip("Test disabled while we enable update quantity support on OrderSynchronizer")
         viewModel.productRows[0].incrementQuantity()
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£17.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£17.00")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -1,12 +1,13 @@
 import XCTest
 import Yosemite
+import Fakes
 @testable import WooCommerce
 
 class ProductRowViewModelTests: XCTestCase {
 
     func test_viewModel_is_created_with_correct_initial_values_from_product() {
         // Given
-        let rowID = "0"
+        let rowID = Int64(0)
         let imageURLString = "https://woo.com/woo.jpg"
         let product = Product.fake().copy(productID: 12,
                                           name: "Test Product",
@@ -38,7 +39,7 @@ class ProductRowViewModelTests: XCTestCase {
 
     func test_viewModel_is_created_with_correct_initial_values_from_product_variation() {
         // Given
-        let rowID = "0"
+        let rowID = Int64(0)
         let imageURLString = "https://woo.com/woo.jpg"
         let name = "Blue - Any Size"
         let productVariation = ProductVariation.fake().copy(productVariationID: 12,

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -3,7 +3,7 @@ import Networking
 
 /// Factory to create convenience order types.
 ///
-enum OrderFactory {
+public enum OrderFactory {
     /// Creates an order suitable to be used as a simple payments order.
     /// Under the hood it uses a fee line with or without taxes to create an order with the desired amount.
     ///
@@ -51,4 +51,8 @@ enum OrderFactory {
               taxes: [],
               attributes: [])
     }
+
+    /// References a new empty order with constants `Date` values.
+    ///
+    public static let emptyNewOrder = Order.empty
 }


### PR DESCRIPTION
closes #6128 

# Why

This PR adds a `LocalOrderSynchronizer` type that stores all modifications done to an order.

I tried to integrate this into our current `NewOrderViewModel` but I found that the module needs some significant changes/refactor and submitting all in one single PR won't be efficient for the reviewers.

For that reason, I will be submitting small PRs against this branch in order to merge all the refactor in one go.

I expect this feature branch to be short-lived so it does not get very out of sync. 

# How

The local synchronizer is very simple, it has an internal store object that is fed via the exposed subjects. 
The most "complex" one is `setProduct` that takes care of adding, removing, and updating items but the rest of them should just assign the correspondent order field.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
