### PR TITLE
[Mobile Payments] Add Canada WisePad 3 order link to In-Person Payments menu

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -130,7 +130,7 @@ private extension InPersonPaymentsMenuViewController {
 //
 extension InPersonPaymentsMenuViewController {
     func orderCardReaderWasPressed() {
-        WebviewHelper.launch(Constants.woocommercePurchaseCardReaderURL, with: self)
+        WebviewHelper.launch(configurationLoader.configuration.purchaseCardReaderUrl, with: self)
     }
 
     func manageCardReaderWasPressed() {
@@ -246,7 +246,6 @@ private enum Row: CaseIterable {
 }
 
 private enum Constants {
-    static let woocommercePurchaseCardReaderURL = URL(string: "https://woocommerce.com/products/m2-card-reader/")!
     static let bbposChipper2XBTManualURL = URL(string: "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf")!
     static let stripeM2ManualURL = URL(string: "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf")!
     static let wisepad3ManualURL = URL(string: "https://stripe.com/files/docs/terminal/wp3_product_sheet.pdf")!

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -5,43 +5,69 @@ public struct CardPresentPaymentsConfiguration {
     public let currencies: [String]
     public let paymentGateways: [String]
     public let supportedReaders: [CardReaderType]
+    public let purchaseCardReaderUrl: URL
 
-    init(paymentMethods: [WCPayPaymentMethodType], currencies: [String], paymentGateways: [String], supportedReaders: [CardReaderType]) {
+
+    init(paymentMethods: [WCPayPaymentMethodType],
+         currencies: [String],
+         paymentGateways: [String],
+         supportedReaders: [CardReaderType],
+         purchaseCardReaderUrl: URL) {
         self.paymentMethods = paymentMethods
         self.currencies = currencies
         self.paymentGateways = paymentGateways
         self.supportedReaders = supportedReaders
+        self.purchaseCardReaderUrl = purchaseCardReaderUrl
     }
 
     public init(country: String, stripeEnabled: Bool, canadaEnabled: Bool) {
         switch country {
         case "US" where stripeEnabled == true:
+            //TODO: update to use Self.purchaseCardReaderUrl(for: country) when pages/redirects are added to the website pdfdoF-su-p2
             self.init(
                 paymentMethods: [.cardPresent],
                 currencies: ["USD"],
                 paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
-                supportedReaders: [.chipper, .stripeM2]
+                supportedReaders: [.chipper, .stripeM2],
+                purchaseCardReaderUrl: Constants.purchaseM2ReaderUrl
             )
         case "US" where stripeEnabled == false:
+            //TODO: update to use Self.purchaseCardReaderUrl(for: country) when pages/redirects are added to the website pdfdoF-su-p2
             self.init(
                 paymentMethods: [.cardPresent],
                 currencies: ["USD"],
                 paymentGateways: [WCPayAccount.gatewayID],
-                supportedReaders: [.chipper, .stripeM2]
+                supportedReaders: [.chipper, .stripeM2],
+                purchaseCardReaderUrl: Constants.purchaseM2ReaderUrl
             )
         case "CA" where canadaEnabled == true:
             self.init(
                 paymentMethods: [.cardPresent, .interacPresent],
                 currencies: ["CAD"],
                 paymentGateways: [WCPayAccount.gatewayID],
-                supportedReaders: [.wisepad3]
+                supportedReaders: [.wisepad3],
+                purchaseCardReaderUrl: Self.purchaseCardReaderUrl(for: country)
             )
         default:
-            self.init(paymentMethods: [], currencies: [], paymentGateways: [], supportedReaders: [])
+            self.init(paymentMethods: [],
+                      currencies: [],
+                      paymentGateways: [],
+                      supportedReaders: [],
+                      purchaseCardReaderUrl: Constants.fallbackInPersonPaymentsUrl)
         }
     }
 
     public var isSupportedCountry: Bool {
         paymentMethods.isEmpty == false && currencies.isEmpty == false && paymentGateways.isEmpty == false
     }
+
+    private static func purchaseCardReaderUrl(for countryCode: String) -> URL {
+        URL(string: Constants.purchaseReaderForCountryUrlBase + countryCode) ?? Constants.fallbackInPersonPaymentsUrl
+    }
+}
+
+private enum Constants {
+    static let purchaseM2ReaderUrl = URL(string: "https://woocommerce.com/products/m2-card-reader/")!
+    static let fallbackInPersonPaymentsUrl = URL(string: "https://woocommerce.com/in-person-payments/")!
+    static let purchaseReaderForCountryUrlBase = "https://woocommerce.com/products/hardware/"
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5981 
Merge after: #6195 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the new country-specific link for purchasing a card reader. `https://woocommerce.com/products/hardware/CA` See pdfdoF-su-p2

It is only used for Canada at present, and the link is not yet live so it takes you to [an unrelated page](https://woocommerce.com/document/subscriptions/develop/cache/). Once the pages are added for the US, we can update all the configurations to use the specific link, as noted in the TODO comments.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Using a US-based store:
1. go to `Menu > ⚙️ > In-Person Payments`
2. tap `Order card reader`
3. observe that you are taken to the M2 reader product page in a webview.

Using a Canada based store, with the `In-Person Payments in Canada` experimental feature toggle on:
Repeat the above, but observe that you are taken to a page related to Subscription Caches in the developer docs – this is the result of an existing redirect and will be fixed on the web side, the same happens if you go to https://woocommerce.com/products/hardware/ca in a browser

Using a store from a third country:
You cannot repeat the above because the option to `Order card reader` is not available

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
