### PR TITLE
Update inbox notes predicate and sort descriptors to match core

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -41,7 +41,7 @@ final class InboxViewModel: ObservableObject {
 
     /// Inbox notes ResultsController.
     private lazy var resultsController: ResultsController<StorageInboxNote> = {
-        let predicate = NSPredicate(format: "siteID == %lld AND isRemoved == %@", siteID, NSNumber(value: false))
+        let predicate = NSPredicate(format: "siteID == %lld AND isRemoved == NO", siteID)
         let sortDescriptorByDateCreated = NSSortDescriptor(keyPath: \StorageInboxNote.dateCreated, ascending: false)
         let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageInboxNote.id, ascending: true)
         let resultsController = ResultsController<StorageInboxNote>(storageManager: storageManager,

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -41,9 +41,12 @@ final class InboxViewModel: ObservableObject {
 
     /// Inbox notes ResultsController.
     private lazy var resultsController: ResultsController<StorageInboxNote> = {
-        let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(keyPath: \StorageInboxNote.dateCreated, ascending: false)
-        let resultsController = ResultsController<StorageInboxNote>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        let predicate = NSPredicate(format: "siteID == %lld AND isRemoved == %@", siteID, NSNumber(value: false))
+        let sortDescriptorByDateCreated = NSSortDescriptor(keyPath: \StorageInboxNote.dateCreated, ascending: false)
+        let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageInboxNote.id, ascending: true)
+        let resultsController = ResultsController<StorageInboxNote>(storageManager: storageManager,
+                                                                    matching: predicate,
+                                                                    sortedBy: [sortDescriptorByDateCreated, sortDescriptorByID])
         return resultsController
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -135,8 +135,12 @@ private extension InboxViewModel {
 
     /// Performs initial fetch from storage and updates results.
     func configureResultsController() {
-        resultsController.onDidChangeContent = updateResults
-        resultsController.onDidResetContent = updateResults
+        resultsController.onDidChangeContent = { [weak self] in
+            self?.updateResults()
+        }
+        resultsController.onDidResetContent = { [weak self] in
+            self?.updateResults()
+        }
 
         do {
             try resultsController.performFetch()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxViewModelTests.swift
@@ -204,6 +204,58 @@ final class InboxViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.noteRowViewModels, [])
     }
+
+    func test_noteRowViewModels_do_not_include_removed_notes() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let note = InboxNote.fake().copy(siteID: sampleSiteID, isRemoved: false)
+        let removedNote = InboxNote.fake().copy(siteID: sampleSiteID, isRemoved: true)
+        stores.whenReceivingAction(ofType: InboxNotesAction.self) { action in
+            guard case let .loadAllInboxNotes(_, _, _, _, _, _, completion) = action else {
+                return
+            }
+            let notes = [removedNote, note]
+            self.insertInboxNotes(notes)
+            completion(.success(notes))
+        }
+        let viewModel = InboxViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then only note with `isRemoved: false` is available
+        XCTAssertEqual(viewModel.noteRowViewModels.count, 1)
+        XCTAssertEqual(viewModel.noteRowViewModels.first, .init(note: note))
+    }
+
+    func test_noteRowViewModels_are_sorted_by_dateCreated_and_id() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        // GMT Monday, February 28, 2022 8:18:04 AM
+        let latestNote = InboxNote.fake().copy(siteID: sampleSiteID, id: 0, dateCreated: .init(timeIntervalSince1970: 1646036284))
+        // GMT Friday, February 25, 2022 8:18:04 AM
+        let date = Date(timeIntervalSince1970: 1645777084)
+        let noteWithDateAndSmallerID = InboxNote.fake().copy(siteID: sampleSiteID, id: 1, dateCreated: date)
+        let noteWithDateAndLargerID = InboxNote.fake().copy(siteID: sampleSiteID, id: 3, dateCreated: date)
+        stores.whenReceivingAction(ofType: InboxNotesAction.self) { action in
+            guard case let .loadAllInboxNotes(_, _, _, _, _, _, completion) = action else {
+                return
+            }
+            let notes = [noteWithDateAndLargerID, noteWithDateAndSmallerID, latestNote]
+            self.insertInboxNotes(notes)
+            completion(.success(notes))
+        }
+        let viewModel = InboxViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then notes are first sorted by descending date and then by ascending ID
+        XCTAssertEqual(viewModel.noteRowViewModels.count, 3)
+        assertEqual(viewModel.noteRowViewModels[0], .init(note: latestNote))
+        assertEqual(viewModel.noteRowViewModels[1], .init(note: noteWithDateAndSmallerID))
+        assertEqual(viewModel.noteRowViewModels[2], .init(note: noteWithDateAndLargerID))
+    }
 }
 
 extension InboxViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6271
- [x] ⚠️ Make sure the base branch is `trunk` before merging ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

During testing, I noticed some notes have the same creation date and the order of these notes keeps changing after each pull-to-refresh action https://github.com/woocommerce/woocommerce-ios/pull/6272. After inspecting the database and comparing with core (via the Chrome network debugger), it looks like the notes are sorted by:

- First: descending creation date (`dateCreated`)
- Second: ascending ID (`id`)

Additionally, this PR updated the following:

- Added a predicate on `isRemoved = false` so that we don't display notes that are removed (though it's unlikely these are returned from the API)
- Fixed a retain issue where `ResultsController`'s callbacks are holding onto `InboxViewModel`: I tested this by visiting Inbox page multiple times and verifying there is only one `InboxViewModel` in the memory debugger

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* Launch the app
* Go to the Menu tab
* Tap on "Inbox" --> after syncing, the notes should match core exactly (under wp-admin > WooCommerce)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
