### PR TITLE
Aligned parameters sent while fetching Inbox Notes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -92,8 +92,8 @@ extension InboxViewModel: PaginationTrackerDelegate {
                                                         pageNumber: pageNumber,
                                                         pageSize: pageSize,
                                                         orderBy: .date,
-                                                        type: nil,
-                                                        status: nil) { [weak self] result in
+                                                        type: [.info, .marketing, .survey, .warning],
+                                                        status: [.unactioned, .actioned]) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let notes):


### PR DESCRIPTION
Closes #6234 

### Description
While I was implementing https://github.com/woocommerce/woocommerce-ios/pull/6235 I discovered that the notes displayed on mobile don't match the notes on the web. The reason was that we don't filter notes on mobile, so in this PR I aligned the filters similar to the web.

### Testing instructions
1. Open the Inbox notes.
2. Check that the notes displayed on mobile match the notes on the web.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
