### PR TITLE
Order Creation: Wire status support to LocalOrderSynchronizer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -225,7 +225,7 @@ final class NewOrderViewModel: ObservableObject {
     func createOrder() {
         performingNetworkRequest = true
 
-        let action = OrderAction.createOrder(siteID: siteID, order: orderDetails.toOrder()) { [weak self] result in
+        orderSynchronizer.commitAllChanges { [weak self] result in
             guard let self = self else { return }
             self.performingNetworkRequest = false
 
@@ -239,7 +239,6 @@ final class NewOrderViewModel: ObservableObject {
                 DDLogError("⛔️ Error creating new order: \(error)")
             }
         }
-        stores.dispatch(action)
         trackCreateButtonTapped()
     }
 
@@ -527,9 +526,9 @@ private extension NewOrderViewModel {
     /// or figure out a better way to get the product count.
     ///
     func trackCreateButtonTapped() {
-        let hasCustomerDetails = orderDetails.billingAddress != nil || orderDetails.shippingAddress != nil
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(status: orderDetails.status,
-                                                                                productCount: orderDetails.items.count,
+        let hasCustomerDetails = orderSynchronizer.order.billingAddress != nil || orderSynchronizer.order.shippingAddress != nil
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(status: orderSynchronizer.order.status,
+                                                                                productCount: orderSynchronizer.order.items.count,
                                                                                 hasCustomerDetails: hasCustomerDetails))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -134,6 +134,12 @@ final class NewOrderViewModel: ObservableObject {
         performingNetworkRequest
     }
 
+    /// Defines the current order status.
+    ///
+    var currentOrderStatus: OrderStatusEnum {
+        orderSynchronizer.order.status
+    }
+
     /// Representation of payment data display properties
     ///
     @Published private(set) var paymentDataViewModel = PaymentDataViewModel()
@@ -268,7 +274,6 @@ extension NewOrderViewModel {
     /// Type to hold all order detail values
     ///
     struct OrderDetails {
-        var status: OrderStatusEnum = .pending
         var items: [NewOrderItem] = []
         var billingAddress: Address?
         var shippingAddress: Address?
@@ -279,7 +284,7 @@ extension NewOrderViewModel {
         let emptyOrder = Order.empty
 
         func toOrder() -> Order {
-            emptyOrder.copy(status: status,
+            emptyOrder.copy(status: .pending,
                             items: items.map { $0.orderItem },
                             billingAddress: billingAddress,
                             shippingAddress: shippingAddress)
@@ -425,10 +430,10 @@ private extension NewOrderViewModel {
     /// Updates status badge viewmodel based on status order property.
     ///
     func configureStatusBadgeViewModel() {
-        $orderDetails
-            .map { [weak self] orderDetails in
-                guard let siteOrderStatus = self?.currentSiteStatuses.first(where: { $0.status == orderDetails.status }) else {
-                    return StatusBadgeViewModel(orderStatusEnum: orderDetails.status)
+        orderSynchronizer.orderPublisher
+            .map { [weak self] order in
+                guard let siteOrderStatus = self?.currentSiteStatuses.first(where: { $0.status == order.status }) else {
+                    return StatusBadgeViewModel(orderStatusEnum: order.status)
                 }
                 return StatusBadgeViewModel(orderStatus: siteOrderStatus)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -142,6 +142,10 @@ final class NewOrderViewModel: ObservableObject {
     ///
     private let analytics: Analytics
 
+    /// Order Synchronizer helper.
+    ///
+    private let orderSynchronizer: OrderSynchronizer
+
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -152,6 +156,7 @@ final class NewOrderViewModel: ObservableObject {
         self.storageManager = storageManager
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.analytics = analytics
+        self.orderSynchronizer = LocalOrderSynchronizer(siteID: siteID, stores: stores)
 
         configureNavigationTrailingItem()
         configureStatusBadgeViewModel()
@@ -245,8 +250,8 @@ final class NewOrderViewModel: ObservableObject {
     /// Updates the order status & tracks its event
     ///
     func updateOrderStatus(newStatus: OrderStatusEnum) {
-        let oldStatus = orderDetails.status
-        orderDetails.status = newStatus
+        let oldStatus = orderSynchronizer.order.status
+        orderSynchronizer.setStatus.send(newStatus)
         analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .creation, orderID: nil, from: oldStatus, to: newStatus))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -278,16 +278,11 @@ extension NewOrderViewModel {
         var billingAddress: Address?
         var shippingAddress: Address?
 
-        /// Used to create `Order` and check if order details have changed from empty/default values.
-        /// Required because `Order` has `Date` properties that have to be the same to be Equatable.
-        ///
-        let emptyOrder = Order.empty
-
         func toOrder() -> Order {
-            emptyOrder.copy(status: .pending,
-                            items: items.map { $0.orderItem },
-                            billingAddress: billingAddress,
-                            shippingAddress: shippingAddress)
+            OrderFactory.emptyNewOrder.copy(status: .pending,
+                                            items: items.map { $0.orderItem },
+                                            billingAddress: billingAddress,
+                                            shippingAddress: shippingAddress)
         }
     }
 
@@ -412,13 +407,13 @@ private extension NewOrderViewModel {
     /// Calculates what navigation trailing item should be shown depending on our internal state.
     ///
     func configureNavigationTrailingItem() {
-        Publishers.CombineLatest($orderDetails, $performingNetworkRequest)
-            .map { orderDetails, performingNetworkRequest -> NavigationItem in
+        Publishers.CombineLatest(orderSynchronizer.orderPublisher, $performingNetworkRequest)
+            .map { order, performingNetworkRequest -> NavigationItem in
                 guard !performingNetworkRequest else {
                     return .loading
                 }
 
-                guard orderDetails.emptyOrder != orderDetails.toOrder() else {
+                guard OrderFactory.emptyNewOrder != order else {
                     return .none
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -34,7 +34,7 @@ struct OrderStatusSection: View {
                 .padding(.trailing, -Layout.linkButtonTrailingPadding) // remove trailing padding to align button title to the side
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
-                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.orderDetails.status) { newStatus in
+                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus) { newStatus in
                         viewModel.updateOrderStatus(newStatus: newStatus)
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -14,7 +14,7 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
         $state
     }
 
-    @Published private(set) var order: Order = Order.empty
+    @Published private(set) var order: Order = OrderFactory.emptyNewOrder
 
     var orderPublisher: Published<Order>.Publisher {
         $order

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -26,7 +26,7 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID)
 
         // When
-        viewModel.orderDetails.status = .processing
+        viewModel.updateOrderStatus(newStatus: .processing)
 
         // Then
         XCTAssertEqual(viewModel.navigationTrailingItem, .create)
@@ -82,7 +82,7 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
 
         // When
-        viewModel.orderDetails.status = .processing
+        viewModel.updateOrderStatus(newStatus: .processing)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .createOrder(_, order, onCompletion):
@@ -144,7 +144,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "Pending payment")
 
         // When
-        viewModel.orderDetails.status = .processing
+        viewModel.updateOrderStatus(newStatus: .processing)
 
         // Then
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "Processing")

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -3,7 +3,7 @@ import Networking
 
 /// Factory to create convenience order types.
 ///
-enum OrderFactory {
+public enum OrderFactory {
     /// Creates an order suitable to be used as a simple payments order.
     /// Under the hood it uses a fee line with or without taxes to create an order with the desired amount.
     ///
@@ -51,4 +51,8 @@ enum OrderFactory {
               taxes: [],
               attributes: [])
     }
+
+    /// References a new empty order with constants `Date` values.
+    ///
+    public static let emptyNewOrder = Order.empty
 }


### PR DESCRIPTION
part of #6128

# Why

Following the migration plan to the `LocalOrderSyncronizer`, this PR:

- Removes `status` from `OrderDetails`
- Refactors `NewOrderViewModel` to send and read the status from the `orderSynchronizer`
- Refactors `NewOrderViewModel` to create the order using the `orderSynchronizer.commitAllChanges` method
- Updates tests.

# Demo
https://user-images.githubusercontent.com/562080/153975378-dfe4d4c5-ba9f-4c81-a2f9-c1d9fbc57fbb.mov


# Testing Scenarios

- See that you can change an order status
- See that the create button is enabled when the status is changed
- See that you can create an order with the desired status.

**NOTE:** This is being merged into a feature branch
**NOTE 2:** Addresses & products are not supported yet.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
