### PR TITLE
Order Creation: Show shipping amount field and currency symbol without fake text field

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -26,26 +26,20 @@ struct ShippingLineDetails: View {
                 VStack(spacing: .zero) {
                     Section {
                         Group {
-                            ZStack(alignment: .center) {
-                                // Hidden input text field
-                                BindableTextfield("", text: $viewModel.amount, focus: $focusAmountInput)
-                                    .keyboardType(.decimalPad)
-                                    .opacity(0)
+                            AdaptiveStack(horizontalAlignment: .leading) {
+                                Text(Localization.amountField)
+                                    .bodyStyle()
+                                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                                // Visible & formatted field
-                                TitleAndTextFieldRow(title: Localization.amountField,
-                                                     placeholder: "",
-                                                     text: .constant(viewModel.formattedAmount),
-                                                     symbol: nil,
-                                                     keyboardType: .decimalPad)
-                                    .foregroundColor(Color(viewModel.amountTextColor))
-                                    .disabled(true)
+                                BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount, focus: $focusAmountInput)
+                                    .keyboardType(.decimalPad)
+                                    .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
+                                    .fixedSize()
+                                    .onTapGesture {
+                                        focusAmountInput = true
+                                    }
                             }
-                            .background(Color(.listForeground))
-                            .fixedSize(horizontal: false, vertical: true)
-                            .onTapGesture {
-                                focusAmountInput = true
-                            }
+                            .padding()
 
                             Divider()
                                 .padding(.leading, Layout.dividerPadding)
@@ -99,6 +93,38 @@ struct ShippingLineDetails: View {
             }
         }
         .wooNavigationBarStyle()
+    }
+}
+
+/// Adds a currency symbol to the left or right of the provided content
+///
+private struct CurrencySymbol: ViewModifier {
+    let symbol: String
+    let position: CurrencySettings.CurrencyPosition
+
+    func body(content: Content) -> some View {
+        HStack {
+            switch position {
+            case .left, .leftSpace:
+                Text(symbol)
+                    .bodyStyle()
+                content
+            case .right, .rightSpace:
+                content
+                Text(symbol)
+                    .bodyStyle()
+            }
+        }
+    }
+}
+
+private extension View {
+    /// Adds the provided symbol to the left or right of the text field
+    /// - Parameters:
+    ///   - symbol: Currency symbol
+    ///   - position: Position for the currency symbol, in relation to the text field
+    func addingCurrencySymbol(_ symbol: String, on position: CurrencySettings.CurrencyPosition) -> some View {
+        modifier(CurrencySymbol(symbol: symbol, position: position))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -39,7 +39,8 @@ struct ShippingLineDetails: View {
                                         focusAmountInput = true
                                     }
                             }
-                            .padding()
+                            .frame(minHeight: Layout.amountRowHeight)
+                            .padding([.leading, .trailing], Layout.amountRowPadding)
 
                             Divider()
                                 .padding(.leading, Layout.dividerPadding)
@@ -133,6 +134,8 @@ private extension ShippingLineDetails {
     enum Layout {
         static let sectionSpacing: CGFloat = 16.0
         static let dividerPadding: CGFloat = 16.0
+        static let amountRowHeight: CGFloat = 44
+        static let amountRowPadding: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -104,14 +104,24 @@ private struct CurrencySymbol: ViewModifier {
     let position: CurrencySettings.CurrencyPosition
 
     func body(content: Content) -> some View {
-        HStack {
+        HStack(spacing: .zero) {
             switch position {
-            case .left, .leftSpace:
+            case .left:
                 Text(symbol)
                     .bodyStyle()
                 content
-            case .right, .rightSpace:
+            case .leftSpace:
+                Text(symbol)
+                    .bodyStyle()
+                Spacer()
                 content
+            case .right:
+                content
+                Text(symbol)
+                    .bodyStyle()
+            case .rightSpace:
+                content
+                Spacer()
                 Text(symbol)
                     .bodyStyle()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -29,12 +29,13 @@ struct ShippingLineDetails: View {
                             AdaptiveStack(horizontalAlignment: .leading) {
                                 Text(Localization.amountField)
                                     .bodyStyle()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .fixedSize()
+
+                                Spacer()
 
                                 BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount, focus: $focusAmountInput)
                                     .keyboardType(.decimalPad)
                                     .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
-                                    .fixedSize()
                                     .onTapGesture {
                                         focusAmountInput = true
                                     }
@@ -102,26 +103,30 @@ struct ShippingLineDetails: View {
 private struct CurrencySymbol: ViewModifier {
     let symbol: String
     let position: CurrencySettings.CurrencyPosition
+    let symbolSpacing: CGFloat?
+
+    init(symbol: String, position: CurrencySettings.CurrencyPosition) {
+        self.symbol = symbol
+        self.position = position
+        self.symbolSpacing = {
+            switch position {
+            case .left, .right:
+                return .zero
+            case .leftSpace, .rightSpace:
+                return nil
+            }
+        }()
+    }
 
     func body(content: Content) -> some View {
-        HStack(spacing: .zero) {
+        HStack(spacing: symbolSpacing) {
             switch position {
-            case .left:
+            case .left, .leftSpace:
                 Text(symbol)
                     .bodyStyle()
                 content
-            case .leftSpace:
-                Text(symbol)
-                    .bodyStyle()
-                Spacer()
+            case .right, .rightSpace:
                 content
-            case .right:
-                content
-                Text(symbol)
-                    .bodyStyle()
-            case .rightSpace:
-                content
-                Spacer()
                 Text(symbol)
                     .bodyStyle()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
@@ -11,25 +11,25 @@ class ShippingLineDetailsViewModel: ObservableObject {
     ///
     private let priceFieldFormatter: PriceFieldFormatter
 
-    /// Formatted amount to display. When empty displays a placeholder value.
+    /// Currency symbol to display with amount text field
     ///
-    var formattedAmount: String {
-        priceFieldFormatter.formattedAmount
-    }
+    let currencySymbol: String
 
-    /// Stores the amount(unformatted) entered by the merchant.
+    /// Position for currency symbol, relative to amount text field
+    ///
+    let currencyPosition: CurrencySettings.CurrencyPosition
+
+    /// Placeholder for amount text field
+    ///
+    let amountPlaceholder: String
+
+    /// Stores the amount entered by the merchant.
     ///
     @Published var amount: String = "" {
         didSet {
             guard amount != oldValue else { return }
             amount = priceFieldFormatter.formatAmount(amount)
         }
-    }
-
-    /// Defines the amount text color.
-    ///
-    var amountTextColor: UIColor {
-        amount.isEmpty ? .textPlaceholder : .text
     }
 
     /// Stores the method title entered by the merchant.
@@ -67,6 +67,9 @@ class ShippingLineDetailsViewModel: ObservableObject {
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          didSelectSave: @escaping ((ShippingLine?) -> Void)) {
         self.priceFieldFormatter = .init(locale: locale, storeCurrencySettings: storeCurrencySettings)
+        self.currencySymbol = storeCurrencySettings.symbol(from: storeCurrencySettings.currencyCode)
+        self.currencyPosition = storeCurrencySettings.currencyPosition
+        self.amountPlaceholder = priceFieldFormatter.formatAmount("0")
 
         self.isExistingShippingLine = inputData.shouldShowShippingTotal
         self.initialMethodTitle = inputData.shippingMethodTitle

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BindableTextField.swift
@@ -46,6 +46,8 @@ struct BindableTextfield: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextField {
         let textfield = UITextField()
         textfield.delegate = context.coordinator
+        textfield.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textfield.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return textfield
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
@@ -17,15 +17,15 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
         viewModel.amount = "hi:11.3005.02-"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmount, "$11.30")
+        XCTAssertEqual(viewModel.amount, "11.30")
     }
 
     func test_view_model_formats_amount_with_custom_currency_settings() {
         // Given
         let customSettings = CurrencySettings(currencyCode: .GBP,
                                               currencyPosition: .rightSpace,
-                                              thousandSeparator: ",",
-                                              decimalSeparator: ".",
+                                              thousandSeparator: ".",
+                                              decimalSeparator: ",",
                                               numberOfDecimals: 3)
 
         let viewModel = ShippingLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: customSettings, didSelectSave: { _ in })
@@ -34,7 +34,9 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
         viewModel.amount = "12.203"
 
         // Then
-        XCTAssertEqual(viewModel.formattedAmount, "12.203 £")
+        XCTAssertEqual(viewModel.amount, "12,203")
+        XCTAssertEqual(viewModel.currencySymbol, "£")
+        XCTAssertEqual(viewModel.currencyPosition, .rightSpace)
     }
 
     func test_view_model_prefills_input_data_correctly() {
@@ -47,7 +49,7 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
-        XCTAssertEqual(viewModel.formattedAmount, "$11.30")
+        XCTAssertEqual(viewModel.amount, "11.30")
         XCTAssertEqual(viewModel.methodTitle, "Flat Rate")
     }
 


### PR DESCRIPTION
## Description

As discussed in https://github.com/woocommerce/woocommerce-ios/pull/6222#pullrequestreview-887222081, the fake `TextField` on the Shipping screen in Order Creation is confusing because it doesn't show a cursor when the field has focus.

This removes that fake field and uses the `BindableTextfield` as the main, visible field on screen with a currency symbol next to the field. (Internal discussion about this approach: p1645206501136169-slack-C02KUCFCSFP)

## Changes

* Replaces the hidden `BindableTextfield` and fake `TitleAndTextFieldRow` in the `ShippingLineDetails` view with a visible `Text` title and `BindableTextfield`, which directly formats the provided input.
* Adds a view modifier `addingCurrencySymbol(_:on:)` that positions the provided symbol to the left or right of the view it modifies. This is added to the `BindableTextfield` to show a currency symbol in the expected position according to the store currency settings.
* Updates the view model with a placeholder (that doesn't contain any currency symbol), currency symbol, and currency position. Removes the unused `formattedAmount` property.
* Updates unit tests to check the `amount` property itself now that the `formattedAmount` is not needed.

## Testing

1. Optional: Change your store's currency options in wp-admin, under WooCommerce > Settings.
2. Build and run the app.
3. Make sure Order Creation is enabled under Settings > Experimental Features.
4. Go to the Orders tab, tap the + button, and select "Create order."
5. Add a product to the order.
6. Select "Add Shipping."
7. Notice the Amount row shows your store's currency symbol, with the correct currency position and a `0` placeholder.
8. Enter a shipping amount and confirm it uses the correct decimal separator and number of decimals, according to your store's settings.
9. Save the shipping and confirm the correct amount is saved and reflected on the order.

## Screenshots

Placeholder|Amount with US currency settings|Amount with alternate currency settings
-|-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-22 at 00 12 57](https://user-images.githubusercontent.com/8658164/155043024-3507293e-1111-48b8-85b5-ae67189abb5b.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-22 at 00 12 51](https://user-images.githubusercontent.com/8658164/155043017-9a49071c-901e-4ad1-aa1a-36ed751fe5ea.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-22 at 00 18 40](https://user-images.githubusercontent.com/8658164/155043035-ba6eb926-752f-41f8-aa33-fb4597e7ab25.png)


https://user-images.githubusercontent.com/8658164/155042947-e6a4c86f-3eca-4e93-b81a-fe97e0a2769a.mp4





## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.