### PR TITLE
Coupons: Add tracks for Milestone 1

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -565,6 +565,12 @@ public enum WooAnalyticsStat: String {
     case hubMenuSwitchStoreTapped = "hub_menu_switch_store_tapped"
     case hubMenuOptionTapped = "hub_menu_option_tapped"
     case hubMenuSettingsTapped = "hub_menu_settings_tapped"
+
+    // MARK: Coupons
+    case couponsLoaded = "coupons_loaded"
+    case couponsLoadedFailed = "coupons_loaded_failed"
+    case couponsListSearchTapped = "coupons_list_search_tapped"
+    case couponDetails = "coupon_details"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -34,6 +34,8 @@ struct CouponDetails: View {
         self.noticePresenter = DefaultNoticePresenter()
         viewModel.syncCoupon()
         viewModel.loadCouponReport()
+
+        ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "loaded"])
     }
 
     private var detailRows: [DetailRow] {
@@ -60,9 +62,11 @@ struct CouponDetails: View {
                                         UIPasteboard.general.string = viewModel.couponCode
                                         let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
                                         noticePresenter.enqueue(notice: notice)
+                                        ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "copied_code"])
                                     }),
                                     .default(Text(Localization.shareCoupon), action: {
                                         showingShareSheet = true
+                                        ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
                                     }),
                                     .cancel()
                                 ]

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -167,7 +167,7 @@ private extension CouponListViewController {
     /// Shows `SearchViewController`.
     ///
     @objc private func displaySearchCoupons() {
-        // TODO: add analytics
+        ServiceLocator.analytics.track(.couponsListSearchTapped)
         let searchViewController = SearchViewController<TitleAndSubtitleAndStatusTableViewCell, CouponSearchUICommand>(
             storeID: siteID,
             command: CouponSearchUICommand(),

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -151,20 +151,23 @@ extension CouponListViewModel: SyncingCoordinatorDelegate {
                                 pageNumber: pageNumber,
                                 pageSize: pageSize) { [weak self] result in
                 guard let self = self else { return }
-                self.handleCouponSyncResult(result: result)
+                self.handleCouponSyncResult(pageNumber: pageNumber, result: result)
                 onCompletion?(result.isSuccess)
         }
 
         storesManager.dispatch(action)
     }
 
-    func handleCouponSyncResult(result: Result<Bool, Error>) {
+    func handleCouponSyncResult(pageNumber: Int, result: Result<Bool, Error>) {
         switch result {
         case .success:
             DDLogInfo("Synchronized coupons")
+            ServiceLocator.analytics.track(.couponsLoaded,
+                                           withProperties: ["is_loading_more": pageNumber != SyncingCoordinator.Defaults.pageFirstIndex])
 
         case .failure(let error):
             DDLogError("⛔️ Error synchronizing coupons: \(error)")
+            ServiceLocator.analytics.track(.couponsLoadedFailed, withError: error)
         }
 
         self.transitionToResultsUpdatedState(hasData: couponViewModels.isNotEmpty)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -151,14 +151,14 @@ extension CouponListViewModel: SyncingCoordinatorDelegate {
                                 pageNumber: pageNumber,
                                 pageSize: pageSize) { [weak self] result in
                 guard let self = self else { return }
-                self.handleCouponSyncResult(pageNumber: pageNumber, result: result)
+                self.handleCouponSyncResult(result: result, pageNumber: pageNumber)
                 onCompletion?(result.isSuccess)
         }
 
         storesManager.dispatch(action)
     }
 
-    func handleCouponSyncResult(pageNumber: Int, result: Result<Bool, Error>) {
+    func handleCouponSyncResult(result: Result<Bool, Error>, pageNumber: Int) {
         switch result {
         case .success:
             DDLogInfo("Synchronized coupons")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
@@ -97,7 +97,7 @@ final class CouponListViewModelTests: XCTestCase {
         setUpWithCouponFetched()
 
         // When
-        sut.handleCouponSyncResult(result: .success(false))
+        sut.handleCouponSyncResult(result: .success(false), pageNumber: 1)
 
         // Then
         XCTAssertEqual(sut.state, .coupons)
@@ -106,7 +106,7 @@ final class CouponListViewModelTests: XCTestCase {
 
     func test_handleCouponSyncResult_shows_empty_when_no_coupons_present() {
         // When
-        sut.handleCouponSyncResult(result: .success(false))
+        sut.handleCouponSyncResult(result: .success(false), pageNumber: 1)
 
         // Then
         XCTAssertEqual(sut.state, .empty)
@@ -140,7 +140,7 @@ final class CouponListViewModelTests: XCTestCase {
         sut.refreshCoupons()
 
         // When
-        sut.handleCouponSyncResult(result: .success(false))
+        sut.handleCouponSyncResult(result: .success(false), pageNumber: 1)
 
         // Then
         XCTAssertEqual(sut.state, .coupons)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6188 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracks events needed for M1 of the Coupon Management project:
- Track when the coupon list is loaded successfully or failed
- Track when the search button on the coupon list is tapped
- Track when a coupon on the coupon list is selected
- Track when the copy button and the share button on the coupon details screen are tapped.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have at least one coupon on your test store. Otherwise, navigate to WP Admin > Marketing > Coupons to create one.
- On the app, make sure that coupon management is enabled in Menu > Settings > Experimental Features.
- Navigate to Menu > Coupons:
  - If the coupon list is loaded successfully, notice in the console: `🔵 Tracked coupons_loaded, properties: [AnyHashable("is_loading_more"): false]`
  - If there are more than 25 items in the list, scroll past the 25th item and notice in the console: `🔵 Tracked coupons_loaded, properties: [AnyHashable("is_loading_more"): true]`.
  - Turn off the connection and try refreshing the list. Notice in the console: `🔵 Tracked coupons_loaded_failed, properties: [AnyHashable("error_description"): "Error Domain=NSURLErrorDomain Code=-1009 \"The Internet connection appears to be offline.\"...]`
- Select the search button on the coupon list, notice in the console: `🔵 Tracked coupons_list_search_tapped, properties: [...]` 
- Select a coupon in the list, notice in the console: `🔵 Tracked coupon_details, properties: [AnyHashable("action"): "loaded"]`
- Select the more button in the coupon details screen and tap Copy Code, notice in the console: `🔵 Tracked coupon_details, properties: [AnyHashable("action"): "copied_code"]`
- Select the more button in the coupon details screen and tap Share Coupon, notice in the console: `🔵 Tracked coupon_details, properties: [AnyHashable("action"): "shared_code"]`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
