### PR TITLE
Inbox view part 3: inbox note row UI - type icon and relative date text

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -28,9 +28,6 @@ struct InboxNoteRow: View {
                     Spacer()
                 }
 
-                Spacer()
-                    .frame(height: 8)
-
                 VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
                     // Title.
                     Text(viewModel.title)

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -5,46 +5,67 @@ import Yosemite
 struct InboxNoteRow: View {
     let viewModel: InboxNoteRowViewModel
 
+    // Tracks the scale of the view due to accessibility changes.
+    @ScaledMetric private var scale: CGFloat = 1
+
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading,
-                   spacing: Constants.verticalSpacing) {
+            VStack(alignment: .leading, spacing: 0) {
                 // HStack with type icon and relative date.
-                // TODO: 5954 - type icon and relative date
-
-                // Title.
-                Text(viewModel.title)
-                    .bodyStyle()
-                    .fixedSize(horizontal: false, vertical: true)
-
-                // Content.
-                AttributedText(viewModel.attributedContent)
-                    .attributedTextLinkColor(Color(.accent))
-
-                // HStack with actions and dismiss action.
-                HStack(spacing: Constants.spacingBetweenActions) {
-                    ForEach(viewModel.actions) { action in
-                        if let url = action.url {
-                            Button(action.title) {
-                                // TODO: 5955 - handle action
-                                print("Handling action with URL: \(url)")
-                            }
-                            .foregroundColor(Color(.accent))
-                            .font(.body)
-                            .buttonStyle(PlainButtonStyle())
-                        } else {
-                            Text(action.title)
-                        }
-                    }
-                    Button(Localization.dismiss) {
-                        // TODO: 5955 - handle dismiss action
-                        print("Handling dismiss action")
-                    }
-                    .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
-                    .font(.body)
-                    .buttonStyle(PlainButtonStyle())
-
+                HStack {
+                    Circle()
+                        .frame(width: scale * Constants.typeIconDimension, height: scale * Constants.typeIconDimension, alignment: .center)
+                        .foregroundColor(Color(Constants.typeIconCircleColor))
+                        .overlay(
+                            viewModel.typeIcon
+                                    .resizable()
+                                    .scaledToFit()
+                                .padding(scale * Constants.typeIconPadding)
+                        )
+                    Text(viewModel.date)
+                        .font(.subheadline)
+                        .foregroundColor(Color(Constants.dateTextColor))
                     Spacer()
+                }
+
+                Spacer()
+                    .frame(height: 8)
+
+                VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                    // Title.
+                    Text(viewModel.title)
+                        .bodyStyle()
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // Content.
+                    AttributedText(viewModel.attributedContent)
+                        .attributedTextLinkColor(Color(.accent))
+
+                    // HStack with actions and dismiss action.
+                    HStack(spacing: Constants.spacingBetweenActions) {
+                        ForEach(viewModel.actions) { action in
+                            if let url = action.url {
+                                Button(action.title) {
+                                    // TODO: 5955 - handle action
+                                    print("Handling action with URL: \(url)")
+                                }
+                                .foregroundColor(Color(.accent))
+                                .font(.body)
+                                .buttonStyle(PlainButtonStyle())
+                            } else {
+                                Text(action.title)
+                            }
+                        }
+                        Button(Localization.dismiss) {
+                            // TODO: 5955 - handle dismiss action
+                            print("Handling dismiss action")
+                        }
+                        .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
+                        .font(.body)
+                        .buttonStyle(PlainButtonStyle())
+
+                        Spacer()
+                    }
                 }
             }
                    .padding(Constants.defaultPadding)
@@ -69,15 +90,21 @@ private extension InboxNoteRow {
         static let verticalSpacing: CGFloat = 14
         static let defaultPadding: CGFloat = 16
         static let dividerHeight: CGFloat = 1
+        static let dateTextColor: UIColor = .withColorStudio(.gray, shade: .shade30)
+        static let typeIconDimension: CGFloat = 29
+        static let typeIconPadding: CGFloat = 5
+        static let typeIconCircleColor: UIColor = .init(light: .withColorStudio(.gray, shade: .shade0), dark: .withColorStudio(.gray, shade: .shade70))
     }
 }
 
 struct InboxNoteRow_Previews: PreviewProvider {
     static var previews: some View {
+        // Monday, February 14, 2022 1:04:42 PM
+        let today = Date(timeIntervalSince1970: 1644843882)
         let note = InboxNote(siteID: 2,
                              id: 6,
                              name: "",
-                             type: "",
+                             type: "marketing",
                              status: "",
                              actions: [.init(id: 2, name: "", label: "Let your customers know about Apple Pay", status: "", url: "https://wordpress.org"),
                                        .init(id: 6, name: "", label: "No URL", status: "", url: "")],
@@ -91,13 +118,33 @@ struct InboxNoteRow_Previews: PreviewProvider {
                              isRemoved: false,
                              isRead: false,
                              dateCreated: .init())
-        let viewModel = InboxNoteRowViewModel(note: note)
+        let shortNote = InboxNote(siteID: 2,
+                             id: 6,
+                             name: "",
+                             type: "",
+                             status: "",
+                             actions: [.init(id: 2, name: "", label: "Learn Apple Pay", status: "", url: "https://wordpress.org"),
+                                       .init(id: 6, name: "", label: "No URL", status: "", url: "")],
+                             title: "Boost sales this holiday season with Apple Pay!",
+                             content: "Increase your conversion rate.",
+                             isRemoved: false,
+                             isRead: false,
+                             dateCreated: today)
         Group {
-            InboxNoteRow(viewModel: viewModel)
+            List {
+                InboxNoteRow(viewModel: .init(note: note.copy(type: "marketing", dateCreated: today), today: today))
+                InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "error").copy(dateCreated: today.addingTimeInterval(-6*60)), today: today))
+                InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "warning").copy(dateCreated: today.addingTimeInterval(-6*3600)), today: today))
+                InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "update").copy(dateCreated: today.addingTimeInterval(-6*86400)), today: today))
+                InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "info").copy(dateCreated: today.addingTimeInterval(-14*86400)), today: today))
+                InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "survey").copy(dateCreated: today.addingTimeInterval(-1.5*86400)), today: today))
+            }
                 .preferredColorScheme(.dark)
