### PR TITLE
Order Creation: Use title case for buttons

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -151,7 +151,7 @@ private extension NewOrder {
         static let title = NSLocalizedString("New Order", comment: "Title for the order creation screen")
         static let createButton = NSLocalizedString("Create", comment: "Button to create an order on the New Order screen")
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating a new order")
-        static let addProduct = NSLocalizedString("Add product", comment: "Title text of the button that adds a product when creating a new order")
+        static let addProduct = NSLocalizedString("Add Product", comment: "Title text of the button that adds a product when creating a new order")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -69,7 +69,7 @@ private extension OrderPaymentSection {
         static let orderTotal = NSLocalizedString("Order Total", comment: "Label for the the row showing the total cost of the order")
         static let taxesInfo = NSLocalizedString("Taxes will be automatically calculated based on your store settings.",
                                                  comment: "Information about taxes and the order total when creating a new order")
-        static let addShipping = NSLocalizedString("Add shipping", comment: "Title text of the button that adds shipping line when creating a new order")
+        static let addShipping = NSLocalizedString("Add Shipping", comment: "Title text of the button that adds shipping line when creating a new order")
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -65,7 +65,7 @@ private extension ProductInOrder {
     enum Localization {
         static let title = NSLocalizedString("Product", comment: "Title for the Product screen during order creation")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Product screen")
-        static let remove = NSLocalizedString("Remove product from order",
+        static let remove = NSLocalizedString("Remove Product from Order",
                                               comment: "Text for the button to remove a product from the order during order creation")
     }
 }


### PR DESCRIPTION
Closes: #6196

## Description

Updates the button titles in Order Creation to use title case (instead of sentence case), per our current design guidelines and Apple's [title-style capitalization](https://help.apple.com/applestyleguide/#/apsgb744e4a3?sub=apdca93e113f1d64) guide.

## Testing

1. Build and run the app.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. While creating a new order, confirm that all the buttons use title case: to add or remove a product from the order, add shipping, etc.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 17 51 38](https://user-images.githubusercontent.com/8658164/154326137-91a9975b-29fc-47c3-8a79-3cfa6ff905cb.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 17 50 09](https://user-images.githubusercontent.com/8658164/154326187-1c2e1703-60db-471d-a198-d23d50e0d547.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 17 51 42](https://user-images.githubusercontent.com/8658164/154326145-cc678bd6-ad56-4155-ae5b-a82770a01487.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 17 50 12](https://user-images.githubusercontent.com/8658164/154326248-4806aa55-d43f-4c90-9636-f00ffb241516.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
