### PR TITLE
What's New: Support icons array for each feature in an announcement

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -86,7 +86,7 @@ def yosemite_pods
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressKit', '~> 4.40.0'
+  pod 'WordPressKit', '~> 4.46.0'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
 
   aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.40.0):
+  - WordPressKit (4.46.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -101,7 +101,7 @@ DEPENDENCIES:
   - StripeTerminal (~> 2.5)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.43.1)
-  - WordPressKit (~> 4.40.0)
+  - WordPressKit (~> 4.46.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.4)
   - Wormholy (~> 1.6.5)
@@ -178,7 +178,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: aa53a5339e241852252e16199e23bd9c3364b983
-  WordPressKit: 062e4f57ce871e2217b632a1f3cb0bbd54b5df6d
+  WordPressKit: 67cc1b0bda0d114c806a631ad726027d535d28a8
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 9e470758bc3a4a25e94478c2babe106f4ae7315a
   Wormholy: 3252bc3e55a1847ef9a0976c1377bd77bf3635fa
@@ -193,6 +193,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: b6a9ecce6af1363b02cde4ceaaa6dcbdcba09ac7
+PODFILE CHECKSUM: 8238650e6eb6a67c58c5626cf8d12ede15dcafb5
 
 COCOAPODS: 1.11.2

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		CC2C030A262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C0306262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataClass.swift */; };
 		CC2C030B262DCC6900928C9C /* ShippingLabelAccountSettings+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C0307262DCC6900928C9C /* ShippingLabelAccountSettings+CoreDataClass.swift */; };
 		CC2C030C262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C0308262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataProperties.swift */; };
+		CCBEBD4027C68E660010C96F /* FeatureIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBEBD3F27C68E660010C96F /* FeatureIcon.swift */; };
 		CCD2E70725DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E70625DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel */; };
 		CE12FBCE221F0E1A00C59248 /* Order+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBCC221F0E1A00C59248 /* Order+CoreDataClass.swift */; };
 		CE12FBCF221F0E1A00C59248 /* Order+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBCD221F0E1A00C59248 /* Order+CoreDataProperties.swift */; };
@@ -419,6 +420,7 @@
 		CC2C0306262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShippingLabelPaymentMethod+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CC2C0307262DCC6900928C9C /* ShippingLabelAccountSettings+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAccountSettings+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CC2C0308262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShippingLabelPaymentMethod+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		CCBEBD3F27C68E660010C96F /* FeatureIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureIcon.swift; sourceTree = "<group>"; };
 		CCD2E70625DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV45toV46.xcmappingmodel; sourceTree = "<group>"; };
 		CE12FBCC221F0E1A00C59248 /* Order+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CE12FBCD221F0E1A00C59248 /* Order+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -968,6 +970,7 @@
 			isa = PBXGroup;
 			children = (
 				D4466F5526D524FC003E931B /* Feature.swift */,
+				CCBEBD3F27C68E660010C96F /* FeatureIcon.swift */,
 				D4ABCACE26D6E7E400CD18F4 /* Announcement.swift */,
 			);
 			name = WhatsNew;
@@ -1278,6 +1281,7 @@
 				CE4FD44D2350EB7600A16B31 /* Refund+CoreDataClass.swift in Sources */,
 				45E4620A2684BCEE00011BF2 /* Country+CoreDataClass.swift in Sources */,
 				02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */,
+				CCBEBD4027C68E660010C96F /* FeatureIcon.swift in Sources */,
 				2618707325409C65006522A1 /* ShippingLineTax+CoreDataClass.swift in Sources */,
 				7474539E2242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift in Sources */,
 				D8FBFF5522D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,

--- a/Storage/Storage/Model/Announcement.swift
+++ b/Storage/Storage/Model/Announcement.swift
@@ -1,5 +1,5 @@
-/// Models an Announcement that containts a list of released features of the app
-/// It has also a displayed property responsible to let us know if this was alreasy shown to user when the application starts
+/// Models an Announcement that contains a list of released features of the app
+/// It has also a displayed property responsible to let us know if this was already shown to user when the application starts
 ///
 /// These entities will be serialised to a plist file
 

