### PR TITLE
Coupons: Usage Details screen (read only)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -24,6 +24,7 @@ struct CouponDetails: View {
     @ObservedObject private var viewModel: CouponDetailsViewModel
     @State private var showingActionSheet: Bool = false
     @State private var showingShareSheet: Bool = false
+    @State private var showingUsageDetails: Bool = false
 
     /// The presenter to display notice when the coupon code is copied.
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
@@ -130,12 +131,15 @@ struct CouponDetails: View {
                             Text(Localization.usageDetails)
                                 .bodyStyle()
                         }, action: {
-                            // TODO-5766: Add usage details screen
+                            showingUsageDetails = true
                         }).padding(.horizontal, insets: geometry.safeAreaInsets)
                     }
                     .background(Color(.listForeground))
                     Divider()
                 }
+                NavigationLink(destination: CouponUsageDetails(), isActive: $showingUsageDetails) {
+                    EmptyView()
+                }.hidden()
             }
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -137,7 +137,7 @@ struct CouponDetails: View {
                     .background(Color(.listForeground))
                     Divider()
                 }
-                NavigationLink(destination: CouponUsageDetails(), isActive: $showingUsageDetails) {
+                NavigationLink(destination: CouponUsageDetails(viewModel: .init(coupon: viewModel.coupon)), isActive: $showingUsageDetails) {
                     EmptyView()
                 }.hidden()
             }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -46,7 +46,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     /// The current coupon
     ///
