### PR TITLE
[Refunds] Prevent selection of `Refund Via` row

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Orders: In the experimental Order Creation feature, product variations added to a new order now show a list of their attributes. [https://github.com/woocommerce/woocommerce-ios/pull/6131]
 - [*] Enlarged the tap area for the action button on the notice view. [https://github.com/woocommerce/woocommerce-ios/pull/6146]
 - [*] Reviews: Fixed crash on iPad when tapping the More button. [https://github.com/woocommerce/woocommerce-ios/pull/6187]
+- [*] Disabled unneccesary selection of the "Refund via" row on the Refund Confirmation screen [https://github.com/woocommerce/woocommerce-ios/pull/6198]
 
 8.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -172,6 +172,7 @@ extension RefundConfirmationViewController: UITableViewDataSource {
             let cell = tableView.dequeueReusableCell(WooBasicTableViewCell.self, for: indexPath)
             cell.applyPlainTextStyle()
             cell.bodyLabel.text = row.text
+            cell.selectionStyle = .none
             return cell
         default:
             assertionFailure("Unsupported row.")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6193
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The `Refund via` row on the Refund confirmation screen was previously selectable, but should not have been as there was no meaning to this selection. 

There is no other use of the `RefundConfirmationViewModel.SimpleTextRow` at present, so it proved safe to prevent selection in every case.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Tap the Orders tab, then select an order with a payment (ideally a card payment from the web, not WCPay In-person payments, but Stripe In-person payments are fine.)
2. Tap `Issue Refund`
3. Select some part of the transaction to refund, then tap `Next`
4. Observe that tapping the `Refund via` row doesn't do anything.
5. Observe that other rows are also not selectable, and the `Reason for refund` can be edited.
6. Observe that the `Refund` button still works

### Screenshots
Before | After
---|---
![Before-tapping-row-selects-it](https://user-images.githubusercontent.com/2472348/154287877-139a9706-2cba-42ae-b97a-a121caa20cd1.gif) | ![After-row-not-selected](https://user-images.githubusercontent.com/2472348/154287313-77b06513-454d-4e50-9bef-2848e97f9894.gif)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
