### PR TITLE
Order Creation: Add fees UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -42,7 +42,7 @@ struct NewOrder: View {
                         if viewModel.shouldShowPaymentSection {
                             OrderPaymentSection(viewModel: viewModel.paymentDataViewModel,
                                                 saveShippingLineClosure: viewModel.saveShippingLine,
-                                                saveFeeClosure: viewModel.saveFeeLine)
+                                                saveFeeLineClosure: viewModel.saveFeeLine)
 
                             Spacer(minLength: Layout.sectionSpacing)
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -352,6 +352,7 @@ extension NewOrderViewModel {
         let shippingMethodTitle: String
 
         let shouldShowFees: Bool
+        let feesBaseAmountForPercentage: Decimal
         let feesTotal: String
 
         init(itemsTotal: String = "",
@@ -359,6 +360,7 @@ extension NewOrderViewModel {
              shippingTotal: String = "",
              shippingMethodTitle: String = "",
              shouldShowFees: Bool = false,
+             feesBaseAmountForPercentage: Decimal = 0,
              feesTotal: String = "",
              orderTotal: String = "",
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
@@ -367,6 +369,7 @@ extension NewOrderViewModel {
             self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? ""
             self.shippingMethodTitle = shippingMethodTitle
             self.shouldShowFees = shouldShowFees
+            self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? ""
             self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? ""
         }
@@ -481,19 +484,22 @@ private extension NewOrderViewModel {
 
                 let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
 
+                let feesBaseAmountForPercentage = itemsTotal.adding(shippingTotal)
+
                 let feesTotal = order.fees
                     .map { $0.total }
                     .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
                     .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
 
-                let orderTotal = itemsTotal.adding(shippingTotal).adding(feesTotal)
+                let orderTotal = feesBaseAmountForPercentage.adding(feesTotal)
 
                 return PaymentDataViewModel(itemsTotal: itemsTotal.stringValue,
                                             shouldShowShippingTotal: order.shippingLines.isNotEmpty,
                                             shippingTotal: shippingTotal.stringValue,
                                             shippingMethodTitle: shippingMethodTitle,
                                             shouldShowFees: order.fees.isNotEmpty,
+                                            feesBaseAmountForPercentage: feesBaseAmountForPercentage as Decimal,
                                             feesTotal: feesTotal.stringValue,
                                             orderTotal: orderTotal.stringValue,
                                             currencyFormatter: self.currencyFormatter)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -484,6 +484,7 @@ private extension NewOrderViewModel {
 
                 let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
 
+                // TODO-6236: move totals calculation to LocalOrderSynchronizer, add tax to feesBaseAmount
                 let feesBaseAmountForPercentage = itemsTotal.adding(shippingTotal)
 
                 let feesTotal = order.fees

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -25,6 +25,13 @@ struct FeeLineDetails: View {
             ScrollView {
                 VStack(spacing: .zero) {
                     Section {
+                        Picker("", selection: $viewModel.feeType) {
+                            Text(viewModel.percentSymbol).tag(FeeLineDetailsViewModel.FeeType.percentage)
+                            Text(viewModel.storeCurrencySymbol).tag(FeeLineDetailsViewModel.FeeType.fixed)
+                        }
+                        .pickerStyle(.segmented)
+                        .padding()
+
                         ZStack(alignment: .center) {
                             // Hidden input text field
                             BindableTextfield("", text: $viewModel.amount, focus: $focusAmountInput)
@@ -32,13 +39,12 @@ struct FeeLineDetails: View {
                                 .opacity(0)
 
                             // Visible & formatted field
-                            TitleAndTextFieldRow(title: Localization.amountField,
-                                                 placeholder: "",
-                                                 text: .constant(viewModel.formattedAmount),
-                                                 symbol: nil,
-                                                 keyboardType: .decimalPad)
-                                .foregroundColor(Color(viewModel.amountTextColor))
-                                .disabled(true)
+                            switch viewModel.feeType {
+                            case .fixed:
+                                inputFixedField
+                            case .percentage:
+                                inputPercentageField
+                            }
                         }
                         .background(Color(.listForeground))
                         .fixedSize(horizontal: false, vertical: true)
@@ -46,9 +52,9 @@ struct FeeLineDetails: View {
                             focusAmountInput = true
                         }
                         .padding(.horizontal, insets: safeAreaInsets)
-                        .addingTopAndBottomDividers()
                     }
                     .background(Color(.listForeground))
+                    .addingTopAndBottomDividers()
 
                     Spacer(minLength: Layout.sectionSpacing)
 
@@ -89,6 +95,26 @@ struct FeeLineDetails: View {
         }
         .wooNavigationBarStyle()
     }
+
+    private var inputFixedField: some View {
+        TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.amountField, viewModel.storeCurrencySymbol),
+                             placeholder: "",
+                             text: .constant(viewModel.formattedAmount),
+                             symbol: nil,
+                             keyboardType: .decimalPad)
+            .foregroundColor(Color(viewModel.amountTextColor))
+            .disabled(true)
+    }
+
+    private var inputPercentageField: some View {
+        TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.amountField, viewModel.percentSymbol),
+                             placeholder: "",
+                             text: .constant(viewModel.amount),
+                             symbol: nil,
+                             keyboardType: .decimalPad)
+            .foregroundColor(Color(viewModel.amountTextColor))
+            .disabled(true)
+    }
 }
 
 // MARK: Constants
@@ -102,7 +128,8 @@ private extension FeeLineDetails {
         static let addFee = NSLocalizedString("Add Fee", comment: "Title for the Fee screen during order creation")
         static let fee = NSLocalizedString("Fee", comment: "Title for the Fee Details screen during order creation")
 
-        static let amountField = NSLocalizedString("Amount", comment: "Title for the amount field on the Fee Details screen during order creation")
+        static let amountField = NSLocalizedString("Amount (%1$@)", comment: "Title for the amount field on the Fee Details screen during order creation"
+                                                   + "Parameters: %1$@ - fee type (percent sign or currency symbol)")
 
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Fee Details screen")
         static let done = NSLocalizedString("Done", comment: "Text for the done button in the Fee Details screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// View to add/edit a single fee line in an order, with the option to remove it.
+///
+struct FeeLineDetails: View {
+
+    /// View model to drive the view content
+    ///
+    @ObservedObject private var viewModel: FeeLineDetailsViewModel
+
+    /// Defines if the amount input text field should be focused. Defaults to `true`
+    ///
+    @State private var focusAmountInput: Bool = true
+
+    @Environment(\.presentationMode) var presentation
+
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
+    init(viewModel: FeeLineDetailsViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: .zero) {
+                    Section {
+                        ZStack(alignment: .center) {
+                            // Hidden input text field
+                            BindableTextfield("", text: $viewModel.amount, focus: $focusAmountInput)
+                                .keyboardType(.decimalPad)
+                                .opacity(0)
+
+                            // Visible & formatted field
+                            TitleAndTextFieldRow(title: Localization.amountField,
+                                                 placeholder: "",
+                                                 text: .constant(viewModel.formattedAmount),
+                                                 symbol: nil,
+                                                 keyboardType: .decimalPad)
+                                .foregroundColor(Color(viewModel.amountTextColor))
+                                .disabled(true)
+                        }
+                        .background(Color(.listForeground))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .onTapGesture {
+                            focusAmountInput = true
+                        }
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .addingTopAndBottomDividers()
+                    }
+                    .background(Color(.listForeground))
+
+                    Spacer(minLength: Layout.sectionSpacing)
+
+                    if viewModel.isExistingFeeLine {
+                        Section {
+                            Button(Localization.remove) {
+                                viewModel.didSelectSave(nil)
+                                presentation.wrappedValue.dismiss()
+                            }
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .foregroundColor(Color(.error))
+                            .padding(.horizontal, insets: safeAreaInsets)
+                            .addingTopAndBottomDividers()
+                        }
+                        .background(Color(.listForeground))
+                    }
+                }
+            }
+            .background(Color(.listBackground))
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+            .navigationTitle(viewModel.isExistingFeeLine ? Localization.fee : Localization.addFee)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.close) {
+                        presentation.wrappedValue.dismiss()
+                    }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button(Localization.done) {
+                        viewModel.saveData()
+                        presentation.wrappedValue.dismiss()
+                    }
+                    .disabled(viewModel.shouldDisableDoneButton)
+                }
+            }
+        }
+        .wooNavigationBarStyle()
+    }
+}
+
+// MARK: Constants
+private extension FeeLineDetails {
+    enum Layout {
+        static let sectionSpacing: CGFloat = 16.0
+        static let dividerPadding: CGFloat = 16.0
+    }
+
+    enum Localization {
+        static let addFee = NSLocalizedString("Add Fee", comment: "Title for the Fee screen during order creation")
+        static let fee = NSLocalizedString("Fee", comment: "Title for the Fee Details screen during order creation")
+
+        static let amountField = NSLocalizedString("Amount", comment: "Title for the amount field on the Fee Details screen during order creation")
+
+        static let close = NSLocalizedString("Close", comment: "Text for the close button in the Fee Details screen")
+        static let done = NSLocalizedString("Done", comment: "Text for the done button in the Fee Details screen")
+        static let remove = NSLocalizedString("Remove Fee from Order",
+                                              comment: "Text for the button to remove a fee from the order during order creation")
+    }
+}
+
+struct FeeLineDetails_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
+                                                               feesBaseAmountForPercentage: 200,
+                                                               feesTotal: "10")
+        FeeLineDetails(viewModel: .init(inputData: viewModel, didSelectSave: { _ in }))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -108,7 +108,7 @@ struct FeeLineDetails: View {
 
     private var inputPercentageField: some View {
         TitleAndTextFieldRow(title: String.localizedStringWithFormat(Localization.amountField, viewModel.percentSymbol),
-                             placeholder: "",
+                             placeholder: "0",
                              text: .constant(viewModel.amount),
                              symbol: nil,
                              keyboardType: .decimalPad)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import struct Yosemite.OrderFeeLine
+
+class FeeLineDetailsViewModel: ObservableObject {
+
+    /// Closure to be invoked when the fee line is updated.
+    ///
+    var didSelectSave: ((OrderFeeLine?) -> Void)
+
+    /// Helper to format price field input.
+    ///
+    private let priceFieldFormatter: PriceFieldFormatter
+
+    /// Formatted amount to display. When empty displays a placeholder value.
+    ///
+    var formattedAmount: String {
+        priceFieldFormatter.formattedAmount
+    }
+
+    /// Stores the amount(unformatted) entered by the merchant.
+    ///
+    @Published var amount: String = "" {
+        didSet {
+            guard amount != oldValue else { return }
+            amount = priceFieldFormatter.formatAmount(amount)
+        }
+    }
+
+    /// Defines the amount text color.
+    ///
+    var amountTextColor: UIColor {
+        amount.isEmpty ? .textPlaceholder : .text
+    }
+
+    private let initialAmount: Decimal
+
+    /// Returns true when existing fee line is edited.
+    ///
+    let isExistingFeeLine: Bool
+
+    /// Returns true when there are no valid pending changes.
+    ///
+    var shouldDisableDoneButton: Bool {
+        guard let amountDecimal = priceFieldFormatter.amountDecimal, amountDecimal > .zero else {
+            return true
+        }
+
+        return amountDecimal == initialAmount
+    }
+
+    init(inputData: NewOrderViewModel.PaymentDataViewModel,
+         locale: Locale = Locale.autoupdatingCurrent,
+         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         didSelectSave: @escaping ((OrderFeeLine?) -> Void)) {
+        self.priceFieldFormatter = .init(locale: locale, storeCurrencySettings: storeCurrencySettings)
+
+        self.isExistingFeeLine = inputData.shouldShowFees
+
+       let currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
+        if let initialAmount = currencyFormatter.convertToDecimal(from: inputData.feesTotal) {
+            self.initialAmount = initialAmount as Decimal
+        } else {
+            self.initialAmount = .zero
+        }
+
+        if initialAmount > 0, let formattedInputAmount = currencyFormatter.formatAmount(initialAmount) {
+            self.amount = priceFieldFormatter.formatAmount(formattedInputAmount)
+        }
+
+        self.didSelectSave = didSelectSave
+    }
+
+    func saveData() {
+        let feeLine = OrderFeeLine(feeID: 0,
+                                   name: "Fee",
+                                   taxClass: "",
+                                   taxStatus: .none,
+                                   total: amount,
+                                   totalTax: "",
+                                   taxes: [],
+                                   attributes: [])
+        didSelectSave(feeLine)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -50,7 +50,7 @@ class FeeLineDetailsViewModel: ObservableObject {
         guard let amountDecimal = priceFieldFormatter.amountDecimal, amountDecimal > .zero else {
             return true
         }
-        let finalAmount = feeType == .percentage ? amountDecimal * 0.01 : amountDecimal
+        let finalAmount = feeType == .percentage ? baseAmountForPercentage * amountDecimal * 0.01 : amountDecimal
 
         return finalAmount == initialAmount
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -9,11 +9,15 @@ struct OrderPaymentSection: View {
 
     /// Closure to create/update the shipping line object
     let saveShippingLineClosure: (ShippingLine?) -> Void
-    let saveFeeClosure: (OrderFeeLine?) -> Void
+    let saveFeeLineClosure: (OrderFeeLine?) -> Void
 
     /// Indicates if the shipping line details screen should be shown or not.
     ///
     @State private var shouldShowShippingLineDetails: Bool = false
+
+    /// Indicates if the fee line details screen should be shown or not.
+    ///
+    @State private var shouldShowFeeLineDetails: Bool = false
 
     ///   Environment safe areas
     ///
@@ -37,6 +41,11 @@ struct OrderPaymentSection: View {
                         }))
                     }
                 feesRow
+                    .sheet(isPresented: $shouldShowFeeLineDetails) {
+                        FeeLineDetails(viewModel: .init(inputData: viewModel, didSelectSave: { newFeeLine in
+                            saveFeeLineClosure(newFeeLine)
+                        }))
+                    }
             }
 
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}
@@ -68,23 +77,11 @@ struct OrderPaymentSection: View {
     @ViewBuilder private var feesRow: some View {
         if viewModel.shouldShowFees {
             TitleAndValueRow(title: Localization.feesTotal, value: .content(viewModel.feesTotal), selectionStyle: .highlight) {
-                // TODO-6027: add navigation to Fee Details UI
-                // Temporary - remove existing fee line
-                saveFeeClosure(nil)
+                shouldShowFeeLineDetails = true
             }
         } else {
             Button(Localization.addFees) {
-                // TODO-6027: add navigation to Add Fee UI
-                // Temporary - add hardcoded fee line
-                let testFeeLine = OrderFeeLine(feeID: 0,
-                                               name: "Fee",
-                                               taxClass: "",
-                                               taxStatus: .none,
-                                               total: "10",
-                                               totalTax: "",
-                                               taxes: [],
-                                               attributes: [])
-                saveFeeClosure(testFeeLine)
+                shouldShowFeeLineDetails = true
             }
             .buttonStyle(PlusButtonStyle())
             .padding()
@@ -111,7 +108,7 @@ struct OrderPaymentSection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00", orderTotal: "20.00")
 
-        OrderPaymentSection(viewModel: viewModel, saveShippingLineClosure: { _ in }, saveFeeClosure: { _ in })
+        OrderPaymentSection(viewModel: viewModel, saveShippingLineClosure: { _ in }, saveFeeLineClosure: { _ in })
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1009,6 +1009,8 @@
 		AE457813275644590092F687 /* OrderStatusSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE457812275644590092F687 /* OrderStatusSection.swift */; };
 		AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */; };
 		AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */; };
+		AE7C957B27C3D5DA007E8E12 /* FeeLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7C957A27C3D5DA007E8E12 /* FeeLineDetails.swift */; };
+		AE7C957D27C3F187007E8E12 /* FeeLineDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7C957C27C3F187007E8E12 /* FeeLineDetailsViewModel.swift */; };
 		AE90475C27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */; };
 		AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9E04742776213E003FA09E /* OrderCustomerSection.swift */; };
 		AEA3F90D27BE76B300B9F555 /* ShippingLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA3F90C27BE76B300B9F555 /* ShippingLineDetails.swift */; };
