### PR TITLE
[Mobile Payments] Remove US-specific voiceover pronunciation, and fix Interac capitalization

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -318,15 +318,11 @@ private extension WCPayCardBrand {
         let localizedDescription = String(format: Localization.cardAccessibilityDescriptionFormat, cardBrandName(), last4)
         let attributedLocalizedDescription = NSMutableAttributedString(string: localizedDescription)
 
-        guard let brandNameRange = localizedDescription.range(of: cardBrandName()),
-              let last4Range = localizedDescription.range(of: last4)
-        else {
+        guard let last4Range = localizedDescription.range(of: last4) else {
             return attributedLocalizedDescription
         }
 
-        let brandNameNSRange = NSRange(brandNameRange, in: localizedDescription)
         let last4NSRange = NSRange(last4Range, in: localizedDescription)
-        attributedLocalizedDescription.setAttributes([.accessibilitySpeechLanguage: "en-US"], range: brandNameNSRange)
         attributedLocalizedDescription.setAttributes([.accessibilitySpeechSpellOut: true], range: last4NSRange)
 
         return attributedLocalizedDescription

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -360,7 +360,7 @@ private extension WCPayCardBrand {
         case .discover:
             return "Discover"
         case .interac:
-            return "interac"
+            return "Interac"
         case .jcb:
             return "JCB"
         case .mastercard:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Final fixes for #6265 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
A couple of code review comments resolved from #6241 – @koke's [review here](https://github.com/woocommerce/woocommerce-ios/pull/6241#pullrequestreview-889422999)


### Testing instructions
With the phone set to a language other than English:

1. In the orders tab, open an order which was paid for with a Card Present payment
2. Tap Issue Refund
3. Select some of the order to refund, and tap Next
4. Observe that the card image is shown alongside the card details
5. With VoiceOver on, hear that the payment method cell is read out as Visa card ending four two four two

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
