### PR TITLE
Added action sheet in Inbox for dismissing all the inbox notes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -61,7 +61,7 @@ struct Inbox: View {
             ActionSheet(
                 title: Text(Localization.title),
                 buttons: [
-                    .default(Text(Localization.dismissAllNotification), action: {
+                    .default(Text(Localization.dismissAllNotes), action: {
                         showingDismissAlert = true
                     }),
                     .cancel()
@@ -71,7 +71,7 @@ struct Inbox: View {
         .alert(isPresented: $showingDismissAlert) {
             return Alert(title: Text(Localization.dismissAlertTitle),
                   message: Text(Localization.dismissAlertMessage),
-                  primaryButton: .default(Text(Localization.dismissAllNotification), action: viewModel.dismissAllInboxNotes),
+                  primaryButton: .default(Text(Localization.dismissAllNotes), action: viewModel.dismissAllInboxNotes),
                   secondaryButton: .cancel())
         }
     }
@@ -90,7 +90,7 @@ private extension Inbox {
                                                          comment: "Title displayed if there are no inbox notes in the inbox screen.")
         static let emptyStateMessage = NSLocalizedString("Come back soon for more tips and insights on growing your store",
                                                          comment: "Message displayed if there are no inbox notes to display in the inbox screen.")
-        static let dismissAllNotification = NSLocalizedString("Dismiss All",
+        static let dismissAllNotes = NSLocalizedString("Dismiss All",
                                                               comment: "Dismiss All button in Inbox Notes for dismissing all the notes.")
         static let dismissAlertTitle = NSLocalizedString("Dismiss all messages",
                                                          comment: "Title of the alert for dismissing all the inbox notes.")

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -55,6 +55,7 @@ struct Inbox: View {
                     Image(uiImage: .moreImage)
                         .renderingMode(.template)
                 })
+                    .renderedIf(viewModel.syncState == .results)
             }
         }
         .actionSheet(isPresented: $showingActionSheet) {

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -69,8 +69,8 @@ struct Inbox: View {
             )
         }
         .alert(isPresented: $showingDismissAlert) {
-            return Alert(title: Text(Localization.dismissAlertTitle),
-                  message: Text(Localization.dismissAlertMessage),
+            return Alert(title: Text(Localization.dismissAllNotesAlertTitle),
+                  message: Text(Localization.dismissAllNotesAlertMessage),
                   primaryButton: .default(Text(Localization.dismissAllNotes), action: viewModel.dismissAllInboxNotes),
                   secondaryButton: .cancel())
         }
@@ -92,9 +92,9 @@ private extension Inbox {
                                                          comment: "Message displayed if there are no inbox notes to display in the inbox screen.")
         static let dismissAllNotes = NSLocalizedString("Dismiss All",
                                                               comment: "Dismiss All button in Inbox Notes for dismissing all the notes.")
-        static let dismissAlertTitle = NSLocalizedString("Dismiss all messages",
+        static let dismissAllNotesAlertTitle = NSLocalizedString("Dismiss all messages",
                                                          comment: "Title of the alert for dismissing all the inbox notes.")
-        static let dismissAlertMessage = NSLocalizedString("Are you sure? Inbox messages will be dismissed forever.",
+        static let dismissAllNotesAlertMessage = NSLocalizedString("Are you sure? Inbox messages will be dismissed forever.",
                                                            comment: "Message displayed in the alert for dismissing all the inbox notes.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -6,6 +6,8 @@ import Yosemite
 struct Inbox: View {
     /// View model that drives the view.
     @ObservedObject private(set) var viewModel: InboxViewModel
+    @State private var showingActionSheet: Bool = false
+    @State private var showingDismissAlert: Bool = false
 
     init(viewModel: InboxViewModel) {
         self.viewModel = viewModel
@@ -45,6 +47,33 @@ struct Inbox: View {
         .onAppear {
             viewModel.onLoadTrigger.send()
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    showingActionSheet = true
+                }, label: {
+                    Image(uiImage: .moreImage)
+                        .renderingMode(.template)
+                })
+            }
+        }
+        .actionSheet(isPresented: $showingActionSheet) {
+            ActionSheet(
+                title: Text(Localization.title),
+                buttons: [
+                    .default(Text(Localization.dismissAllNotification), action: {
+                        showingDismissAlert = true
+                    }),
+                    .cancel()
+                ]
+            )
+        }
+        .alert(isPresented: $showingDismissAlert) {
+            return Alert(title: Text(Localization.dismissAlertTitle),
+                  message: Text(Localization.dismissAlertMessage),
+                  primaryButton: .default(Text(Localization.dismissAllNotification), action: viewModel.dismissAllInboxNotes),
+                  secondaryButton: .cancel())
+        }
     }
 }
 
@@ -61,6 +90,12 @@ private extension Inbox {
                                                          comment: "Title displayed if there are no inbox notes in the inbox screen.")
         static let emptyStateMessage = NSLocalizedString("Come back soon for more tips and insights on growing your store",
                                                          comment: "Message displayed if there are no inbox notes to display in the inbox screen.")
+        static let dismissAllNotification = NSLocalizedString("Dismiss All",
+                                                              comment: "Dismiss All button in Inbox Notes for dismissing all the notes.")
+        static let dismissAlertTitle = NSLocalizedString("Dismiss all messages",
+                                                         comment: "Title of the alert for dismissing all the inbox notes.")
+        static let dismissAlertMessage = NSLocalizedString("Are you sure? Inbox messages will be dismissed forever.",
+                                                           comment: "Message displayed in the alert for dismissing all the inbox notes.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -111,6 +111,18 @@ extension InboxViewModel: PaginationTrackerDelegate {
         }
         stores.dispatch(action)
     }
+
+    func dismissAllInboxNotes() {
+        let action = InboxNotesAction.dismissAllInboxNotes(siteID: siteID) { result in
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                DDLogError("⛔️ Error on dismissing all inbox notes: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
 }
 
 // MARK: - Configuration


### PR DESCRIPTION
Closes #6232 

### Description
This is the final PR before closing #6232. Here I added the ellipsis menu in the navbar for dismissing all the inbox notes.

### Testing instructions
**Note that after dismissing all the notes on a site, you can't go back anymore, so it's best to test on a Jurassic ninja store.**

1. Open Inbox Notes.
2. Press the ellipsis menu in the navbar.
3. Dismiss all the inbox notes.
4. Check that all the inbox notes are dismissed locally and also on the website.

I experience also a case where the API for fetching the inbox notes continued to return the inbox notes for around 30 seconds after dismissing them, but I wasn't able to replicate it a second time. Probably it's a bug about the cache on the web APIs, so if you are able to replicate this use case, please, post more information in this PR.

### Video
https://user-images.githubusercontent.com/495617/155158204-45d20912-4d68-46d4-87c9-2d0c68f71fee.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
