### PR TITLE
Migrated `InfiniteScrollList` from `List` to `LazyVStack`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -18,13 +18,9 @@ struct Inbox: View {
                 InfiniteScrollList(isLoading: viewModel.shouldShowBottomActivityIndicator,
                                    loadAction: viewModel.onLoadNextPageAction) {
                     ForEach(viewModel.noteRowViewModels) { rowViewModel in
-                        if #available(iOS 15.0, *) {
-                            // In order to show full-width separator, the default list separator is hidden and a `Divider` is shown inside the row.
-                            InboxNoteRow(viewModel: rowViewModel)
-                        } else {
-                            InboxNoteRow(viewModel: rowViewModel)
-                        }
-                    }.background(Color(.listForeground))
+                        InboxNoteRow(viewModel: rowViewModel)
+                    }
+                    .background(Color(.listForeground))
                 }
             case .empty:
                 // TODO: 5954 - update empty state

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -29,14 +29,16 @@ struct Inbox: View {
                            image: .emptyProductsTabImage)
                     .frame(maxHeight: .infinity)
             case .syncingFirstPage:
-                List {
-                    ForEach(viewModel.placeholderRowViewModels) { rowViewModel in
-                        InboxNoteRow(viewModel: rowViewModel)
-                            .redacted(reason: .placeholder)
-                            .shimmering()
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(viewModel.placeholderRowViewModels) { rowViewModel in
+                            InboxNoteRow(viewModel: rowViewModel)
+                                .redacted(reason: .placeholder)
+                                .shimmering()
+                        }
+                        .background(Color(.listForeground))
                     }
                 }
-                .listStyle(PlainListStyle())
             }
         }
         .background(Color(.listBackground).ignoresSafeArea())

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -20,7 +20,7 @@ struct Inbox: View {
                     ForEach(viewModel.noteRowViewModels) { rowViewModel in
                         InboxNoteRow(viewModel: rowViewModel)
                     }
-                    .background(Color(.listForeground))
+                    .background(Constants.listForeground)
                 }
             case .empty:
                 // TODO: 5954 - update empty state
@@ -36,12 +36,12 @@ struct Inbox: View {
                                 .redacted(reason: .placeholder)
                                 .shimmering()
                         }
-                        .background(Color(.listForeground))
+                        .background(Constants.listForeground)
                     }
                 }
             }
         }
-        .background(Color(.listBackground).ignoresSafeArea())
+        .background(Constants.listBackground.ignoresSafeArea())
         .navigationTitle(Localization.title)
         .onAppear {
             viewModel.onLoadTrigger.send()
@@ -50,6 +50,12 @@ struct Inbox: View {
 }
 
 private extension Inbox {
+
+    enum Constants {
+        static let listForeground: Color = Color(.listForeground)
+        static let listBackground: Color = Color(.listBackground)
+    }
+
     enum Localization {
         static let title = NSLocalizedString("Inbox", comment: "Title for the screen that shows inbox notes.")
         static let emptyStateTitle = NSLocalizedString("Congrats, you’ve read everything!",

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -24,7 +24,7 @@ struct Inbox: View {
                         } else {
                             InboxNoteRow(viewModel: rowViewModel)
                         }
-                    }
+                    }.background(Color(.listForeground))
                 }
             case .empty:
                 // TODO: 5954 - update empty state

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -21,7 +21,6 @@ struct Inbox: View {
                         if #available(iOS 15.0, *) {
                             // In order to show full-width separator, the default list separator is hidden and a `Divider` is shown inside the row.
                             InboxNoteRow(viewModel: rowViewModel)
-                                .listRowSeparator(.hidden)
                         } else {
                             InboxNoteRow(viewModel: rowViewModel)
                         }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -49,13 +49,9 @@ struct InboxNoteRow: View {
             }
                    .padding(Constants.defaultPadding)
 
-            if #available(iOS 15.0, *) {
-                // In order to show full-width separator, the default list separator is hidden and a `Divider` is shown inside the row.
-                Divider()
-                    .frame(height: Constants.dividerHeight)
-            }
+            Divider()
+                .frame(height: Constants.dividerHeight)
         }
-        .listRowInsets(.zero)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -21,6 +21,7 @@ struct AddProductToOrder: View {
                                        loadAction: viewModel.syncNextPage) {
                         ForEach(viewModel.productRows) { rowViewModel in
                             createProductRow(rowViewModel: rowViewModel)
+                            Divider().frame(height: Constants.dividerHeight)
                         }
                     }
                 case .empty:
