### PR TITLE
Order Creation: Lazily create an order when a new order is modified.

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -77,8 +77,14 @@ public struct OrderItem: Decodable, Equatable, Hashable, GeneratedFakeable, Gene
         }
 
         let quantity = try container.decode(Decimal.self, forKey: .quantity)
-        let decimalPrice = try container.decodeIfPresent(Decimal.self, forKey: .price) ?? Decimal(0)
-        let price = NSDecimalNumber(decimal: decimalPrice)
+
+        /// WC versions lower than `6.3` send the item price as a `number`.
+        /// WC Versions equal or greater than `6.3` send the item price as a `string`.
+        ///
+        let decimalPrice = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                             forKey: .price,
+                                                             alternativeTypes: [.decimal { String(describing: $0) }])
+        let price = NSDecimalNumber(string: decimalPrice)
 
         let sku = try container.decodeIfPresent(String.self, forKey: .sku)
         let subtotal = try container.decode(String.self, forKey: .subtotal)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Yosemite
 import Combine
-import SwiftUI
 
 /// Type that syncs the order with the remote server.
 ///
@@ -46,10 +45,6 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
     /// Subscriptions store.
     ///
     private var subscriptions = Set<AnyCancellable>()
-
-    // MARK: DELETE
-    var created = false
-
 
     // MARK: Initializers
 
@@ -141,7 +136,6 @@ private extension RemoteOrderSynchronizer {
             .sink { [weak self] order in // When a value is received update state & order
                 self?.state = .synced
                 self?.order = order
-                print("Order Created: \(order)")
             }
             .store(in: &subscriptions)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import TestKit
 import Fakes
+import Combine
 
 @testable import WooCommerce
 @testable import Yosemite
@@ -11,6 +12,12 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     private let sampleProductID: Int64 = 234
     private let sampleInputID: Int64 = 345
     private let sampleShippingID: Int64 = 456
+    private var subscriptions = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        subscriptions.removeAll()
+    }
 
     func test_sending_status_input_updates_local_order() throws {
         // Given
@@ -133,5 +140,211 @@ class RemoteOrderSynchronizerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(synchronizer.order.shippingLines, [])
+    }
+
+    func test_sending_product_input_triggers_order_creation() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let orderCreationInvoked: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder:
+                    promise(true)
+                default:
+                    promise(false)
+                }
+            }
+
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            synchronizer.setProduct.send(input)
+        }
+
+        // Then
+        XCTAssertTrue(orderCreationInvoked)
+    }
+
+    func test_sending_addresses_input_triggers_order_creation() {
+        // Given
+        let address = Address.fake().copy(firstName: "Woo", lastName: "Customer")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let orderCreationInvoked: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder:
+                    promise(true)
+                default:
+                    promise(false)
+                }
+            }
+
+            let input = OrderSyncAddressesInput(billing: address, shipping: address)
+            synchronizer.setAddresses.send(input)
+        }
+
+        // Then
+        XCTAssertTrue(orderCreationInvoked)
+    }
+
+    func test_sending_shipping_input_triggers_order_creation() {
+        // Given
+        let shippingLine = ShippingLine.fake().copy(shippingID: sampleShippingID)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let orderCreationInvoked: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder:
+                    promise(true)
+                default:
+                    promise(false)
+                }
+            }
+
+            synchronizer.setShipping.send(shippingLine)
+        }
+
+        // Then
+        XCTAssertTrue(orderCreationInvoked)
+    }
+
+    func test_sending_fee_input_triggers_order_creation() {
+        // Given
+        let fee = OrderFeeLine.fake().copy()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let orderCreationInvoked: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder:
+                    promise(true)
+                default:
+                    promise(false)
+                }
+            }
+
+            synchronizer.setFee.send(fee)
+        }
+
+        // Then
+        XCTAssertTrue(orderCreationInvoked)
+    }
+
+    func test_states_are_properly_set_upon_success_order_creation() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .createOrder(_, _, let completion):
+                completion(.success(.fake()))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        synchronizer.setProduct.send(input)
+
+        let states: [OrderSyncState] = waitFor { promise in
+            synchronizer.statePublisher
+                .dropFirst()
+                .collect(2)
+                .sink { states in
+                    promise(states)
+                }
+                .store(in: &self.subscriptions)
+        }
+
+        // Then
+        XCTAssertEqual(states, [.syncing, .synced])
+    }
+
+    func test_states_are_properly_set_upon_failing_order_creation() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let error = NSError(domain: "", code: 0, userInfo: nil)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .createOrder(_, _, let completion):
+                completion(.failure(error))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        synchronizer.setProduct.send(input)
+
+        let states: [OrderSyncState] = waitFor { promise in
+            synchronizer.statePublisher
+                .dropFirst()
+                .collect(2)
+                .sink { states in
+                    promise(states)
+                }
+                .store(in: &self.subscriptions)
+        }
+
+        // Then
+        assertEqual(states, [.syncing, .error(error)])
+    }
+
+    func test_sending_double_input_triggers_only_one_order_creation() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let exp = expectation(description: #function)
+        exp.expectedFulfillmentCount = 1
+        exp.assertForOverFulfill = true
+
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .createOrder:
+                exp.fulfill()
+            default:
+                break
+            }
+        }
+
+        let input1 = OrderSyncProductInput(product: .product(product), quantity: 1)
+        synchronizer.setProduct.send(input1)
+
+        let input2 = OrderSyncProductInput(product: .product(product), quantity: 2)
+        synchronizer.setProduct.send(input2)
+
+        // Then
+        wait(for: [exp], timeout: 1.0)
+    }
+}
+
+extension OrderSyncState: Equatable {
+    public static func == (lhs: OrderSyncState, rhs: OrderSyncState) -> Bool {
+        switch (lhs, rhs) {
+        case (.syncing, .syncing), (.synced, .synced):
+            return true
+        case (.error(let error1), .error(let error2)):
+            return error1 as NSError == error2 as NSError
+        default:
+            return false
+        }
     }
 }


### PR DESCRIPTION
closes #6132

# Why

This PR fires an order creation request when any of the following inputs are fired.

- set product
- set addresses
- set shipping
- set fees

Setting a `status` does not fire an order creation request.

# How

- Merge all necessary inputs into a single publisher
- Debounce them using a `0.5s`  window.
- Continue if the order does not exist remotely.
- Fire an order creation request(only allow one request at a time) and set the state to `.syncing`
- If error: set `state` to `.error`
- if success: set `sate` to `.success` and replace the current order.

Note: the order creation request is fired with the `auto-draft` or `.pending` state but the selected status is overwritten again after the order is created.

# Testing

## Prerequisites
- Set your store to wc `6.3.0-beta.1`
- Enable the `orderCreationRemoteSynchronizer` local feature flag

## Steps
- Navigate to the order creation screen
- Select a product || enter customer details || set shipping
- See that after `0.5s` and order is created. 

## Notes 
- You can verify that the order has been created by going back and seeing the order in the status list. We should probably hide or never store the `auto-draft` orders.
- After the order is created you will see empty customer details rendered, this is because the API returns empty Billing & Shipping addresses. We should hide empty addresses from the view.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
