### PR TITLE
Order Creation: Fix styles for variable product rows in the product list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -11,6 +11,10 @@ struct AddProductToOrder: View {
     ///
     @ObservedObject var viewModel: AddProductToOrderViewModel
 
+    /// Keeps track of the current screen scale
+    ///
+    @ScaledMetric private var scale = 1
+
     var body: some View {
         NavigationView {
             VStack {
@@ -65,7 +69,17 @@ struct AddProductToOrder: View {
         if rowViewModel.numberOfVariations > 0,
            let addVariationToOrderVM = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
             LazyNavigationLink(destination: AddProductVariationToOrder(isPresented: $isPresented, viewModel: addVariationToOrderVM)) {
-                ProductRow(viewModel: rowViewModel)
+                HStack {
+                    ProductRow(viewModel: rowViewModel)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Image(uiImage: .chevronImage)
+                        .resizable()
+                        .flipsForRightToLeftLayoutDirection(true)
+                        .frame(width: Constants.chevronSize(scale: scale), height: Constants.chevronSize(scale: scale))
+                        .foregroundColor(Color(.systemGray))
+                        .accessibility(hidden: true)
+                }
             }
         } else {
             ProductRow(viewModel: rowViewModel)
@@ -81,6 +95,9 @@ private extension AddProductToOrder {
     enum Constants {
         static let dividerHeight: CGFloat = 1
         static let defaultPadding: CGFloat = 16
+        static func chevronSize(scale: CGFloat) -> CGFloat {
+            22 * scale
+        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -11,10 +11,6 @@ struct AddProductToOrder: View {
     ///
     @ObservedObject var viewModel: AddProductToOrderViewModel
 
-    /// Keeps track of the current screen scale
-    ///
-    @ScaledMetric private var scale = 1
-
     var body: some View {
         NavigationView {
             VStack {
@@ -73,12 +69,7 @@ struct AddProductToOrder: View {
                     ProductRow(viewModel: rowViewModel)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
-                    Image(uiImage: .chevronImage)
-                        .resizable()
-                        .flipsForRightToLeftLayoutDirection(true)
-                        .frame(width: Constants.chevronSize(scale: scale), height: Constants.chevronSize(scale: scale))
-                        .foregroundColor(Color(.systemGray))
-                        .accessibility(hidden: true)
+                    DisclosureIndicator()
                 }
             }
         } else {
@@ -95,9 +86,6 @@ private extension AddProductToOrder {
     enum Constants {
         static let dividerHeight: CGFloat = 1
         static let defaultPadding: CGFloat = 16
-        static func chevronSize(scale: CGFloat) -> CGFloat {
-            22 * scale
-        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -30,6 +30,7 @@ struct ProductRow: View {
                     // Product details
                     VStack(alignment: .leading) {
                         Text(viewModel.name)
+                            .bodyStyle()
                         Text(viewModel.productDetailsLabel)
                             .subheadlineStyle()
                         Text(viewModel.skuLabel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -150,13 +150,7 @@ private struct MethodRow: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                Image(uiImage: .chevronImage)
-                    .resizable()
-                    .flipsForRightToLeftLayoutDirection(true)
-                    .frame(width: SimplePaymentsMethod.Layout.chevronWidthHeight(scale: scale),
-                           height: SimplePaymentsMethod.Layout.chevronWidthHeight(scale: scale))
-                    .foregroundColor(Color(.systemGray))
-                    .accessibility(hidden: true)
+                DisclosureIndicator()
             }
             .padding(.vertical, SimplePaymentsMethod.Layout.verticalPadding)
             .padding(.horizontal, insets: safeAreaInsets)
@@ -205,10 +199,6 @@ private extension SimplePaymentsMethod {
 
         static func iconWidthHeight(scale: CGFloat) -> CGFloat {
             24 * scale
-        }
-
-        static func chevronWidthHeight(scale: CGFloat) -> CGFloat {
-            22 * scale
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/DisclosureIndicator.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/DisclosureIndicator.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct DisclosureIndicator: View {
+    /// Keeps track of the current screen scale
+    ///
+    @ScaledMetric private var scale = 1
+
+    var body: some View {
+        Image(uiImage: .chevronImage)
+            .resizable()
+            .flipsForRightToLeftLayoutDirection(true)
+            .frame(width: Constants.chevronSize(scale: scale), height: Constants.chevronSize(scale: scale))
+            .foregroundColor(Color(.systemGray))
+            .accessibility(hidden: true)
+    }
+}
+
+// MARK: Constants
+private extension DisclosureIndicator {
+    enum Constants {
+        static func chevronSize(scale: CGFloat) -> CGFloat {
+            22 * scale
+        }
+    }
+}
+
+struct DisclosureIndicator_Previews: PreviewProvider {
+    static var previews: some View {
+        DisclosureIndicator()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/NavigationRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/NavigationRow.swift
@@ -16,10 +16,6 @@ struct NavigationRow<Content: View>: View {
     ///
     let action: () -> Void
 
-    /// Keeps track of the current screen scale
-    ///
-    @ScaledMetric private var scale = 1
-
     /// Environment safe areas
     ///
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
@@ -37,13 +33,7 @@ struct NavigationRow<Content: View>: View {
             HStack {
                 content
                 Spacer()
-                Image(uiImage: .chevronImage)
-                    .resizable()
-                    .flipsForRightToLeftLayoutDirection(true)
-                    .frame(width: Layout.chevronWidthHeight(scale: scale),
-                           height: Layout.chevronWidthHeight(scale: scale))
-                    .foregroundColor(Color(.systemGray))
-                    .accessibility(hidden: true)
+                DisclosureIndicator()
                     .renderedIf(selectable)
             }
             .padding()
@@ -56,9 +46,6 @@ struct NavigationRow<Content: View>: View {
 
 private enum Layout {
     static let minHeight: CGFloat = 44
-    static func chevronWidthHeight(scale: CGFloat) -> CGFloat {
-        22 * scale
-    }
 }
 
 struct NavigationRow_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -33,11 +33,8 @@ struct TitleAndValueRow: View {
                         .padding(.vertical, Constants.verticalPadding)
                 }
 
-                Image(uiImage: .chevronImage)
-                    .flipsForRightToLeftLayoutDirection(true)
+                DisclosureIndicator()
                     .renderedIf(selectionStyle == .disclosure)
-                    .frame(width: Constants.imageSize, height: Constants.imageSize)
-                    .foregroundColor(Color(UIColor.gray(.shade30)))
             }
             .contentShape(Rectangle())
         })
@@ -99,7 +96,6 @@ private extension Text {
 
 private extension TitleAndValueRow {
     enum Constants {
-        static let imageSize: CGFloat = 22
         static let minHeight: CGFloat = 44
         static let maxHeight: CGFloat = 136
         static let horizontalPadding: CGFloat = 16

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1189,6 +1189,7 @@
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
 		CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */; };
+		CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC72BB6327BD842500837876 /* DisclosureIndicator.swift */; };
 		CC770C8A27B1497700CE6ABC /* SearchHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC770C8927B1497700CE6ABC /* SearchHeader.swift */; };
 		CC77488E2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
@@ -2820,6 +2821,7 @@
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
+		CC72BB6327BD842500837876 /* DisclosureIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclosureIndicator.swift; sourceTree = "<group>"; };
 		CC770C8927B1497700CE6ABC /* SearchHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHeader.swift; sourceTree = "<group>"; };
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderViewModelTests.swift; sourceTree = "<group>"; };
@@ -5084,6 +5086,7 @@
 				AEACCB6C2785FF4A000D01F0 /* NavigationRow.swift */,
 				CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */,
 				CC770C8927B1497700CE6ABC /* SearchHeader.swift */,
+				CC72BB6327BD842500837876 /* DisclosureIndicator.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -8967,6 +8970,7 @@
 				0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,
+				CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */,
 				77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */,
 				0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,


### PR DESCRIPTION
Closes: #6203

## Description

This fixes two regressions with the styles for variable product rows in the product list, during Order Creation:

- The product name always uses the body style (not highlighted in pink)
- There is a disclosure indicator on the row

## Changes

* Adds a reusable `DisclosureIndicator` SwiftUI view, which replaces the various implementations across SwiftUI views.
* Adds a `DisclosureIndicator` to the variable product rows in `AddProductToOrder`. (This was previously done for us when the product list was contained in a `List` view, but we have to add them otherwise.)
* Sets the `bodyStyle()` modifier on the product name to prevent it from being styled pink.

## Testing

1. Build and run the app.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. Select "Add Product."
5. Find a variable product in the product list and confirm the styles look as expected.
6. Resize the text on your device/simulator and confirm the disclosure indicator scales as expected.

You can also confirm that other SwiftUI screens using the new `DisclosureIndicator` are unchanged (see screenshots below).

## Screenshots

/|Before|After
-|-|-
Variable product row in Order Creation|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 27 07](https://user-images.githubusercontent.com/8658164/154343500-288048e2-b4b7-4a39-910a-8e13d365c982.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 21 09](https://user-images.githubusercontent.com/8658164/154343274-48d30c75-be29-4d99-b0d4-cf587c28dfa4.png)
Country row (using `TitleAndValueRow`) in Customer Details in Order Creation|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 27 12](https://user-images.githubusercontent.com/8658164/154343297-d5b3b814-3327-4aa0-a528-3cab8afc49a9.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 21 14](https://user-images.githubusercontent.com/8658164/154343304-db0801fd-9d41-448e-a758-053c77b3d91e.png)
Payment method rows in Simple payments|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 29 00](https://user-images.githubusercontent.com/8658164/154343314-5a4f3951-f349-422e-a8b6-9d03f3755392.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 22 13](https://user-images.githubusercontent.com/8658164/154343320-145b02bc-b2c0-4410-8a0c-40677ef86a79.png)
Coupon management (using `NavigationRow`)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 26 37](https://user-images.githubusercontent.com/8658164/154343167-34eab3a2-2603-4cb2-ae84-b44191d8c116.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 19 31 33](https://user-images.githubusercontent.com/8658164/154343136-df042898-0be2-4b10-bba6-a5e03bd855d8.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
