### PR TITLE
[Mobile Payments] Support for Interac payments

### DIFF
--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -37,11 +37,18 @@ public struct PaymentIntentParameters {
     ///
     public let customerID: String?
 
+    /// Supported payment methods for this intent.
+    ///
+    /// Can be `card_present`, `interac_present`.
+    ///
+    public let paymentMethodTypes: [String]
+
     public init(amount: Decimal,
                 currency: String,
                 receiptDescription: String? = nil,
                 statementDescription: String? = nil,
                 receiptEmail: String? = nil,
+                paymentMethodTypes: [String] = [],
                 metadata: [AnyHashable: Any]? = nil,
                 customerID: String? = nil) {
         self.amount = amount
@@ -49,6 +56,7 @@ public struct PaymentIntentParameters {
         self.receiptDescription = receiptDescription
         self.statementDescription = statementDescription
         self.receiptEmail = receiptEmail
+        self.paymentMethodTypes = paymentMethodTypes
         self.metadata = metadata
         self.customerID = customerID
     }

--- a/Hardware/Hardware/CardReader/PaymentMethod.swift
+++ b/Hardware/Hardware/CardReader/PaymentMethod.swift
@@ -5,8 +5,27 @@ public enum PaymentMethod {
 
     /// A card present payment method.
     /// If this is a card present payment method, this contains additional information.
-    case presentCard(details: CardPresentTransactionDetails)
+    case cardPresent(details: CardPresentTransactionDetails)
+
+    /// An Interac present payment method.
+    /// If this is a card present payment method, this contains additional information.
+    case interacPresent(details: CardPresentTransactionDetails)
 
     /// An unknown type.
     case unknown
+}
+
+extension PaymentMethod {
+    /// Returns the associated card present transaction details if the payment method was `cardPresent` or `interacPresent`.
+    ///
+    public var cardPresentDetails: CardPresentTransactionDetails? {
+        switch self {
+        case .cardPresent(details: let details):
+            return details
+        case .interacPresent(details: let details):
+            return details
+        default:
+            return nil
+        }
+    }
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -10,13 +10,18 @@ extension Hardware.PaymentIntentParameters {
             return nil
         }
 
+        // Shortcircuit if we do not have a valid payment method
+        guard !paymentMethodTypes.isEmpty else {
+            return nil
+        }
+
         /// The amount of the payment needs to be provided in the currency’s smallest unit.
         /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)amount
         let amountInSmallestUnit = amount * 100
 
         let amountForStripe = NSDecimalNumber(decimal: amountInSmallestUnit).uintValue
 
-        let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: currency)
+        let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: currency, paymentMethodTypes: paymentMethodTypes)
         returnValue.stripeDescription = receiptDescription
 
         /// Stripe allows the credit card statement descriptor to be nil, but not an empty string

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
@@ -17,7 +17,13 @@ extension PaymentMethod {
                 self = .unknown
                 return
             }
-            self = .presentCard(details: CardPresentTransactionDetails(details: details))
+            self = .cardPresent(details: CardPresentTransactionDetails(details: details))
+        case .interacPresent:
+            guard let details = method.interacPresent else {
+                self = .unknown
+                return
+            }
+            self = .interacPresent(details: CardPresentTransactionDetails(details: details))
         case .unknown:
             self = .unknown
         default:

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -215,9 +215,9 @@ extension StripeCardReaderService: CardReaderService {
             .flatMap { intent in
                 self.collectPaymentMethod(intent: intent)
             }.flatMap { intent in
-                self.waitForInsertedCardToBeRemoved(intent: intent)
-            }.flatMap { intent in
                 self.processPayment(intent: intent)
+            }.flatMap { intent in
+                self.waitForInsertedCardToBeRemoved(intent: intent)
             }.eraseToAnyPublisher()
     }
 
@@ -406,7 +406,7 @@ private extension StripeCardReaderService {
         }
     }
 
