### PR TITLE
Order Creation: Don't store/list auto-draft orders

### DIFF
--- a/Networking/NetworkingTests/Responses/order-auto-draft-status.json
+++ b/Networking/NetworkingTests/Responses/order-auto-draft-status.json
@@ -1,0 +1,205 @@
+{
+    "data":              {
+        "id": 963,
+        "parent_id": 0,
+        "number": "963",
+        "status": "auto-draft",
+        "order_key": "abc123",
+        "currency": "USD",
+        "date_created_gmt": "2018-04-03T23:05:12",
+        "date_modified_gmt": "2018-04-03T23:05:14",
+        "discount_total": "30.00",
+        "discount_tax": "1.20",
+        "shipping_total": "0.00",
+        "shipping_tax": "0.00",
+        "cart_tax": "1.20",
+        "total": "31.20",
+        "total_tax": "1.20",
+        "customer_id": 11,
+        "customer_note": "",
+        "billing": {
+            "first_name": "Johnny",
+            "last_name": "Appleseed",
+            "company": "",
+            "address_1": "234 70th Street",
+            "address_2": "",
+            "city": "Niagara Falls",
+            "state": "NY",
+            "postcode": "14304",
+            "country": "US",
+            "email": "scrambled@scrambled.com",
+            "phone": "333-333-3333"
+        },
+        "shipping": {
+            "first_name": "Johnny",
+            "last_name": "Appleseed",
+            "company": "",
+            "address_1": "234 70th Street",
+            "address_2": "",
+            "city": "Niagara Falls",
+            "state": "NY",
+            "postcode": "14304",
+            "country": "US",
+            "email": "scrambled@scrambled.com",
+            "phone": "333-333-3333"
+        },
+        "shipping_lines": [
+            {
+                "id": 123,
+                "method_title": "International Priority Mail Express Flat Rate",
+                "method_id": "usps",
+                "instance_id": "5",
+                "total": "133.00",
+                "total_tax": "0.00",
+                "taxes": [
+                    {
+                        "id": 1,
+                        "total": "0.62125",
+                        "subtotal": ""
+                    }
+                ],
+                "meta_data": [
+                    {
+                        "id": 1307,
+                        "key": "Package 1",
+                        "value": "1 × 1 × 1 (in) 4lbs × 1"
+                    },
+                    {
+                        "id": 1308,
+                        "key": "Package 2",
+                        "value": "1 × 1 × 1 (in) 1lbs × 1"
+                    }
+                ]
+            }
+        ],
+        "fee_lines": [
+            {
+                "id": 60,
+                "name": "$125.50 fee",
+                "tax_class": "",
+                "tax_status": "taxable",
+                "amount": "125.5",
+                "total": "125.50",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": []
+            }
+        ],
+        "tax_lines": [
+            {
+                "id": 1330,
+                "rate_code": "US-NY-STATE-2",
+                "rate_id": 6,
+                "label": "State",
+                "compound": true,
+                "tax_total": "7.71",
+                "shipping_tax_total": "0.00",
+                "rate_percent": 4.5,
+                "meta_data": []
+            }
+        ],
+        "payment_method": "stripe",
+        "payment_method_title": "Credit Card (Stripe)",
+        "date_paid_gmt": "2018-04-03T23:05:14",
+        "date_completed_gmt": null,
+        "line_items": [
+                       {
+                       "id": 890,
+                       "name": "Fruits Basket (Mix & Match Product)",
+                       "product_id": 52,
+                       "variation_id": 0,
+                       "quantity": 2,
+                       "tax_class": "",
+                       "subtotal": "50.00",
+                       "subtotal_tax": "2.00",
+                       "total": "30.00",
+                       "total_tax": "1.20",
+                       "taxes": [
+                                 {
+                                 "id": 1,
+                                 "total": "1.2",
+                                 "subtotal": "2"
+                                 }
+                                 ],
+                       "meta_data": [],
+                       "sku": "",
+                       "price": 30
+                       },
+                       {
+                       "id": 891,
+                       "name": "Fruits Bundle",
+                       "product_id": 234,
+                       "variation_id": 0,
+                       "quantity": 1.5,
+                       "tax_class": "",
+                       "subtotal": "10.00",
+                       "subtotal_tax": "0.40",
+                       "total": "0.00",
+                       "total_tax": "0.00",
+                       "taxes": [
+                           {
+                               "id": 1,
+                               "total": "0",
+                               "subtotal": "0.4"
+                           }
+                                 ],
+                       "meta_data": [],
+                       "sku": "5555-A",
+                       "price": 0.00
+                       }
+                       ],
+        "coupon_lines": [
+                         {
+                         "id": 894,
+                         "code": "30$off",
+                         "discount": "30",
+                         "discount_tax": "1.2",
+                         "meta_data": [
+                                       {
+                                       "id": 6515,
+                                       "key": "coupon_data",
+                                       "value": {
+                                       "id": 673,
+                                       "code": "30$off",
+                                       "amount": "30",
+                                       "date_created": {
+                                       "date": "2017-10-29 18:20:07.000000",
+                                       "timezone_type": 3,
+                                       "timezone": "America/New_York"
+                                       },
+                                       "date_modified": {
+                                       "date": "2017-10-29 18:20:07.000000",
+                                       "timezone_type": 3,
+                                       "timezone": "America/New_York"
+                                       },
+                                       "date_expires": null,
+                                       "discount_type": "fixed_cart",
+                                       "description": "",
+                                       "usage_count": 2,
+                                       "individual_use": false,
+                                       "product_ids": [],
+                                       "excluded_product_ids": [],
+                                       "usage_limit": 0,
+                                       "usage_limit_per_user": 0,
+                                       "limit_usage_to_x_items": null,
+                                       "free_shipping": false,
+                                       "product_categories": [],
+                                       "excluded_product_categories": [],
+                                       "exclude_sale_items": false,
+                                       "minimum_amount": "",
+                                       "maximum_amount": "",
+                                       "email_restrictions": [],
+                                       "used_by": [
+                                                   "1",
+                                                   "1"
+                                                   ],
+                                       "virtual": false,
+                                       "meta_data": []
+                                       }
+                                       }
+                                       ]
+                         }
+                         ]
+    }
+}
+

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -320,6 +320,10 @@ private extension OrderStore {
                            fields: [.status, .items, .billingAddress, .shippingAddress, .shippingLines, .feeLines]) { [weak self] result in
             switch result {
             case .success(let order):
+                // Auto-draft orders are temporary and should not be stored
+                guard order.status != .autoDraft else {
+                    return onCompletion(result)
+                }
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
                     onCompletion(result)
                 })
