### PR TITLE
[Mobile Payments] Remove the localization for brand names

### DIFF
--- a/Hardware/Hardware/CardReader/CardBrand.swift
+++ b/Hardware/Hardware/CardReader/CardBrand.swift
@@ -22,27 +22,6 @@ public enum CardBrand: String, CaseIterable, Codable {
     case unknown
 }
 
-extension CardBrand: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .visa:
-            return "Visa"
-        case .amex:
-            return "American Express"
-        case .masterCard:
-            return "Mastercard"
-        case .discover:
-            return "Discover"
-        case .jcb:
-            return "JCB"
-        case .dinersClub:
-            return "Diners Club"
-        case .unknown:
-            return "Other"
-        }
-    }
-}
-
 extension CardBrand {
     // The initializer for Bundle only works with class types.
     // We use this class as a shortcut to find the bundle for the CardBrand enum type

--- a/Hardware/Hardware/CardReader/CardBrand.swift
+++ b/Hardware/Hardware/CardReader/CardBrand.swift
@@ -26,60 +26,20 @@ extension CardBrand: CustomStringConvertible {
     public var description: String {
         switch self {
         case .visa:
-            return Localization.visa
+            return "Visa"
         case .amex:
-            return Localization.amex
+            return "American Express"
         case .masterCard:
-            return Localization.masterCard
+            return "Mastercard"
         case .discover:
-            return Localization.discover
+            return "Discover"
         case .jcb:
-            return Localization.jcb
+            return "JCB"
         case .dinersClub:
-            return Localization.dinersClub
+            return "Diners Club"
         case .unknown:
-            return Localization.other
+            return "Other"
         }
-    }
-}
-
-
-private extension CardBrand {
-    enum Localization {
-        static let visa = NSLocalizedString(
-            "Visa",
-            comment: "A credit card brand"
-        )
-
-        static let amex = NSLocalizedString(
-            "American Express",
-            comment: "A credit card brand"
-        )
-
-        static let masterCard = NSLocalizedString(
-            "MasterCard",
-            comment: "A credit card brand"
-        )
-
-        static let discover = NSLocalizedString(
-            "Discover",
-            comment: "A credit card brand"
-        )
-
-        static let jcb = NSLocalizedString(
-            "JCB",
-            comment: "A credit card brand"
-        )
-
-        static let dinersClub = NSLocalizedString(
-            "Diners Club",
-            comment: "A credit card brand"
-        )
-
-        static let other = NSLocalizedString(
-            "Other",
-            comment: "A credit card brand"
-        )
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6265 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In #6130, we [decided not to localize card brand names](https://github.com/woocommerce/woocommerce-ios/pull/6130#discussion_r805682065) when displaying them on the Refund Confirmation screen.

Some cards (e.g. Mastercard) have guidelines which restrict us from localizing the names, with the exception of limited numbers of authorized translations. None of these are relevant to markets where In-Person Payments is available.

This removes the `description` and localization for these card names, as they are not actually used anywhere. They were added in #4024 for use on receipts, and superseded in #4165 when `.brand` in the following line was replaced with the card icon in the `ReceiptRenderer`

```
\(parameters.cardDetails.brand) - \(parameters.cardDetails.last4)
```

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to the `Orders` tab, tap `+`
2. Enter an amount, then tap through to take payment
3. Take payment by card
4. Tap `Print Receipt` or `Email Receipt` and note that the card details (icon and number) still show on the receipt, but that the names do not.

You can confirm from `trunk` that there is no difference in the view. Description was not used elsewhere either.

### Screenshots
`trunk` | #6265
---|---
![trunk](https://user-images.githubusercontent.com/2472348/155197937-6ee6876a-2997-4789-aaea-934c55321a3e.png) | ![6265](https://user-images.githubusercontent.com/2472348/155198067-68716fdb-f12d-46c6-a101-ec6b686f31a8.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
