### PR TITLE
Dismiss all Inbox Notes - Yosemite Layer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -94,7 +94,7 @@ extension InboxNoteRowViewModel {
         stores.dispatch(action)
     }
 
-    func dismissInboxNote(onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+    func dismissInboxNote(onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let action = InboxNotesAction.dismissInboxNote(siteID: siteID, noteID: id) { result in
             switch result {
             case .success:

--- a/Yosemite/Yosemite/Actions/InboxNotesAction.swift
+++ b/Yosemite/Yosemite/Actions/InboxNotesAction.swift
@@ -22,6 +22,12 @@ public enum InboxNotesAction: Action {
                           noteID: Int64,
                           completion: (Result<Bool, Error>) -> ())
 
+    /// Dismiss all `InboxNote`s.
+    /// This marks all notifications is_deleted field to true and the inbox notes will be deleted locally.
+    ///
+    case dismissAllInboxNotes(siteID: Int64,
+                              completion: (Result<Bool, Error>) -> ())
+
     /// Set an `InboxNote` as `actioned`.
     /// This internally marks a notification’s status as `actioned`.
     ///

--- a/Yosemite/Yosemite/Actions/InboxNotesAction.swift
+++ b/Yosemite/Yosemite/Actions/InboxNotesAction.swift
@@ -20,13 +20,13 @@ public enum InboxNotesAction: Action {
     ///
     case dismissInboxNote(siteID: Int64,
                           noteID: Int64,
-                          completion: (Result<Bool, Error>) -> ())
+                          completion: (Result<Void, Error>) -> ())
 
     /// Dismiss all `InboxNote`s.
     /// This marks all notifications is_deleted field to true and the inbox notes will be deleted locally.
     ///
     case dismissAllInboxNotes(siteID: Int64,
-                              completion: (Result<Bool, Error>) -> ())
+                              completion: (Result<Void, Error>) -> ())
 
     /// Set an `InboxNote` as `actioned`.
     /// This internally marks a notification’s status as `actioned`.

--- a/Yosemite/Yosemite/Stores/InboxNotesStore.swift
+++ b/Yosemite/Yosemite/Stores/InboxNotesStore.swift
@@ -79,7 +79,7 @@ private extension InboxNotesStore {
     ///
     func dismissInboxNote(for siteID: Int64,
                           noteID: Int64,
-                          completion: @escaping (Result<Bool, Error>) -> ()) {
+                          completion: @escaping (Result<Void, Error>) -> ()) {
         remote.dismissInboxNote(for: siteID, noteID: noteID) { [weak self] result in
             switch result {
             case .failure(let error):
@@ -87,7 +87,7 @@ private extension InboxNotesStore {
 
             case .success(_):
                 self?.deleteStoredInboxNoteInBackground(siteID: siteID, noteID: noteID, onCompletion: {
-                    completion(.success(true))
+                    completion(.success(()))
                 })
             }
         }
@@ -97,15 +97,15 @@ private extension InboxNotesStore {
     /// This marks all notifications is_deleted field to true and the inbox notes will be deleted locally.
     ///
     func dismissAllInboxNotes(siteID: Int64,
-                              completion: @escaping (Result<Bool, Error>) -> ()) {
+                              completion: @escaping (Result<Void, Error>) -> ()) {
         remote.dismissAllInboxNotes(for: siteID) { [weak self] result in
             switch result {
             case .failure(let error):
                 completion(.failure(error))
 
-            case .success(_):
+            case .success:
                 self?.deleteStoredInboxNotesInBackground(siteID: siteID, onCompletion: {
-                    completion(.success(true))
+                    completion(.success(()))
                 })
             }
         }

--- a/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
@@ -164,7 +164,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissInboxNote` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -189,7 +189,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 1)
 
         // When dispatching a `dismissInboxNote` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -212,7 +212,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissInboxNote` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -234,7 +234,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissInboxNote` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -256,7 +256,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissAllInboxNotes` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -282,7 +282,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 2)
 
         // When dispatching a `dismissAllInboxNotes` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -304,7 +304,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissAllInboxNotes` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
@@ -325,7 +325,7 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertEqual(storedInboxNotesCount, 0)
 
         // When dispatching a `dismissAllInboxNotes` action
-        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+        let result: Result<Void, Error> = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }

--- a/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/InboxNotesStoreTests.swift
@@ -250,6 +250,97 @@ final class InboxNotesStoreTests: XCTestCase {
         XCTAssertFalse(result.isSuccess)
     }
 
+    func test_dismissAllInboxNotes_do_nothing_if_no_inbox_notes_exist_upon_successful_response() {
+        // Given a stubbed inbox note network response
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/all", filename: "inbox-note-list")
+        XCTAssertEqual(storedInboxNotesCount, 0)
+
+        // When dispatching a `dismissAllInboxNotes` action
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+            guard let self = self else {
+                return
+            }
+
+            let action = InboxNotesAction.dismissAllInboxNotes(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then no inbox notes should be stored
+        XCTAssertEqual(storedInboxNotesCount, 0)
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_dismissAllInboxNotes_delete_existing_inbox_notes_upon_successful_response() {
+        // Given two initial stored inbox note and a stubbed inbox notes network response
+        let initialInboxNote = sampleInboxNote(id: 296)
+        let initialInboxNote2 = sampleInboxNote(id: 297)
+        storageManager.insertSampleInboxNote(readOnlyInboxNote: initialInboxNote)
+        storageManager.insertSampleInboxNote(readOnlyInboxNote: initialInboxNote2)
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/all", filename: "inbox-note-list")
+        XCTAssertEqual(storedInboxNotesCount, 2)
+
+        // When dispatching a `dismissAllInboxNotes` action
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+            guard let self = self else {
+                return
+            }
+
+            let action = InboxNotesAction.dismissAllInboxNotes(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then no inbox notes should be stored
+        XCTAssertEqual(storedInboxNotesCount, 0)
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_dismissAllInboxNotes_then_it_returns_error_upon_response_error() {
+        // Given a stubbed generic-error network response
+        network.simulateResponse(requestUrlSuffix: "admin/notes/delete/all", filename: "generic_error")
+        XCTAssertEqual(storedInboxNotesCount, 0)
+
+        // When dispatching a `dismissAllInboxNotes` action
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+            guard let self = self else {
+                return
+            }
+
+            let action = InboxNotesAction.dismissAllInboxNotes(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then no inbox notes should be stored
+        XCTAssertEqual(storedInboxNotesCount, 0)
+        XCTAssertFalse(result.isSuccess)
+    }
+
+    func test_dismissAllInboxNotes_then_it_returns_error_upon_empty_response() {
+        // Given an empty network response
+        XCTAssertEqual(storedInboxNotesCount, 0)
+
+        // When dispatching a `dismissAllInboxNotes` action
+        let result: Result<Bool, Error> = waitFor { [weak self] promise in
+            guard let self = self else {
+                return
+            }
+
+            let action = InboxNotesAction.dismissAllInboxNotes(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then no inbox notes should be stored
+        XCTAssertEqual(storedInboxNotesCount, 0)
+        XCTAssertFalse(result.isSuccess)
+    }
+
     func test_markInboxNoteAsActioned_then_it_updates_stored_inbox_notes_and_inbox_action_upon_successful_response() {
         // Given a stubbed inbox note network response
         let sampleInboxNoteID: Int64 = 296


### PR DESCRIPTION
Part of #6232 

### Description
In this PR I implemented the method in the Yosemite Layer for dismissing all the Inbox Notes.

### Testing instructions
Just CI, the code is still not in use.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
