### PR TITLE
Order Creation: Sync order updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -122,7 +122,6 @@ private extension RemoteOrderSynchronizer {
             .debounce(for: 1, scheduler: DispatchQueue.main) // Group & wait for 0.5s since the last signal was emitted.
             .compactMap { [weak self] in
                 guard let self = self else { return nil }
-                print ("ME: 1 - Trigger Sent")
                 return SyncOperation(order: self.order) // Imperative `withLatestFrom` as it appears to have bugs when assigning a new order value.
             }
             .share()
@@ -145,7 +144,6 @@ private extension RemoteOrderSynchronizer {
             }
             .withLatestFrom(syncTrigger) // Get the latest sync request to evaluate if we need to fire an update after the order is created.
             .sink { [weak self] response, latestRequest in
-                print("ME: 3 - Order Created")
                 // If there are no pending update requests, update state & order.
                 if response.id == latestRequest.id {
                     self?.state = .synced
@@ -178,7 +176,6 @@ private extension RemoteOrderSynchronizer {
                 return Empty().eraseToAnyPublisher()
             }
             .sink { [weak self] response in // When finished, update state & order.
-                print("ME: 3 - Order Updated")
                 self?.state = .synced
                 self?.order = response.order
             }
@@ -191,8 +188,6 @@ private extension RemoteOrderSynchronizer {
     func createOrderRemotely(_ request: SyncOperation) -> AnyPublisher<SyncOperation, Error> {
         Future<SyncOperation, Error> { [weak self] promise in
             guard let self = self else { return }
-
-            print ("ME: 2 - Creating Order")
 
             // Creates the order with the `draft` status
             let draftOrder = request.order.copy(status: self.baseSyncStatus)
@@ -221,8 +216,6 @@ private extension RemoteOrderSynchronizer {
     func updateOrderRemotely(_ request: SyncOperation) -> AnyPublisher<SyncOperation, Error> {
         Future<SyncOperation, Error> { [weak self] promise in
             guard let self = self else { return }
-
-            print ("ME: 2 - Updating Order")
 
             // Creates the order with the `draft` status
             let draftOrder = request.order.copy(status: self.baseSyncStatus)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -105,6 +105,12 @@ private extension RemoteOrderSynchronizer {
                 order.copy(shippingLines: shippingLineInput.flatMap { [$0] } ?? [])
             }
             .assign(to: &$order)
+
+        setFee.withLatestFrom(orderPublisher)
+            .map { feeLineInput, order in
+                order.copy(fees: feeLineInput.flatMap { [$0] } ?? [])
+            }
+            .assign(to: &$order)
     }
 
     /// Creates or updates the order when a significant order input occurs.


### PR DESCRIPTION
Closes: #6258 
Closes: #6142
Closes #6139

# Why

In #6227 we added support for creating a "draft" order as soon as a significant change* occurs to it.
This PR adds support to update the order after upcoming significant changes* occur.

Scenarios handled:

- Update change happens after the order is created.
- Update change happens while the order is being created.
- Update change happens while the order is being updated.

**Significant Change:** Any change that is not a status change

# How

- Copy fee update from `LocalOrderSynchonizer`

- Added `bindOrderCreation` method to abstract the logic of creating an order. The significant change here is to keep track of the latest request to determine if we need to fire a subsequent update request when the order creation ends.

- Added `bindOrderUpdate ` method to abstract the logic of updating an order. The Key change here is that we fire update requests as signals arrive but only listen to the result of the latest fired one. Ideally, we would want to cancel previous update requests but our Networking layer lacks that functionality.

- Adds `updateOrderRemotely` this returns a publisher that updates an order. The key change here is that we are not updating the `status` of the order as we want the status to remain with the "draft" status.


# Limitations

- The remote synchronizer can't sync product updates because our `OrdersRemote` class does not have support for `line_items` yet.
https://github.com/woocommerce/woocommerce-ios/issues/6136
https://github.com/woocommerce/woocommerce-ios/issues/6138
https://github.com/woocommerce/woocommerce-ios/issues/6137


- Removing Shipping & Fees is not yet supported.
https://github.com/woocommerce/woocommerce-ios/issues/6140
https://github.com/woocommerce/woocommerce-ios/issues/6141

- After Updating / Creating an order, the customer details are always rendered. 
https://github.com/woocommerce/woocommerce-ios/issues/6230

- Drafts orders are visible on the order list screen. 
https://github.com/woocommerce/woocommerce-ios/issues/6228


# Demo

https://user-images.githubusercontent.com/562080/155344852-a88ded25-7682-434a-8b16-e867b24af33a.mov

# Testing 

## Prerequisites
- Set your store to wc 6.3.0-beta.1
- Enable the orderCreationRemoteSynchronizer local feature flag

## Steps
- Navigate to the order creation screen
- Select a product || enter customer details || set shipping
- See that after 1s the order is created, see visible loading indicator.

- Set customer details || set shipping
- See that after 1s the order is updated, see visible loading indicator.

Note: You can navigate back and see the draft-order to confirm the updates.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