@@ -2637,6 +2639,8 @@
 		AE457812275644590092F687 /* OrderStatusSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusSection.swift; sourceTree = "<group>"; };
 		AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveStack.swift; sourceTree = "<group>"; };
 		AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AddingDividers.swift"; sourceTree = "<group>"; };
+		AE7C957A27C3D5DA007E8E12 /* FeeLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeLineDetails.swift; sourceTree = "<group>"; };
+		AE7C957C27C3F187007E8E12 /* FeeLineDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeLineDetailsViewModel.swift; sourceTree = "<group>"; };
 		AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrderAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		AE9E04742776213E003FA09E /* OrderCustomerSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerSection.swift; sourceTree = "<group>"; };
 		AEA3F90C27BE76B300B9F555 /* ShippingLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineDetails.swift; sourceTree = "<group>"; };
@@ -6310,6 +6314,8 @@
 				CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */,
 				AEA3F90C27BE76B300B9F555 /* ShippingLineDetails.swift */,
 				AEA3F90E27BE8EB400B9F555 /* ShippingLineDetailsViewModel.swift */,
+				AE7C957A27C3D5DA007E8E12 /* FeeLineDetails.swift */,
+				AE7C957C27C3F187007E8E12 /* FeeLineDetailsViewModel.swift */,
 			);
 			path = PaymentSection;
 			sourceTree = "<group>";
