### PR TITLE
Order Creation: Add support for creating order with fees in Yosemite layer

### DIFF
--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -315,7 +315,9 @@ private extension OrderStore {
     /// Creates a manual order with the provided order details.
     ///
     func createOrder(siteID: Int64, order: Order, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        remote.createOrder(siteID: siteID, order: order, fields: [.status, .items, .billingAddress, .shippingAddress, .shippingLines]) { [weak self] result in
+        remote.createOrder(siteID: siteID,
+                           order: order,
+                           fields: [.status, .items, .billingAddress, .shippingAddress, .shippingLines, .feeLines]) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -783,6 +783,7 @@ final class OrderStoreTests: XCTestCase {
         let receivedKeys = Array(request.parameters.keys).sorted()
         let expectedKeys = [
             "billing",
+            "fee_lines",
             "line_items",
             "shipping",
             "shipping_lines",


### PR DESCRIPTION
Part of: #6030 

## Description

Adds support in the Yosemite layer for creating a new, complete order with fee lines.

## Changes

* Adds the `.feeLines` field to the remote order creation request when creating a manual order.
* Updates the related unit test to check that the fee lines are included in the request.

## Testing

We don't yet support adding shipping to a new order in the app. However, you can test this by firing the `OrderAction.createOrder` action with a new order that includes fee lines.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
