### PR TITLE
Handle the actions when the user taps on an Inbox Note

### DIFF
--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -91,7 +91,7 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .wcAnalytics,
                                      method: .delete,
                                      siteID: siteID,
-                                     path: Path.notes + "/\(noteID)",
+                                     path: Path.notes + "/delete/\(noteID)",
                                      parameters: nil)
 
         let mapper = InboxNoteMapper(siteID: siteID)

--- a/Networking/NetworkingTests/Remote/InboxNotesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/InboxNotesRemoteTests.swift
@@ -110,7 +110,7 @@ final class InboxNotesRemoteTests: XCTestCase {
         let remote = InboxNotesRemote(network: network)
         let sampleInboxNoteID: Int64 = 296
 
-        network.simulateResponse(requestUrlSuffix: "admin/notes/\(sampleInboxNoteID)", filename: "inbox-note")
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", filename: "inbox-note")
 
         // When
         let result = waitFor { promise in
@@ -133,7 +133,7 @@ final class InboxNotesRemoteTests: XCTestCase {
         let sampleInboxNoteID: Int64 = 296
 
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)
-        network.simulateError(requestUrlSuffix: "admin/notes/\(sampleInboxNoteID)", error: error)
+        network.simulateError(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", error: error)
 
         // When
         let result = waitFor { promise in

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -7,7 +7,7 @@ struct InboxNoteRow: View {
 
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1
-    @State private var actionURL: URL?
+    @State private var tappedAction: InboxNoteRowActionViewModel?
     @State private var showsWebView: Bool = false
     @State private var isDismissButtonLoading: Bool = false
 
@@ -46,7 +46,7 @@ struct InboxNoteRow: View {
                         ForEach(viewModel.actions) { action in
                             if let url = action.url {
                                 Button(action.title) {
-                                    actionURL = url
+                                    tappedAction = action
                                     showsWebView = true
                                     viewModel.markInboxNoteAsActioned(actionID: action.id)
                                 }
@@ -76,9 +76,9 @@ struct InboxNoteRow: View {
                 }
             }
             .padding(Constants.defaultPadding)
-            .sheet(isPresented: $showsWebView, content: {
-                webView
-            })
+            .sheet(item: $tappedAction) { action in
+                webView(url: action.url ?? WooConstants.URLs.blog.asURL())
+            }
 
             Divider()
                 .frame(height: Constants.dividerHeight)
@@ -86,9 +86,8 @@ struct InboxNoteRow: View {
     }
 
     @ViewBuilder
-    private var webView: some View {
+    private func webView(url: URL) -> some View {
         let isWPComStore = ServiceLocator.stores.sessionManager.defaultSite?.isWordPressStore ?? false
-        let url = actionURL?.absoluteURL ?? WooConstants.URLs.blog.asURL()
 
         if isWPComStore {
         NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -45,7 +45,6 @@ struct InboxNoteRow: View {
                         ForEach(viewModel.actions) { action in
                             if let url = action.url {
                                 Button(action.title) {
-                                    // TODO: 5955 - handle action
                                     print("Handling action with URL: \(url)")
                                     displayedURL = url
                                     showWebView = true

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -8,7 +8,6 @@ struct InboxNoteRow: View {
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1
     @State private var tappedAction: InboxNoteRowActionViewModel?
-    @State private var showsWebView: Bool = false
     @State private var isDismissButtonLoading: Bool = false
 
     var body: some View {
@@ -44,10 +43,9 @@ struct InboxNoteRow: View {
                     // HStack with actions and dismiss action.
                     HStack(spacing: Constants.spacingBetweenActions) {
                         ForEach(viewModel.actions) { action in
-                            if let url = action.url {
+                            if action.url != nil {
                                 Button(action.title) {
                                     tappedAction = action
-                                    showsWebView = true
                                     viewModel.markInboxNoteAsActioned(actionID: action.id)
                                 }
                                 .foregroundColor(Color(.accent))
@@ -91,7 +89,7 @@ struct InboxNoteRow: View {
 
         if isWPComStore {
         NavigationView {
-            AuthenticatedWebView(isPresented: $showsWebView,
+            AuthenticatedWebView(isPresented: .constant(tappedAction != nil),
                                  url: url,
                                  urlToTriggerExit: nil) {
 
@@ -101,7 +99,7 @@ struct InboxNoteRow: View {
              .toolbar {
                  ToolbarItem(placement: .confirmationAction) {
                      Button(action: {
-                         showsWebView = false
+                         tappedAction = nil
                      }, label: {
                          Text(Localization.doneButtonWebview)
                      })

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -58,8 +58,8 @@ struct InboxNoteRow: View {
                             }
                         }
                         Button(Localization.dismiss) {
-                            // TODO: 5955 - handle dismiss action
                             print("Handling dismiss action")
+                            viewModel.dismissInboxNote()
                         }
                         .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
                         .font(.body)

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -8,7 +8,7 @@ struct InboxNoteRow: View {
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1
     @State private var actionURL: URL?
-    @State private var showWebView: Bool = false
+    @State private var showsWebView: Bool = false
     @State private var dismissButtonIsLoading: Bool = false
 
     var body: some View {
@@ -47,7 +47,7 @@ struct InboxNoteRow: View {
                             if let url = action.url {
                                 Button(action.title) {
                                     actionURL = url
-                                    showWebView = true
+                                    showsWebView = true
                                     viewModel.markInboxNoteAsActioned()
                                 }
                                 .foregroundColor(Color(.accent))
@@ -76,7 +76,7 @@ struct InboxNoteRow: View {
                 }
             }
             .padding(Constants.defaultPadding)
-            .sheet(isPresented: $showWebView, content: {
+            .sheet(isPresented: $showsWebView, content: {
                 webView
             })
 
@@ -92,7 +92,7 @@ struct InboxNoteRow: View {
 
         if isWPComStore {
         NavigationView {
-            AuthenticatedWebView(isPresented: $showWebView,
+            AuthenticatedWebView(isPresented: $showsWebView,
                                  url: url,
                                  urlToTriggerExit: nil) {
 
@@ -102,7 +102,7 @@ struct InboxNoteRow: View {
              .toolbar {
                  ToolbarItem(placement: .confirmationAction) {
                      Button(action: {
-                         showWebView = false
+                         showsWebView = false
                      }, label: {
                          Text(Localization.doneButtonWebview)
                      })

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -48,6 +48,7 @@ struct InboxNoteRow: View {
                                     print("Handling action with URL: \(url)")
                                     displayedURL = url
                                     showWebView = true
+                                    viewModel.markInboxNoteAsActioned()
                                 }
                                 .foregroundColor(Color(.accent))
                                 .font(.body)

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -48,7 +48,7 @@ struct InboxNoteRow: View {
                                 Button(action.title) {
                                     actionURL = url
                                     showsWebView = true
-                                    viewModel.markInboxNoteAsActioned()
+                                    viewModel.markInboxNoteAsActioned(actionID: action.id)
                                 }
                                 .foregroundColor(Color(.accent))
                                 .font(.body)

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -9,7 +9,7 @@ struct InboxNoteRow: View {
     @ScaledMetric private var scale: CGFloat = 1
     @State private var actionURL: URL?
     @State private var showsWebView: Bool = false
-    @State private var dismissButtonIsLoading: Bool = false
+    @State private var isDismissButtonLoading: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -57,14 +57,14 @@ struct InboxNoteRow: View {
                                 Text(action.title)
                             }
                         }
-                        if dismissButtonIsLoading {
+                        if isDismissButtonLoading {
                             ActivityIndicator(isAnimating: .constant(true), style: .medium)
                         }
                         else {
                             Button(Localization.dismiss) {
-                                dismissButtonIsLoading = true
+                                isDismissButtonLoading = true
                                 viewModel.dismissInboxNote { _ in
-                                    dismissButtonIsLoading = false
+                                    isDismissButtonLoading = false
                                 }
                             }
                         .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -88,11 +88,12 @@ struct InboxNoteRow: View {
     @ViewBuilder
     private var webView: some View {
         let isWPComStore = ServiceLocator.stores.sessionManager.defaultSite?.isWordPressStore ?? false
+        let url = displayedURL?.absoluteURL ?? WooConstants.URLs.blog.asURL()
 
         if isWPComStore {
         NavigationView {
             AuthenticatedWebView(isPresented: $showWebView,
-                                 url: displayedURL?.absoluteURL ?? WooConstants.URLs.blog.asURL(),
+                                 url: url,
                                  urlToTriggerExit: nil) {
 
             }
@@ -111,7 +112,7 @@ struct InboxNoteRow: View {
         .wooNavigationBarStyle()
         }
         else {
-            SafariSheetView(url: displayedURL ?? WooConstants.URLs.blog.asURL())
+            SafariSheetView(url: url)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -7,7 +7,7 @@ struct InboxNoteRow: View {
 
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1
-    @State private var displayedURL: URL?
+    @State private var actionURL: URL?
     @State private var showWebView: Bool = false
     @State private var dismissButtonIsLoading: Bool = false
 
@@ -46,7 +46,7 @@ struct InboxNoteRow: View {
                         ForEach(viewModel.actions) { action in
                             if let url = action.url {
                                 Button(action.title) {
-                                    displayedURL = url
+                                    actionURL = url
                                     showWebView = true
                                     viewModel.markInboxNoteAsActioned()
                                 }
@@ -88,7 +88,7 @@ struct InboxNoteRow: View {
     @ViewBuilder
     private var webView: some View {
         let isWPComStore = ServiceLocator.stores.sessionManager.defaultSite?.isWordPressStore ?? false
-        let url = displayedURL?.absoluteURL ?? WooConstants.URLs.blog.asURL()
+        let url = actionURL?.absoluteURL ?? WooConstants.URLs.blog.asURL()
 
         if isWPComStore {
         NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -45,7 +45,6 @@ struct InboxNoteRow: View {
                         ForEach(viewModel.actions) { action in
                             if let url = action.url {
                                 Button(action.title) {
-                                    print("Handling action with URL: \(url)")
                                     displayedURL = url
                                     showWebView = true
                                     viewModel.markInboxNoteAsActioned()
@@ -58,7 +57,6 @@ struct InboxNoteRow: View {
                             }
                         }
                         Button(Localization.dismiss) {
-                            print("Handling dismiss action")
                             viewModel.dismissInboxNote()
                         }
                         .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -9,6 +9,7 @@ struct InboxNoteRow: View {
     @ScaledMetric private var scale: CGFloat = 1
     @State private var displayedURL: URL?
     @State private var showWebView: Bool = false
+    @State private var dismissButtonIsLoading: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -56,13 +57,20 @@ struct InboxNoteRow: View {
                                 Text(action.title)
                             }
                         }
-                        Button(Localization.dismiss) {
-                            viewModel.dismissInboxNote()
+                        if dismissButtonIsLoading {
+                            ActivityIndicator(isAnimating: .constant(true), style: .medium)
                         }
+                        else {
+                            Button(Localization.dismiss) {
+                                dismissButtonIsLoading = true
+                                viewModel.dismissInboxNote { _ in
+                                    dismissButtonIsLoading = false
+                                }
+                            }
                         .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
                         .font(.body)
                         .buttonStyle(PlainButtonStyle())
-
+                        }
                         Spacer()
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// View model for `InboxNoteRow`.
 struct InboxNoteRowViewModel: Identifiable, Equatable {
@@ -20,7 +21,21 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Actions for the note.
     let actions: [InboxNoteRowActionViewModel]
 
-    init(note: InboxNote, today: Date = .init(), locale: Locale = .current, calendar: Calendar = .current) {
+    /// SiteID related to the Inbox note.
+    private let siteID: Int64
+
+    /// Stores to handle note actions.
+    private let stores: StoresManager
+
+    /// Storage to fetch inbox notes.
+    private let storageManager: StorageManagerType
+
+    init(note: InboxNote,
+         today: Date = .init(),
+         locale: Locale = .current,
+         calendar: Calendar = .current,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         let attributedContent = note.content.htmlToAttributedString
             .addingAttributes([
                 .font: UIFont.body,
@@ -34,21 +49,59 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
             return formatter.localizedString(for: note.dateCreated, relativeTo: today)
         }()
         let actions = note.actions.map { InboxNoteRowActionViewModel(action: $0) }
+
         self.init(id: note.id,
                   date: date,
                   typeIcon: (NoteType(rawValue: note.type) ?? .info).image,
                   title: note.title,
                   attributedContent: attributedContent,
-                  actions: actions)
+                  actions: actions,
+                  siteID: note.siteID,
+                  stores: stores,
+                  storageManager: storageManager)
     }
 
-    init(id: Int64, date: String, typeIcon: Image, title: String, attributedContent: NSAttributedString, actions: [InboxNoteRowActionViewModel]) {
+    init(id: Int64,
+         date: String,
+         typeIcon: Image,
+         title: String,
+         attributedContent: NSAttributedString, actions: [InboxNoteRowActionViewModel],
+         siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.id = id
         self.date = date
         self.typeIcon = typeIcon
         self.title = title
         self.attributedContent = attributedContent
         self.actions = actions
+        self.siteID = siteID
+        self.stores = stores
+        self.storageManager = storageManager
+    }
+
+    static func == (lhs: InboxNoteRowViewModel, rhs: InboxNoteRowViewModel) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.siteID == rhs.siteID
+    }
+}
+
+extension InboxNoteRowViewModel {
+    func markInboxNoteAsActioned() {
+        guard let actionID = actions.first?.id else {
+            return
+        }
+        let action = InboxNotesAction.markInboxNoteAsActioned(siteID: siteID,
+                                                              noteID: id,
+                                                              actionID: actionID) { result in
+            switch result {
+            case .success(_):
+                break
+            case .failure(let error):
+                DDLogError("⛔️ Error on mark inbox note as actioned: \(error)")
+            }
+        }
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -27,15 +27,11 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Stores to handle note actions.
     private let stores: StoresManager
 
-    /// Storage to fetch inbox notes.
-    private let storageManager: StorageManagerType
-
     init(note: InboxNote,
          today: Date = .init(),
          locale: Locale = .current,
          calendar: Calendar = .current,
-         stores: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         stores: StoresManager = ServiceLocator.stores) {
         let attributedContent = note.content.htmlToAttributedString
             .addingAttributes([
                 .font: UIFont.body,
@@ -57,8 +53,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
                   attributedContent: attributedContent,
                   actions: actions,
                   siteID: note.siteID,
-                  stores: stores,
-                  storageManager: storageManager)
+                  stores: stores)
     }
 
     init(id: Int64,
@@ -67,8 +62,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
          title: String,
          attributedContent: NSAttributedString, actions: [InboxNoteRowActionViewModel],
          siteID: Int64,
-         stores: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         stores: StoresManager = ServiceLocator.stores) {
         self.id = id
         self.date = date
         self.typeIcon = typeIcon
@@ -77,7 +71,6 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
         self.actions = actions
         self.siteID = siteID
         self.stores = stores
-        self.storageManager = storageManager
     }
 
     static func == (lhs: InboxNoteRowViewModel, rhs: InboxNoteRowViewModel) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -104,13 +104,14 @@ extension InboxNoteRowViewModel {
         stores.dispatch(action)
     }
 
-    func dismissInboxNote() {
+    func dismissInboxNote(onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         let action = InboxNotesAction.dismissInboxNote(siteID: siteID, noteID: id) { result in
             switch result {
             case .success(_):
-                break
+                onCompletion(.success(true))
             case .failure(let error):
                 DDLogError("⛔️ Error on dismissing an inbox note: \(error)")
+                onCompletion(.failure(error))
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -103,6 +103,18 @@ extension InboxNoteRowViewModel {
         }
         stores.dispatch(action)
     }
+
+    func dismissInboxNote() {
+        let action = InboxNotesAction.dismissInboxNote(siteID: siteID, noteID: id) { result in
+            switch result {
+            case .success(_):
+                break
+            case .failure(let error):
+                DDLogError("⛔️ Error on dismissing an inbox note: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
 }
 
 private extension InboxNoteRowViewModel {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Yosemite
-import protocol Storage.StorageManagerType
 
 /// View model for `InboxNoteRow`.
 struct InboxNoteRowViewModel: Identifiable, Equatable {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -108,11 +108,11 @@ extension InboxNoteRowViewModel {
         let action = InboxNotesAction.dismissInboxNote(siteID: siteID, noteID: id) { result in
             switch result {
             case .success(_):
-                onCompletion(.success(true))
+                break
             case .failure(let error):
                 DDLogError("⛔️ Error on dismissing an inbox note: \(error)")
-                onCompletion(.failure(error))
             }
+            onCompletion(result)
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -85,7 +85,7 @@ extension InboxNoteRowViewModel {
                                                               noteID: actionID,
                                                               actionID: actionID) { result in
             switch result {
-            case .success(_):
+            case .success:
                 break
             case .failure(let error):
                 DDLogError("⛔️ Error on mark inbox note as actioned: \(error)")
@@ -97,7 +97,7 @@ extension InboxNoteRowViewModel {
     func dismissInboxNote(onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         let action = InboxNotesAction.dismissInboxNote(siteID: siteID, noteID: id) { result in
             switch result {
-            case .success(_):
+            case .success:
                 break
             case .failure(let error):
                 DDLogError("⛔️ Error on dismissing an inbox note: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -80,12 +80,9 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
 }
 
 extension InboxNoteRowViewModel {
-    func markInboxNoteAsActioned() {
-        guard let actionID = actions.first?.id else {
-            return
-        }
+    func markInboxNoteAsActioned(actionID: Int64) {
         let action = InboxNotesAction.markInboxNoteAsActioned(siteID: siteID,
-                                                              noteID: id,
+                                                              noteID: actionID,
                                                               actionID: actionID) { result in
             switch result {
             case .success(_):

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -19,7 +19,8 @@ final class InboxViewModel: ObservableObject {
                               typeIcon: .init(uiImage: .infoImage),
                               title: "            ",
                               attributedContent: .init(string: "\n\n\n"),
-                              actions: [.init(id: 0, title: "Placeholder", url: nil)])
+                              actions: [.init(id: 0, title: "Placeholder", url: nil)],
+                              siteID: 123)
     }
 
     // MARK: Sync

--- a/Yosemite/Yosemite/Actions/InboxNotesAction.swift
+++ b/Yosemite/Yosemite/Actions/InboxNotesAction.swift
@@ -16,11 +16,11 @@ public enum InboxNotesAction: Action {
                            completion: (Result<[InboxNote], Error>) -> ())
 
     /// Dismiss one `InboxNote`.
-    /// This internally marks a notification’s is_deleted field to true and such notifications do not show in the results anymore.
+    /// This marks a notification’s is_deleted field to true and the inbox note will be deleted locally.
     ///
     case dismissInboxNote(siteID: Int64,
                           noteID: Int64,
-                          completion: (Result<InboxNote, Error>) -> ())
+                          completion: (Result<Bool, Error>) -> ())
 
     /// Set an `InboxNote` as `actioned`.
     /// This internally marks a notification’s status as `actioned`.

--- a/Yosemite/Yosemite/Stores/InboxNotesStore.swift
+++ b/Yosemite/Yosemite/Stores/InboxNotesStore.swift
@@ -131,8 +131,8 @@ private extension InboxNotesStore {
                 self.deleteStoredInboxNotes(siteID: siteID, in: derivedStorage)
             }
             self.upsertStoredInboxNotes(readOnlyInboxNotes: readOnlyInboxNotes,
-                                         in: derivedStorage,
-                                         siteID: siteID)
+                                        in: derivedStorage,
+                                        siteID: siteID)
         }
 
         storageManager.saveDerivedType(derivedStorage: derivedStorage) {

--- a/Yosemite/Yosemite/Stores/InboxNotesStore.swift
+++ b/Yosemite/Yosemite/Stores/InboxNotesStore.swift
@@ -171,7 +171,7 @@ private extension InboxNotesStore {
         storageInboxNote.actions = Set(storageInboxActions)
     }
 
-    /// Deletes specified Inbox Note Entity in a background thread
+    /// Deletes a single Inbox Note Entity in a background thread
     /// `onCompletion` will be called on the main thread.
     ///
     func deleteStoredInboxNoteInBackground(siteID: Int64,

--- a/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
@@ -157,13 +157,13 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertFalse(result.isSuccess)
     }
 
-    func test_dismissInboxNote_then_it_update_inbox_note_upon_successful_response() {
+    func test_dismissInboxNote_do_nothing_if_no_inbox_notes_exist_upon_successful_response() {
         // Given a stubbed inbox note network response
         let sampleInboxNoteID: Int64 = 296
         network.simulateResponse(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", filename: "inbox-note")
 
         // When dispatching a `dismissInboxNote` action
-        let result: Result<Networking.InboxNote, Error> = waitFor { [weak self] promise in
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -174,8 +174,33 @@ final class InboxNotesStoreTests: XCTestCase {
             self.store.onAction(action)
         }
 
-        // Then a valid inbox note should be stored
+        // Then no inbox notes should be stored
+        XCTAssertEqual(storedInboxNotesCount, 0)
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_dismissInboxNote_delete_existing_inbox_note_upon_successful_response() {
+        // Given an initial stored inbox note and a stubbed inbox notes network response
+        let sampleInboxNoteID: Int64 = 296
+        let initialInboxNote = sampleInboxNote(id: 296)
+        storageManager.insertSampleInboxNote(readOnlyInboxNote: initialInboxNote)
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", filename: "inbox-note")
         XCTAssertEqual(storedInboxNotesCount, 1)
+
+        // When dispatching a `dismissInboxNote` action
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+            guard let self = self else {
+                return
+            }
+
+            let action = InboxNotesAction.dismissInboxNote(siteID: self.sampleSiteID, noteID: sampleInboxNoteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then no inbox notes should be stored
+        XCTAssertEqual(storedInboxNotesCount, 0)
         XCTAssertTrue(result.isSuccess)
     }
 
@@ -186,7 +211,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissInboxNote` action
-        let result: Result<Networking.InboxNote, Error> = waitFor { [weak self] promise in
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -208,7 +233,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissInboxNote` action
-        let result: Result<Networking.InboxNote, Error> = waitFor { [weak self] promise in
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }

--- a/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
@@ -160,7 +160,7 @@ final class InboxNotesStoreTests: XCTestCase {
     func test_dismissInboxNote_then_it_update_inbox_note_upon_successful_response() {
         // Given a stubbed inbox note network response
         let sampleInboxNoteID: Int64 = 296
-        network.simulateResponse(requestUrlSuffix: "admin/notes/\(sampleInboxNoteID)", filename: "inbox-note")
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", filename: "inbox-note")
 
         // When dispatching a `dismissInboxNote` action
         let result: Result<Networking.InboxNote, Error> = waitFor { [weak self] promise in
@@ -182,7 +182,7 @@ final class InboxNotesStoreTests: XCTestCase {
     func test_dismissInboxNote_then_it_returns_error_upon_response_error() {
         // Given a stubbed generic-error network response
         let sampleInboxNoteID: Int64 = 296
-        network.simulateResponse(requestUrlSuffix: "admin/notes/\(sampleInboxNoteID)", filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", filename: "generic_error")
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissInboxNote` action

--- a/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
@@ -161,7 +161,8 @@ final class InboxNotesStoreTests: XCTestCase {
         // Given a stubbed inbox note network response
         let sampleInboxNoteID: Int64 = 296
         network.simulateResponse(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", filename: "inbox-note")
-
+        XCTAssertEqual(storedInboxNotesCount, 0)
+        
         // When dispatching a `dismissInboxNote` action
         let result: Result<Bool, Error> = waitFor { [weak self] promise in
             guard let self = self else {

--- a/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
@@ -162,7 +162,7 @@ final class InboxNotesStoreTests: XCTestCase {
         let sampleInboxNoteID: Int64 = 296
         network.simulateResponse(requestUrlSuffix: "admin/notes/delete/\(sampleInboxNoteID)", filename: "inbox-note")
         XCTAssertEqual(storedInboxNotesCount, 0)
-        
+
         // When dispatching a `dismissInboxNote` action
         let result: Result<Bool, Error> = waitFor { [weak self] promise in
             guard let self = self else {


### PR DESCRIPTION
Closes: #5955 

## Description
In this PR I implemented the actions when the user taps on a note: we should present a Safari View Controller or the Authenticated web View (only for sites hosted on WP.com) based on the site currently selected. Plus, when the user tap "dismiss" on a note, we need to remove it.
Note that for the dismissing action, I updated also the yosemite layer because it doesn't make sense for us to store notes that we don't need to show anymore and that will be hidden.

**Two important things to consider:**
- While testing, I discovered that the notes we display in the app are not similar to the one displayed on the web. We display more elements because on the web there are some extra filters, so we should align the request. https://github.com/woocommerce/woocommerce-ios/issues/6234
- We should test if the pagination works as expected also after dismissing a note, after that we apply the fix above.

## Testing instructions

#### Case 1
1. Select a self-hosted website.
2. Open the inbox notes.
3. Press the action button (the one in "purple/pink") on a note that in the web is not "actioned" (unread).
4. Go on the web, you should see the note as "read" (actioned).
5. Also, you should see the Safari View Controller opened with the URL of the inbox note.

#### Case 2
1. Select a store hosted on WPCom.
2. Open the inbox notes.
3. Press the action button (the one in "purple/pink") on a note that in the web is not "actioned" (unread).
4. Go on the web, you should see the note as "read" (actioned).
5. Also, you should see the Authenticated WebView opened with the URL of the inbox note.

#### Case 3
1. Open the inbox notes.
2. Press dismiss on a note.
3. You should see the note dismissed on the app and also on the web.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
