### PR TITLE
Order Creation: Add support for removing fees from order in Networking layer

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -334,7 +334,7 @@ extension Order {
 extension OrderFeeLine {
     public func copy(
         feeID: CopiableProp<Int64> = .copy,
-        name: CopiableProp<String> = .copy,
+        name: NullableCopiableProp<String> = .copy,
         taxClass: CopiableProp<String> = .copy,
         taxStatus: CopiableProp<OrderFeeTaxStatus> = .copy,
         total: CopiableProp<String> = .copy,
@@ -1741,8 +1741,8 @@ extension WCPayCardPresentPaymentDetails {
 extension WCPayCardPresentReceiptDetails {
     public func copy(
         accountType: CopiableProp<WCPayCardFunding> = .copy,
-        applicationPreferredName: CopiableProp<String> = .copy,
-        dedicatedFileName: CopiableProp<String> = .copy
+        applicationPreferredName: NullableCopiableProp<String> = .copy,
+        dedicatedFileName: NullableCopiableProp<String> = .copy
     ) -> WCPayCardPresentReceiptDetails {
         let accountType = accountType ?? self.accountType
         let applicationPreferredName = applicationPreferredName ?? self.applicationPreferredName

--- a/Networking/Networking/Model/OrderFeeLine.swift
+++ b/Networking/Networking/Model/OrderFeeLine.swift
@@ -5,7 +5,13 @@ import Codegen
 ///
 public struct OrderFeeLine: Equatable, Codable, GeneratedFakeable, GeneratedCopiable {
     public let feeID: Int64
-    public let name: String
+
+    /// Fee Name
+    ///
+    /// Sending a null value to the REST API removes the Fee Line from the Order.
+    ///
+    public let name: String?
+
     public let taxClass: String
     public let taxStatus: OrderFeeTaxStatus
     public let total: String
@@ -16,7 +22,7 @@ public struct OrderFeeLine: Equatable, Codable, GeneratedFakeable, GeneratedCopi
     /// OrderFeeLine struct initializer.
     ///
     public init(feeID: Int64,
-                name: String,
+                name: String?,
                 taxClass: String,
                 taxStatus: OrderFeeTaxStatus,
                 total: String,


### PR DESCRIPTION
Part of: #6030

## Description

During order creation, we want to support removing a fee line, including removing it from a draft/pending order that exists remotely.

To remove a fee line from an order that exists remotely, we have to send a request to `POST /orders/:order_id` with the fee line's `name` set to null. This PR updates the `OrderFeeLine` model to support that.

## Changes

* Makes the `name` property optional in `OrderFeeLine`, so it can be set to `nil` for fee lines we want to remove. (The model already has a public `encode(to:)` method that will encode the `name` even if it is `nil`.)
* Updates the generated `copy()` method for `OrderFeeLine`. (The `copy()` method for `WCPayCardPresentReceiptDetails` was also updated when I ran `rake generate`, related to the optionals added in #6059. FYI @joshheald)
* Adds a unit test to check that the fee line is encoded as expected.

## Testing

We don't yet support removing fee lines from existing orders in the app.

You can test this by firing `OrdersRemote.updateOrder` or the Yosemite `OrderAction.updateOrder` action for an existing order with a fee line, passing the order with its fee line `name` set to `nil` (see the unit test for an example). I have tested and confirmed that this removes the fee line from the remote order.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