@@ -354,6 +358,10 @@ private extension OrderStore {
         remote.updateOrder(from: siteID, order: order, fields: fields) { [weak self] result in
             switch result {
             case .success(let order):
+                // Auto-draft orders are temporary and should not be stored
+                guard order.status != .autoDraft else {
+                    return onCompletion(result)
+                }
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
                     onCompletion(result)
                 })

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -794,38 +794,38 @@ final class OrderStoreTests: XCTestCase {
 
     func test_create_order_does_not_upsert_autodrafts() throws {
         // Given
-        let expectation = self.expectation(description: "Create auto-draft order")
         let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "orders", filename: "order-auto-draft-status")
 
         // When
-        let action = OrderAction.createOrder(siteID: sampleSiteID, order: sampleOrder()) { result in
-            XCTAssertTrue(result.isSuccess)
-            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
-            expectation.fulfill()
+        let result: Result<Yosemite.Order, Error> = waitFor { promise in
+            let action = OrderAction.createOrder(siteID: self.sampleSiteID, order: self.sampleOrder()) { result in
+                promise(result)
+            }
+            store.onAction(action)
         }
-        store.onAction(action)
 
         // Then
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
     }
 
     func test_update_order_does_not_upsert_autodrafts() throws {
         // Given
-        let expectation = self.expectation(description: "Update auto-draft order")
         let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order-auto-draft-status")
 
         // When
-        let action = OrderAction.updateOrder(siteID: sampleSiteID, order: sampleOrder(), fields: []) { result in
-            XCTAssertTrue(result.isSuccess)
-            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
-            expectation.fulfill()
+        let result: Result<Yosemite.Order, Error> = waitFor { promise in
+            let action = OrderAction.updateOrder(siteID: self.sampleSiteID, order: self.sampleOrder(), fields: []) { result in
+                promise(result)
+            }
+            store.onAction(action)
         }
-        store.onAction(action)
 
         // Then
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -791,6 +791,42 @@ final class OrderStoreTests: XCTestCase {
         ]
         assertEqual(expectedKeys, receivedKeys)
     }
+
+    func test_create_order_does_not_upsert_autodrafts() throws {
+        // Given
+        let expectation = self.expectation(description: "Create auto-draft order")
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "order-auto-draft-status")
+
+        // When
+        let action = OrderAction.createOrder(siteID: sampleSiteID, order: sampleOrder()) { result in
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
+            expectation.fulfill()
+        }
+        store.onAction(action)
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_update_order_does_not_upsert_autodrafts() throws {
+        // Given
+        let expectation = self.expectation(description: "Update auto-draft order")
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order-auto-draft-status")
+
+        // When
+        let action = OrderAction.updateOrder(siteID: sampleSiteID, order: sampleOrder(), fields: []) { result in
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
+            expectation.fulfill()
+        }
+        store.onAction(action)
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }
 
 


### PR DESCRIPTION
Closes: #6228

## Description

During Order Creation, when we create an order as part of the `RemoteOrderSynchronizer` logic, it is stored and shown in the order list screen. However, `auto-draft` orders should not be shown as they are not returned by the `Order API`. This updates the order creation and update actions in `OrderStore` to not store `auto-draft` orders, so they won't appear in the order list.

## Changes

(Note that most of the diff line count comes from a new JSON mock response; actual code changes are relatively few lines.)

* In `OrderStore`, updates `createOrder` and `updateOrder` so orders with `auto-draft` status are not upserted in storage.
* Adds tests and a new JSON mock response for an `auto-draft` order.

## Testing

### Prerequisites

- Set your store to WC 6.3.0-beta.1.
- Enable the `orderCreationRemoteSynchronizer` local feature flag.

### Steps

1. Build and run the app.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. Select a product, enter customer details, or add shipping/fee.
5. See that after 1s the order is created, see visible loading indicator.
6. Navigate back to the order list and confirm the order does not appear in the order list.

You can also repeat these steps on a store with WC <6.3 and confirm that the order is created with a `pending` status and appears in the order list. (This UX will be improved with a discard changes prompt that cleans up these orders: #5815.)

## Screenshots

https://user-images.githubusercontent.com/8658164/155571021-2821e8f8-133b-4c80-a9ba-8a53fbf4c1fc.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
