### PR TITLE
Order Creation: Hide fee percentage option when Order Total is 0

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -29,20 +29,22 @@ struct FeeLineDetails: View {
             ScrollView {
                 VStack(spacing: .zero) {
                     Section {
-                        Picker("", selection: $viewModel.feeType) {
-                            Text(viewModel.percentSymbol).tag(FeeLineDetailsViewModel.FeeType.percentage)
-                            Text(viewModel.currencySymbol).tag(FeeLineDetailsViewModel.FeeType.fixed)
-                        }
-                        .onChange(of: viewModel.feeType, perform: { feeType in
-                            switch feeType {
-                            case .fixed:
-                                focusFixedAmountInput = true
-                            case .percentage:
-                                focusPercentageAmountInput = true
+                        if viewModel.isPercentageOptionAvailable {
+                            Picker("", selection: $viewModel.feeType) {
+                                Text(viewModel.percentSymbol).tag(FeeLineDetailsViewModel.FeeType.percentage)
+                                Text(viewModel.currencySymbol).tag(FeeLineDetailsViewModel.FeeType.fixed)
                             }
-                        })
-                        .pickerStyle(.segmented)
-                        .padding()
+                            .onChange(of: viewModel.feeType, perform: { feeType in
+                                switch feeType {
+                                case .fixed:
+                                    focusFixedAmountInput = true
+                                case .percentage:
+                                    focusPercentageAmountInput = true
+                                }
+                            })
+                            .pickerStyle(.segmented)
+                            .padding()
+                        }
 
                         Group {
                             switch viewModel.feeType {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -57,6 +57,12 @@ class FeeLineDetailsViewModel: ObservableObject {
     ///
     let isExistingFeeLine: Bool
 
+    /// Returns true when base amount for percentage > 0.
+    ///
+    var isPercentageOptionAvailable: Bool {
+        baseAmountForPercentage > 0
+    }
+
     /// Returns true when there are no valid pending changes.
     ///
     var shouldDisableDoneButton: Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -17,6 +17,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         viewModel.amount = "hi:11.3005.02-"
 
         // Then
+        XCTAssertFalse(viewModel.isPercentageOptionAvailable)
         XCTAssertEqual(viewModel.amount, "11.30")
         XCTAssertEqual(viewModel.currencySymbol, "$")
         XCTAssertEqual(viewModel.currencyPosition, .left)
@@ -36,6 +37,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         viewModel.amount = "12.203"
 
         // Then
+        XCTAssertFalse(viewModel.isPercentageOptionAvailable)
         XCTAssertEqual(viewModel.amount, "12.203")
         XCTAssertEqual(viewModel.currencySymbol, "£")
         XCTAssertEqual(viewModel.currencyPosition, .rightSpace)
@@ -50,6 +52,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
 
         // Then
+        XCTAssertTrue(viewModel.isPercentageOptionAvailable)
         XCTAssertTrue(viewModel.isExistingFeeLine)
         XCTAssertEqual(viewModel.feeType, .fixed)
         XCTAssertEqual(viewModel.amount, "10.00")


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6263.
Based on https://github.com/woocommerce/woocommerce-ios/pull/6304.

## Description

This PR updates "Fee Details" screen to hide the percentage option when Order Total is 0.

## Changes

- Adds `isPercentageOptionAvailable` to `FeeLineDetailsViewModel`.
- Updates `FeeLineDetails` to hide type picker based on `isPercentageOptionAvailable`.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Tap "Add Fees" button.
5. Check the Fee Details screen, confirm you don't see "percentage" option.
6. Close  the Fee Details screen.
7. Tap "Add Product" button and select any product.
8. Tap "Add Fees" button.
9. Confirm that you can see a type picker.
10. Enter percentage amount and save.

## Screenshots

empty order|non-empty order
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/155537022-dd67cb87-42e5-42a2-ad10-a303029accad.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/155537029-dafd6b69-0a30-40a3-80ce-2e5100679b0b.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
