### PR TITLE
Remove `largeTitles` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -7,8 +7,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .barcodeScanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .largeTitles:
-            return true
         case .shippingLabelsM2M3:
             return true
         case .shippingLabelsInternational:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -10,10 +10,6 @@ public enum FeatureFlag: Int {
     ///
     case barcodeScanner
 
-    /// Large titles on the main tabs
-    ///
-    case largeTitles
-
     /// Product Reviews
     ///
     case reviews

--- a/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
@@ -9,24 +9,16 @@ extension UINavigationBar {
     /// Applies the default WC's Appearance
     ///
     class func applyWooAppearance() {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = .listForeground
-            appearance.titleTextAttributes = [.foregroundColor: UIColor.text]
-            appearance.largeTitleTextAttributes = [.foregroundColor: UIColor.text]
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .listForeground
+        appearance.titleTextAttributes = [.foregroundColor: UIColor.text]
+        appearance.largeTitleTextAttributes = [.foregroundColor: UIColor.text]
 
-            UINavigationBar.appearance().tintColor = .accent // The color of bar button items in the navigation bar
-            UINavigationBar.appearance().standardAppearance = appearance
-            UINavigationBar.appearance().compactAppearance = appearance
-            UINavigationBar.appearance().scrollEdgeAppearance = appearance
-        } else {
-            let appearance = UINavigationBar.appearance()
-            appearance.barTintColor = .appBar
-            appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
-            appearance.isTranslucent = false
-            appearance.tintColor = .white
-        }
+        UINavigationBar.appearance().tintColor = .accent // The color of bar button items in the navigation bar
+        UINavigationBar.appearance().standardAppearance = appearance
+        UINavigationBar.appearance().compactAppearance = appearance
+        UINavigationBar.appearance().scrollEdgeAppearance = appearance
     }
 
     /// Applies UIKit's Default Appearance

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -158,12 +158,7 @@ extension UIColor {
     /// App Navigation Bar.
     ///
     static var appBar: UIColor {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            return UIColor(light: .white, dark: .black)
-        } else {
-            return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
-                           dark: .systemColor(.secondarySystemGroupedBackground))
-        }
+        UIColor(light: .white, dark: .black)
     }
 
     /// App Tab Bar.
@@ -283,11 +278,7 @@ extension UIColor {
     /// Color for loading indicators within navigation bars
     ///
     static var navigationBarLoadingIndicator: UIColor {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            return .systemGray
-        } else {
-            return .white
-        }
+        .systemGray
     }
 
     /// SearchBar background color.

--- a/WooCommerce/Classes/System/WooTabNavigationController.swift
+++ b/WooCommerce/Classes/System/WooTabNavigationController.swift
@@ -6,10 +6,8 @@ import UIKit
 final class WooTabNavigationController: WooNavigationController {
     init() {
         super.init(nibName: nil, bundle: nil)
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            navigationBar.prefersLargeTitles = true
-            delegate = self
-        }
+        navigationBar.prefersLargeTitles = true
+        delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -17,7 +15,7 @@ final class WooTabNavigationController: WooNavigationController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) ? .default : StyleManager.statusBarLight
+        .default
     }
 
     private func updateNavigationBarAppearance(largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -213,13 +213,11 @@ private extension DashboardViewController {
     }
 
     func configureDashboardUIContainer() {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            hiddenScrollView.configureForLargeTitleWorkaround()
-            // Adds the "hidden" scroll view to the root of the UIViewController for large titles.
-            view.addSubview(hiddenScrollView)
-            hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
-            view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
-        }
+        hiddenScrollView.configureForLargeTitleWorkaround()
+        // Adds the "hidden" scroll view to the root of the UIViewController for large titles.
+        view.addSubview(hiddenScrollView)
+        hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
 
         // A container view is added to respond to safe area insets from the view controller.
         // This is needed when the child view controller's view has to use a frame-based layout
@@ -265,9 +263,7 @@ private extension DashboardViewController {
 
     func reloadDashboardUIStatsVersion(forced: Bool) {
         dashboardUIFactory.reloadDashboardUI(onUIUpdate: { [weak self] dashboardUI in
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-                dashboardUI.scrollDelegate = self
-            }
+            dashboardUI.scrollDelegate = self
             self?.onDashboardUIUpdate(forced: forced, updatedDashboardUI: dashboardUI)
         })
     }
@@ -287,8 +283,7 @@ private extension DashboardViewController {
     }
 
     func updateUI(site: Site?) {
-        guard let siteName = site?.name, siteName.isEmpty == false,
-              ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) else {
+        guard let siteName = site?.name, siteName.isEmpty == false else {
             shouldShowStoreNameAsSubtitle = false
             storeNameLabel.text = nil
             return

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -83,7 +83,7 @@ final class MainTabBarController: UITabBarController {
     /// Used for overriding the status bar style for all child view controllers
     ///
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) ? .default: StyleManager.statusBarLight
+        .default
     }
 
     /// Notifications badge

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -186,15 +186,13 @@ private extension OrdersRootViewController {
 
     func configureChildViewController() {
         // Configure large title using the `hiddenScrollView` trick.
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            hiddenScrollView.configureForLargeTitleWorkaround()
-            // Adds the "hidden" scroll view to the root of the UIViewController for large title workaround.
-            view.addSubview(hiddenScrollView)
-            view.sendSubviewToBack(hiddenScrollView)
-            hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
-            view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
-            ordersViewController.delegate = self
-        }
+        hiddenScrollView.configureForLargeTitleWorkaround()
+        // Adds the "hidden" scroll view to the root of the UIViewController for large title workaround.
+        view.addSubview(hiddenScrollView)
+        view.sendSubviewToBack(hiddenScrollView)
+        hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
+        ordersViewController.delegate = self
 
         // Add contentView to stackview
         let contentView = ordersViewController.view!


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Closes: #3751 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We released large titles Q1 2021 and it's overdue to remove the feature flag and unused code! The diffs are all removing the conditional checks on the feature flag and the unused code paths.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to launch the app, and everything should run like before!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
