### PR TITLE
Order Creation: Display Payment section loading indicator during remote sync

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -30,6 +30,7 @@ struct OrderPaymentSection: View {
                 Spacer()
 
                 ProgressView()
+                    .renderedIf(viewModel.isLoading)
             }
             .padding()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -23,9 +23,15 @@ struct OrderPaymentSection: View {
         Divider()
 
         VStack(alignment: .leading, spacing: .zero) {
-            Text(Localization.payment)
-                .headlineStyle()
-                .padding()
+            HStack {
+                Text(Localization.payment)
+                    .headlineStyle()
+
+                Spacer()
+
+                ProgressView()
+            }
+            .padding()
 
             TitleAndValueRow(title: Localization.productsTotal, value: .content(viewModel.itemsTotal), selectionStyle: .none) {}
 


### PR DESCRIPTION
Closes: #6133

## Description

During Order Creation, while the order is being remotely synced, we now show a loading indicator at the top of the Payment section (to the right of the "Payment" heading), to indicate that the payment details are being updated.

## Changes

* Adds a `ProgressView()` to `OrderPaymentSection`, displayed conditionally.
* Adds an `isLoading` property to `PaymentDataViewModel`. This is updated in `configurePaymentDataViewModel()` by subscribing to `orderSynchronizer.statePublisher` and changing the value depending on whether the sync state is `.syncing`.
* Adds a unit test to check that `isLoading` is updated as expected during and after remote sync is performed.

## Testing

1. In `DefaultFeatureFlagService` set the `.orderCreationRemoteSynchronizer` feature flag to `true`, to enable remote sync.
2. Build and run the app.
3. Make sure Order Creation is enabled under Settings > Experimental Features.
4. Go to the Orders tab, tap the + button, and select "Create order."
5. Add a product to the order.
6. Notice that the Payment section appears with a loading indicator visible while the order syncs remotely, and the loading indicator disappears after sync is complete.

## Screenshots

https://user-images.githubusercontent.com/8658164/154989159-bf1ce184-202f-4ea3-9a65-1784315e88ab.mp4


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