@@ -8443,6 +8449,7 @@
 				B6E851F3276320C70041D1BA /* RefundFeesDetailsViewModel.swift in Sources */,
 				024DF31F23743045006658FE /* Header+AztecFormatting.swift in Sources */,
 				029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */,
+				AE7C957B27C3D5DA007E8E12 /* FeeLineDetails.swift in Sources */,
 				B5A8F8AD20B88D9900D211DE /* LoginPrologueViewController.swift in Sources */,
 				B5D1AFC620BC7B7300DB0E8C /* StorePickerViewController.swift in Sources */,
 				02DD81FB242CAA400060E50B /* WordPressMediaLibraryPickerDataSource.swift in Sources */,
@@ -9115,6 +9122,7 @@
 				024DF31423742B7A006658FE /* AztecUnderlineFormatBarCommand.swift in Sources */,
 				CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */,
 				0217399C2772F9DD0084CD89 /* StoreStatsV4PeriodViewController.swift in Sources */,
+				AE7C957D27C3F187007E8E12 /* FeeLineDetailsViewModel.swift in Sources */,
 				4520A15C2721B2A9001FA573 /* FilterOrderListViewModel.swift in Sources */,
 				D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */,
 				B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1011,6 +1011,7 @@
 		AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */; };
 		AE7C957B27C3D5DA007E8E12 /* FeeLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7C957A27C3D5DA007E8E12 /* FeeLineDetails.swift */; };
 		AE7C957D27C3F187007E8E12 /* FeeLineDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7C957C27C3F187007E8E12 /* FeeLineDetailsViewModel.swift */; };
