### PR TITLE
Update Ruby tooling to expect Bundler 2.3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,4 +345,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.2.27
+   2.3.7


### PR DESCRIPTION
This version fixes an issue that could have created confusion when running `BUNDLE_WITH=screenshots bundle install` would result in an automated change to `.bundle/config`.

### Testing instructions

- Run `gem update bundler` and verify `bundle --version` returns 2.3.7 (the latest at the time of writing)
- Run `bundle install` and verify no file has changed
- Run `BUNDLE_WITH=screenshots bundle install` and verify no file has changed – This is the actual fix. With previous versions of Bundler, `.bundle/config` would have now had that environment setting, which is not what we wanted.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.
