### PR TITLE
[Mobile Payments] Bump minimum Stripe extension version to 6.2.0 for IPP

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Enlarged the tap area for the action button on the notice view. [https://github.com/woocommerce/woocommerce-ios/pull/6146]
 - [*] Reviews: Fixed crash on iPad when tapping the More button. [https://github.com/woocommerce/woocommerce-ios/pull/6187]
 - [*] Disabled unneccesary selection of the "Refund via" row on the Refund Confirmation screen [https://github.com/woocommerce/woocommerce-ios/pull/6198]
+- [*] Increased minimum version of Stripe extension for In-Person Payments to 6.2.0 [https://github.com/woocommerce/woocommerce-ios/pull/xxxx]
 
 8.5
 -----

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -665,7 +665,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
     }
 
     enum StripePluginVersion: String {
-        case minimumSupportedVersion = "6.1.0" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
+        case minimumSupportedVersion = "6.2.0" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
         case unsupportedVersion = "5.8.1"
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -666,7 +666,7 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
 
     enum StripePluginVersion: String {
         case minimumSupportedVersion = "6.2.0" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
-        case unsupportedVersion = "5.8.1"
+        case unsupportedVersion = "6.1.0"
     }
 
 }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -121,7 +121,7 @@ public enum CardPresentPaymentsPlugins: Equatable, CaseIterable {
         case .wcPay:
             return "3.2.1"
         case .stripe:
-            return "6.1.0"
+            return "6.2.0"
         }
     }
 }


### PR DESCRIPTION
Closes: #6033

### Description
- Although the iOS app no longer requires the null descriptor fix in Stripe extension 6.2.0, [since it will pass a null (instead of an empty string) to payment intent creation](https://github.com/woocommerce/woocommerce-ios/pull/6041), we want to set the first release of IPP for Stripe extension to 6.2.0

### Testing instructions
- Ensure unit tests pass
- Attempt to enter IPP flows with Stripe extension version less than 6.2.0. Ensure you are prompted to update
- Attempt to enter IPP flows with Stripe extension version of 6.2.0 or newer. Ensure you are NOT prompted to update

### Screenshots
N/A

fyi @malinajirka @ctarda 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
