### PR TITLE
[Mobile Payments] Configuration loader

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -260,6 +260,14 @@ extension ServiceLocator {
         _shippingSettingsService = mock
     }
 
+    static func setSelectedSiteSettings(_ mock: SelectedSiteSettings) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _selectedSiteSettings = mock
+    }
+
     static func setCurrencySettings(_ mock: CurrencySettings) {
         guard isRunningTests() else {
             return

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Yosemite
+
+final class CardPresentConfigurationLoader {
+    let stores: StoresManager
+
+    private var stripeGatewayIPPEnabled: Bool = false
+    private var canadaIPPEnabled: Bool = false
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+        let stripeAction = AppSettingsAction.loadStripeInPersonPaymentsSwitchState(onCompletion: { [weak self] result in
+            switch result {
+            case .success(let stripeGatewayIPPEnabled):
+                self?.stripeGatewayIPPEnabled = stripeGatewayIPPEnabled
+            default:
+                break
+            }
+        })
+        stores.dispatch(stripeAction)
+
+        let canadaAction = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState(onCompletion: { [weak self]  result in
+            switch result {
+            case .success(let canadaIPPEnabled):
+                self?.canadaIPPEnabled = canadaIPPEnabled
+            default:
+                break
+            }
+        })
+        stores.dispatch(canadaAction)
+    }
+
+    var configuration: CardPresentPaymentsConfiguration {
+        .init(
+            country: SiteAddress().countryCode,
+            stripeEnabled: stripeGatewayIPPEnabled,
+            canadaEnabled: canadaIPPEnabled
+        )
+    }
+}

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -2,13 +2,10 @@ import Foundation
 import Yosemite
 
 final class CardPresentConfigurationLoader {
-    let stores: StoresManager
-
     private var stripeGatewayIPPEnabled: Bool = false
     private var canadaIPPEnabled: Bool = false
 
     init(stores: StoresManager = ServiceLocator.stores) {
-        self.stores = stores
         let stripeAction = AppSettingsAction.loadStripeInPersonPaymentsSwitchState(onCompletion: { [weak self] result in
             switch result {
             case .success(let stripeGatewayIPPEnabled):

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -7,11 +7,8 @@ final class CardPresentConfigurationLoader {
 
     init(stores: StoresManager = ServiceLocator.stores) {
         let stripeAction = AppSettingsAction.loadStripeInPersonPaymentsSwitchState(onCompletion: { [weak self] result in
-            switch result {
-            case .success(let stripeGatewayIPPEnabled):
+            if case .success(let stripeGatewayIPPEnabled) = result {
                 self?.stripeGatewayIPPEnabled = stripeGatewayIPPEnabled
-            default:
-                break
             }
         })
         stores.dispatch(stripeAction)

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -14,11 +14,8 @@ final class CardPresentConfigurationLoader {
         stores.dispatch(stripeAction)
 
         let canadaAction = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState(onCompletion: { [weak self]  result in
-            switch result {
-            case .success(let canadaIPPEnabled):
+            if case .success(let canadaIPPEnabled) = result {
                 self?.canadaIPPEnabled = canadaIPPEnabled
-            default:
-                break
             }
         })
         stores.dispatch(canadaAction)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1520,6 +1520,7 @@
 		DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
+		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
 		E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */; };
 		E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */; };
@@ -3153,6 +3154,7 @@
 		DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSelectedRate.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
+		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
 		E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsSupportLink.swift; sourceTree = "<group>"; };
 		E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableVStack.swift; sourceTree = "<group>"; };
@@ -5789,6 +5791,7 @@
 				024A543222BA6DD500F4F38E /* Developer */,
 				02C0CD2823B5BAFB00F880B1 /* ImageService */,
 				029700EA24FE389C00D242F8 /* InfiniteScroll */,
+				E10459C427BBC20C00C1DCBA /* In-Person Payments */,
 				B5A03699214C0E7000774E2C /* Logging */,
 				B58B4ABC2108F7F800076FDD /* Notices */,
 				45C11B7D2508E99A006C2089 /* Shared Site Settings */,
@@ -7393,6 +7396,14 @@
 			path = Plugins;
 			sourceTree = "<group>";
 		};
+		E10459C427BBC20C00C1DCBA /* In-Person Payments */ = {
+			isa = PBXGroup;
+			children = (
+				E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */,
+			);
+			path = "In-Person Payments";
+			sourceTree = "<group>";
+		};
 		E107FCDD26C1295600BAF51B /* Onboarding Errors */ = {
 			isa = PBXGroup;
 			children = (
@@ -8567,6 +8578,7 @@
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,
 				26F94E2E267A96A000DB6CCF /* ProductAddOnViewModel.swift in Sources */,
 				02A9BCD42737DE0D00159C79 /* JetpackBenefitsView.swift in Sources */,
+				E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */,
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
 				45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */,
 				02A410F52583A84C005E2925 /* SpacerTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1548,6 +1548,7 @@
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */; };
 		E1C5E78226C2A971008D4C47 /* InPersonPaymentsPluginNotSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5E78126C2A971008D4C47 /* InPersonPaymentsPluginNotSetup.swift */; };
+		E1C6535C27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C6535B27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift */; };
 		E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D4E84326776A6A00256B83 /* HeadlineTableViewCell.swift */; };
 		E1D4E84526776AD900256B83 /* HeadlineTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1D4E84226776A6A00256B83 /* HeadlineTableViewCell.xib */; };
 		E1E125AA26EB42530068A9B0 /* CardPresentModalUpdateProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E125A926EB42530068A9B0 /* CardPresentModalUpdateProgress.swift */; };
@@ -3182,6 +3183,7 @@
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingStack.swift; sourceTree = "<group>"; };
 		E1C5E78126C2A971008D4C47 /* InPersonPaymentsPluginNotSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsPluginNotSetup.swift; sourceTree = "<group>"; };
+		E1C6535B27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoaderTests.swift; sourceTree = "<group>"; };
 		E1D4E84226776A6A00256B83 /* HeadlineTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeadlineTableViewCell.xib; sourceTree = "<group>"; };
 		E1D4E84326776A6A00256B83 /* HeadlineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlineTableViewCell.swift; sourceTree = "<group>"; };
 		E1E125A926EB42530068A9B0 /* CardPresentModalUpdateProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalUpdateProgress.swift; sourceTree = "<group>"; };
@@ -5671,6 +5673,7 @@
 		B53A569521123D27000776C9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				E1C6535A27BD1CFC003E87D4 /* In-Person Payments */,
 				029700ED24FE38DE00D242F8 /* InfiniteScroll */,
 				028AFFB42484ED7F00693C09 /* Logging */,
 				D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */,
@@ -7447,6 +7450,14 @@
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
 				E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */,
 				E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */,
+			);
+			path = "In-Person Payments";
+			sourceTree = "<group>";
+		};
+		E1C6535A27BD1CFC003E87D4 /* In-Person Payments */ = {
+			isa = PBXGroup;
+			children = (
+				E1C6535B27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -9375,6 +9386,7 @@
 				02524A5D252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift in Sources */,
 				028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */,
 				02BC5AA824D2802B00C43326 /* MockProductVariationStoresManager.swift in Sources */,
+				E1C6535C27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift in Sources */,
 				2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */,
 				DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */,
 				45B98E1F25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class CardPresentConfigurationLoaderTests: XCTestCase {
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Mock Stores
+    ///
+    private var stores: MockStoresManager!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        storageManager = MockStorageManager()
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadStripeInPersonPaymentsSwitchState(let completion):
+                completion(.success(true))
+            case .loadCanadaInPersonPaymentsSwitchState(let completion):
+                completion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.sessionManager.setStoreId(sampleSiteID)
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
+    }
+
+    override func tearDownWithError() throws {
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings())
+        storageManager.reset()
+        storageManager = nil
+        stores = nil
+        try super.tearDownWithError()
+    }
+
+    func test_configuration_for_US_with_stripe_enabled_and_canada_enabled() {
+        // Given
+        setupFeatures(stripe: true, canada: true)
+        setupCountry(country: .us)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores)
+        let configuration = loader.configuration
+
+        // Then
+        XCTAssertTrue(configuration.isSupportedCountry)
+    }
+
+    func test_configuration_for_Canada_with_stripe_enabled_and_canada_enabled() {
+        // Given
+        setupFeatures(stripe: true, canada: true)
+        setupCountry(country: .ca)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores)
+        let configuration = loader.configuration
+
+        // Then
+        XCTAssertTrue(configuration.isSupportedCountry)
+    }
+
+    func test_configuration_for_Spain_with_stripe_enabled_and_canada_enabled() {
+        // Given
+        setupFeatures(stripe: true, canada: true)
+        setupCountry(country: .es)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores)
+        let configuration = loader.configuration
+
+        // Then
+        XCTAssertFalse(configuration.isSupportedCountry)
+    }
+}
+
+private extension CardPresentConfigurationLoaderTests {
+    func setupCountry(country: Country) {
+        let setting = SiteSetting.fake()
+            .copy(
+                siteID: sampleSiteID,
+                settingID: "woocommerce_default_country",
+                value: country.rawValue,
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        ServiceLocator.selectedSiteSettings.refresh()
+    }
+
+    enum Country: String {
+        case us = "US:CA"
+        case ca = "CA:NS"
+        case es = "ES"
+    }
+
+    func setupFeatures(stripe: Bool, canada: Bool) {
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadStripeInPersonPaymentsSwitchState(onCompletion: let completion):
+                completion(.success(stripe))
+            case .loadCanadaInPersonPaymentsSwitchState(onCompletion: let completion):
+                completion(.success(canada))
+            default:
+                break
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -31,6 +31,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
             }
         }
         stores.sessionManager.setStoreId(sampleSiteID)
+        ServiceLocator.setSelectedSiteSettings(.init(stores: stores, storageManager: storageManager))
     }
 
     override func tearDownWithError() throws {
@@ -609,6 +610,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
                 settingGroupKey: SiteSettingGroup.general.rawValue
             )
         storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        ServiceLocator.selectedSiteSettings.refresh()
     }
 
     enum Country: String {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -31,10 +31,12 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
             }
         }
         stores.sessionManager.setStoreId(sampleSiteID)
