### PR TITLE
Coupons: Fix incorrect expiry date check 

### DIFF
--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -42,7 +42,7 @@ extension Coupon {
         var calendar = Calendar.current
         calendar.timeZone = gmtTimeZone
 
-        // Compare the dates by hour to get around edge cases of timezone differences.
+        // Compare the dates by minute to get around edge cases of timezone differences.
         let result = calendar.compare(expiryDate, to: now, toGranularity: .minute)
         return result == .orderedDescending ? .active : .expired
     }

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -43,7 +43,7 @@ extension Coupon {
         calendar.timeZone = gmtTimeZone
 
         // Compare the dates by hour to get around edge cases of timezone differences.
-        let result = calendar.compare(expiryDate, to: now, toGranularity: .hour)
+        let result = calendar.compare(expiryDate, to: now, toGranularity: .minute)
         return result == .orderedDescending ? .active : .expired
     }
 

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -42,7 +42,8 @@ extension Coupon {
         var calendar = Calendar.current
         calendar.timeZone = gmtTimeZone
 
-        let result = calendar.compare(expiryDate, to: now, toGranularity: .day)
+        // Compare the dates by hour to get around edge cases of timezone differences.
+        let result = calendar.compare(expiryDate, to: now, toGranularity: .hour)
         return result == .orderedDescending ? .active : .expired
     }
 

--- a/WooCommerce/WooCommerceTests/Model/CouponWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CouponWooTests.swift
@@ -13,10 +13,10 @@ final class CouponWooTests: XCTestCase {
 
     func test_expiry_status_is_active_if_dateExpires_is_later_than_current_date() {
         // Given
-        // GMT: Wednesday, January 21, 2122 5:26:04 AM
-        let expiryDate = Date(timeIntervalSince1970: 4798416364)
-        // GMT: Friday, January 21, 2022 9:03:45 AM
-        let now = Date(timeIntervalSince1970: 1642755825)
+        // GMT: Monday, February 21, 2022 5:00:00 PM
+        let expiryDate = Date(timeIntervalSince1970: 1645462800)
+        // GMT: Monday, February 21, 2022 11:01:36 AM
+        let now = Date(timeIntervalSince1970: 1645441296)
         let coupon = Coupon.fake().copy(dateExpires: expiryDate)
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6254 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes an edge case when setting the expiry date to the next day in a timezone that is ahead of GMT.
To be more specific: in my case, I'm in GMT+7 timezone, so when I set the next day (Feb 22nd) as the expiry date, I get Feb 21st 17:00 as the expiry date in GMT time. When I test the coupon list in my PM (at 17:00 for example), my current date is also Feb 21st in GMT time, so the old expiry date check finds that I'm on the same day as the expiry date and decides that the coupon has expired.

The solution is to set the granularity of the check to `hour` instead of `day` as before. This makes sure that the check is always correct regardless of the timezone I'm in.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure the timezone on your computer is ahead of GMT so that setting the next day as the coupon expiry date results in the same day in GMT time. E.g: 6 pm Feb 21 GMT+7. 
- Create a coupon for your test store (in WP Admin > Marketing > Coupons). Set the expiry date to the next day.
- Open the app and load the coupon list (Menu > Coupons). Notice that the created coupon is still marked as Active.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before: 

https://user-images.githubusercontent.com/5533851/154949124-66061b8c-ba4e-43a8-b133-d3578c5c297c.mp4

After:

https://user-images.githubusercontent.com/5533851/154949179-7a18b41a-5f10-4d92-a6b7-45588f565526.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
