### PR TITLE
Order Creation: Add support in Networking layer to remove a shipping line from an order

### DIFF
--- a/Networking/Networking/Model/ShippingLine.swift
+++ b/Networking/Networking/Model/ShippingLine.swift
@@ -6,7 +6,13 @@ import Codegen
 public struct ShippingLine: Codable, Equatable, GeneratedFakeable {
     public let shippingID: Int64
     public let methodTitle: String
-    public let methodID: String
+
+    /// Shipping Method ID
+    ///
+    /// Sending a null value to the REST API removes the Shipping Line.
+    ///
+    public let methodID: String?
+
     public let total: String
     public let totalTax: String
     public let taxes: [ShippingLineTax]
@@ -15,7 +21,7 @@ public struct ShippingLine: Codable, Equatable, GeneratedFakeable {
     ///
     public init(shippingID: Int64,
                 methodTitle: String,
-                methodID: String,
+                methodID: String?,
                 total: String,
                 totalTax: String,
                 taxes: [ShippingLineTax]) {

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -415,7 +415,7 @@ final class OrdersRemoteTests: XCTestCase {
         let expected: [String: AnyHashable] = [
             "id": shipping.shippingID,
             "method_title": shipping.methodTitle,
-            "method_id": shipping.methodID,
+            "method_id": shipping.methodID ?? "",
             "total": shipping.total
         ]
         assertEqual(received, expected)

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -211,6 +211,27 @@ final class OrdersRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    func test_update_order_properly_encodes_shipping_lines_for_removal_from_order() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let shipping = ShippingLine(shippingID: 333, methodTitle: "Shipping", methodID: nil, total: "1.23", totalTax: "", taxes: [])
+        let order = Order.fake().copy(shippingLines: [shipping])
+
+        // When
+        remote.updateOrder(from: 123, order: order, fields: [.shippingLines]) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["shipping_lines"] as? [[String: AnyHashable]]).first
+        let expected: [String: AnyHashable] = [
+            "id": shipping.shippingID,
+            "method_title": shipping.methodTitle,
+            "method_id": NSNull(),
+            "total": shipping.total
+        ]
+        assertEqual(received, expected)
+    }
+
 
     // MARK: - Load Order Notes Tests
 


### PR DESCRIPTION
Closes: #6026

## Description

During order creation, we want to support removing a shipping line, including removing it from a draft/pending order that exists remotely.

To remove a shipping line from an order that exists remotely, we have to send a request to `POST /orders/:order_id` with the shipping line's `method_id` set to `null`. This PR updates the `ShippingLine` model to support that.

## Changes

* Makes the `methodID` optional in `ShippingLine`, so it can be set to `nil` for shipping lines we want to remove. (The model already has a public `encode(to:)` method that will encode the `methodID` even if it is `nil`.)
* Adds a unit test to check that the shipping line is encoded as expected.

## Testing

We don't yet support removing shipping lines from existing orders in the app.

You can test this by firing `OrdersRemote.updateOrder` or the Yosemite `OrderAction.updateOrder` action for an existing order with shipping, passing the order with its shipping line methodID set to `nil` (see the unit test for an example). I have tested and confirmed that this removes the shipping line from the remote order.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
