### PR TITLE
Order Creation: Wire remove product support to LocalOrderSynchronizer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -106,11 +106,10 @@ private struct ProductsSection: View {
                 ForEach(viewModel.productRows) { productRow in
                     ProductRow(viewModel: productRow)
                         .onTapGesture {
-                            // TODO: Support selecting an order item
-                            // viewModel.selectOrderItem(productRow.id)
+                            viewModel.selectOrderItem(productRow.id)
                         }
-                        .sheet(item: $viewModel.selectedOrderItem) { item in
-                            createProductInOrderView(for: item)
+                        .sheet(item: $viewModel.selectedProductViewModel) { productViewModel in
+                            ProductInOrder(viewModel: productViewModel)
                         }
 
                     Divider()
@@ -137,17 +136,6 @@ private struct ProductsSection: View {
 
             Divider()
         }
-    }
-
-    @ViewBuilder private func createProductInOrderView(for item: NewOrderViewModel.NewOrderItem) -> some View {
-        // TODO: Support selecting an order item
-//        if let productRowViewModel = viewModel.createProductRowViewModel(for: item, canChangeQuantity: false) {
-//            let productInOrderViewModel = ProductInOrderViewModel(productRowViewModel: productRowViewModel) {
-//                viewModel.removeItemFromOrder(item)
-//            }
-//            ProductInOrder(viewModel: productInOrderViewModel)
-//        }
-        EmptyView()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -12,10 +12,6 @@ final class NewOrderViewModel: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    /// Order details used to create the order
-    ///
-    @Published var orderDetails = OrderDetails()
-
     /// Active navigation bar trailing item.
     /// Defaults to no visible button.
     ///
@@ -272,19 +268,6 @@ extension NewOrderViewModel {
         case loading
     }
 
-    /// Type to hold all order detail values
-    ///
-    struct OrderDetails {
-        var items: [NewOrderItem] = []
-
-        func toOrder() -> Order {
-            OrderFactory.emptyNewOrder.copy(status: .pending,
-                                            items: items.map { $0.orderItem },
-                                            billingAddress: nil,
-                                            shippingAddress: nil)
-        }
-    }
-
     /// Representation of order status display properties
     ///
     struct StatusBadgeViewModel {
@@ -310,52 +293,6 @@ extension NewOrderViewModel {
         init(orderStatusEnum: OrderStatusEnum) {
             let siteOrderStatus = OrderStatus(name: nil, siteID: 0, slug: orderStatusEnum.rawValue, total: 0)
             self.init(orderStatus: siteOrderStatus)
-        }
-    }
-
-    /// Representation of new items in an order.
-    ///
-    struct NewOrderItem: Equatable, Identifiable {
-        let id: String
-        let productID: Int64
-        let variationID: Int64
-        var quantity: Decimal
-        let price: NSDecimalNumber
-        var subtotal: String {
-            String(describing: quantity * price.decimalValue)
-        }
-
-        var orderItem: OrderItem {
-            OrderItem(itemID: 0,
-                      name: "",
-                      productID: productID,
-                      variationID: variationID,
-                      quantity: quantity,
-                      price: price,
-                      sku: nil,
-                      subtotal: subtotal,
-                      subtotalTax: "",
-                      taxClass: "",
-                      taxes: [],
-                      total: "",
-                      totalTax: "",
-                      attributes: [])
-        }
-
-        init(product: Product, quantity: Decimal) {
-            self.id = UUID().uuidString
-            self.productID = product.productID
-            self.variationID = 0 // Products in an order are represented in Core with a variation ID of 0
-            self.quantity = quantity
-            self.price = NSDecimalNumber(string: product.price)
-        }
-
-        init(variation: ProductVariation, quantity: Decimal) {
-            self.id = UUID().uuidString
-            self.productID = variation.productID
-            self.variationID = variation.productVariationID
-            self.quantity = quantity
-            self.price = NSDecimalNumber(string: variation.price)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -2,7 +2,13 @@ import Yosemite
 
 /// View model for `ProductInOrder`.
 ///
-final class ProductInOrderViewModel {
+final class ProductInOrderViewModel: Identifiable {
+
+    /// Underlying row ID.
+    ///
+    var ID: Int64 {
+        productRowViewModel.id
+    }
 
     /// The product being edited.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -3,13 +3,6 @@ import Yosemite
 /// View model for `ProductInOrder`.
 ///
 final class ProductInOrderViewModel: Identifiable {
-
-    /// Underlying row ID.
-    ///
-    var ID: Int64 {
-        productRowViewModel.id
-    }
-
     /// The product being edited.
     ///
     let productRowViewModel: ProductRowViewModel

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -164,7 +164,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
     }
 
-    func test_order_details_are_updated_when_product_quantity_changes() throws {
+    func test_order_details_are_updated_when_product_quantity_changes() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -184,8 +184,6 @@ class NewOrderViewModelTests: XCTestCase {
     }
 
     func test_selectOrderItem_selects_expected_order_item() throws {
-        throw XCTSkip("Test disabled while we enable select order support on OrderSynchronizer")
-
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -194,14 +192,15 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product.productID)
 
         // When
-        let expectedOrderItem = viewModel.orderDetails.items[0]
-        viewModel.selectOrderItem(expectedOrderItem.id)
+        let expectedRow = viewModel.productRows[0]
+        viewModel.selectOrderItem(expectedRow.id)
 
         // Then
-        XCTAssertEqual(viewModel.selectedOrderItem, expectedOrderItem)
+        XCTAssertNotNil(viewModel.selectedProductViewModel)
+        XCTAssertEqual(viewModel.selectedProductViewModel?.productRowViewModel.id, expectedRow.id)
     }
 
-    func test_view_model_is_updated_when_product_is_removed_from_order() throws {
+    func test_view_model_is_updated_when_product_is_removed_from_order() {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
@@ -214,13 +213,13 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.addProductViewModel.selectProduct(product1.productID)
 
         // When
-        throw XCTSkip("Test disabled while we enable remove item support on OrderSynchronizer")
-        let expectedRemainingItem = viewModel.orderDetails.items[1]
-        viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
+        let expectedRemainingRow = viewModel.productRows[1]
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)
+        viewModel.removeItemFromOrder(itemToRemove)
 
         // Then
         XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product0.productID }))
-        XCTAssertEqual(viewModel.orderDetails.items, [expectedRemainingItem])
+        XCTAssertEqual(viewModel.productRows.map { $0.id }, [expectedRemainingRow].map { $0.id })
     }
 
     func test_createProductRowViewModel_creates_expected_row_for_product() {
@@ -321,7 +320,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
     }
 
-    func test_payment_section_only_displayed_when_order_has_products() throws {
+    func test_payment_section_only_displayed_when_order_has_products() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         let storageManager = MockStorageManager()
@@ -333,12 +332,13 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldShowPaymentSection)
 
         // When & Then
-        throw XCTSkip("This unit test needs to be reenabled when the remove item method is migrated")
-        viewModel.removeItemFromOrder(viewModel.orderDetails.items[0])
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id, productID: product.productID)
+        viewModel.removeItemFromOrder(itemToRemove)
+
         XCTAssertFalse(viewModel.shouldShowPaymentSection)
     }
 
-    func test_payment_section_is_updated_when_products_update() throws {
+    func test_payment_section_is_updated_when_products_update() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)


### PR DESCRIPTION
part of https://github.com/woocommerce/woocommerce-ios/issues/6128

# Why
Following the migration plan to the LocalOrderSyncronizer, this PR:

- Refactors `NewOrderViewModel` to select a product item and to send inputs to delete the selected product on `LocalOrderSynchronizer`
- Removes `OrderDetails` & `NewOrderItem` struct.
- Updates tests.

# Demo

https://user-images.githubusercontent.com/562080/154141851-0aa4505a-ed71-4baa-8279-9b4bc11d2b41.mov


# Testing Scenarios
- See that you can select a product
- See that you can delete a product
- See that you can create an order with the correct products.