### PR TITLE
Fix inbox note placeholder when the view is loading

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -27,7 +27,7 @@ struct InboxNoteRow: View {
                     // Content.
                     // Showing `AttributedText` in placeholder state results in animated height changes, thus a `Text` is shown instead.
                     if viewModel.isPlaceholder {
-                        Text(viewModel.attributedContent.string)
+                        Text(String(repeating: " ", count: 120))
                             .bodyStyle()
                     } else {
                         AttributedText(viewModel.attributedContent)
@@ -166,7 +166,7 @@ struct InboxNoteRow_Previews: PreviewProvider {
         let placeholderViewModel = InboxNoteRowViewModel(id: 1,
                                                          date: .init(),
                                                          title: "       ",
-                                                         attributedContent: .init(string: String(repeating: " ", count: 120)),
+                                                         attributedContent: .init(),
                                                          actions: [],
                                                          siteID: 1,
                                                          isPlaceholder: true)

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -25,8 +25,14 @@ struct InboxNoteRow: View {
                         .fixedSize(horizontal: false, vertical: true)
 
                     // Content.
-                    AttributedText(viewModel.attributedContent)
-                        .attributedTextLinkColor(Color(.accent))
+                    // Showing `AttributedText` in placeholder state results in animated height changes, thus a `Text` is shown instead.
+                    if viewModel.isPlaceholder {
+                        Text(viewModel.attributedContent.string)
+                            .bodyStyle()
+                    } else {
+                        AttributedText(viewModel.attributedContent)
+                            .attributedTextLinkColor(Color(.accent))
+                    }
 
                     // HStack with actions and dismiss action.
                     HStack(spacing: Constants.spacingBetweenActions) {
@@ -156,8 +162,16 @@ struct InboxNoteRow_Previews: PreviewProvider {
                              isRemoved: false,
                              isRead: false,
                              dateCreated: today)
+
+        let placeholderViewModel = InboxNoteRowViewModel(id: 1,
+                                                         date: .init(),
+                                                         title: "       ",
+                                                         attributedContent: .init(string: String(repeating: " ", count: 120)),
+                                                         actions: [],
+                                                         siteID: 1,
+                                                         isPlaceholder: true)
         Group {
-            List {
+            VStack {
                 InboxNoteRow(viewModel: .init(note: note.copy(type: "marketing", dateCreated: today), today: today))
                 InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "error").copy(dateCreated: today.addingTimeInterval(-6*60)), today: today))
                 InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "warning").copy(dateCreated: today.addingTimeInterval(-6*3600)), today: today))
@@ -173,6 +187,14 @@ struct InboxNoteRow_Previews: PreviewProvider {
             InboxNoteRow(viewModel: .init(note: note.copy(dateCreated: today.addingTimeInterval(-6*60)), today: today))
                 .preferredColorScheme(.light)
                 .environment(\.sizeCategory, .extraExtraExtraLarge)
+            InboxNoteRow(viewModel: placeholderViewModel)
+                .redacted(reason: .placeholder)
+                .shimmering()
+                .preferredColorScheme(.light)
+            InboxNoteRow(viewModel: placeholderViewModel)
+                .redacted(reason: .placeholder)
+                .shimmering()
+                .preferredColorScheme(.dark)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -23,6 +23,9 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Stores to handle note actions.
     private let stores: StoresManager
 
+    /// Whether the row is shown in placeholder state.
+    let isPlaceholder: Bool
+
     init(note: InboxNote,
          today: Date = .init(),
          locale: Locale = .current,
@@ -48,15 +51,18 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
                   attributedContent: attributedContent,
                   actions: actions,
                   siteID: note.siteID,
-                  stores: stores)
+                  stores: stores,
+                  isPlaceholder: false)
     }
 
     init(id: Int64,
          date: String,
          title: String,
-         attributedContent: NSAttributedString, actions: [InboxNoteRowActionViewModel],
+         attributedContent: NSAttributedString,
+         actions: [InboxNoteRowActionViewModel],
          siteID: Int64,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         isPlaceholder: Bool) {
         self.id = id
         self.date = date
         self.title = title
@@ -64,6 +70,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
         self.actions = actions
         self.siteID = siteID
         self.stores = stores
+        self.isPlaceholder = isPlaceholder
     }
 
     static func == (lhs: InboxNoteRowViewModel, rhs: InboxNoteRowViewModel) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -17,9 +17,10 @@ final class InboxViewModel: ObservableObject {
         InboxNoteRowViewModel(id: $0,
                               date: "   ",
                               title: "            ",
-                              attributedContent: .init(string: "\n\n\n"),
+                              attributedContent: .init(string: String(repeating: " ", count: 120)),
                               actions: [.init(id: 0, title: "Placeholder", url: nil)],
-                              siteID: 123)
+                              siteID: 123,
+                              isPlaceholder: true)
     }
 
     // MARK: Sync

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -17,7 +17,7 @@ final class InboxViewModel: ObservableObject {
         InboxNoteRowViewModel(id: $0,
                               date: "   ",
                               title: "            ",
-                              attributedContent: .init(string: String(repeating: " ", count: 120)),
+                              attributedContent: .init(),
                               actions: [.init(id: 0, title: "Placeholder", url: nil)],
                               siteID: 123,
                               isPlaceholder: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6190 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Using `AttributedText` (internally `UITextView`) for the HTML content view has an unexpected side effect when it's shown in placeholder state with `.redacted(reason: .placeholder).shimmering()` - the height is changed as shown in the screencast in https://github.com/woocommerce/woocommerce-ios/issues/6190. To fix this, I tried a few things and ended up showing `Text` with 120 characters of empty space.

What I tried to match design vbzgTKHV9XsyyN5cxxAuhv-fi-2733%3A92636 that shows 3 full-width lines:
- Show a `Text` with three empty lines like `   \n  \n  \n` or three `Text` views in a `VStack`: the redacted state for `Text` only includes the space with text content, and doesn't take the full width
- Show a `Rectangle` with 16px height: the color of shimmering is very different from the other `Text` and `Button` views, and I couldn't find an easy way to match the color

With the PR solution to show 120 characters of empty space (the note content has max 255 characters), I think it also looks closer to the results state in different device sizes and orientations.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* Launch the app
* Go to the Menu tab
* Tap on "Inbox" --> while the notes are syncing, the placeholder content height should stay the same

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark | landscape
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2022-02-24 at 10 42 56](https://user-images.githubusercontent.com/1945542/155450766-c763c779-71df-4e5d-8a4a-85c2d10341f0.png) | ![Simulator Screen Shot - iPhone 11 - 2022-02-24 at 11 12 09](https://user-images.githubusercontent.com/1945542/155450790-bb242e90-1e85-4d71-9ff2-2f783e6f658f.png) | ![Simulator Screen Shot - iPhone 11 - 2022-02-24 at 10 43 12](https://user-images.githubusercontent.com/1945542/155450775-05665004-9908-4831-8ea1-4792c0befa43.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->