--- a/Storage/Storage/Model/Feature.swift
+++ b/Storage/Storage/Model/Feature.swift
@@ -4,15 +4,18 @@
 public struct Feature: Codable {
     public let title: String
     public let subtitle: String
+    public let icons: [FeatureIcon]?
     public let iconUrl: String
     public let iconBase64: String?
 
     public init(title: String,
                 subtitle: String,
+                icons: [FeatureIcon]?,
                 iconUrl: String,
                 iconBase64: String?) {
         self.title = title
         self.subtitle = subtitle
+        self.icons = icons
         self.iconUrl = iconUrl
         self.iconBase64 = iconBase64
     }

--- a/Storage/Storage/Model/FeatureIcon.swift
+++ b/Storage/Storage/Model/FeatureIcon.swift
@@ -1,0 +1,15 @@
+/// Models a Feature Icon that belongs to an Feature
+///
+public struct FeatureIcon: Codable {
+    public let iconUrl: String
+    public let iconBase64: String
+    public let iconType: String
+
+    public init(iconUrl: String,
+                iconBase64: String,
+                iconType: String) {
+        self.iconUrl = iconUrl
+        self.iconBase64 = iconBase64
+        self.iconType = iconType
+    }
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -165,6 +165,7 @@ public typealias StorageAddOnGroup = Storage.AddOnGroup
 public typealias StorageAnnouncement = Storage.Announcement
 public typealias StorageEligibilityErrorInfo = Storage.EligibilityErrorInfo
 public typealias StorageFeature = Storage.Feature
+public typealias StorageFeatureIcon = Storage.FeatureIcon
 public typealias StorageInboxNote = Storage.InboxNote
 public typealias StorageInboxAction = Storage.InboxAction
 public typealias StorageNote = Storage.Note

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -123,11 +123,18 @@ private extension AnnouncementsStore {
 private extension AnnouncementsStore {
     /// Map `WordPressKit.Announcement` to `StorageAnnouncement` model
     func mapAnnouncementToStorageModel(_ announcement: Announcement) -> StorageAnnouncement {
-        let mappedFeatures = announcement.features.map {
-            StorageFeature(title: $0.title,
-                           subtitle: $0.subtitle,
-                           iconUrl: $0.iconUrl,
-                           iconBase64: $0.iconBase64)
+        let mappedFeatures: [StorageFeature] = announcement.features.map {
+            let mappedIcons = $0.icons?.map {
+                StorageFeatureIcon(iconUrl: $0.iconUrl,
+                                   iconBase64: $0.iconBase64,
+                                   iconType: $0.iconType)
+            }
+
+            return StorageFeature(title: $0.title,
+                                  subtitle: $0.subtitle,
+                                  icons: mappedIcons,
+                                  iconUrl: $0.iconUrl,
+                                  iconBase64: $0.iconBase64)
         }
 
         return StorageAnnouncement(appVersionName: announcement.appVersionName,

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -189,6 +189,11 @@ private extension AnnouncementsStoreTests {
             "features": [[
                 "title": "foo",
                 "subtitle": "bar",
+                "icons": [[
+                    "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
+                    "iconBase64": "",
+                    "iconType": ""
+                ]],
                 "iconBase64": "",
                 "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
             ]],


### PR DESCRIPTION
⚠️ When these changes are merged, remember to disable the test announcement in MC. ⚠️

## Description

The "What's New" feature currently sends the announcement json with a single icon for each feature. An `icons` property will be added to the announcement json, to eventually support displaying light and dark icons for each feature (internal ref: p91TBi-5Wo-p2#comment-7534).

WordPressKit version 4.46.0 adds an optional `icons` property to the `Feature` struct so decoding doesn't fail if it is present. This PR updates WordPressKit and our Storage models to prepare for that json change.

## Changes

* Updates WordPressKit to version 4.46.0.
* Adds a `FeatureIcon` storage model to store the new `icons` data.
* Updates `AnnouncementsStore` to map the `icons` data to the new `StorageFeatureIcon` model.

## Testing

⚠️ Prerequisite ⚠️
There are no announcements for the current release, so you'll need to make the following changes to display a test announcement:

In `SettingsViewModel`:

![Screen Shot 2022-02-23 at 4 27 25 PM](https://user-images.githubusercontent.com/8658164/155364860-5ec64670-e911-4758-a5ac-d506c2000c7b.png)

In `AnnouncementsStore`:

![Screen Shot 2022-02-23 at 4 27 54 PM](https://user-images.githubusercontent.com/8658164/155364871-9bc75b5e-3c97-4666-90e4-8f78a9836824.png)

1. Build and run the app.
2. Confirm the "What's New" modal appears when the app launches.

## Screenshots

<img src="https://user-images.githubusercontent.com/8658164/155360876-0e3f8a49-e9f1-4919-9ed3-9d76615e2593.png" width="300px">



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.