+		AE7C957F27C417FA007E8E12 /* FeeLineDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7C957E27C417FA007E8E12 /* FeeLineDetailsViewModelTests.swift */; };
 		AE90475C27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */; };
 		AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9E04742776213E003FA09E /* OrderCustomerSection.swift */; };
 		AEA3F90D27BE76B300B9F555 /* ShippingLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA3F90C27BE76B300B9F555 /* ShippingLineDetails.swift */; };
@@ -2641,6 +2642,7 @@
 		AE77EA4F27A47C99006A21BD /* View+AddingDividers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AddingDividers.swift"; sourceTree = "<group>"; };
 		AE7C957A27C3D5DA007E8E12 /* FeeLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeLineDetails.swift; sourceTree = "<group>"; };
 		AE7C957C27C3F187007E8E12 /* FeeLineDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeLineDetailsViewModel.swift; sourceTree = "<group>"; };
+		AE7C957E27C417FA007E8E12 /* FeeLineDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeLineDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrderAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		AE9E04742776213E003FA09E /* OrderCustomerSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerSection.swift; sourceTree = "<group>"; };
 		AEA3F90C27BE76B300B9F555 /* ShippingLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineDetails.swift; sourceTree = "<group>"; };
@@ -6369,6 +6371,7 @@
 				CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */,
 				AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */,
 				AEA3F91227BEC40A00B9F555 /* ShippingLineDetailsViewModelTests.swift */,
