### PR TITLE
Dismiss all Inbox Notes - Networking layer

### DIFF
--- a/Networking/Networking/Remote/InboxNotesRemote.swift
+++ b/Networking/Networking/Remote/InboxNotesRemote.swift
@@ -17,6 +17,9 @@ public protocol InboxNotesRemoteProtocol {
                           noteID: Int64,
                           completion: @escaping (Result<InboxNote, Error>) -> ())
 
+    func dismissAllInboxNotes(for siteID: Int64,
+                              completion: @escaping (Result<[InboxNote], Error>) -> ())
+
     func markInboxNoteAsActioned(for siteID: Int64,
                                  noteID: Int64,
                                  actionID: Int64,
@@ -87,7 +90,6 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
     public func dismissInboxNote(for siteID: Int64,
                                  noteID: Int64,
                                  completion: @escaping (Result<InboxNote, Error>) -> ()) {
-
         let request = JetpackRequest(wooApiVersion: .wcAnalytics,
                                      method: .delete,
                                      siteID: siteID,
@@ -95,6 +97,28 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
                                      parameters: nil)
 
         let mapper = InboxNoteMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    // MARK: - DISMISS all Inbox Notes
+
+    /// Dismiss all `InboxNote`s.
+    /// This internally marks all notification’s is_deleted field to true and these notifications do not show in the results anymore.
+    ///
+    /// - Parameters:
+    ///     - siteID: The site for which we'll dismiss all the InboxNotes.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func dismissAllInboxNotes(for siteID: Int64,
+                                     completion: @escaping (Result<[InboxNote], Error>) -> ()) {
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics,
+                                     method: .delete,
+                                     siteID: siteID,
+                                     path: Path.notes + "/delete/all",
+                                     parameters: nil)
+
+        let mapper = InboxNoteListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/NetworkingTests/Remote/InboxNotesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/InboxNotesRemoteTests.swift
@@ -148,6 +148,51 @@ final class InboxNotesRemoteTests: XCTestCase {
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
     }
 
+    // MARK: - Dismiss all Inbox Notes tests
+
+    /// Verifies that dismissAllInboxNotes properly parses the `InboxNote`s sample response.
+    ///
+    func test_dismissAllInboxNotes_properly_returns_parsed_InboxNotes() throws {
+        // Given
+        let remote = InboxNotesRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/all", filename: "inbox-note-list")
+
+        // When
+        let result = waitFor { promise in
+            remote.dismissAllInboxNotes(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssert(result.isSuccess)
+        let inboxNotes = try XCTUnwrap(result.get())
+        XCTAssertEqual(inboxNotes.count, 24)
+    }
+
+    /// Verifies that dismissAllInboxNotes properly relays Networking Layer errors.
+    ///
+    func test_dismissAllInboxNotes_properly_relays_networking_errors() throws {
+        // Given
+        let remote = InboxNotesRemote(network: network)
+
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "admin/notes/delete/all", error: error)
+
+        // When
+        let result = waitFor { promise in
+            remote.dismissAllInboxNotes(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
+    }
+
     // MARK: - Mark an Inbox Note as `actioned`
 
     /// Verifies that markInboxNoteAsActioned properly parses the `InboxNote` sample response.


### PR DESCRIPTION
Part of #6232 

### Description
Since we are implementing the functionality for dismissing all the inbox notes at the same time, in this PR I implemented the method `dismissAllInboxNotes` in the Networking Layer.

### Testing instructions
Just CI for the moment, the method is still not in use.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
