### PR TITLE
Coupons: Update and enable feature flag for milestone 1

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -37,7 +37,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .myStoreTabUpdates:
             return true
-        case .couponsView:
+        case .couponView:
             return true
         case .productSKUInputScanner:
             return true

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -37,8 +37,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .myStoreTabUpdates:
             return true
-        case .couponManagement:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .couponsView:
+            return true
         case .productSKUInputScanner:
             return true
         case .canadaInPersonPayments:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -76,7 +76,7 @@ public enum FeatureFlag: Int {
 
     /// Displays the option to view coupons
     ///
-    case couponsView
+    case couponView
 
     /// Barcode scanner for product SKU input
     ///

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -74,9 +74,9 @@ public enum FeatureFlag: Int {
     ///
     case myStoreTabUpdates
 
-    /// Displays the option to manage coupons
+    /// Displays the option to view coupons
     ///
-    case couponManagement
+    case couponsView
 
     /// Barcode scanner for product SKU input
     ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 8.6
 -----
+- [***] Merchants can now view coupons in their stores by enabling Coupon Management in Experimental Features. [https://github.com/woocommerce/woocommerce-ios/pull/6209]
 - [*] Orders: In the experimental Order Creation feature, product variations added to a new order now show a list of their attributes. [https://github.com/woocommerce/woocommerce-ios/pull/6131]
 - [*] Enlarged the tap area for the action button on the notice view. [https://github.com/woocommerce/woocommerce-ios/pull/6146]
 - [*] Reviews: Fixed crash on iPad when tapping the More button. [https://github.com/woocommerce/woocommerce-ios/pull/6187]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -119,7 +119,7 @@ private extension BetaFeaturesViewController {
     }
 
     func couponManagementSection() -> Section? {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponsView) else {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponView) else {
             return nil
         }
         return Section(rows: [.couponManagement,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -119,7 +119,7 @@ private extension BetaFeaturesViewController {
     }
 
     func couponManagementSection() -> Section? {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponManagement) else {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponsView) else {
             return nil
         }
         return Section(rows: [.couponManagement,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For the Coupons project, we want to enable viewing coupons only for Milestone 1. Therefore, this PR updates the feature flag for M1 from `couponManagement` to `couponView` to clarify that. For next milestones, the feature flags will be `couponUpdate` and `couponCreation`.

This PR also enables the `couponView` feature flag to make this feature available in the next release.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please feel free to test the features for M1 again if needed:
- Coupon management should be a section in Beta feature screen.
- With coupon management enabled, notice that the Coupon menu is available on the Menu screen.
- Make sure that the coupon list and details for your coupons are correct.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
