### PR TITLE
Order List: Allow order items price to be decoded as a string

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -77,8 +77,14 @@ public struct OrderItem: Decodable, Equatable, Hashable, GeneratedFakeable, Gene
         }
 
         let quantity = try container.decode(Decimal.self, forKey: .quantity)
-        let decimalPrice = try container.decodeIfPresent(Decimal.self, forKey: .price) ?? Decimal(0)
-        let price = NSDecimalNumber(decimal: decimalPrice)
+
+        /// WC versions lower than `6.3` send the item price as a `number`.
+        /// WC Versions equal or greater than `6.3` send the item price as a `string`.
+        ///
+        let decimalPrice = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                             forKey: .price,
+                                                             alternativeTypes: [.decimal { String(describing: $0) }])
+        let price = NSDecimalNumber(string: decimalPrice)
 
         let sku = try container.decodeIfPresent(String.self, forKey: .sku)
         let subtotal = try container.decode(String.self, forKey: .subtotal)

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -65,8 +65,14 @@ public struct OrderItemRefund: Codable, Equatable, GeneratedFakeable, GeneratedC
         let variationID = try container.decode(Int64.self, forKey: .variationID)
 
         let quantity = try container.decode(Decimal.self, forKey: .quantity)
-        let decimalPrice = try container.decodeIfPresent(Decimal.self, forKey: .price) ?? Decimal(0)
-        let price = NSDecimalNumber(decimal: decimalPrice)
+
+        /// WC versions lower than `6.3` send the item price as a `number`.
+        /// WC Versions equal or greater than `6.3` send the item price as a `string`.
+        ///
+        let decimalPrice = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                             forKey: .price,
+                                                             alternativeTypes: [.decimal { String(describing: $0) }])
+        let price = NSDecimalNumber(string: decimalPrice)
 
         let sku = try container.decodeIfPresent(String.self, forKey: .sku)
         let subtotal = try container.decode(String.self, forKey: .subtotal)


### PR DESCRIPTION
ref: pb22l9-18e-p2#comment-1150

# Why

`WC 6.3` changes the way how order items are delivered via the `Order API`. 
Specifically, an order items price field is now a `string` instead of a `number`. 

This PR mitigates the change by allowing the price to be decoded either as a `string` or as a `number`.

# Testing Steps

- Set up your WC store to `6.3-beta.1` version
- Load an order
- See that items are properly rendered

# Screenshots

Before | After
---- | ----
<img width="437" alt="before" src="https://user-images.githubusercontent.com/562080/154602734-e8e960d1-13ae-47aa-90db-5fc5a009b643.png"> | <img width="433" alt="after" src="https://user-images.githubusercontent.com/562080/154602738-fe7e3af2-6b96-437a-bac4-a6d1d361c75e.png">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
