### PR TITLE
[Mobile Payments] Use stripe domain URL for reader purchase for stripe extension

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -53,11 +53,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func refresh() {
-        var completed = false
-        if case .completed(_) = state { // Swift is weird
-            completed = true
-        }
-        if !completed {
+        if !state.isCompleted {
             state = .loading
         }
         synchronizeStoreCountryAndPlugins { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -53,7 +53,11 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func refresh() {
-        if state != .completed {
+        var completed = false
+        if case .completed(_) = state { // Swift is weird
+            completed = true
+        }
+        if !completed {
             state = .loading
         }
         synchronizeStoreCountryAndPlugins { [weak self] in
@@ -226,7 +230,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: account)
         stores.dispatch(setAccount)
 
-        return .completed
+        return .completed(plugin: plugin)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -3,10 +3,12 @@ import SwiftUI
 import Yosemite
 
 final class InPersonPaymentsMenuViewController: UITableViewController {
+    private let plugin: CardPresentPaymentsPlugins
     private var rows = [Row]()
     private let configurationLoader: CardPresentConfigurationLoader
 
-    init() {
+    init(plugin: CardPresentPaymentsPlugins) {
+        self.plugin = plugin
         configurationLoader = CardPresentConfigurationLoader()
         super.init(style: .grouped)
     }
@@ -130,7 +132,7 @@ private extension InPersonPaymentsMenuViewController {
 //
 extension InPersonPaymentsMenuViewController {
     func orderCardReaderWasPressed() {
-        WebviewHelper.launch(configurationLoader.configuration.purchaseCardReaderUrl, with: self)
+        WebviewHelper.launch(configurationLoader.configuration.purchaseCardReaderUrl(for: plugin), with: self)
     }
 
     func manageCardReaderWasPressed() {
@@ -257,8 +259,10 @@ private enum Constants {
 /// SwiftUI wrapper for CardReaderSettingsPresentingViewController
 ///
 struct InPersonPaymentsMenu: UIViewControllerRepresentable {
+    let plugin: CardPresentPaymentsPlugins
+
     func makeUIViewController(context: Context) -> some UIViewController {
-        InPersonPaymentsMenuViewController()
+        InPersonPaymentsMenuViewController(plugin: plugin)
     }
 
     func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -56,8 +56,8 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsStripeAcountReview()
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected()
-            case .completed:
-                InPersonPaymentsMenu()
+            case .completed(let plugin):
+                InPersonPaymentsMenu(plugin: plugin)
             case .noConnectionError:
                 InPersonPaymentsNoConnection(onRefresh: viewModel.refresh)
             default:

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -220,7 +220,13 @@ private extension SimplePaymentsMethodsViewModel {
     func bindStoreCPPState() {
         cppStoreStateObserver
             .statePublisher
-            .map { $0 == .completed }
+            .map {
+                if case .completed(_) = $0 {
+                    return true
+                } else {
+                    return false
+                }
+            }
             .removeDuplicates()
             .assign(to: &$showPayWithCardRow)
         cppStoreStateObserver.refresh()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -220,13 +220,7 @@ private extension SimplePaymentsMethodsViewModel {
     func bindStoreCPPState() {
         cppStoreStateObserver
             .statePublisher
-            .map {
-                if case .completed(_) = $0 {
-                    return true
-                } else {
-                    return false
-                }
-            }
+            .map { $0.isCompleted }
             .removeDuplicates()
             .assign(to: &$showPayWithCardRow)
         cppStoreStateObserver.refresh()

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -237,7 +237,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_version_has_newer_patch_release() {
@@ -251,7 +251,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_version_has_newer_unpatched_release() {
@@ -265,7 +265,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
     }
 
     func test_onboarding_returns_complete_when_stripe_active_and_wcpay_plugin_installed_but_not_active() {
@@ -280,7 +280,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .stripe))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_active() {
@@ -294,7 +294,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_is_network_active() {
@@ -308,7 +308,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
     }
 
     func test_onboarding_sends_use_wcpay_account_action_when_wcpay_plugin_is_used_with_an_account_meeting_requirements() throws {
@@ -354,7 +354,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .stripe))
     }
 
     func test_onboarding_sends_use_stripe_account_action_when_stripe_plugin_is_used_with_an_account_meeting_requirements() throws {
@@ -595,7 +595,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed)
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -657,13 +657,13 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
     enum WCPayPluginVersion: String {
         case unsupportedVersionWithPatch = "2.4.2"
         case unsupportedVersionWithoutPatch = "3.2"
-        case minimumSupportedVersion = "3.2.1" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
+        case minimumSupportedVersion = "3.2.1" // Should match `CardPresentPaymentOnboardingState` `minimumSupportedPluginVersion`
         case supportedVersionWithPatch = "3.2.5"
         case supportedVersionWithoutPatch = "3.3"
     }
 
     enum StripePluginVersion: String {
-        case minimumSupportedVersion = "6.2.0" // Should match `CardPresentPaymentsOnboardingState` `minimumSupportedPluginVersion`
+        case minimumSupportedVersion = "6.2.0" // Should match `CardPresentPaymentOnboardingState` `minimumSupportedPluginVersion`
         case unsupportedVersion = "6.1.0"
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -295,7 +295,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
 
     func test_card_row_is_shown_for_cpp_store() {
         // Given
-        let cppStateObserver = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
+        let cppStateObserver = MockCardPresentPaymentsOnboardingUseCase(initial: .completed(plugin: .wcPay))
         let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00", cppStoreStateObserver: cppStateObserver)
 
         // Then
@@ -319,7 +319,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showPayWithCardRow)
 
         // When
-        subject.send(.completed)
+        subject.send(.completed(plugin: .wcPay))
 
         // Then
         XCTAssertTrue(viewModel.showPayWithCardRow)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -99,6 +99,14 @@ extension CardPresentPaymentOnboardingState {
             return "no_connection_error"
         }
     }
+
+    public var isCompleted: Bool {
+        if case .completed(_) = self {
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 public enum CardPresentPaymentsPlugins: Equatable, CaseIterable {

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -6,7 +6,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// All the requirements are met and the feature is ready to use
     ///
-    case completed
+    case completed(plugin: CardPresentPaymentsPlugins)
 
     /// There is more than one plugin installed and activated. The user must deactivate one.
     /// 

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct CardPresentPaymentsConfiguration {
     private let countryCode: String
+    private let stripeTerminalforCanadaEnabled: Bool
 
     public let paymentMethods: [WCPayPaymentMethodType]
     public let currencies: [String]
@@ -9,11 +10,13 @@ public struct CardPresentPaymentsConfiguration {
     public let supportedReaders: [CardReaderType]
 
     init(countryCode: String,
+         stripeTerminalforCanadaEnabled: Bool,
          paymentMethods: [WCPayPaymentMethodType],
          currencies: [String],
          paymentGateways: [String],
          supportedReaders: [CardReaderType]) {
         self.countryCode = countryCode
+        self.stripeTerminalforCanadaEnabled = stripeTerminalforCanadaEnabled
         self.paymentMethods = paymentMethods
         self.currencies = currencies
         self.paymentGateways = paymentGateways
@@ -25,6 +28,7 @@ public struct CardPresentPaymentsConfiguration {
         case "US":
             self.init(
                 countryCode: country,
+                stripeTerminalforCanadaEnabled: canadaEnabled,
                 paymentMethods: [.cardPresent],
                 currencies: ["USD"],
                 paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
@@ -33,6 +37,7 @@ public struct CardPresentPaymentsConfiguration {
         case "CA" where canadaEnabled == true:
             self.init(
                 countryCode: country,
+                stripeTerminalforCanadaEnabled: true,
                 paymentMethods: [.cardPresent, .interacPresent],
                 currencies: ["CAD"],
                 paymentGateways: [WCPayAccount.gatewayID],
@@ -41,6 +46,7 @@ public struct CardPresentPaymentsConfiguration {
         default:
             self.init(
                 countryCode: country,
+                stripeTerminalforCanadaEnabled: canadaEnabled,
                 paymentMethods: [],
                 currencies: [],
                 paymentGateways: [],
@@ -61,11 +67,11 @@ public struct CardPresentPaymentsConfiguration {
             return Constants.stripeReaderPurchaseUrl
         }
 
-        // TODO
-        // remove this when pages/redirects are added to the website pdfdoF-su-p2 and
-        // return URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
-        // instead
-        return Constants.purchaseM2ReaderUrl
+        if !stripeTerminalforCanadaEnabled {
+            return Constants.purchaseM2ReaderUrl
+        }
+
+        return URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
     }
 }
 

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -67,11 +67,12 @@ public struct CardPresentPaymentsConfiguration {
             return Constants.stripeReaderPurchaseUrl
         }
 
-        if !stripeTerminalforCanadaEnabled {
-            return Constants.purchaseM2ReaderUrl
-        }
+        // TODO when https://woocommerce.com/products/hardware/US and
+        // https://woocommerce.com/products/hardware/CA are live, return the
+        // following instead
+        // URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
 
-        return URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
+        return Constants.purchaseM2ReaderUrl
     }
 }
 

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -61,7 +61,11 @@ public struct CardPresentPaymentsConfiguration {
             return Constants.stripeReaderPurchaseUrl
         }
 
-        return URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
+        // TODO
+        // remove this when pages/redirects are added to the website pdfdoF-su-p2 and
+        // return URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
+        // instead
+        return Constants.purchaseM2ReaderUrl
     }
 }
 

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -1,50 +1,51 @@
 import Foundation
 
 public struct CardPresentPaymentsConfiguration {
+    private let countryCode: String
+
     public let paymentMethods: [WCPayPaymentMethodType]
     public let currencies: [String]
     public let paymentGateways: [String]
     public let supportedReaders: [CardReaderType]
-    public let purchaseCardReaderUrl: URL
 
-
-    init(paymentMethods: [WCPayPaymentMethodType],
+    init(countryCode: String,
+         paymentMethods: [WCPayPaymentMethodType],
          currencies: [String],
          paymentGateways: [String],
-         supportedReaders: [CardReaderType],
-         purchaseCardReaderUrl: URL) {
+         supportedReaders: [CardReaderType]) {
+        self.countryCode = countryCode
         self.paymentMethods = paymentMethods
         self.currencies = currencies
         self.paymentGateways = paymentGateways
         self.supportedReaders = supportedReaders
-        self.purchaseCardReaderUrl = purchaseCardReaderUrl
     }
 
     public init(country: String, canadaEnabled: Bool) {
         switch country {
         case "US":
-            //TODO: update to use Self.purchaseCardReaderUrl(for: country) when pages/redirects are added to the website pdfdoF-su-p2
             self.init(
+                countryCode: country,
                 paymentMethods: [.cardPresent],
                 currencies: ["USD"],
                 paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
-                supportedReaders: [.chipper, .stripeM2],
-                purchaseCardReaderUrl: Constants.purchaseM2ReaderUrl
+                supportedReaders: [.chipper, .stripeM2]
             )
         case "CA" where canadaEnabled == true:
             self.init(
+                countryCode: country,
                 paymentMethods: [.cardPresent, .interacPresent],
                 currencies: ["CAD"],
                 paymentGateways: [WCPayAccount.gatewayID],
-                supportedReaders: [.wisepad3],
-                purchaseCardReaderUrl: Self.purchaseCardReaderUrl(for: country)
+                supportedReaders: [.wisepad3]
             )
         default:
-            self.init(paymentMethods: [],
-                      currencies: [],
-                      paymentGateways: [],
-                      supportedReaders: [],
-                      purchaseCardReaderUrl: Constants.fallbackInPersonPaymentsUrl)
+            self.init(
+                countryCode: country,
+                paymentMethods: [],
+                currencies: [],
+                paymentGateways: [],
+                supportedReaders: []
+            )
         }
     }
 
@@ -52,8 +53,15 @@ public struct CardPresentPaymentsConfiguration {
         paymentMethods.isEmpty == false && currencies.isEmpty == false && paymentGateways.isEmpty == false && supportedReaders.isEmpty == false
     }
 
-    private static func purchaseCardReaderUrl(for countryCode: String) -> URL {
-        URL(string: Constants.purchaseReaderForCountryUrlBase + countryCode) ?? Constants.fallbackInPersonPaymentsUrl
+    /// Given a two character country code and the active plugin, returns a URL
+    /// where the merchant can purchase a card reader
+    ///
+    public func purchaseCardReaderUrl(for plugin: CardPresentPaymentsPlugins) -> URL {
+        if case .stripe = plugin {
+            return Constants.stripeReaderPurchaseUrl
+        }
+
+        return URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
     }
 }
 
@@ -61,4 +69,5 @@ private enum Constants {
     static let purchaseM2ReaderUrl = URL(string: "https://woocommerce.com/products/m2-card-reader/")!
     static let fallbackInPersonPaymentsUrl = URL(string: "https://woocommerce.com/in-person-payments/")!
     static let purchaseReaderForCountryUrlBase = "https://woocommerce.com/products/hardware/"
+    static let stripeReaderPurchaseUrl = URL(string: "https://stripe.com/terminal/stripe-reader")!
 }

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -10,7 +10,7 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpayUS)
         XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 
@@ -31,7 +31,7 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpayCA)
         XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 
@@ -54,7 +54,17 @@ class CardPresentConfigurationTests: XCTestCase {
         }
 
         enum PurchaseURL {
+            /// This is the older URL format for ordering card  readers for WCPay stores
+            ///
             static let wcpay = "https://woocommerce.com/products/m2-card-reader/"
+
+            /// The new URL format (behind feature flag at the moment) directs users to a country specific page
+            ///
+            static let wcpayUS = "https://woocommerce.com/products/hardware/US"
+            static let wcpayCA = "https://woocommerce.com/products/hardware/CA"
+
+            /// Merchants using the Stripe extension should order their readers from Stripe directly
+            ///
             static let stripe = "https://stripe.com/terminal/stripe-reader"
         }
     }

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -10,7 +10,7 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpayUS)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
         XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 
@@ -31,7 +31,7 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpayCA)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
         XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -10,6 +10,8 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 
     func test_configuration_for_US_with_Canada_disabled() throws {
@@ -18,6 +20,8 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 
     // MARK: - Canada Tests
@@ -27,11 +31,15 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 
     func test_configuration_for_Canada_with_Canada_disabled() {
         let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: false)
         XCTAssertFalse(configuration.isSupportedCountry)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
     }
 
     private enum Constants {
@@ -43,6 +51,11 @@ class CardPresentConfigurationTests: XCTestCase {
         enum PaymentGateway {
             static let wcpay = "woocommerce-payments"
             static let stripe = "woocommerce-stripe"
+        }
+
+        enum PurchaseURL {
+            static let wcpay = "https://woocommerce.com/products/m2-card-reader/"
+            static let stripe = "https://stripe.com/terminal/stripe-reader"
         }
     }
 }


### PR DESCRIPTION
Closes: #6218

fyi @malinajirka 

### Description
- Refactors CardPresentPaymentsConfiguration a little to return a purchase URL based on the active plugin on the store
- Passes the active plugin into the InPersonPayments views
- Updates impacted unit tests

### Testing instructions
- Enter settings for a store powered by the WCPay extension. Ensure tapping on the order reader link takes you to a country specific ordering flow on woocommerce.com
- Enter settings for a store powered by the Stripe extension. Ensure tapping on the order reader link takes you to a stripe.com hosted flow

### Screenshots

For Stores using Stripe:

![IMG_0315](https://user-images.githubusercontent.com/1595739/155394366-bc4a8ed4-1202-4e56-bb9a-5c69174abf59.jpg)

For Stores using WCPay:

![IMG_0316](https://user-images.githubusercontent.com/1595739/155394397-393ae286-7a2e-4e75-9689-748480a9954b.jpg)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
