### PR TITLE
Order Creation: Wire customer details support to LocalOrderSynchronizer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -477,7 +477,7 @@ private extension NewOrderViewModel {
     /// Updates customer data viewmodel based on order addresses.
     ///
     func configureCustomerDataViewModel() {
-        $orderDetails
+        orderSynchronizer.orderPublisher
             .map {
                 CustomerDataViewModel(billingAddress: $0.billingAddress, shippingAddress: $0.shippingAddress)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -509,7 +509,7 @@ private extension NewOrderViewModel {
     ///
     func trackCustomerDetailsAdded() {
         let areAddressesDifferent: Bool = {
-            guard let billingAddress = orderDetails.billingAddress, let shippingAddress = orderDetails.shippingAddress else {
+            guard let billingAddress = orderSynchronizer.order.billingAddress, let shippingAddress = orderSynchronizer.order.shippingAddress else {
                 return false
             }
             return billingAddress != shippingAddress
@@ -547,7 +547,7 @@ private extension NewOrderViewModel {
     /// Expects `billing` and `shipping` addresses to exists together,
     ///
     static func createAddressesInput(from data: CreateOrderAddressFormViewModel.NewOrderAddressData) -> OrderSyncAddressesInput? {
-        guard let billingAddress = data.shippingAddress, let shippingAddress = data.shippingAddress else {
+        guard let billingAddress = data.billingAddress, let shippingAddress = data.shippingAddress else {
             return nil
         }
         return OrderSyncAddressesInput(billing: billingAddress, shipping: shippingAddress)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -275,14 +275,12 @@ extension NewOrderViewModel {
     ///
     struct OrderDetails {
         var items: [NewOrderItem] = []
-        var billingAddress: Address?
-        var shippingAddress: Address?
 
         func toOrder() -> Order {
             OrderFactory.emptyNewOrder.copy(status: .pending,
                                             items: items.map { $0.orderItem },
-                                            billingAddress: billingAddress,
-                                            shippingAddress: shippingAddress)
+                                            billingAddress: nil,
+                                            shippingAddress: nil)
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -273,10 +273,13 @@ class NewOrderViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let addressViewModel = viewModel.createOrderAddressFormViewModel()
         XCTAssertFalse(viewModel.customerDataViewModel.isDataAvailable)
 
         // When
-        viewModel.orderDetails.billingAddress = sampleAddress1()
+        addressViewModel.fields.firstName = sampleAddress1().firstName
+        addressViewModel.fields.lastName = sampleAddress1().lastName
+        addressViewModel.saveAddress(onFinish: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.customerDataViewModel.isDataAvailable)


### PR DESCRIPTION
part of https://github.com/woocommerce/woocommerce-ios/issues/6128

# Why
Following the migration plan to the LocalOrderSyncronizer, this PR:

- Removes addresses from `OrderDetails`.
- Refactors `NewOrderViewModel` to send and read the addresses from the `orderSynchronizer`.
- Updates tests.


# Demo

https://user-images.githubusercontent.com/562080/153984866-78a95906-f885-40f1-80b5-9d59234f1e74.mov

**Note:** The shipping address is not visible on the demo because the order does not has a physical product but it is synced in core

<img width="1216" alt="shipping-addresses" src="https://user-images.githubusercontent.com/562080/153984954-3002b61c-5c27-49d9-8575-aedeccd1a255.png">

# Testing Scenarios

- See that you can change an order customer details
- See that the create button is enabled when the customer details are updated.
- See that you can create an order with the desired customer details.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
