### PR TITLE
Adding bulk update view model with synching method for all variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// View Model logic for the Bulk Variations Update
+final class BulkUpdateViewModel {
+
+    /// Represents possible states for syncing product variations.
+    enum SyncState: Equatable {
+        case syncing
+        case syncedResults
+        case syncingError
+        case notStarted
+    }
+
+    private let storageManager: StorageManagerType
+    private let storesManager: StoresManager
+    private let siteID: Int64
+    private let productID: Int64
+
+    /// The state of synching all variations
+    private(set) var syncState: SyncState {
+        didSet {
+            observeSyncState?(syncState)
+        }
+    }
+
+    /// Called when syncing state changes
+    var observeSyncState: ((SyncState) -> Void)?
+
+    /// Product Variations Controller.
+    ///
+    private lazy var resultsController: ResultsController<StorageProductVariation> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [])
+
+        return resultsController
+    }()
+
+    private var bulkUpdateFormDataModel: BulkUpdateFormDataModel?
+
+    init(siteID: Int64,
+         productID: Int64,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         storesManager: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.productID = productID
+        self.storageManager = storageManager
+        self.storesManager = storesManager
+        syncState = .notStarted
+    }
+
+    /// This is the main activation method for this view model.
+    ///
+    /// This should only be called when the corresponding view was loaded.
+    /// 
+    func activate() {
+        synchAllProductVariations()
+    }
+
+    /// Start synching all product variations.
+    ///
+    func synchAllProductVariations() {
+        syncState = .syncing
+
+        let numberOfObjects = Constants.numberOfObjects
+        // There is a limitof 100 objects for bulk update API, so we fetch 101 so see if user has more that 100.
+        let pageNumber = Constants.pageNumber
+        let action = ProductVariationAction
+            .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: numberOfObjects) { [weak self] error in
+                guard let self = self else {
+                    return
+                }
+
+                if let error = error {
+                    self.syncState = .syncingError
+
+                    DDLogError("⛔️ Error synchronizing product variations: \(error)")
+                }
+                self.configureResultsController()
+            }
+
+        storesManager.dispatch(action)
+    }
+
+    /// Setup: Results Controller
+    ///
+    private func configureResultsController() {
+        resultsController.onDidChangeContent = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.bulkUpdateFormDataModel = BulkUpdateFormDataModel(productVariations: self.resultsController.fetchedObjects)
+            self.syncState = .syncedResults
+        }
+
+        do {
+            try resultsController.performFetch()
+        } catch {
+            DDLogError("⛔️ Error fetching product variations: \(error)")
+        }
+    }
+}
+
+extension BulkUpdateViewModel {
+
+    private enum Constants {
+
+        /// The page to be syched
+        static let pageNumber = 1
+
+        /// The bulk update API limits the objects to be update to 100. 100 is also the page limit.
+        static let numberOfObjects = 100
+    }
+}
+
+// Holds an array of product variations and provides caggregate data to for the bulk update form
+///
+final class BulkUpdateFormDataModel {
+
+    /// The aggregate of a single value over all product variations
+    ///
+    enum BulkValue<T> {
+        /// All variations have the same value
+        case value(T)
+        /// Variations have mixed values
+        case mixed
+//        case mixed(min: T, max: T)
+        /// None of the variation has a value
+        case none
+    }
+
+    let productVariations: [ProductVariation]
+
+    init(productVariations: [ProductVariation]) {
+        self.productVariations = productVariations
+    }
+
+    func regularPrice() -> BulkValue<String> {
+        let results = productVariations.map(\.regularPrice).compactMap({ $0 }).uniqued()
+
+        if let samePrice = results.first {
+            return BulkValue.value(samePrice)
+        } else if results.count != 1 {
+            return BulkValue.mixed
+        } else {
+            return BulkValue.none
+        }
+    }
+
+    func salePrice() -> BulkValue<String> {
+        let results = productVariations.map(\.salePrice).compactMap({ $0 }).uniqued()
+
+        if let samePrice = results.first {
+            return BulkValue.value(samePrice)
+        } else if results.count != 1 {
+            return BulkValue.mixed
+        } else {
+            return BulkValue.none
+        }
+    }
+}
+
+

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -415,6 +415,8 @@
 		03FBDAFD263EE4E800ACE257 /* CouponListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */; };
 		094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */; };
 		098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */; };