@@ -74,6 +75,10 @@ struct AddProductToOrder: View {
 }
 
 private extension AddProductToOrder {
+    enum Constants {
+        static let dividerHeight: CGFloat = 1
+    }
+
     enum Localization {
         static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -21,7 +21,9 @@ struct AddProductToOrder: View {
                                        loadAction: viewModel.syncNextPage) {
                         ForEach(viewModel.productRows) { rowViewModel in
                             createProductRow(rowViewModel: rowViewModel)
+                                .padding(Constants.defaultPadding)
                             Divider().frame(height: Constants.dividerHeight)
+                                .padding(.leading, Constants.defaultPadding)
                         }
                     }
                                        .background(Color(.listForeground))
@@ -78,6 +80,7 @@ struct AddProductToOrder: View {
 private extension AddProductToOrder {
     enum Constants {
         static let dividerHeight: CGFloat = 1
+        static let defaultPadding: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -24,6 +24,7 @@ struct AddProductToOrder: View {
                             Divider().frame(height: Constants.dividerHeight)
                         }
                     }
+                                       .background(Color(.listForeground))
                 case .empty:
                     EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
                         .frame(maxHeight: .infinity)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -21,11 +21,13 @@ struct AddProductVariationToOrder: View {
                                    loadAction: viewModel.syncNextPage) {
                     ForEach(viewModel.productVariationRows) { rowViewModel in
                         ProductRow(viewModel: rowViewModel)
+                            .padding(Constants.defaultPadding)
                             .onTapGesture {
                                 viewModel.selectVariation(rowViewModel.productOrVariationID)
                                 isPresented.toggle()
                             }
                         Divider().frame(height: Constants.dividerHeight)
+                            .padding(.leading, Constants.defaultPadding)
                     }
                     .background(Color(.listForeground))
                 }
@@ -68,6 +70,7 @@ struct AddProductVariationToOrder: View {
 private extension AddProductVariationToOrder {
     enum Constants {
         static let dividerHeight: CGFloat = 1
+        static let defaultPadding: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -25,6 +25,7 @@ struct AddProductVariationToOrder: View {
                                 viewModel.selectVariation(rowViewModel.productOrVariationID)
                                 isPresented.toggle()
                             }
+                        Divider().frame(height: Constants.dividerHeight)
                     }
                 }
             case .empty:
@@ -64,6 +65,10 @@ struct AddProductVariationToOrder: View {
 }
 
 private extension AddProductVariationToOrder {
+    enum Constants {
+        static let dividerHeight: CGFloat = 1
+    }
+
     enum Localization {
         static let emptyStateMessage = NSLocalizedString("No product variations found",
                                                          comment: "Message displayed if there are no product variations for a product.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -27,6 +27,7 @@ struct AddProductVariationToOrder: View {
                             }
                         Divider().frame(height: Constants.dividerHeight)
                     }
+                    .background(Color(.listForeground))
                 }
             case .empty:
                 EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
@@ -31,7 +31,7 @@ struct InfiniteScrollList<Content: View>: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack {
+            LazyVStack(spacing: 0) {
                 listContent
 
                 InfiniteScrollIndicator(showContent: isLoading)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollList.swift
@@ -30,15 +30,16 @@ struct InfiniteScrollList<Content: View>: View {
     }
 
     var body: some View {
-        List {
-            listContent
+        ScrollView {
+            LazyVStack {
+                listContent
 
-            InfiniteScrollIndicator(showContent: isLoading)
-                .onAppear {
-                    loadAction()
-                }
+                InfiniteScrollIndicator(showContent: isLoading)
+                    .onAppear {
+                        loadAction()
+                    }
+            }
         }
-        .listStyle(PlainListStyle())
     }
 }
 


### PR DESCRIPTION

### Description
@jaclync during the implementation of the Inbox Note Row using the `InfiniteScrollList` componted, she discovered a bug on some simulators like iPod Touch 7gen iOS 15.2, where the text view isn't at the right size until she start scrolling up or down.
So, for solving the issue, in this PR I moved away from `List` inside `InfiniteScrollList`, and I implemented `LazyVStack`. 
We should always use `LazyVStack` instead of `List` in our app, because:
- `List` is a wrapper of `UITableView` with some limitations on customizations.
- `LazyVStack` is a native implementation of `UITableView` in SwiftUI.
- Since we dropped iOS 13, there are no reasons to use `List` instead of `LazyVStack` (available from iOS 14).
- Separators in `LazyVStack` are easily customizable.
- The behavior in `LazyVStack` is more predictable.

I also made some improvements to the padding of the rows of `AddProductToOrder` and `AddProductVariationToOrder` because it was wrong originally (not similar to the other sections of the app, so I believe it should be updated).

### Testing instructions
Because of this update, we should test that the appearance of 3 different screens is still ok after this update.
1. Open the Inbox Notes (under the Hub Menu) running the app on iPod Touch 7gen iOS 15.2. -> Everything should be fine.
2. Open the Orders -> Create Order -> Add Product. The list should be OK.
3. Always in the Add Product screen, tap a product with variations. The list should be OK also here.

### Screenshots
| Inbox Notes (before)            |  Inbox Notes (after) |
:-------------------------:|:-------------------------:
![Before 1](https://user-images.githubusercontent.com/495617/154085379-03c370b0-7739-458b-b687-100c7ad41492.png) | ![after 1](https://user-images.githubusercontent.com/495617/154085402-f3515359-494d-4875-a5a2-a90da57b6a68.png)




| Orders -> New Order -> Add Product (before)             |  Orders -> New Order -> Add Product (after) |
:-------------------------:|:-------------------------:
![before 2](https://user-images.githubusercontent.com/495617/154085542-22525202-f7d5-4a4d-9dfd-7dc62d682730.png) | ![After 2](https://user-images.githubusercontent.com/495617/154085575-168b0434-da17-47e3-90c4-43c018519454.png)



| Orders -> New Order -> Add Product Variation (before)             |  Orders -> New Order -> Add Product Variation (after) |
:-------------------------:|:-------------------------:
![before 3](https://user-images.githubusercontent.com/495617/154085721-66ff7e6a-ca46-4080-8ca5-21c85a6412a6.png) | ![after 3](https://user-images.githubusercontent.com/495617/154085736-f8a49e66-b383-4df2-bf0b-7e4316f160e8.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
