### PR TITLE
Coupons: Improve UX for the Performance section on Coupon Details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -83,14 +83,20 @@ struct CouponDetails: View {
                                     .secondaryBodyStyle()
                                 Text(viewModel.discountedOrdersCount)
                                     .font(.title)
+                                Spacer()
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                             VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
                                 Text(Localization.amount)
                                     .secondaryBodyStyle()
-                                Text(viewModel.discountedAmount)
-                                    .font(.title)
+                                if let amount = viewModel.discountedAmount {
+                                    Text(amount)
+                                        .font(.title)
+                                } else {
+                                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                                }
+                                Spacer()
                             }
                             .padding(.leading, Constants.margin)
                             .frame(maxWidth: .infinity, alignment: .leading)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -42,7 +42,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     /// Total amount deducted from orders that applied the coupon
     ///
-    @Published private(set) var discountedAmount: String = ""
+    @Published private(set) var discountedAmount: String?
 
     /// The current coupon
     ///
@@ -61,7 +61,6 @@ final class CouponDetailsViewModel: ObservableObject {
         self.coupon = coupon
         self.stores = stores
         self.currencySettings = currencySettings
-        self.discountedAmount = formatStringAmount("0")
         populateDetails()
     }
 
@@ -102,6 +101,10 @@ private extension CouponDetailsViewModel {
     func populateDetails() {
         couponCode = coupon.code
         description = coupon.description
+        discountedOrdersCount = "\(coupon.usageCount)"
+        if coupon.usageCount == 0 {
+            discountedAmount = formatStringAmount("0")
+        }
 
         switch coupon.discountType {
         case .percent:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5765 (I actually closed it in #6161, but this is a minor update to make it complete).
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In #6161, @pmusolino pointed out that the UX for the performance section could be improved to show some loading indicators when the coupon report is being fetched. This PR fixes that by adding a few changes:
- Get the orders count from the coupon instead of the coupon analytics report to avoid unnecessary delay to show the data when it's already available.
- Make the property for the discounted amount optional.
- If the orders count is 0, update the discounted amount to 0 immediately.
- Otherwise, show a loading indicator until the coupon report is fetched and the amount is no longer nil.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have at least one coupon on your test store. Otherwise, navigate to WP Admin > Marketing > Coupons to create one.
- On the app, make sure that coupon management is enabled in Menu > Settings > Experimental Features.
- On the Menu tab, select Coupons and then select a coupon in the list. Pay attention to the Performance section and notice that: 
  - The orders count is always available immediately.
  - If the count is 0, the amount should display 0 immediately. Otherwise, a loading indicator is displayed until the amount is fetched and filled in.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/153997382-3076c14e-bb88-4dd6-bfea-8990f145e723.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
