### PR TITLE
Coupons: Replace toggle rows with value rows on Usage Details screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 8.7
 -----
 - [**] In-Person Payments: Added card details to refund confirmation screen to help with refunding to the payment card [https://github.com/woocommerce/woocommerce-ios/pull/6241]
+- [*] Coupons: Replace the toggles on Usage Details screen with text for uneditable contents. [https://github.com/woocommerce/woocommerce-ios/pull/6287]
 - [internal] Removed all feature flags for Shipping Labels. Please smoke test all parts of Shipping Labels to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6270]
 
 8.6

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponUsageDetails.swift
@@ -79,16 +79,16 @@ struct CouponUsageDetails: View {
                         .padding(.horizontal, insets: geometry.safeAreaInsets)
                     VStack(alignment: .leading, spacing: 0) {
                         Divider()
-                        TitleAndToggleRow(title: Localization.individualUseOnly, isOn: .constant(viewModel.individualUseOnly))
+                        TitleAndValueRow(title: Localization.individualUseOnly,
+                                         value: .content(viewModel.individualUseOnly ? Localization.yes : Localization.no))
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
-                            .padding(.horizontal, Constants.margin)
                             .padding(.vertical, Constants.verticalSpacing)
                         Divider()
                             .padding(.leading, Constants.margin)
                             .padding(.leading, insets: geometry.safeAreaInsets)
-                        TitleAndToggleRow(title: Localization.excludeSaleItems, isOn: .constant(viewModel.excludeSaleItems))
+                        TitleAndValueRow(title: Localization.excludeSaleItems,
+                                         value: .content(viewModel.excludeSaleItems ? Localization.yes : Localization.no))
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
-                            .padding(.horizontal, Constants.margin)
                             .padding(.vertical, Constants.verticalSpacing)
                         Divider()
                     }
@@ -159,6 +159,14 @@ private extension CouponUsageDetails {
         static let noRestrictions = NSLocalizedString(
             "No Restrictions",
             comment: "Value for the allowed emails row in Coupon Usage Details screen when no restriction is set"
+        )
+        static let yes = NSLocalizedString(
+            "Yes",
+            comment: "Value for the individual use only row or the exclude sale items row in Coupon Usage Details screen when the value is true"
+        )
+        static let no = NSLocalizedString(
+            "No",
+            comment: "Value for the individual use only row or the exclude sale items row in Coupon Usage Details screen when the value is false"
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6284 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the toggle rows on the Usage Details to simple value rows to display Yes/No text to make it less misleading for the non-editable contents.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that your test store has Coupons enabled in WC settings and configured at least one coupon in WP Admin > Marketing > Coupons.
- On the app, navigate to Menu > Coupons > select one coupon to see its details.
- On the Coupon Details screen, select Usage Details. Notice that the two rows: 


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ----- | ----- | 
| <img src="https://user-images.githubusercontent.com/5533851/155288939-1e48107e-00cb-45d0-9640-5bb1fce0c7ec.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/155289027-086b8933-6c01-4e72-9314-bac8cc464208.png" width=320 /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