-        ServiceLocator.setSelectedSiteSettings(.init(stores: stores, storageManager: storageManager))
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
     }
 
     override func tearDownWithError() throws {
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings())
+        storageManager.reset()
         storageManager = nil
         stores = nil
         try super.tearDownWithError()

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -11,7 +11,7 @@ public struct CardPresentPaymentsConfiguration {
         self.paymentGateways = paymentGateways
     }
 
-    public init(country: String, stripeEnabled: Bool, canadaEnabled: Bool) throws {
+    public init(country: String, stripeEnabled: Bool, canadaEnabled: Bool) {
         switch country {
         case "US" where stripeEnabled == true:
             self.init(
@@ -32,9 +32,11 @@ public struct CardPresentPaymentsConfiguration {
                 paymentGateways: [WCPayAccount.gatewayID]
             )
         default:
-            throw CardPresentPaymentsConfigurationMissingError()
+            self.init(paymentMethods: [], currencies: [], paymentGateways: [])
         }
     }
-}
 
-public struct CardPresentPaymentsConfigurationMissingError: Error {}
+    public var isSupportedCountry: Bool {
+        paymentMethods.isEmpty == false && currencies.isEmpty == false && paymentGateways.isEmpty == false
+    }
+}

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -5,28 +5,32 @@ import XCTest
 class CardPresentConfigurationTests: XCTestCase {
     // MARK: - US Tests
     func test_configuration_for_US_with_Stripe_enabled_Canada_enabled() throws {
-        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: true)
+        let configuration = CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: true)
+        XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
     }
 
     func test_configuration_for_US_with_Stripe_enabled_Canada_disabled() throws {
-        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: false)
+        let configuration = CardPresentPaymentsConfiguration(country: "US", stripeEnabled: true, canadaEnabled: false)
+        XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
     }
 
     func test_configuration_for_US_with_Stripe_disabled_Canada_enabled() throws {
-        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: true)
+        let configuration = CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: true)
+        XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
     }
 
     func test_configuration_for_US_with_Stripe_disabled_Canada_disabled() throws {
-        let configuration = try CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: false)
+        let configuration = CardPresentPaymentsConfiguration(country: "US", stripeEnabled: false, canadaEnabled: false)
+        XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
@@ -34,25 +38,29 @@ class CardPresentConfigurationTests: XCTestCase {
 
     // MARK: - Canada Tests
     func test_configuration_for_Canada_with_Stripe_enabled_Canada_enabled() throws {
-        let configuration = try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: true)
+        let configuration = CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: true)
+        XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
     }
 
     func test_configuration_for_Canada_with_Stripe_enabled_Canada_disabled() {
-        XCTAssertThrowsError(try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: false))
+        let configuration = CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: true, canadaEnabled: false)
+        XCTAssertFalse(configuration.isSupportedCountry)
     }
 
     func test_configuration_for_Canada_with_Stripe_disabled_Canada_enabled() throws {
-        let configuration = try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: true)
+        let configuration = CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: true)
+        XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
     }
 
     func test_configuration_for_Canada_with_Stripe_disabled_Canada_disabled() throws {
-        XCTAssertThrowsError(try CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: false))
+        let configuration = CardPresentPaymentsConfiguration(country: "CA", stripeEnabled: false, canadaEnabled: false)
+        XCTAssertFalse(configuration.isSupportedCountry)
     }
 
     private enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Started this as part of #5980, but doing a separate PR as it's not really specific to showing the WisePad 3 manual.
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #6083, I added a new `CardPresentPaymentsConfiguration` to encapsulate In-Person Payments configuration, depending on the store country, and the currently enabled experimental features.

This was already being used by `CardPresentPaymentsOnboardingUseCase`, but in this PR I'm extracting that initialization to a new `CardPresentConfigurationLoader` helper. This will make it easier to load the configuration from other places outside `CardPresentPaymentsOnboardingUseCase` where it's needed. I'll put up the WisePad 3 manual PR after this, but this commit would be an example use case: 8ba76cb7146e596cacd5509526e504042aa0745b.

Also, I didn't want to change the logic much in this initial PR, but having a central place to load configuration will make it easier if we want it to observe and propagate changes to experimental features or site address. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Unit tests should pass. There should be no change in behavior, this can be tested by trying to see In-Person Payment settings for the different configurations (store in US/CA/Other, Stripe flag enabled/disabled, Canada flag enabled/disabled).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
