### PR TITLE
Reviews: Fixed crash on iPad when opening More popover

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Orders: In the experimental Order Creation feature, product variations added to a new order now show a list of their attributes. [https://github.com/woocommerce/woocommerce-ios/pull/6131]
 - [*] Enlarged the tap area for the action button on the notice view. [https://github.com/woocommerce/woocommerce-ios/pull/6146]
+- [*] Reviews: Fixed crash on iPad when tapping the More button. [https://github.com/woocommerce/woocommerce-ios/pull/6187]
 
 8.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -256,6 +256,7 @@ private extension ReviewsViewController {
     @IBAction func presentMoreActions() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
+        actionSheet.popoverPresentationController?.barButtonItem = rightBarButton
 
         actionSheet.addCancelActionWithTitle(Localization.ActionSheet.cancelAction)
         actionSheet.addDefaultActionWithTitle(Localization.ActionSheet.markAsReadAction) { [weak self] _ in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6185 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the crash on iPad when tapping the More button on the Reviews screen. The crash happens due to the missing source view for the popover to be displayed on iPad. The solution is to set the right bar button item to the popover so that it can be displayed when tapping the button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Add a new review on a product on your test store.
- Open the app on an iPad and navigate to Menu > Reviews.
- Tap the more button on the top right of the screen. Notice that a popover is displayed with the button Mark all reviews as read.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![IMG_8353C943630D-1](https://user-images.githubusercontent.com/5533851/154220404-9c80b187-7c84-45b3-b5a7-cbf3c64bf680.jpeg)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
