### PR TITLE
Order Creation: Add fees line in the payment section

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -40,7 +40,9 @@ struct NewOrder: View {
                         Spacer(minLength: Layout.sectionSpacing)
 
                         if viewModel.shouldShowPaymentSection {
-                            OrderPaymentSection(viewModel: viewModel.paymentDataViewModel, saveShippingLineClosure: viewModel.saveShippingLine)
+                            OrderPaymentSection(viewModel: viewModel.paymentDataViewModel,
+                                                saveShippingLineClosure: viewModel.saveShippingLine,
+                                                saveFeeClosure: viewModel.saveFeeLine)
 
                             Spacer(minLength: Layout.sectionSpacing)
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -9,6 +9,7 @@ struct OrderPaymentSection: View {
 
     /// Closure to create/update the shipping line object
     let saveShippingLineClosure: (ShippingLine?) -> Void
+    let saveFeeClosure: (OrderFeeLine?) -> Void
 
     ///   Environment safe areas
     ///
@@ -26,6 +27,7 @@ struct OrderPaymentSection: View {
 
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) {
                 shippingRow
+                feesRow
             }
 
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}
@@ -59,6 +61,28 @@ struct OrderPaymentSection: View {
             .padding()
         }
     }
+
+    @ViewBuilder private var feesRow: some View {
+        if viewModel.shouldShowFees {
+            TitleAndValueRow(title: Localization.feesTotal, value: .content(viewModel.feesTotal), selectionStyle: .highlight) {
+                saveFeeClosure(nil)
+            }
+        } else {
+            Button(Localization.addFees) {
+                let testFeeLine = OrderFeeLine(feeID: 0,
+                                               name: "Fee",
+                                               taxClass: "",
+                                               taxStatus: .none,
+                                               total: "10",
+                                               totalTax: "",
+                                               taxes: [],
+                                               attributes: [])
+                saveFeeClosure(testFeeLine)
+            }
+            .buttonStyle(PlusButtonStyle())
+            .padding()
+        }
+    }
 }
 
 // MARK: Constants
@@ -71,6 +95,8 @@ private extension OrderPaymentSection {
                                                  comment: "Information about taxes and the order total when creating a new order")
         static let addShipping = NSLocalizedString("Add Shipping", comment: "Title text of the button that adds shipping line when creating a new order")
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
+        static let addFees = NSLocalizedString("Add Fees", comment: "Title text of the button that adds fees when creating a new order")
+        static let feesTotal = NSLocalizedString("Fees", comment: "Label for the row showing the cost of fees in the order")
     }
 }
 
@@ -78,7 +104,7 @@ struct OrderPaymentSection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00", orderTotal: "20.00")
 
-        OrderPaymentSection(viewModel: viewModel, saveShippingLineClosure: { _ in })
+        OrderPaymentSection(viewModel: viewModel, saveShippingLineClosure: { _ in }, saveFeeClosure: { _ in })
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -68,10 +68,14 @@ struct OrderPaymentSection: View {
     @ViewBuilder private var feesRow: some View {
         if viewModel.shouldShowFees {
             TitleAndValueRow(title: Localization.feesTotal, value: .content(viewModel.feesTotal), selectionStyle: .highlight) {
+                // TODO-6027: add navigation to Fee Details UI
+                // Temporary - remove existing fee line
                 saveFeeClosure(nil)
             }
         } else {
             Button(Localization.addFees) {
+                // TODO-6027: add navigation to Add Fee UI
+                // Temporary - add hardcoded fee line
                 let testFeeLine = OrderFeeLine(feeID: 0,
                                                name: "Fee",
                                                taxClass: "",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -87,6 +87,10 @@ private extension LocalOrderSynchronizer {
             }
             .assign(to: &$order)
 
-        // TODO: Bind fees input
+        setFee.withLatestFrom(orderPublisher)
+            .map { feeLineInput, order in
+                order.copy(fees: feeLineInput.flatMap { [$0] } ?? [])
+            }
+            .assign(to: &$order)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -390,6 +390,42 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£0.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
     }
+
+    func test_payment_section_is_updated_when_fee_line_updated() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, currencySettings: currencySettings)
+
+        // When
+        viewModel.addProductViewModel.selectProduct(product.productID)
+        let testFeeLine = OrderFeeLine(feeID: 0,
+                                       name: "Fee",
+                                       taxClass: "",
+                                       taxStatus: .none,
+                                       total: "10",
+                                       totalTax: "",
+                                       taxes: [],
+                                       attributes: [])
+        viewModel.saveFeeLine(testFeeLine)
+
+        // Then
+        XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowFees)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£10.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£18.50")
+
+        // When
+        viewModel.saveFeeLine(nil)
+
+        // Then
+        XCTAssertFalse(viewModel.paymentDataViewModel.shouldShowFees)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
+    }
 }
 
 private extension MockStorageManager {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6028

This PR adds "Fees" actionable row to the "Payment" section in the new order screen.

## Changes

- Adds new row in `OrderPaymentSection` behind feature flag.
- Adds 2 properties to `PaymentDataViewModel`.
- Updates `PaymentDataViewModel` sync flow to use `FeeLine` in "order total" calculation and update new fees row properties.
- Connects `FeeLine` flow to `orderSynchronizer`.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "Add Product" button and select any product to enable "Payment" section.
5. Tap "Add Fees" button to add a hardcoded $10 fee.
6. Confirm that the "Order Total" is correctly updated to display products + fee price.
7. Tap "Fees" row to remove the fee line.
8. Confirm that the "Order Total" is correctly updated to display products price.
9. Tap "Add Fees" button again.
10. Tap "Done" to create an order.
11. Verify that created order has correct fees value.

## Screenshots


Add fee | Fees | Order Details
--|--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/154555398-9e90fd4b-022e-4f83-9cef-a41d3df99a01.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/154555436-f5a25bac-60c8-4f68-bbcf-a13448a9ea65.png)|![Simulator Screen Shot - 3](https://user-images.githubusercontent.com/3132438/154555461-e0157064-a496-4737-aa42-cf7b179c0e5d.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.