### PR TITLE
Order Creation: Add helpers for deleted fee and shipping lines

### DIFF
--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -52,6 +52,18 @@ public enum OrderFactory {
               attributes: [])
     }
 
+    /// Creates a fee line suitable to delete a fee line already saved remotely in an order.
+    ///
+    public static func deletedFeeLine(_ feeLine: OrderFeeLine) -> OrderFeeLine {
+        feeLine.copy(name: .some(nil))
+    }
+
+    /// Creates a shipping line suitable to delete a shipping line already saved remotely in an order.
+    ///
+    public static func deletedShippingLine(_ shippingLine: ShippingLine) -> ShippingLine {
+        shippingLine.copy(methodID: .some(nil))
+    }
+
     /// References a new empty order with constants `Date` values.
     ///
     public static let emptyNewOrder = Order.empty


### PR DESCRIPTION
## Description

As mentioned in https://github.com/woocommerce/woocommerce-ios/pull/6201#pullrequestreview-885223367, it would be helpful to have helper methods to construct fee lines and shipping lines that need to be removed from remotely saved orders.

Removing these lines from the remotely saved orders requires sending the line to the Orders endpoint with [its resource ID set to null](https://github.com/woocommerce/woocommerce/blob/3457917a3a128aa97698d2874d590eaeb6df497f/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php#L902-L919). Since it isn't intuitive which field need to be updated for each line, these helper methods make sure the line is constructed correctly so it can be deleted.

## Changes

`Yosemite.OrderFactory` now has two helpers (`deletedFeeLine(_:)` and `deletedShippingLine(_:)`) that nullify the relevant resource ID, so it can be used in the related order.

I added these helpers here for a couple reasons, but let me know if you think they'd be better placed elsewhere:

1. These are specifically for use when updating an `Order` on the Orders endpoint, so conceptually they seemed to fit within `OrderFactory` rather than separate factories.
2. They are public methods in the Yosemite layer so they can be used in the UI layer (e.g. assembling the properties in an Order in `RemoteOrderSynchronizer`) but also can eventually be used in `OrderStore`, e.g. to support an order action that removes just the shipping line or fee line from an order during order editing.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
