### PR TITLE
[Mobile Payments] Use configuration loader to decide which reader manual to show

### DIFF
--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -133,6 +133,7 @@ public typealias CardReaderEvent = Hardware.CardReaderEvent
 public typealias CardReaderSoftwareUpdateState = Hardware.CardReaderSoftwareUpdateState
 public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDiscoveryStatus
 public typealias CardReaderServiceError = Hardware.CardReaderServiceError
+public typealias CardReaderType = Hardware.CardReaderType
 public typealias CardReaderConfigError = Hardware.CardReaderConfigError
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
 public typealias PaymentIntent = Hardware.PaymentIntent

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -42,6 +42,6 @@ public struct CardPresentPaymentsConfiguration {
     }
 
     public var isSupportedCountry: Bool {
-        paymentMethods.isEmpty == false && currencies.isEmpty == false && paymentGateways.isEmpty == false
+        paymentMethods.isEmpty == false && currencies.isEmpty == false && paymentGateways.isEmpty == false && supportedReaders.isEmpty == false
     }
 }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -4,11 +4,13 @@ public struct CardPresentPaymentsConfiguration {
     public let paymentMethods: [WCPayPaymentMethodType]
     public let currencies: [String]
     public let paymentGateways: [String]
+    public let supportedReaders: [CardReaderType]
 
-    init(paymentMethods: [WCPayPaymentMethodType], currencies: [String], paymentGateways: [String]) {
+    init(paymentMethods: [WCPayPaymentMethodType], currencies: [String], paymentGateways: [String], supportedReaders: [CardReaderType]) {
         self.paymentMethods = paymentMethods
         self.currencies = currencies
         self.paymentGateways = paymentGateways
+        self.supportedReaders = supportedReaders
     }
 
     public init(country: String, stripeEnabled: Bool, canadaEnabled: Bool) {
@@ -17,22 +19,25 @@ public struct CardPresentPaymentsConfiguration {
             self.init(
                 paymentMethods: [.cardPresent],
                 currencies: ["USD"],
-                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID]
+                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
+                supportedReaders: [.chipper, .stripeM2]
             )
         case "US" where stripeEnabled == false:
             self.init(
                 paymentMethods: [.cardPresent],
                 currencies: ["USD"],
-                paymentGateways: [WCPayAccount.gatewayID]
+                paymentGateways: [WCPayAccount.gatewayID],
+                supportedReaders: [.chipper, .stripeM2]
             )
         case "CA" where canadaEnabled == true:
             self.init(
                 paymentMethods: [.cardPresent, .interacPresent],
                 currencies: ["CAD"],
-                paymentGateways: [WCPayAccount.gatewayID]
+                paymentGateways: [WCPayAccount.gatewayID],
+                supportedReaders: [.wisepad3]
             )
         default:
-            self.init(paymentMethods: [], currencies: [], paymentGateways: [])
+            self.init(paymentMethods: [], currencies: [], paymentGateways: [], supportedReaders: [])
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5980 
Merge after: #6194
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a link to the WisePad 3 manual and decides which manuals to show depending on store country

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Go to Settings -> In-Person Payments:

- On a US Store, there should be links to the Chipper and M2 manuals
- On a Canada Store, there should be a link to the WisePad 3 manual

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

US | Canada
-|-
![Simulator Screen Shot - iPhone 13 - 2022-02-16 at 13 35 57](https://user-images.githubusercontent.com/8739/154265703-ea20a655-1b35-4e18-a629-41263851601e.png)|![Simulator Screen Shot - iPhone 13 - 2022-02-16 at 13 35 28](https://user-images.githubusercontent.com/8739/154265699-bfba7563-e11d-454d-bfe0-11614c787c79.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