+				AE7C957E27C417FA007E8E12 /* FeeLineDetailsViewModelTests.swift */,
 				2602A64027BD89B300B347F1 /* Synchronizer */,
 			);
 			path = "Order Creation";
@@ -9566,6 +9569,7 @@
 				022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,
 				26F94E34267AA42F00DB6CCF /* ProductAddOnViewModelTests.swift in Sources */,
+				AE7C957F27C417FA007E8E12 /* FeeLineDetailsViewModelTests.swift in Sources */,
 				0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */,
 				7E7C5F8B2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift in Sources */,
 				020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+import Combine
+
+@testable import WooCommerce
+@testable import struct Yosemite.OrderFeeLine
+
+final class FeeLineDetailsViewModelTests: XCTestCase {
+
+    private let usLocale = Locale(identifier: "en_US")
+    private let usStoreSettings = CurrencySettings() // Default is US settings
+
+    func test_view_model_formats_amount_correctly() {
+        // Given
+        let viewModel = FeeLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+
+        // When
+        viewModel.amount = "hi:11.3005.02-"
+
+        // Then
+        XCTAssertEqual(viewModel.formattedAmount, "$11.30")
+    }
+
+    func test_view_model_formats_amount_with_custom_currency_settings() {
+        // Given
+        let customSettings = CurrencySettings(currencyCode: .GBP,
+                                              currencyPosition: .rightSpace,
+                                              thousandSeparator: ",",
+                                              decimalSeparator: ".",
+                                              numberOfDecimals: 3)
+
+        let viewModel = FeeLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: customSettings, didSelectSave: { _ in })
+
+        // When
+        viewModel.amount = "12.203"
+
+        // Then
+        XCTAssertEqual(viewModel.formattedAmount, "12.203 £")
+    }
+
+    func test_view_model_prefills_input_data_correctly() {
+        // Given
+        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
+                                                               feesTotal: "15.30")
+
+        let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isExistingFeeLine)
+        XCTAssertEqual(viewModel.feeType, .fixed)
+        XCTAssertEqual(viewModel.formattedAmount, "$15.30")
+    }
+
+    func test_view_model_disables_done_button_for_empty_state_and_enables_with_input() {
+        // Given
+        let viewModel = FeeLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+
+        // When
+        viewModel.amount = "11.30"
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisableDoneButton)
+
+        // When
+        viewModel.amount = ""
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+    }
+
+    func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_changes() {
+        // Given
+        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
+                                                               feesBaseAmountForPercentage: 100,
+                                                               feesTotal: "11.30")
+
+        let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+
+        // When & Then
+        viewModel.amount = "11.50"
+        XCTAssertFalse(viewModel.shouldDisableDoneButton)
+
+        // When & Then
+        viewModel.amount = "11.30"
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+
+        // When & Then
+        viewModel.feeType = .percentage
+        XCTAssertFalse(viewModel.shouldDisableDoneButton)
+    }
+
+    func test_view_model_creates_fee_line_with_fixed_amount() {
+        // Given
+        var savedFeeLine: OrderFeeLine?
+        let viewModel = FeeLineDetailsViewModel(inputData: .init(),
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { newFeeLine in
+            savedFeeLine = newFeeLine
+        })
+
+        // When
+        viewModel.amount = "$11.30"
+
+        // Then
+        viewModel.saveData()
+        XCTAssertEqual(savedFeeLine?.total, "11.30")
+    }
+
+    func test_view_model_creates_fee_line_with_percentage_amount() {
+        // Given
+        var savedFeeLine: OrderFeeLine?
+        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
+                                                               feesBaseAmountForPercentage: 200,
+                                                               feesTotal: "10")
+        let viewModel = FeeLineDetailsViewModel(inputData: inputData,
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { newFeeLine in
+            savedFeeLine = newFeeLine
+        })
+
+        // When
+        viewModel.feeType = .percentage
+
+        // Then
+        viewModel.saveData()
+        XCTAssertEqual(savedFeeLine?.total, "20")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -87,7 +87,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
 
         // When & Then
         viewModel.feeType = .percentage
