### PR TITLE
Inbox view part 5: show notes from storage layer

### DIFF
--- a/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
@@ -16,7 +16,7 @@ protocol PaginationTrackerDelegate: AnyObject {
 /// Keeps track of the pagination for API syncing to support infinite scroll.
 final class PaginationTracker {
     /// Default Settings
-    private enum Defaults {
+    enum Defaults {
         static let pageFirstIndex = Store.Default.firstPageNumber
         static let pageSize = 25
     }

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -23,7 +23,6 @@ struct Inbox: View {
                     .background(Constants.listForeground)
                 }
             case .empty:
-                // TODO: 5954 - update empty state
                 EmptyState(title: Localization.emptyStateTitle,
                            description: Localization.emptyStateMessage,
                            image: .emptyInboxNotesImage)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5954 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Before the storage layer was implemented in https://github.com/woocommerce/woocommerce-ios/issues/6057, the `InboxViewModel` was showing inbox notes from the API results. This PR updated the view model to set the inbox notes from the storage layer.

Now that we're showing the data from the storage layer, each storage update could trigger the `ResultsController.onDidChangeContent` callback and thus update the UI. During testing, I noticed that the empty UI was shown right before the results and it was from the deletion of existing notes before upserting new ones for the first page in `InboxNotesStore`. That's why I moved the deletion call to be the same storage session as the upsert.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* Launch the app
* Go to the Menu tab
* Tap on "Inbox" --> if the store has any inbox notes, the notes should be shown after syncing

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
