### PR TITLE
[Mobile Payments] Test fetching charge for Refund Confirmation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -106,8 +106,15 @@ final class IssueRefundViewModel {
 
     private let analytics: Analytics
 
-    init(order: Order, refunds: [Refund], currencySettings: CurrencySettings, analytics: Analytics = ServiceLocator.analytics) {
+    private let stores: StoresManager
+
+    init(order: Order,
+         refunds: [Refund],
+         currencySettings: CurrencySettings,
+         analytics: Analytics = ServiceLocator.analytics,
+         stores: StoresManager = ServiceLocator.stores) {
         self.analytics = analytics
+        self.stores = stores
         let items = Self.filterItems(from: order, with: refunds)
         state = State(order: order, refunds: refunds, itemsToRefund: items, currencySettings: currencySettings)
         sections = createSections()
@@ -246,7 +253,7 @@ private extension IssueRefundViewModel {
             return
         }
         let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: state.order.siteID, chargeID: chargeID, onCompletion: { _ in })
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6180
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a unit test deferred from #5976 that we fetch the charge when building the Refund Confirmation screen, so that we can show fresh card details if we have them

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Run unit tests

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
