### PR TITLE
Product list: Improve image loading for thumbnails

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [**] In-Person Payments: Added card details to refund confirmation screen to help with refunding to the payment card [https://github.com/woocommerce/woocommerce-ios/pull/6241]
 - [*] Coupons: Replace the toggles on Usage Details screen with text for uneditable contents. [https://github.com/woocommerce/woocommerce-ios/pull/6287]
+- [*] Improve image loading for thumbnails especially on the Product list. [https://github.com/woocommerce/woocommerce-ios/pull/6299]
 - [internal] Removed all feature flags for Shipping Labels. Please smoke test all parts of Shipping Labels to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6270]
 
 8.6

--- a/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
+++ b/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
@@ -13,7 +13,13 @@ struct DefaultImageService: ImageService {
     private let imageDownloader: ImageDownloader
     private let imageCache: ImageCache
 
+    /// A generous number to use for the `DownsamplingImageProcessor`.
+    /// The exact ratio isn't important because the library only needs
+    /// the higher dimension for creating the thumbnail.
     private let defaultThumbnailSize = CGSize(width: 800, height: 800)
+
+    /// Options for downloading images
+    ///
     private var defaultOptions: KingfisherOptionsInfo {
         let options: KingfisherOptionsInfo = [
             .targetCache(imageCache),

--- a/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
+++ b/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
@@ -13,9 +13,9 @@ struct DefaultImageService: ImageService {
     private let imageDownloader: ImageDownloader
     private let imageCache: ImageCache
 
-    /// A generous number to use for the `DownsamplingImageProcessor`.
+    /// A generous size to use for the `DownsamplingImageProcessor`.
     /// The exact ratio isn't important because the library only needs
-    /// the higher dimension for creating the thumbnail.
+    /// the higher dimension for creating thumbnails.
     private let defaultThumbnailSize = CGSize(width: 800, height: 800)
 
     /// Options for downloading images

--- a/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
+++ b/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
@@ -66,7 +66,6 @@ struct DefaultImageService: ImageService {
                                            completion: ImageDownloadCompletion? = nil) {
         let encodedString = url?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
         let url = URL(string: encodedString ?? "")
-        imageView.kf.cancelDownloadTask()
         imageView.kf.setImage(with: url,
                               placeholder: placeholder,
                               options: defaultOptions,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6297 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When setting high-resolution images for the products, loading the images on the product list can cause the list to be unresponsive for a few seconds. This is more noticeable when I tested on a simulator, but maybe can be obvious on older real devices as well.

The reason for this unresponsiveness is that we're loading full-size images (unfortunately the [API doesn't support thumbnail images](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-images-properties)); and when the images are set to `UIImageView`, the system needs to manipulate the images before showing them on the view. This manipulation happens on the main thread and blocks all UI interactions until it's done.

A solution to this would be to resize the images in a background thread before sending them to `UIImageView`'s. But since we're already using Kingfisher to load the images, we can follow [this guide](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#using-downsamplingimageprocessor-for-high-resolution-images):
- Add their built-in `DownsamplingImageProcessor` to one of the options for downloading images. This requires a parameter for the image size. The recommended use for this parameter is to input the size of the image view. I tried setting the bounds size of the image views to this but got an issue with image views not being properly sized (with zero value) when setting up the cells. I ended up hardcoding a generous size for the thumbnail (800x800 points) - the exact ratio doesn't really matter since [the implementation](https://github.com/onevcat/Kingfisher/blob/4561cc1cf7d36b4dc3d29317673b72ef59fc9ce4/Sources/Image/Image.swift#L366) only uses the larger dimension to create the thumbnail.
- The guide also suggested using the processor along with `.scaleFactor`, which "provides a reasonable image pixel scale" for the UI. This scale requires the specific scale for the images, not the device screen's scale, so I'm omitting this option to use the default 1.0 scale for the images. Plus, adding the screen scale option seems to cause the processor's performance to suffer a bit from my testing.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Added a few high-dimension images to the products on your test store. Let me know if you need access to my test store for the test.
- Build the app to a simulator or a lower-end real device. This is important because the issue is not very obvious on more powerful devices.
- Launch the app and switch to the Product tab. Try immediately scrolling the list and switching to other tabs. Notice that the app still works smoothly.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before:
https://user-images.githubusercontent.com/5533851/155452826-bb1ebf83-0cd9-4398-b4ed-49c0e1e1bd3e.mov

After:
https://user-images.githubusercontent.com/5533851/155454886-dd8a550d-2c85-4f87-87a7-a4ebc57bfd20.mov

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
