### PR TITLE
Order Creation: Defines base status for order sync

### DIFF
--- a/Networking/Networking/Model/OrderStatusEnum.swift
+++ b/Networking/Networking/Model/OrderStatusEnum.swift
@@ -7,6 +7,7 @@ import Codegen
 /// and it is used to determine the user facing display order
 ///
 public enum OrderStatusEnum: Codable, Hashable, Comparable, GeneratedFakeable {
+    case autoDraft
     case pending
     case processing
     case onHold
@@ -25,6 +26,8 @@ extension OrderStatusEnum: RawRepresentable {
     ///
     public init(rawValue: String) {
         switch rawValue {
+        case Keys.autoDraft:
+            self = .autoDraft
         case Keys.pending:
             self = .pending
         case Keys.processing:
@@ -48,6 +51,7 @@ extension OrderStatusEnum: RawRepresentable {
     ///
     public var rawValue: String {
         switch self {
+        case .autoDraft:            return Keys.autoDraft
         case .pending:              return Keys.pending
         case .processing:           return Keys.processing
         case .onHold:               return Keys.onHold
@@ -64,6 +68,7 @@ extension OrderStatusEnum: RawRepresentable {
 /// Enum containing the 'Known' OrderStatus Keys
 ///
 private enum Keys {
+    static let autoDraft    = "auto-draft"
     static let pending      = "pending"
     static let processing   = "processing"
     static let onHold       = "on-hold"

--- a/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
@@ -27,7 +27,7 @@ extension UILabel {
     ///
     private func applyBackground(for statusEnum: OrderStatusEnum) {
         switch statusEnum {
-        case .pending, .completed, .cancelled, .refunded, .custom:
+        case .autoDraft, .pending, .completed, .cancelled, .refunded, .custom:
             backgroundColor = .gray(.shade5)
         case .onHold:
             backgroundColor = .withColorStudio(.orange, shade: .shade5)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -280,7 +280,7 @@ extension NewOrderViewModel {
             title = orderStatus.name ?? orderStatus.slug
             color = {
                 switch orderStatus.status {
-                case .pending, .completed, .cancelled, .refunded, .custom:
+                case .autoDraft, .pending, .completed, .cancelled, .refunded, .custom:
                     return .gray(.shade5)
                 case .onHold:
                     return .withColorStudio(.orange, shade: .shade5)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolver.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolver.swift
@@ -1,0 +1,42 @@
+import Yosemite
+
+/// Helper that defines which `status` a new order should initially have.
+///
+struct NewOrderInitialStatusResolver {
+
+    /// Current site ID
+    ///
+    private let siteID: Int64
+
+    /// Stores.
+    ///
+    private let stores: StoresManager
+
+    /// Defines the WC version where `auto-draft` should be available.
+    ///
+    private let draftMinSupportedVersion = "6.3.0"
+
+    /// WooCommerce plugin name.
+    ///
+    private let wcPluginName = "WooCommerce"
+
+
+    /// Decides the initial `status` for a new order based on the current store version.
+    ///
+    func resolve(onCompletion: @escaping (OrderStatusEnum) -> ()) {
+        let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: wcPluginName) { wooPlugin in
+            guard let wooPlugin = wooPlugin else {
+                return onCompletion(.pending)
+            }
+
+            // auto-draft should exists in versions greater than `6.3.0`
+            switch draftMinSupportedVersion.compare(wooPlugin.version, options: .numeric) {
+            case .orderedAscending, .orderedSame:
+                onCompletion(.autoDraft)
+            case .orderedDescending:
+                onCompletion(.pending)
+            }
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolver.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolver.swift
@@ -3,7 +3,6 @@ import Yosemite
 /// Helper that defines which `status` a new order should initially have.
 ///
 struct NewOrderInitialStatusResolver {
-
     /// Current site ID
     ///
     private let siteID: Int64
@@ -20,6 +19,10 @@ struct NewOrderInitialStatusResolver {
     ///
     private let wcPluginName = "WooCommerce"
 
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
 
     /// Decides the initial `status` for a new order based on the current store version.
     ///
@@ -37,6 +40,6 @@ struct NewOrderInitialStatusResolver {
                 onCompletion(.pending)
             }
         }
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -38,11 +38,17 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
 
     private let stores: StoresManager
 
+    /// This is the order status that we will use to keep the order in sync with the remote source.
+    ///
+    private var baseSyncStatus: OrderStatusEnum = .pending
+
     // MARK: Initializers
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.stores = stores
+
+        updateBaseSyncOrderStatus()
     }
 
     // MARK: Methods
@@ -54,5 +60,16 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
     ///
     func commitAllChanges(onCompletion: @escaping (Result<Order, Error>) -> Void) {
         // TODO: Implement
+    }
+}
+
+// MARK: Helpers
+private extension RemoteOrderSynchronizer {
+    /// Updates the base sync order status.
+    ///
+    func updateBaseSyncOrderStatus() {
+        NewOrderInitialStatusResolver(siteID: siteID, stores: stores).resolve { [weak self] baseStatus in
+            self?.baseSyncStatus = baseStatus
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -117,6 +117,8 @@ extension OrderStatusEnum: FilterType {
     ///
     var description: String {
         switch self {
+        case .autoDraft:
+            return NSLocalizedString("Draft", comment: "Display label for auto-draft order status.")
         case .pending:
             return NSLocalizedString("Pending", comment: "Display label for pending order status.")
         case .processing:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C4F2502AEE200F49B68 /* EventLogging.swift */; };
 		2602A63D27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */; };
+		2602A63F27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */; };
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
@@ -2058,6 +2059,7 @@
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteOrderSynchronizer.swift; sourceTree = "<group>"; };
+		2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderInitialStatusResolver.swift; sourceTree = "<group>"; };
 		260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModel.swift; sourceTree = "<group>"; };
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
@@ -4526,6 +4528,7 @@
 				26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */,
 				26C6439427B9A1B300DD00D1 /* LocalOrderSynchronizer.swift */,
 				2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */,
+				2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */,
 			);
 			path = Synchronizer;
 			sourceTree = "<group>";
@@ -8397,6 +8400,7 @@
 				02817B39242B34560050AD8B /* ToolbarView.swift in Sources */,
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
 				022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */,
+				2602A63F27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift in Sources */,
 				E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */,
 				456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */,
 				E15FC74326BC1D2700CF83E6 /* SafariSheet.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C4F2502AEE200F49B68 /* EventLogging.swift */; };
 		2602A63D27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */; };
 		2602A63F27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */; };
+		2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64127BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift */; };
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
@@ -2060,6 +2061,7 @@
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteOrderSynchronizer.swift; sourceTree = "<group>"; };
 		2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderInitialStatusResolver.swift; sourceTree = "<group>"; };
+		2602A64127BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderInitialStatusResolverTests.swift; sourceTree = "<group>"; };
 		260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModel.swift; sourceTree = "<group>"; };
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
@@ -4293,6 +4295,14 @@
 			path = "Edit Order Status";
 			sourceTree = "<group>";
 		};
+		2602A64027BD89B300B347F1 /* Synchronizer */ = {
+			isa = PBXGroup;
+			children = (
+				2602A64127BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift */,
+			);
+			path = Synchronizer;
+			sourceTree = "<group>";
+		};
 		2611EE57243A46C500A74490 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -6306,6 +6316,7 @@
 				CC53FB3F2759042600C4CA4F /* AddProductToOrderViewModelTests.swift */,
 				CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */,
 				AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */,
+				2602A64027BD89B300B347F1 /* Synchronizer */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -9289,6 +9300,7 @@
 				31F635DC273AF0B100E14F10 /* VersionHelpersTests.swift in Sources */,
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
+				2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */,
 				570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */,
 				CC77488E2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolverTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+import TestKit
+import Fakes
+
+@testable import WooCommerce
+@testable import Yosemite
+
+class NewOrderInitialStatusResolverTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 1234
+
+    func test_no_store_version_use_pending_status() {
+        // Given
+        let stores = createStoreWithVersion(nil)
+
+        // When
+        let resolver = NewOrderInitialStatusResolver(siteID: sampleSiteID, stores: stores)
+        let initialStatus: OrderStatusEnum = waitFor { promise in
+            resolver.resolve { status in
+                promise(status)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(initialStatus, .pending)
+    }
+
+    func test_older_store_version_use_pending_status() {
+        // Given
+        let stores = createStoreWithVersion("6.2.5")
+
+        // When
+        let resolver = NewOrderInitialStatusResolver(siteID: sampleSiteID, stores: stores)
+        let initialStatus: OrderStatusEnum = waitFor { promise in
+            resolver.resolve { status in
+                promise(status)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(initialStatus, .pending)
+    }
+
+    func test_same_store_version_use_draft_status() {
+        // Given
+        let stores = createStoreWithVersion("6.3.0")
+
+        // When
+        let resolver = NewOrderInitialStatusResolver(siteID: sampleSiteID, stores: stores)
+        let initialStatus: OrderStatusEnum = waitFor { promise in
+            resolver.resolve { status in
+                promise(status)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(initialStatus, .autoDraft)
+    }
+
+    func test_newer_store_version_use_draft_status() {
+        // Given
+        let stores = createStoreWithVersion("6.4.0")
+
+        // When
+        let resolver = NewOrderInitialStatusResolver(siteID: sampleSiteID, stores: stores)
+        let initialStatus: OrderStatusEnum = waitFor { promise in
+            resolver.resolve { status in
+                promise(status)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(initialStatus, .autoDraft)
+    }
+
+    func test_beta_store_version_use_draft_status() {
+        // Given
+        let stores = createStoreWithVersion("6.3.0-beta.1")
+
+        // When
+        let resolver = NewOrderInitialStatusResolver(siteID: sampleSiteID, stores: stores)
+        let initialStatus: OrderStatusEnum = waitFor { promise in
+            resolver.resolve { status in
+                promise(status)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(initialStatus, .autoDraft)
+    }
+}
+
+private extension NewOrderInitialStatusResolverTests {
+
+    /// Creates a mock store manager that returns the provided version as part of the `SystemStatusAction.fetchSystemPlugin` action.
+    ///
+    func createStoreWithVersion(_ version: String?) -> StoresManager {
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                guard let version = version else {
+                    return onCompletion(nil)
+                }
+                let plugin = SystemPlugin.fake().copy(version: version)
+                onCompletion(plugin)
+            default:
+                XCTFail("Unexpected action received: \(action)")
+            }
+        }
+        return stores
+    }
+}


### PR DESCRIPTION
closes #6129

# Why

This PR updates the `RemoteOrderSynchronizer` to set into a private variable the base status that should be used when synching an order. The status can be either `.pending` or `.autoDraft` depending on the store version.

# How

- Add a new `.autoDraft` enum case to the `OrderStatusEnum` type.
- Adds a new `NewOrderInitialStatusResolver` type to resolve the correct status based on the store version. The store version is fetched when the app is launched(or the store is switched) while syncing system plugins.
- Update `RemoteOrderSynchronizer` to store the correct base status.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
