### PR TITLE
Fix: action sheet presentation on iPad under Inbox Notes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -14,6 +14,26 @@ struct Inbox: View {
     }
 
     var body: some View {
+        // Anchor the action sheet at the top to be able to show the popover on iPad in the most appropriate position
+        Divider()
+            .actionSheet(isPresented: $showingActionSheet) {
+                ActionSheet(
+                    title: Text(Localization.title),
+                    buttons: [
+                        .default(Text(Localization.dismissAllNotes), action: {
+                            showingDismissAlert = true
+                        }),
+                        .cancel()
+                    ]
+                )
+            }
+            .alert(isPresented: $showingDismissAlert) {
+                return Alert(title: Text(Localization.dismissAllNotesAlertTitle),
+                             message: Text(Localization.dismissAllNotesAlertMessage),
+                             primaryButton: .default(Text(Localization.dismissAllNotes), action: viewModel.dismissAllInboxNotes),
+                             secondaryButton: .cancel())
+            }
+
         Group {
             switch viewModel.syncState {
             case .results:
@@ -57,23 +77,6 @@ struct Inbox: View {
                 })
                     .renderedIf(viewModel.syncState == .results)
             }
-        }
-        .actionSheet(isPresented: $showingActionSheet) {
-            ActionSheet(
-                title: Text(Localization.title),
-                buttons: [
-                    .default(Text(Localization.dismissAllNotes), action: {
-                        showingDismissAlert = true
-                    }),
-                    .cancel()
-                ]
-            )
-        }
-        .alert(isPresented: $showingDismissAlert) {
-            return Alert(title: Text(Localization.dismissAllNotesAlertTitle),
-                  message: Text(Localization.dismissAllNotesAlertMessage),
-                  primaryButton: .default(Text(Localization.dismissAllNotes), action: viewModel.dismissAllInboxNotes),
-                  secondaryButton: .cancel())
         }
     }
 }


### PR DESCRIPTION
### Description
As @jaclync said here https://github.com/woocommerce/woocommerce-ios/pull/6275#discussion_r812521142, we should adopt a workaround for the action sheet presentation on iPad under the Inbox Notes, so I made the changes following the approach used before by @itsmeichigo under Coupons (creating a divider that the action sheet is anchored at).

### Testing instructions
1. Launch the app on iPhone and on iPad.
2. Navigate to Inbox Notes.
3. Press the button on the navigation bar.
4. It should be presented correctly on both devices.

### Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![155253836-24f84cc5-b847-43f2-8918-cb37fb5eb38e](https://user-images.githubusercontent.com/495617/155347436-d2fcd171-17b6-4d62-bd8c-3b260270b0e4.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-02-23 at 15 37 59](https://user-images.githubusercontent.com/495617/155347507-a9aa1cfa-376d-432d-9380-94e5bbe80d6e.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