-    @Published private var coupon: Coupon {
+    @Published private(set) var coupon: Coupon {
         didSet {
             populateDetails()
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -15,20 +15,31 @@ struct CouponUsageDetails: View {
                     ListHeaderView(text: Localization.usageRestriction.uppercased(), alignment: .left)
                     VStack(alignment: .leading, spacing: 0) {
                         Divider()
-                        TitleAndValueRow(title: String.localizedStringWithFormat(Localization.minimumSpend, viewModel.currencySymbol),
-                                         value: .content(viewModel.minimumSpend))
+                        TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.minimumSpend, viewModel.currencySymbol),
+                                             placeholder: Localization.none,
+                                             text: $viewModel.minimumSpend,
+                                             symbol: viewModel.currencySymbol,
+                                             editable: false,
+                                             keyboardType: .decimalPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
-                        TitleAndValueRow(title: String.localizedStringWithFormat(Localization.maximumSpend, viewModel.currencySymbol),
-                                         value: .content(viewModel.maximumSpend))
+                        TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.maximumSpend, viewModel.currencySymbol),
+                                             placeholder: Localization.none,
+                                             text: $viewModel.maximumSpend,
+                                             symbol: viewModel.currencySymbol,
+                                             editable: false,
+                                             keyboardType: .decimalPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
-                        TitleAndValueRow(title: Localization.usageLimitPerCoupon,
-                                         value: .content(viewModel.usageLimitPerCoupon))
+                        TitleAndTextFieldRow(title: Localization.usageLimitPerCoupon,
+                                             placeholder: Localization.unlimited,
+                                             text: $viewModel.usageLimitPerCoupon,
+                                             editable: false,
+                                             keyboardType: .asciiCapableNumberPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                     }
@@ -37,14 +48,19 @@ struct CouponUsageDetails: View {
 
                     VStack(alignment: .leading, spacing: 0) {
                         Divider()
-                        TitleAndValueRow(title: Localization.limitUsageToXItems,
-                                         value: .content(viewModel.limitUsageToXItems))
+                        TitleAndTextFieldRow(title: Localization.limitUsageToXItems,
+                                             placeholder: Localization.allQualifyingInCart,
+                                             text: $viewModel.limitUsageToXItems,
+                                             editable: false,
+                                             keyboardType: .asciiCapableNumberPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
                         TitleAndValueRow(title: Localization.allowedEmails,
-                                         value: .content(viewModel.allowedEmails))
+                                         value: viewModel.allowedEmails.isNotEmpty ?
+                                            .content(viewModel.allowedEmails) :
+                                            .placeholder(Localization.noRestrictions))
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                     }
@@ -59,12 +75,8 @@ struct CouponUsageDetails: View {
                             .padding(.horizontal, Constants.margin)
                             .padding(.vertical, Constants.verticalSpacing)
                         Divider()
-                    }
-                    .background(Color(.listForeground))
-                    .padding(.bottom, Constants.margin)
-
-                    VStack(alignment: .leading, spacing: 0) {
-                        Divider()
+                            .padding(.leading, Constants.margin)
+                            .padding(.leading, insets: geometry.safeAreaInsets)
                         TitleAndToggleRow(title: Localization.excludeSaleItems, isOn: .constant(viewModel.excludeSaleItems))
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                             .padding(.horizontal, Constants.margin)
@@ -72,6 +84,7 @@ struct CouponUsageDetails: View {
                         Divider()
                     }
                     .background(Color(.listForeground))
+                    .padding(.bottom, Constants.margin)
                 }
             }
             .background(Color(.listBackground))
@@ -121,6 +134,16 @@ private extension CouponUsageDetails {
         static let excludeSaleItems = NSLocalizedString(
             "Exclude Sale Items",
             comment: "Title for the exclude sale items row in coupon usage details screen."
+        )
+        static let none = NSLocalizedString("None", comment: "Value for fields in Coupon Usage Details screen when no value is set")
+        static let unlimited = NSLocalizedString("Unlimited", comment: "Value for fields in Coupon Usage Details screen when no limit is set")
+        static let allQualifyingInCart = NSLocalizedString(
+            "All Qualifying in Cart",
+            comment: "Value for the limit usage to X items row in Coupon Usage Details screen when no limit is set"
+        )
+        static let noRestrictions = NSLocalizedString(
+            "No Restrictions",
+            comment: "Value for the allowed emails row in Coupon Usage Details screen when no restriction is set"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CouponUsageDetails: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct CouponUsageDetails_Previews: PreviewProvider {
+    static var previews: some View {
+        CouponUsageDetails()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -2,20 +2,65 @@ import SwiftUI
 
 struct CouponUsageDetails: View {
 
-    @ObservedObject private var viewModel: CouponDetailsViewModel
+    @ObservedObject private var viewModel: CouponUsageDetailsViewModel
 
-    init(viewModel: CouponDetailsViewModel) {
+    init(viewModel: CouponUsageDetailsViewModel) {
         self.viewModel = viewModel
     }
 
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ListHeaderView(text: Localization.usageRestriction, alignment: .left)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Divider()
+                        TitleAndValueRow(title: String.localizedStringWithFormat(Localization.minimumSpend, viewModel.currencySymbol),
+                                         value: .content(viewModel.minimumSpend),
+                                         selectable: false,
+                                         action: {})
+                            .padding(.horizontal, Constants.margin)
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
+                            .padding(.leading, Constants.margin)
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                        TitleAndValueRow(title: String.localizedStringWithFormat(Localization.maximumSpend, viewModel.currencySymbol),
+                                         value: .content(viewModel.maximumSpend),
+                                         selectable: false,
+                                         action: {})
+                            .padding(.horizontal, Constants.margin)
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
+                            .padding(.leading, Constants.margin)
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                        TitleAndValueRow(title: Localization.usageLimitPerCoupon,
+                                         value: .content(viewModel.usageLimitPerCoupon),
+                                         selectable: false,
+                                         action: {})
+                            .padding(.horizontal, Constants.margin)
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
+                    }
+                    .background(Color(.listForeground))
+                }
+            }
+            .background(Color(.listBackground))
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+        }
     }
 }
 
 private extension CouponUsageDetails {
+    enum Constants {
+        static let margin: CGFloat = 16
+        static let verticalSpacing: CGFloat = 8
+    }
+
     enum Localization {
-        static let usageRestriction = NSLocalizedString("Usage Restrictions", comment: "Title for the usage restrictions section on coupon usage details screen")
+        static let usageRestriction = NSLocalizedString(
+            "Usage Restrictions",
+            comment: "Title for the usage restrictions section on coupon usage details screen"
+        )
         static let minimumSpend = NSLocalizedString(
             "Minimum Spend (%1$@)",
             comment: "Title for the minimum spend row on coupon usage details screen with currency symbol within the brackets. " +
@@ -54,6 +99,9 @@ private extension CouponUsageDetails {
 struct CouponUsageDetails_Previews: PreviewProvider {
     static var previews: some View {
         CouponUsageDetails(viewModel: .init(coupon: .sampleCoupon))
+
+        CouponUsageDetails(viewModel: .init(coupon: .sampleCoupon))
+            .previewLayout(.fixed(width: 715, height: 320))
     }
 }
 #endif

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -12,34 +12,70 @@ struct CouponUsageDetails: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    ListHeaderView(text: Localization.usageRestriction, alignment: .left)
+                    ListHeaderView(text: Localization.usageRestriction.uppercased(), alignment: .left)
                     VStack(alignment: .leading, spacing: 0) {
                         Divider()
                         TitleAndValueRow(title: String.localizedStringWithFormat(Localization.minimumSpend, viewModel.currencySymbol),
                                          value: .content(viewModel.minimumSpend))
-                            .padding(.horizontal, Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
                         TitleAndValueRow(title: String.localizedStringWithFormat(Localization.maximumSpend, viewModel.currencySymbol),
                                          value: .content(viewModel.maximumSpend))
-                            .padding(.horizontal, Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
                         TitleAndValueRow(title: Localization.usageLimitPerCoupon,
                                          value: .content(viewModel.usageLimitPerCoupon))
-                            .padding(.horizontal, Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
+                    }
+                    .background(Color(.listForeground))
+                    .padding(.bottom, Constants.margin)
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        Divider()
+                        TitleAndValueRow(title: Localization.limitUsageToXItems,
+                                         value: .content(viewModel.limitUsageToXItems))
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
+                            .padding(.leading, Constants.margin)
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                        TitleAndValueRow(title: Localization.allowedEmails,
+                                         value: .content(viewModel.allowedEmails))
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
+                    }
+                    .background(Color(.listForeground))
+                    .padding(.top, Constants.margin)
+
+                    ListHeaderView(text: Localization.usageLimits.uppercased(), alignment: .left)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Divider()
+                        TitleAndToggleRow(title: Localization.individualUseOnly, isOn: .constant(viewModel.individualUseOnly))
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                            .padding(.horizontal, Constants.margin)
+                            .padding(.vertical, Constants.verticalSpacing)
+                        Divider()
+                    }
+                    .background(Color(.listForeground))
+                    .padding(.bottom, Constants.margin)
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        Divider()
+                        TitleAndToggleRow(title: Localization.excludeSaleItems, isOn: .constant(viewModel.excludeSaleItems))
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                            .padding(.horizontal, Constants.margin)
+                            .padding(.vertical, Constants.verticalSpacing)
                         Divider()
                     }
                     .background(Color(.listForeground))
                 }
             }
             .background(Color(.listBackground))
-            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+            .ignoresSafeArea(.container, edges: [.horizontal])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -13,6 +13,43 @@ struct CouponUsageDetails: View {
     }
 }
 
+private extension CouponUsageDetails {
+    enum Localization {
+        static let usageRestriction = NSLocalizedString("Usage Restrictions", comment: "Title for the usage restrictions section on coupon usage details screen")
+        static let minimumSpend = NSLocalizedString(
+            "Minimum Spend (%1$@)",
+            comment: "Title for the minimum spend row on coupon usage details screen with currency symbol within the brackets. " +
+            "Reads like: Minimum Spend ($)"
+        )
+        static let maximumSpend = NSLocalizedString(
+            "Maximum Spend (%1$@)",
+            comment: "Title for the maximum spend row on coupon usage details screen with currency symbol within the brackets. " +
+            "Reads like: Maximum Spend ($)"
+        )
+        static let usageLimitPerCoupon = NSLocalizedString(
+            "Usage Limit Per Coupon",
+            comment: "Title for the usage limit per coupon row in coupon usage details screen."
+        )
+        static let limitUsageToXItems = NSLocalizedString(
+            "Limit Usage to X Items",
+            comment: "Title for the limit usage to X items row in coupon usage details screen."
+        )
+        static let allowedEmails = NSLocalizedString(
+            "Allowed Emails",
+            comment: "Title for the allowed email row in coupon usage details screen."
+        )
+        static let usageLimits = NSLocalizedString("Usage Limits", comment: "Title for the usage limits section on coupon usage details screen")
+        static let individualUseOnly = NSLocalizedString(
+            "Individual Use Only",
+            comment: "Title for the individual use only row in coupon usage details screen."
+        )
+        static let excludeSaleItems = NSLocalizedString(
+            "Exclude Sale Items",
+            comment: "Title for the exclude sale items row in coupon usage details screen."
+        )
+    }
+}
+
 #if DEBUG
 struct CouponUsageDetails_Previews: PreviewProvider {
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -88,6 +88,7 @@ struct CouponUsageDetails: View {
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal])
         }
+        .navigationTitle(Localization.usageDetails)
     }
 }
 
@@ -98,6 +99,7 @@ private extension CouponUsageDetails {
     }
 
     enum Localization {
+        static let usageDetails = NSLocalizedString("Usage Details", comment: "Navigation title for usage details screen")
         static let usageRestriction = NSLocalizedString(
             "Usage Restrictions",
             comment: "Title for the usage restrictions section on coupon usage details screen"

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -1,13 +1,22 @@
 import SwiftUI
 
 struct CouponUsageDetails: View {
+
+    @ObservedObject private var viewModel: CouponDetailsViewModel
+
+    init(viewModel: CouponDetailsViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }
 }
 
+#if DEBUG
 struct CouponUsageDetails_Previews: PreviewProvider {
     static var previews: some View {
-        CouponUsageDetails()
+        CouponUsageDetails(viewModel: .init(coupon: .sampleCoupon))
     }
 }
+#endif

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -13,6 +13,7 @@ struct CouponUsageDetails: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     ListHeaderView(text: Localization.usageRestriction.uppercased(), alignment: .left)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
                     VStack(alignment: .leading, spacing: 0) {
                         Divider()
                         TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.minimumSpend, viewModel.currencySymbol),
@@ -75,6 +76,7 @@ struct CouponUsageDetails: View {
                     .padding(.top, Constants.margin)
 
                     ListHeaderView(text: Localization.usageLimits.uppercased(), alignment: .left)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
                     VStack(alignment: .leading, spacing: 0) {
                         Divider()
                         TitleAndToggleRow(title: Localization.individualUseOnly, isOn: .constant(viewModel.individualUseOnly))

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -18,7 +18,6 @@ struct CouponUsageDetails: View {
                         TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.minimumSpend, viewModel.currencySymbol),
                                              placeholder: Localization.none,
                                              text: $viewModel.minimumSpend,
-                                             symbol: viewModel.currencySymbol,
                                              editable: false,
                                              keyboardType: .decimalPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
@@ -28,7 +27,6 @@ struct CouponUsageDetails: View {
                         TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.maximumSpend, viewModel.currencySymbol),
                                              placeholder: Localization.none,
                                              text: $viewModel.maximumSpend,
-                                             symbol: viewModel.currencySymbol,
                                              editable: false,
                                              keyboardType: .decimalPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
@@ -60,7 +58,7 @@ struct CouponUsageDetails: View {
                         TitleAndValueRow(title: Localization.allowedEmails,
                                          value: viewModel.allowedEmails.isNotEmpty ?
                                             .content(viewModel.allowedEmails) :
-                                            .placeholder(Localization.noRestrictions))
+                                            .content(Localization.noRestrictions))
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -16,27 +16,21 @@ struct CouponUsageDetails: View {
                     VStack(alignment: .leading, spacing: 0) {
                         Divider()
                         TitleAndValueRow(title: String.localizedStringWithFormat(Localization.minimumSpend, viewModel.currencySymbol),
-                                         value: .content(viewModel.minimumSpend),
-                                         selectable: false,
-                                         action: {})
+                                         value: .content(viewModel.minimumSpend))
                             .padding(.horizontal, Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
                         TitleAndValueRow(title: String.localizedStringWithFormat(Localization.maximumSpend, viewModel.currencySymbol),
-                                         value: .content(viewModel.maximumSpend),
-                                         selectable: false,
-                                         action: {})
+                                         value: .content(viewModel.maximumSpend))
                             .padding(.horizontal, Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
                         TitleAndValueRow(title: Localization.usageLimitPerCoupon,
-                                         value: .content(viewModel.usageLimitPerCoupon),
-                                         selectable: false,
-                                         action: {})
+                                         value: .content(viewModel.usageLimitPerCoupon))
                             .padding(.horizontal, Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -40,6 +40,15 @@ struct CouponUsageDetails: View {
                                              keyboardType: .asciiCapableNumberPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
                         Divider()
+                            .padding(.leading, Constants.margin)
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                        TitleAndTextFieldRow(title: Localization.usageLimitPerUser,
+                                             placeholder: Localization.unlimited,
+                                             text: $viewModel.usageLimitPerUser,
+                                             editable: false,
+                                             keyboardType: .asciiCapableNumberPad)
+                            .padding(.horizontal, insets: geometry.safeAreaInsets)
+                        Divider()
                     }
                     .background(Color(.listForeground))
                     .padding(.bottom, Constants.margin)
@@ -117,6 +126,10 @@ private extension CouponUsageDetails {
         static let usageLimitPerCoupon = NSLocalizedString(
             "Usage Limit Per Coupon",
             comment: "Title for the usage limit per coupon row in coupon usage details screen."
+        )
+        static let usageLimitPerUser = NSLocalizedString(
+            "Usage Limit Per User",
+            comment: "Title for the usage limit per user row in coupon usage details screen."
         )
         static let limitUsageToXItems = NSLocalizedString(
             "Limit Usage to X Items",

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
@@ -9,61 +9,54 @@ final class CouponUsageDetailsViewModel: ObservableObject {
 
     let currencySymbol: String
 
-    @Published var minimumSpend: String = ""
+    @Published var minimumSpend: String
 
-    @Published var maximumSpend: String = ""
+    @Published var maximumSpend: String
 
-    @Published var usageLimitPerCoupon: String = ""
+    @Published var usageLimitPerCoupon: String
 
-    @Published var usageLimitPerUser: String = ""
+    @Published var usageLimitPerUser: String
 
-    @Published var limitUsageToXItems: String = ""
+    @Published var limitUsageToXItems: String
 
-    @Published var allowedEmails: String = ""
+    @Published var allowedEmails: String
 
-    @Published var individualUseOnly: Bool = false
+    @Published var individualUseOnly: Bool
 
-    @Published var excludeSaleItems: Bool = false
+    @Published var excludeSaleItems: Bool
 
     init(coupon: Coupon,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.coupon = coupon
         self.currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
-        populateDetails()
-    }
-}
 
-// MARK: - Private helpers
-//
-private extension CouponUsageDetailsViewModel {
-    func populateDetails() {
-        minimumSpend = coupon.minimumAmount
-        maximumSpend = coupon.maximumAmount
+        self.minimumSpend = coupon.minimumAmount
+        self.maximumSpend = coupon.maximumAmount
         if let perCoupon = coupon.usageLimit {
-            usageLimitPerCoupon = "\(perCoupon)"
+            self.usageLimitPerCoupon = "\(perCoupon)"
         } else {
-            usageLimitPerCoupon = ""
+            self.usageLimitPerCoupon = ""
         }
 
         if let perUser = coupon.usageLimitPerUser {
-            usageLimitPerUser = "\(perUser)"
+            self.usageLimitPerUser = "\(perUser)"
         } else {
-            usageLimitPerUser = ""
+            self.usageLimitPerUser = ""
         }
 
         if let limitUsageItemCount = coupon.limitUsageToXItems {
-            limitUsageToXItems = "\(limitUsageItemCount)"
+            self.limitUsageToXItems = "\(limitUsageItemCount)"
         } else {
-            limitUsageToXItems = ""
+            self.limitUsageToXItems = ""
         }
 
         if coupon.emailRestrictions.isNotEmpty {
-            allowedEmails = coupon.emailRestrictions.joined(separator: ", ")
+            self.allowedEmails = coupon.emailRestrictions.joined(separator: ", ")
         } else {
-            allowedEmails = ""
+            self.allowedEmails = ""
         }
 
-        individualUseOnly = coupon.individualUse
-        excludeSaleItems = coupon.excludeSaleItems
+        self.individualUseOnly = coupon.individualUse
+        self.excludeSaleItems = coupon.excludeSaleItems
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
@@ -1,8 +1,55 @@
 import Combine
 import Foundation
+import Yosemite
 
 /// View Model for `CouponUsageDetails`
 ///
 final class CouponUsageDetailsViewModel: ObservableObject {
-    // TODO
+    private let coupon: Coupon
+    private let currencySettings: CurrencySettings
+
+    var currencySymbol: String {
+        currencySettings.symbol(from: currencySettings.currencyCode)
+    }
+
+    @Published private(set) var minimumSpend: String = ""
+
+    @Published private(set) var maximumSpend: String = ""
+
+    @Published private(set) var usageLimitPerCoupon: String = ""
+
+    init(coupon: Coupon,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        self.coupon = coupon
+        self.currencySettings = currencySettings
+        populateDetails()
+    }
+}
+
+// MARK: - Private helpers
+//
+private extension CouponUsageDetailsViewModel {
+    func populateDetails() {
+        minimumSpend = coupon.minimumAmount.isNotEmpty ? formatStringAmount(coupon.minimumAmount) : Localization.none
+        maximumSpend = coupon.maximumAmount.isNotEmpty ? formatStringAmount(coupon.maximumAmount) : Localization.none
+        if let usageLimit = coupon.usageLimit {
+            usageLimitPerCoupon = "\(usageLimit)"
+        } else {
+            usageLimitPerCoupon = Localization.unlimited
+        }
+    }
+
+    func formatStringAmount(_ amount: String) -> String {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        return currencyFormatter.formatAmount(amount) ?? ""
+    }
+}
+
+// MARK: - Subtypes
+//
+private extension CouponUsageDetailsViewModel {
+    enum Localization {
+        static let none = NSLocalizedString("None", comment: "Value for fields in Coupon Usage Details screen when no value is set")
+        static let unlimited = NSLocalizedString("Unlimited", comment: "Value for fields in Coupon Usage Details screen when no limit is set")
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
@@ -1,0 +1,8 @@
+import Combine
+import Foundation
+
+/// View Model for `CouponUsageDetails`
+///
+final class CouponUsageDetailsViewModel: ObservableObject {
+    // TODO
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
@@ -12,19 +12,19 @@ final class CouponUsageDetailsViewModel: ObservableObject {
         currencySettings.symbol(from: currencySettings.currencyCode)
     }
 
-    @Published private(set) var minimumSpend: String = ""
+    @Published var minimumSpend: String = ""
 
-    @Published private(set) var maximumSpend: String = ""
+    @Published var maximumSpend: String = ""
 
-    @Published private(set) var usageLimitPerCoupon: String = ""
+    @Published var usageLimitPerCoupon: String = ""
 
-    @Published private(set) var limitUsageToXItems: String = ""
+    @Published var limitUsageToXItems: String = ""
 
-    @Published private(set) var allowedEmails: String = ""
+    @Published var allowedEmails: String = ""
 
-    @Published private(set) var individualUseOnly: Bool = false
+    @Published var individualUseOnly: Bool = false
 
-    @Published private(set) var excludeSaleItems: Bool = false
+    @Published var excludeSaleItems: Bool = false
 
     init(coupon: Coupon,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
@@ -38,49 +38,27 @@ final class CouponUsageDetailsViewModel: ObservableObject {
 //
 private extension CouponUsageDetailsViewModel {
     func populateDetails() {
-        minimumSpend = coupon.minimumAmount.isNotEmpty ? formatStringAmount(coupon.minimumAmount) : Localization.none
-        maximumSpend = coupon.maximumAmount.isNotEmpty ? formatStringAmount(coupon.maximumAmount) : Localization.none
+        minimumSpend = coupon.minimumAmount
+        maximumSpend = coupon.maximumAmount
         if let usageLimit = coupon.usageLimit {
             usageLimitPerCoupon = "\(usageLimit)"
         } else {
-            usageLimitPerCoupon = Localization.unlimited
+            usageLimitPerCoupon = ""
         }
 
         if let limitUsageItemCount = coupon.limitUsageToXItems {
             limitUsageToXItems = "\(limitUsageItemCount)"
         } else {
-            limitUsageToXItems = Localization.allQualifyingInCart
+            limitUsageToXItems = ""
         }
 
         if coupon.emailRestrictions.isNotEmpty {
             allowedEmails = coupon.emailRestrictions.joined(separator: ", ")
         } else {
-            allowedEmails = Localization.noRestrictions
+            allowedEmails = ""
         }
 
         individualUseOnly = coupon.individualUse
         excludeSaleItems = coupon.excludeSaleItems
-    }
-
-    func formatStringAmount(_ amount: String) -> String {
-        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        return currencyFormatter.formatAmount(amount) ?? ""
-    }
-}
-
-// MARK: - Subtypes
-//
-private extension CouponUsageDetailsViewModel {
-    enum Localization {
-        static let none = NSLocalizedString("None", comment: "Value for fields in Coupon Usage Details screen when no value is set")
-        static let unlimited = NSLocalizedString("Unlimited", comment: "Value for fields in Coupon Usage Details screen when no limit is set")
-        static let allQualifyingInCart = NSLocalizedString(
-            "All Qualifying in Cart",
-            comment: "Value for the limit usage to X items row in Coupon Usage Details screen when no limit is set"
-        )
-        static let noRestrictions = NSLocalizedString(
-            "No Restrictions",
-            comment: "Value for the allowed emails row in Coupon Usage Details screen when no restriction is set"
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
@@ -18,6 +18,14 @@ final class CouponUsageDetailsViewModel: ObservableObject {
 
     @Published private(set) var usageLimitPerCoupon: String = ""
 
+    @Published private(set) var limitUsageToXItems: String = ""
+
+    @Published private(set) var allowedEmails: String = ""
+
+    @Published private(set) var individualUseOnly: Bool = false
+
+    @Published private(set) var excludeSaleItems: Bool = false
+
     init(coupon: Coupon,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.coupon = coupon
@@ -37,6 +45,21 @@ private extension CouponUsageDetailsViewModel {
         } else {
             usageLimitPerCoupon = Localization.unlimited
         }
+
+        if let limitUsageItemCount = coupon.limitUsageToXItems {
+            limitUsageToXItems = "\(limitUsageItemCount)"
+        } else {
+            limitUsageToXItems = Localization.allQualifyingInCart
+        }
+
+        if coupon.emailRestrictions.isNotEmpty {
+            allowedEmails = coupon.emailRestrictions.joined(separator: ", ")
+        } else {
+            allowedEmails = Localization.noRestrictions
+        }
+
+        individualUseOnly = coupon.individualUse
+        excludeSaleItems = coupon.excludeSaleItems
     }
 
     func formatStringAmount(_ amount: String) -> String {
@@ -51,5 +74,13 @@ private extension CouponUsageDetailsViewModel {
     enum Localization {
         static let none = NSLocalizedString("None", comment: "Value for fields in Coupon Usage Details screen when no value is set")
         static let unlimited = NSLocalizedString("Unlimited", comment: "Value for fields in Coupon Usage Details screen when no limit is set")
+        static let allQualifyingInCart = NSLocalizedString(
+            "All Qualifying in Cart",
+            comment: "Value for the limit usage to X items row in Coupon Usage Details screen when no limit is set"
+        )
+        static let noRestrictions = NSLocalizedString(
+            "No Restrictions",
+            comment: "Value for the allowed emails row in Coupon Usage Details screen when no restriction is set"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
@@ -6,11 +6,8 @@ import Yosemite
 ///
 final class CouponUsageDetailsViewModel: ObservableObject {
     private let coupon: Coupon
-    private let currencySettings: CurrencySettings
 
-    var currencySymbol: String {
-        currencySettings.symbol(from: currencySettings.currencyCode)
-    }
+    let currencySymbol: String
 
     @Published var minimumSpend: String = ""
 
@@ -31,7 +28,7 @@ final class CouponUsageDetailsViewModel: ObservableObject {
     init(coupon: Coupon,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.coupon = coupon
-        self.currencySettings = currencySettings
+        self.currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
         populateDetails()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetailsViewModel.swift
@@ -18,6 +18,8 @@ final class CouponUsageDetailsViewModel: ObservableObject {
 
     @Published var usageLimitPerCoupon: String = ""
 
+    @Published var usageLimitPerUser: String = ""
+
     @Published var limitUsageToXItems: String = ""
 
     @Published var allowedEmails: String = ""
@@ -40,10 +42,16 @@ private extension CouponUsageDetailsViewModel {
     func populateDetails() {
         minimumSpend = coupon.minimumAmount
         maximumSpend = coupon.maximumAmount
-        if let usageLimit = coupon.usageLimit {
-            usageLimitPerCoupon = "\(usageLimit)"
+        if let perCoupon = coupon.usageLimit {
+            usageLimitPerCoupon = "\(perCoupon)"
         } else {
             usageLimitPerCoupon = ""
+        }
+
+        if let perUser = coupon.usageLimitPerUser {
+            usageLimitPerUser = "\(perUser)"
+        } else {
+            usageLimitPerUser = ""
         }
 
         if let limitUsageItemCount = coupon.limitUsageToXItems {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
@@ -3,23 +3,27 @@ import SwiftUI
 /// Renders a row with a label on the left side, and a text field on the right side, with eventually a symbol (like $)
 ///
 struct TitleAndTextFieldRow: View {
-    let title: String
-    let placeholder: String
-    @Binding var text: String
-    let symbol: String?
-    let keyboardType: UIKeyboardType
-    let onEditingChanged: ((Bool) -> Void)?
+    private let title: String
+    private let placeholder: String
+    private let symbol: String?
+    private let keyboardType: UIKeyboardType
+    private let onEditingChanged: ((Bool) -> Void)?
+    private let editable: Bool
+
+    @Binding private var text: String
 
     init(title: String,
          placeholder: String,
          text: Binding<String>,
          symbol: String? = nil,
+         editable: Bool = true,
          keyboardType: UIKeyboardType = .default,
          onEditingChanged: ((Bool) -> Void)? = nil) {
         self.title = title
         self.placeholder = placeholder
         self._text = text
         self.symbol = symbol
+        self.editable = editable
         self.keyboardType = keyboardType
         self.onEditingChanged = onEditingChanged
     }
@@ -35,6 +39,7 @@ struct TitleAndTextFieldRow: View {
                     .multilineTextAlignment(.trailing)
                     .font(.body)
                     .keyboardType(keyboardType)
+                    .disabled(!editable)
                 if let symbol = symbol {
                     Text(symbol)
                         .bodyStyle()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -4,11 +4,19 @@ import SwiftUI
 ///
 struct TitleAndValueRow: View {
 
-    let title: String
-    let value: Value
-    var bold: Bool = false
-    let selectable: Bool
-    var action: () -> Void
+    private let title: String
+    private let value: Value
+    private let bold: Bool
+    private let selectable: Bool
+    private let action: () -> Void
+
+    init(title: String, value: Value, bold: Bool = false, selectable: Bool = false, action: @escaping () -> Void = {}) {
+        self.title = title
+        self.value = value
+        self.bold = bold
+        self.selectable = selectable
+        self.action = action
+    }
 
     var body: some View {
         Button(action: {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1489,6 +1489,8 @@
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
 		DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */; };
+		DE69C54A27BB715D000BB888 /* CouponUsageDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69C54927BB715D000BB888 /* CouponUsageDetailsViewModel.swift */; };
+		DE69C54D27BB719A000BB888 /* CouponUsageDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69C54C27BB719A000BB888 /* CouponUsageDetails.swift */; };
 		DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */; };
 		DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */; };
 		DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */; };
@@ -3129,6 +3131,8 @@
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
 		DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
+		DE69C54927BB715D000BB888 /* CouponUsageDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponUsageDetailsViewModel.swift; sourceTree = "<group>"; };
+		DE69C54C27BB719A000BB888 /* CouponUsageDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponUsageDetails.swift; sourceTree = "<group>"; };
 		DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleRow.swift; sourceTree = "<group>"; };
 		DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageItem.swift; sourceTree = "<group>"; };
 		DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Localized.swift"; sourceTree = "<group>"; };
@@ -4260,6 +4264,7 @@
 		03FBDA9B263AD47200ACE257 /* Coupons */ = {
 			isa = PBXGroup;
 			children = (
+				DE69C54B27BB7163000BB888 /* UsageDetails */,
 				DE7B479127A38ABC0018742E /* CouponDetails */,
 				03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */,
 				03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */,
@@ -7341,6 +7346,15 @@
 			path = "Review Order";
 			sourceTree = "<group>";
 		};
+		DE69C54B27BB7163000BB888 /* UsageDetails */ = {
+			isa = PBXGroup;
+			children = (
+				DE69C54927BB715D000BB888 /* CouponUsageDetailsViewModel.swift */,
+				DE69C54C27BB719A000BB888 /* CouponUsageDetails.swift */,
+			);
+			path = UsageDetails;
+			sourceTree = "<group>";
+		};
 		DE792E1926EF37D80071200C /* Connectivity */ = {
 			isa = PBXGroup;
 			children = (
@@ -8488,6 +8502,7 @@
 				024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */,
 				BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */,
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,
+				DE69C54D27BB719A000BB888 /* CouponUsageDetails.swift in Sources */,
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */,
@@ -8874,6 +8889,7 @@
 				773077ED251E943700178696 /* Product+DownloadFileViewModels.swift in Sources */,
 				743EDD9F214B05350039071B /* TopEarnerStatsItem+Woo.swift in Sources */,
 				B5BBD6DE21B1703700E3207E /* PushNotificationsManager.swift in Sources */,
+				DE69C54A27BB715D000BB888 /* CouponUsageDetailsViewModel.swift in Sources */,
 				CE1EC8EC20B8A3FF009762BF /* LeftImageTableViewCell.swift in Sources */,
 				DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */,
 				45E9A6E924DAE3B800A600E8 /* ProductReviewsDataSource.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1491,6 +1491,7 @@
 		DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */; };
 		DE69C54A27BB715D000BB888 /* CouponUsageDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69C54927BB715D000BB888 /* CouponUsageDetailsViewModel.swift */; };
 		DE69C54D27BB719A000BB888 /* CouponUsageDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69C54C27BB719A000BB888 /* CouponUsageDetails.swift */; };
+		DE69C54F27BCB4B7000BB888 /* CouponUsageDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69C54E27BCB4B6000BB888 /* CouponUsageDetailsViewModelTests.swift */; };
 		DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */; };
 		DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */; };
 		DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */; };
@@ -3133,6 +3134,7 @@
 		DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE69C54927BB715D000BB888 /* CouponUsageDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponUsageDetailsViewModel.swift; sourceTree = "<group>"; };
 		DE69C54C27BB719A000BB888 /* CouponUsageDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponUsageDetails.swift; sourceTree = "<group>"; };
+		DE69C54E27BCB4B6000BB888 /* CouponUsageDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponUsageDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleRow.swift; sourceTree = "<group>"; };
 		DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageItem.swift; sourceTree = "<group>"; };
 		DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Localized.swift"; sourceTree = "<group>"; };
@@ -4280,6 +4282,7 @@
 			children = (
 				03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */,
 				DE7B479627A3C4980018742E /* CouponDetailsViewModelTests.swift */,
+				DE69C54E27BCB4B6000BB888 /* CouponUsageDetailsViewModelTests.swift */,
 			);
 			path = Coupons;
 			sourceTree = "<group>";
@@ -9375,6 +9378,7 @@
 				31AD0B1326E95998000B6391 /* CardPresentModalConnectingFailedTests.swift in Sources */,
 				E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
+				DE69C54F27BCB4B7000BB888 /* CouponUsageDetailsViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,
 				26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */,
 				D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponUsageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponUsageDetailsViewModelTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class CouponUsageDetailsViewModelTests: XCTestCase {
+
+    func test_usage_details_are_correct() {
+        // Given
+        let coupon = Coupon.fake().copy(individualUse: true,
+                                        usageLimit: 1000,
+                                        usageLimitPerUser: 1,
+                                        limitUsageToXItems: 10,
+                                        excludeSaleItems: false,
+                                        minimumAmount: "10.00",
+                                        maximumAmount: "1000.00",
+                                        emailRestrictions: ["*@a8c.com", "vip@mail.com"])
+        let viewModel = CouponUsageDetailsViewModel(coupon: coupon, currencySettings: CurrencySettings())
+
+        // Then
+        XCTAssertEqual(viewModel.minimumSpend, "10.00")
+        XCTAssertEqual(viewModel.maximumSpend, "1000.00")
+        XCTAssertEqual(viewModel.usageLimitPerCoupon, "1000")
+        XCTAssertEqual(viewModel.usageLimitPerUser, "1")
+        XCTAssertEqual(viewModel.limitUsageToXItems, "10")
+        XCTAssertEqual(viewModel.allowedEmails, "*@a8c.com, vip@mail.com")
+        XCTAssertEqual(viewModel.individualUseOnly, true)
+        XCTAssertEqual(viewModel.excludeSaleItems, false)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5766 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the usage details screen that can be navigated from the coupon details screen. The fields on the screen are currently not editable since we support viewing coupon details only in Milestone 1. Changes include:
- Update the Coupon Details view to navigate to the Usage Details upon tapping on the Usage Details row.
- Add UI and populate details on the Usage Details screen.
- Update some reusable views:
  - TitleAndValueRow to have a custom initializer and default values for `bold`, `selectable` and `action`.
  - TitleAndTextFieldRow to have a new parameter `editable` in its initializer.

### Design Reviews
To design team: I tweaked this screen a bit to match with the goal of Milestone 1, which is to view coupon details only:
- The text fields and toggles cannot be edited
- A missing field for Usage Limit Per User is added
- Subtitles in the Usage Limits section are not present for now since the toggles are disabled.
- Also: I'm leaving the Exclusions section out of this screen following the comment: p1644401679450069-slack-C02TD63FZA8. Let me know if we should put it back.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have at least one coupon on your test store. Otherwise, navigate to WP Admin > Marketing > Coupons to create one.
- On the app, make sure that coupon management is enabled in Menu > Settings > Experimental Features.
- On the Menu tab, select Coupons and then select a coupon in the list and choose Usage Details. Notice that the information is displayed correctly and not editable.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/154198202-3b0f5f46-dc9b-4edc-a224-e7cfccf9206a.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->