-    func waitForInsertedCardToBeRemoved(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {
+    func waitForInsertedCardToBeRemoved(intent: PaymentIntent) -> Future<PaymentIntent, Error> {
         return Future() { [weak self] promise in
             guard let self = self else {
                 return

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -3,31 +3,37 @@ import XCTest
 
 final class PaymentIntentParametersTests: XCTestCase {
     func test_validEmail_is_saved() {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "validemail@validdomain.us")
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "validemail@validdomain.us", paymentMethodTypes: ["card_present"])
 
         XCTAssertNotNil(params.receiptEmail)
     }
 
     func test_not_validEmail_is_ignored() {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "woocommerce")
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "woocommerce", paymentMethodTypes: ["card_present"])
 
         XCTAssertNil(params.receiptEmail)
     }
 
     func test_currency_is_lowercased() {
-        let params = PaymentIntentParameters(amount: 100, currency: "USD")
+        let params = PaymentIntentParameters(amount: 100, currency: "USD", paymentMethodTypes: ["card_present"])
 
         XCTAssertEqual(params.currency, "usd")
     }
 
     func test_parameters_do_not_validate_if_currency_code_is_not_supported() {
-        let params = PaymentIntentParameters(amount: 100, currency: "cesar")
+        let params = PaymentIntentParameters(amount: 100, currency: "cesar", paymentMethodTypes: ["card_present"])
 
         XCTAssertNil(params.toStripe())
     }
 
     func test_parameters_do_not_validate_if_currency_code_is_empty() {
-        let params = PaymentIntentParameters(amount: 100, currency: "")
+        let params = PaymentIntentParameters(amount: 100, currency: "", paymentMethodTypes: ["card_present"])
+
+        XCTAssertNil(params.toStripe())
+    }
+
+    func test_parameters_do_not_validate_if_payment_methods_is_empty() {
+        let params = PaymentIntentParameters(amount: 100, currency: "", paymentMethodTypes: [])
 
         XCTAssertNil(params.toStripe())
     }
@@ -36,14 +42,19 @@ final class PaymentIntentParametersTests: XCTestCase {
         let amount = Decimal(120.10)
         let expectation = UInt(12010)
 
-        let params = PaymentIntentParameters(amount: amount, currency: "usd")
+        let params = PaymentIntentParameters(amount: amount, currency: "usd", paymentMethodTypes: ["card_present"])
         let stripeParams = try XCTUnwrap(params.toStripe())
 
         XCTAssertEqual(expectation, stripeParams.amount)
     }
 
     func test_statementDescription_replaces_expected_characters() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A < DESCRIPTION' longer THAN 22 Characters")
+        let params = PaymentIntentParameters(
+            amount: 100,
+            currency: "usd",
+            statementDescription: "A < DESCRIPTION' longer THAN 22 Characters",
+            paymentMethodTypes: ["card_present"]
+        )
 
         let statementDescription = try XCTUnwrap(params.statementDescription)
 
@@ -52,7 +63,7 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_statementDescription_leaves_strings_untouched_when_no_replacement_is_necessary() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION")
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION", paymentMethodTypes: ["card_present"])
 
         let statementDescription = try XCTUnwrap(params.statementDescription)
 
@@ -60,7 +71,12 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_statementDescription_trims_strings_to_22_characters() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION LONGER THAN 22 CHARACTERS")
+        let params = PaymentIntentParameters(
+            amount: 100,
+            currency: "usd",
+            statementDescription: "A DESCRIPTION LONGER THAN 22 CHARACTERS",
+            paymentMethodTypes: ["card_present"]
+        )
 
         let statementDescription = try XCTUnwrap(params.statementDescription)
 
@@ -68,7 +84,7 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_statementDescription_is_passed_as_nil_when_empty() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "")
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "", paymentMethodTypes: ["card_present"])
 
         let stripeParameters = params.toStripe()
 
@@ -76,7 +92,7 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_statementDescription_is_passed_as_nil_when_nil() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: nil)
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: nil, paymentMethodTypes: ["card_present"])
 
         let stripeParameters = params.toStripe()
 