-            InboxNoteRow(viewModel: viewModel)
+                .environment(\.sizeCategory, .extraSmall)
+                .previewLayout(.sizeThatFits)
+            InboxNoteRow(viewModel: .init(note: note.copy(dateCreated: today.addingTimeInterval(-86400*2)), today: today))
                 .preferredColorScheme(.light)
-            InboxNoteRow(viewModel: viewModel)
+            InboxNoteRow(viewModel: .init(note: note.copy(dateCreated: today.addingTimeInterval(-6*60)), today: today))
                 .preferredColorScheme(.light)
                 .environment(\.sizeCategory, .extraExtraExtraLarge)
         }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -10,7 +10,7 @@ struct InboxNoteRow: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: Constants.spacingBetweenTopHStackAndContentVStack) {
                 // HStack with type icon and relative date.
                 HStack {
                     Circle()
@@ -87,6 +87,7 @@ private extension InboxNoteRow {
 
     enum Constants {
         static let spacingBetweenActions: CGFloat = 16
+        static let spacingBetweenTopHStackAndContentVStack: CGFloat = 8
         static let verticalSpacing: CGFloat = 14
         static let defaultPadding: CGFloat = 16
         static let dividerHeight: CGFloat = 1

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -1,33 +1,82 @@
+import SwiftUI
 import Yosemite
 
 /// View model for `InboxNoteRow`.
 struct InboxNoteRowViewModel: Identifiable, Equatable {
     let id: Int64
+
+    /// Relative date when the note was created.
+    let date: String
+
+    /// Icon for the note type (e.g. marketing, info).
+    let typeIcon: Image
+
+    /// Title of the note.
     let title: String
 
     /// HTML note content.
     let attributedContent: NSAttributedString
 
+    /// Actions for the note.
     let actions: [InboxNoteRowActionViewModel]
 
-    init(note: InboxNote) {
+    init(note: InboxNote, today: Date = .init(), locale: Locale = .current, calendar: Calendar = .current) {
         let attributedContent = note.content.htmlToAttributedString
             .addingAttributes([
                 .font: UIFont.body,
                 .foregroundColor: UIColor.secondaryLabel
             ])
+        let date: String = {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.locale = locale
+            formatter.calendar = calendar
+            formatter.dateTimeStyle = .named
+            return formatter.localizedString(for: note.dateCreated, relativeTo: today)
+        }()
         let actions = note.actions.map { InboxNoteRowActionViewModel(action: $0) }
         self.init(id: note.id,
+                  date: date,
+                  typeIcon: (NoteType(rawValue: note.type) ?? .info).image,
                   title: note.title,
                   attributedContent: attributedContent,
                   actions: actions)
     }
 
-    init(id: Int64, title: String, attributedContent: NSAttributedString, actions: [InboxNoteRowActionViewModel]) {
+    init(id: Int64, date: String, typeIcon: Image, title: String, attributedContent: NSAttributedString, actions: [InboxNoteRowActionViewModel]) {
         self.id = id
+        self.date = date
+        self.typeIcon = typeIcon
         self.title = title
         self.attributedContent = attributedContent
         self.actions = actions
+    }
+}
+
+private extension InboxNoteRowViewModel {
+    enum NoteType: String {
+        case error
+        case warning
+        case update
+        case info
+        case marketing
+        case survey
+
+        var image: Image {
+            switch self {
+            case .error:
+                return Image(uiImage: .infoImage)
+            case .warning:
+                return Image(uiImage: .infoImage)
+            case .update:
+                return Image(uiImage: .infoImage)
+            case .info:
+                return Image(uiImage: .infoImage)
+            case .marketing:
+                return Image(systemName: "lightbulb.fill")
+            case .survey:
+                return Image(uiImage: .infoImage)
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -64,17 +64,17 @@ private extension InboxNoteRowViewModel {
         var image: Image {
             switch self {
             case .error:
-                return Image(uiImage: .infoImage)
+                return Image(systemName: "exclamationmark.octagon.fill")
             case .warning:
-                return Image(uiImage: .infoImage)
+                return Image(systemName: "exclamationmark.bubble.fill")
             case .update:
-                return Image(uiImage: .infoImage)
+                return Image(systemName: "gearshape.fill")
             case .info:
                 return Image(uiImage: .infoImage)
             case .marketing:
                 return Image(systemName: "lightbulb.fill")
             case .survey:
-                return Image(uiImage: .infoImage)
+                return Image(systemName: "doc.plaintext")
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -16,7 +16,10 @@ final class InboxViewModel: ObservableObject {
     /// View models for placeholder rows.
     let placeholderRowViewModels: [InboxNoteRowViewModel] = [Int64](0..<3).map {
         // The content does not matter because the text in placeholder rows is redacted.
-        InboxNoteRowViewModel(id: $0, title: "            ",
+        InboxNoteRowViewModel(id: $0,
+                              date: "   ",
+                              typeIcon: .init(uiImage: .infoImage),
+                              title: "            ",
                               attributedContent: .init(string: "\n\n\n"),
                               actions: [.init(id: 0, title: "Placeholder", url: nil)])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 import Yosemite
 @testable import WooCommerce
@@ -5,7 +6,7 @@ import Yosemite
 final class InboxNoteRowViewModelTests: XCTestCase {
     // MARK: - `InboxNoteRowViewModel`
 
-    func test_initializing_InboxNoteRowViewModel_with_note_has_expected_properties() throws {
+    func test_initializing_InboxNoteRowViewModel_with_note_has_expected_title_content_actions() throws {
         // Given
         let action = InboxAction.fake().copy(id: 606)
         let note = InboxNote.fake().copy(actions: [action])
@@ -20,6 +21,91 @@ final class InboxNoteRowViewModelTests: XCTestCase {
 
         let actionViewModel = try XCTUnwrap(viewModel.actions.first)
         XCTAssertEqual(actionViewModel.id, action.id)
+    }
+
+    func test_initializing_InboxNoteRowViewModel_with_supported_note_types_sets_typeIcon_accordingly() {
+        // Given
+        let types = ["error", "warning", "update", "info", "marketing", "survey"]
+        // TODO: 5954 - update type icons after design updates
+        let expectedTypeIcons = [Image(uiImage: .infoImage), // error
+                                Image(uiImage: .infoImage), // warning
+                                Image(uiImage: .infoImage), // update
+                                Image(uiImage: .infoImage), // info
+                                Image(systemName: "lightbulb.fill"), // marketing
+                                Image(uiImage: .infoImage) // survey
+        ]
+
+        for (type, expectedTypeIcon) in zip(types, expectedTypeIcons) {
+            // When
+            let note = InboxNote.fake().copy(type: type)
+            let viewModel = InboxNoteRowViewModel(note: note)
+
+            // Then
+            XCTAssertEqual(viewModel.typeIcon, expectedTypeIcon)
+        }
+    }
+
+    func test_initializing_InboxNoteRowViewModel_with_unsupported_note_type_sets_typeIcon_to_info_type() {
+        // When
+        let note = InboxNote.fake().copy(type: "special")
+        let viewModel = InboxNoteRowViewModel(note: note)
+
+        // Then
+        // TODO: 5954 - update type icon after design updates
+        let infoTypeIcon = Image(uiImage: .infoImage)
+        XCTAssertEqual(viewModel.typeIcon, infoTypeIcon)
+    }
+
+    func test_initializing_InboxNoteRowViewModel_with_dateCreated_now_sets_date_to_now() throws {
+        // Given
+        // GMT Tuesday, February 15, 2022 6:55:28 AM
+        let today = Date(timeIntervalSince1970: 1644908128)
+        let note = InboxNote.fake().copy(dateCreated: today)
+        let locale = Locale(identifier: "en_US")
+        let timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        let calendar = Calendar(identifier: .gregorian, timeZone: timeZone)
+
+        // When
+        let viewModel = InboxNoteRowViewModel(note: note, today: today, locale: locale, calendar: calendar)
+
+        // Then
+        XCTAssertEqual(viewModel.date, "now")
+    }
+
+    func test_initializing_InboxNoteRowViewModel_with_dateCreated_2_months_ago_sets_date_accordingly() throws {
+        // Given
+        // GMT Tuesday, February 15, 2022 6:55:28 AM
+        let today = Date(timeIntervalSince1970: 1644908128)
+        // GMT Wednesday, December 15, 2021 6:55:28 AM
+        let twoMonthsAgo = Date(timeIntervalSince1970: 1639551328)
+        let note = InboxNote.fake().copy(dateCreated: twoMonthsAgo)
+        let locale = Locale(identifier: "en_US")
+        let timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        let calendar = Calendar(identifier: .gregorian, timeZone: timeZone)
+
+        // When
+        let viewModel = InboxNoteRowViewModel(note: note, today: today, locale: locale, calendar: calendar)
+
+        // Then
+        XCTAssertEqual(viewModel.date, "2 months ago")
+    }
+
+    func test_initializing_InboxNoteRowViewModel_with_dateCreated_2_months_later_sets_date_accordingly() throws {
+        // Given
+        // GMT Tuesday, February 15, 2022 6:55:28 AM
+        let today = Date(timeIntervalSince1970: 1644908128)
+        // GMT Friday, April 15, 2022 6:55:28 AM
+        let twoMonthsLater = Date(timeIntervalSince1970: 1650005728)
+        let note = InboxNote.fake().copy(dateCreated: twoMonthsLater)
+        let locale = Locale(identifier: "en_US")
+        let timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        let calendar = Calendar(identifier: .gregorian, timeZone: timeZone)
+
+        // When
+        let viewModel = InboxNoteRowViewModel(note: note, today: today, locale: locale, calendar: calendar)
+
+        // Then
+        XCTAssertEqual(viewModel.date, "in 2 months")
     }
 
     // MARK: - `InboxNoteRowActionViewModel`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
@@ -27,12 +27,12 @@ final class InboxNoteRowViewModelTests: XCTestCase {
         // Given
         let types = ["error", "warning", "update", "info", "marketing", "survey"]
         // TODO: 5954 - update type icons after design updates
-        let expectedTypeIcons = [Image(uiImage: .infoImage), // error
-                                Image(uiImage: .infoImage), // warning
-                                Image(uiImage: .infoImage), // update
-                                Image(uiImage: .infoImage), // info
-                                Image(systemName: "lightbulb.fill"), // marketing
-                                Image(uiImage: .infoImage) // survey
+        let expectedTypeIcons = [Image(systemName: "exclamationmark.octagon.fill"), // error
+                                 Image(systemName: "exclamationmark.bubble.fill"), // warning
+                                 Image(systemName: "gearshape.fill"), // update
+                                 Image(uiImage: .infoImage), // info
+                                 Image(systemName: "lightbulb.fill"), // marketing
+                                 Image(systemName: "doc.plaintext") // survey
         ]
 
         for (type, expectedTypeIcon) in zip(types, expectedTypeIcons) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5954
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR added a type icon and relative date text to each inbox note row. Please note that the type icons are not well mapped yet from currently supported values ("error", "warning", "update", "info", "marketing", "survey") from Amanda's spike p6q6po-b6x-p2. I'm going to p2 about this mapping, since it's unlikely we are adding another field to the inbox notes API for the icon.

Right now, the type icon is a SwiftUI `Image` in the row view model because this allows us to use `Image(systemName:)` and `Image(uiImage:)`. When a system image is initialized as `Image(uiImage:)`, the image is blurred out as it scales. It shows the lightbulb icon for `marketing` type, and different temporary icons for other types.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* Launch the app
* Go to the Menu tab
* Tap on "Inbox" --> after syncing, a type icon and relative date text are shown at the top of the note

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 11 - 2022-02-15 at 15 24 37](https://user-images.githubusercontent.com/1945542/154013133-2917d730-3e6f-4e88-b328-e72416c0f0aa.png) | ![Simulator Screen Shot - iPhone 11 - 2022-02-15 at 15 24 46](https://user-images.githubusercontent.com/1945542/154013137-c1a438ce-018b-4bad-ac94-921ca3e706e8.png)

Other cases:

all types | larger font size | loading state
-- | -- | --
<img width="376" alt="Screen Shot 2022-02-15 at 3 23 56 PM" src="https://user-images.githubusercontent.com/1945542/154013108-b9244870-ac9d-42c8-8698-ebf36cb1ff50.png"> | <img width="413" alt="Screen Shot 2022-02-15 at 3 24 08 PM" src="https://user-images.githubusercontent.com/1945542/154013121-285ae23c-10ff-4fca-908e-14d3c93c1489.png"> | ![Simulator Screen Shot - iPhone 11 - 2022-02-15 at 15 24 18](https://user-images.githubusercontent.com/1945542/154013130-a4de1da6-1549-451d-94e2-9f5cb99c10cf.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->