+		09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */; };
+		09E41E1D27B90B3C00BFCB7C /* BulkUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -2071,6 +2073,8 @@
 		03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModelTests.swift; sourceTree = "<group>"; };
 		094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModelTests.swift; sourceTree = "<group>"; };
 		098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSourceTests.swift; sourceTree = "<group>"; };
+		09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModelTests.swift; sourceTree = "<group>"; };
+		09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModel.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
@@ -3875,6 +3879,7 @@
 		026CF637237E9AA5009563D4 /* Variations */ = {
 			isa = PBXGroup;
 			children = (
+				09E41E1527B7BB7500BFCB7C /* Bulk Update */,
 				026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */,
 				026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */,
 				CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */,
@@ -4327,6 +4332,22 @@
 				098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */,
 			);
 			path = "Edit Order Status";
+			sourceTree = "<group>";
+		};
+		09C6A26027C01151001FAD73 /* Bulk Update */ = {
+			isa = PBXGroup;
+			children = (
+				09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */,
+			);
+			path = "Bulk Update";
+			sourceTree = "<group>";
+		};
+		09E41E1527B7BB7500BFCB7C /* Bulk Update */ = {
+			isa = PBXGroup;
+			children = (
+				09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */,
+			);
+			path = "Bulk Update";
 			sourceTree = "<group>";
 		};
 		2602A64027BD89B300B347F1 /* Synchronizer */ = {
@@ -6371,6 +6392,7 @@
 		CCD2E68725DD528000BD975D /* Variations */ = {
 			isa = PBXGroup;
 			children = (
+				09C6A26027C01151001FAD73 /* Bulk Update */,
 				CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */,
 				26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */,
 			);
@@ -8994,6 +9016,7 @@
 				57CFCD28248845B4003F51EC /* PrimarySectionHeaderView.swift in Sources */,
 				023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */,
 				B5C3876421C41B9F006CE970 /* UIApplication+Woo.swift in Sources */,
+				09E41E1D27B90B3C00BFCB7C /* BulkUpdateViewModel.swift in Sources */,
 				D85136B9231CED5800DD0539 /* ReviewAge.swift in Sources */,
 				5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */,
 				028BAC4022F2EFA5008BB4AF /* OldStoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
@@ -9575,6 +9598,7 @@
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
 				02645D8A27BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift in Sources */,
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
+				09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */,
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 				023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */,
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import Yosemite
+import Combine
+
+@testable import WooCommerce
+
+/// Tests for `BulkUpdateViewModel`.
+///
+final class BulkUpdateViewModelTests: XCTestCase {
+
+    private var storesManager: MockStoresManager!
+    private var storageManager: MockStorageManager!
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+        storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        storesManager = nil
+        super.tearDown()
+    }
+
+    func test_all_products_are_synchronized_on_the_viewload_event() throws {
+        // Given
+        let expectedSiteID: Int64 = 42
+        let expectedProductID: Int64 = 19
+        let expectedPageSize = 101
+        let expectedPageNumber = 1
+        let viewModel = BulkUpdateViewModel(siteID: expectedSiteID, productID: expectedProductID, storageManager: storageManager, storesManager: storesManager)
+
+        // When
+        viewModel.activate()
+
+        // Then
+        let action = try XCTUnwrap(storesManager.receivedActions.first as? ProductVariationAction)
+
+        guard case let .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, _) = action else {
+            XCTFail("Expected \(action) to be \(ProductVariationAction.self).synchronizeProductVariations.")
+            return
+        }
+
+        XCTAssertEqual(siteID, expectedSiteID)
+        XCTAssertEqual(productID, expectedProductID)
+        XCTAssertEqual(pageNumber, expectedPageNumber)
+        XCTAssertEqual(pageSize, expectedPageSize)
+    }
+
+    func test_initial_sync_state() throws {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .notStarted)
+    }
+
+    func test_sync_state_updates_to_loading_when_product_variations_syncing_starts() {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { _ in
+            // do nothing to stay in "syncing" state
+        }
+
+        // When
+        viewModel.activate()
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .syncing)
+    }
+
+    func test_sync_state_updates_to_syncerror_when_product_variations_syncing_fails() {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+                onCompletion(NSError.init(domain: "sample error", code: 0, userInfo: nil))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.activate()
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .syncingError)
+    }
+
+    func test_sync_state_updates_to_syncResults_when_product_variations_syncing_is_successful() {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+                onCompletion(nil)
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.activate()
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .syncedResults)
+    }
+}


### PR DESCRIPTION
Part of #6239. 

### Description

Adds the initial view model for the "bulk update" screen for product variations. It has a main activation method that fetches all variations, and a synch state property as well as a closure to notify for updates, and unit tests to validate the expected behaviour.

### Testing instructions
Not special testing needed. Just running the unit tests.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