-        XCTAssertFalse(viewModel.shouldDisableDoneButton)
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
     }
 
     func test_view_model_disables_done_button_for_matched_percentage_value() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -90,6 +90,28 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldDisableDoneButton)
     }
 
+    func test_view_model_disables_done_button_for_matched_percentage_value() {
+        // Given
+        // Initial fee is $10/5%
+        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
+                                                               feesBaseAmountForPercentage: 200,
+                                                               feesTotal: "10")
+
+        let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+
+        // When & Then
+        // Change fee to $5
+        viewModel.amount = "5"
+        XCTAssertFalse(viewModel.shouldDisableDoneButton)
+
+        // When & Then
+        // Change fee to 5%
+        viewModel.amount = "5"
+        viewModel.feeType = .percentage
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+    }
+
     func test_view_model_creates_fee_line_with_fixed_amount() {
         // Given
         var savedFeeLine: OrderFeeLine?

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -380,6 +380,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£10.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£18.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 18.50)
 
         // When
         viewModel.saveShippingLine(nil)
@@ -389,6 +390,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£0.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
 
     func test_payment_section_is_updated_when_fee_line_updated() {
@@ -416,6 +418,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£10.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£18.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
 
         // When
         viewModel.saveFeeLine(nil)
@@ -425,6 +428,7 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£0.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
 }
 


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6027

## Description

This PR adds navigation to the fully functional "Fee Details" screen from the new order screen.

## Changes

- Adds `FeeLineDetails` view.
- Adds `feesBaseAmountForPercentage` to `PaymentDataViewModel`.
- Connects navigation and data flow to `FeeLineDetails` view.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "Add Product" button and select any product to enable "Payment" section.
5. Tap "Add Fees" button.
6. Check the Fee Details screen, enter a fixed amount and save.
7. Confirm that the "Payment" section displays correct fees and total values.
8. Tap the "Fees" row to open Fee Details, check that it's prefilled correctly.
9. Switch to the percentage fee type, save.
10. Confirm that the "Payment" section displays correct fees and total values.
11. Tap the "Fees" row -> "Delete Fee from Order".
12. Confirm that the fees row is replaced with a button and the "Order Total" is correctly updated.

## Video

https://user-images.githubusercontent.com/3132438/155014512-4286778f-0700-4607-92d5-88acb4b1db6e.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