@@ -85,7 +101,13 @@ final class PaymentIntentParametersTests: XCTestCase {
 
     func test_customer_id_is_passed_to_stripe() {
         let customerID = "customer_id"
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION", customerID: customerID)
+        let params = PaymentIntentParameters(
+            amount: 100,
+            currency: "usd",
+            statementDescription: "A DESCRIPTION",
+            paymentMethodTypes: ["card_present"],
+            customerID: customerID
+        )
 
         let stripeParameters = params.toStripe()
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -233,6 +233,7 @@ private extension PaymentCaptureOrchestrator {
                                  receiptDescription: receiptDescription(orderNumber: order.number),
                                  statementDescription: statementDescriptor,
                                  receiptEmail: order.billingAddress?.email,
+                                 paymentMethodTypes: ["card_present"],
                                  metadata: metadata,
                                  customerID: customerID)
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -17,6 +17,7 @@ final class PaymentCaptureOrchestrator {
 
     func collectPayment(for order: Order,
                         paymentGatewayAccount: PaymentGatewayAccount,
+                        paymentMethodTypes: [String],
                         onWaitingForInput: @escaping () -> Void,
                         onProcessingMessage: @escaping () -> Void,
                         onDisplayMessage: @escaping (String) -> Void,
@@ -50,6 +51,7 @@ final class PaymentCaptureOrchestrator {
             guard let parameters = paymentParameters(
                     order: order,
                     statementDescriptor: paymentGatewayAccount.statementDescriptor,
+                    paymentMethodTypes: paymentMethodTypes,
                     customerID: customerID
             ) else {
                 DDLogError("Error: failed to create payment parameters for an order")
@@ -213,7 +215,7 @@ private extension PaymentCaptureOrchestrator {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func paymentParameters(order: Order, statementDescriptor: String?, customerID: String?) -> PaymentParameters? {
+    func paymentParameters(order: Order, statementDescriptor: String?, paymentMethodTypes: [String], customerID: String?) -> PaymentParameters? {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
             DDLogError("Error: attempted to collect payment for an order without a valid total.")
             return nil
@@ -233,7 +235,7 @@ private extension PaymentCaptureOrchestrator {
                                  receiptDescription: receiptDescription(orderNumber: order.number),
                                  statementDescription: statementDescriptor,
                                  receiptEmail: order.billingAddress?.email,
-                                 paymentMethodTypes: ["card_present"],
+                                 paymentMethodTypes: paymentMethodTypes,
                                  metadata: metadata,
                                  customerID: customerID)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -74,6 +74,11 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                                        alertsProvider: CardReaderSettingsAlerts())
     }()
 
+    /// IPP Configuration loader
+    private lazy var configurationLoader = {
+        CardPresentConfigurationLoader(stores: stores)
+    }()
+
     init(siteID: Int64,
          order: Order,
          formattedAmount: String,
@@ -172,6 +177,7 @@ private extension CollectOrderPaymentUseCase {
         paymentOrchestrator.collectPayment(
             for: order,
                paymentGatewayAccount: paymentGatewayAccount,
+               paymentMethodTypes: configurationLoader.configuration.paymentMethods.map(\.rawValue),
                onWaitingForInput: { [weak self] in
                    // Request card input
                    self?.alerts.tapOrInsertCard(onCancel: {

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -5,8 +5,7 @@ public extension PaymentIntent {
     /// render a receipt.
     /// - Returns: an optional struct containing all the data that needs to go into a receipt
     func receiptParameters() -> CardPresentReceiptParameters? {
-        guard let paymentMethod = self.charges.first?.paymentMethod,
-              case .presentCard(details: let cardDetails) = paymentMethod else {
+        guard let cardDetails = self.charges.first?.paymentMethod?.cardPresentDetails else {
             return nil
         }
 

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockPaymentIntent.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockPaymentIntent.swift
@@ -28,7 +28,7 @@ private extension MockPaymentIntent {
     }
 
     static func mockPaymentMethod() -> PaymentMethod {
-        .presentCard(details: mockCardDetails())
+        .cardPresent(details: mockCardDetails())
     }
 
     static func mockCardDetails() -> CardPresentTransactionDetails {

--- a/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
@@ -10,8 +10,7 @@ final class PaymentIntent_ReceiptParametersTests: XCTestCase {
         XCTAssertEqual(receiptParameters?.amount, intent.amount)
         XCTAssertEqual(receiptParameters?.currency, intent.currency)
 
-        guard let paymentMethod = intent.charges.first?.paymentMethod,
-              case .presentCard(details: let cardDetails) = paymentMethod else {
+        guard let cardDetails = self.charges.first?.paymentMethod?.cardPresentDetails else {
             XCTFail()
             return
         }

--- a/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
@@ -10,7 +10,7 @@ final class PaymentIntent_ReceiptParametersTests: XCTestCase {
         XCTAssertEqual(receiptParameters?.amount, intent.amount)
         XCTAssertEqual(receiptParameters?.currency, intent.currency)
 
-        guard let cardDetails = self.charges.first?.paymentMethod?.cardPresentDetails else {
+        guard let cardDetails = intent.charges.first?.paymentMethod?.cardPresentDetails else {
             XCTFail()
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5979 
Requires WCPay changes from https://github.com/Automattic/woocommerce-payments/pull/3837
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To support payments with Interac cards, this PR adds 3 changes:
- Include `paymentMethodTypes` when creating a payment intent. Depending on the current configuration that might be `card_present` only, or also include `interac_present`
- Don't wait for an inserted card to be removed before processing payment. The WisePad 3 will ask for PIN on a chip card, but then it seems like it doesn't prompt you to remove the card until the payment has been authorized (calling `processPayment`). If we tried to wait for the card to be removed before processing payment, the transaction would time out and be declined.
- Updates the receipt parameters extraction so it can get card details from Interac intents.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With the currently released version of WooCommerce Payments, you should still be able to capture a payment from the app, but the API call to the store will fail. To fully test this, you'll need to use the branch from https://github.com/Automattic/woocommerce-payments/pull/3837

I'm sharing a built version of the plugin to make it easier ([woocommerce-payments.zip](https://github.com/woocommerce/woocommerce-ios/files/8124376/woocommerce-payments.zip)), but otherwise:

```
# Check out the repo
git clone https://github.com/Automattic/woocommerce-payments.git`
cd woocommerce-payments
# Switch to the branch with the fix
git checkout update/3764-register-captured-terminal-payment
# Install dependencies
npm install
# Build the plugin
npm run build
```

There should be a `woocommerce-payments.zip` file in the current directory that you can upload to your store.

Once the plugin is updated:

1. Create an order or simple payment, make sure the currency is CAD
2. Start the flow to capture payment
3. Connect to a WisePad 3 reader
4. Insert your Interac test card. The reader will ask for a PIN, enter it
5. The payment should go through without an error

You can verify that everything went fine in the Order page in wp-admin, Payments tab, or Stripe dashboard.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
