### PR TITLE
Adding new bulk variations update feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -47,6 +47,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .bulkEditProductVariations:
+            return buildConfig == .localDeveloper
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -48,7 +48,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .bulkEditProductVariations:
-            return buildConfig == .localDeveloper
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -93,4 +93,8 @@ public enum FeatureFlag: Int {
     /// Displays the Inbox option under the Hub Menu.
     ///
     case inbox
+
+    /// Displays the bulk update option in product variations
+    ///
+    case bulkEditProductVariations
 }


### PR DESCRIPTION
Part of #6238

### Description
Adds a new feature flag to be used for enable bulk price updates (see #5762).

### Testing instructions
No testing is needed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

