### PR TITLE
Order Creation: Enable Create button by default for new orders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -57,8 +57,6 @@ struct NewOrder: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 switch viewModel.navigationTrailingItem {
-                case .none:
-                    EmptyView()
                 case .create:
                     Button(Localization.createButton) {
                         viewModel.createOrder()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -13,9 +13,9 @@ final class NewOrderViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
 
     /// Active navigation bar trailing item.
-    /// Defaults to no visible button.
+    /// Defaults to create button.
     ///
-    @Published private(set) var navigationTrailingItem: NavigationItem = .none
+    @Published private(set) var navigationTrailingItem: NavigationItem = .create
 
     /// Tracks if a network request is being performed.
     ///
@@ -275,7 +275,6 @@ extension NewOrderViewModel {
     /// Representation of possible navigation bar trailing buttons
     ///
     enum NavigationItem: Equatable {
-        case none
         case create
         case loading
     }
@@ -385,10 +384,6 @@ private extension NewOrderViewModel {
             .map { order, performingNetworkRequest -> NavigationItem in
                 guard !performingNetworkRequest else {
                     return .loading
-                }
-
-                guard OrderFactory.emptyNewOrder != order else {
-                    return .none
                 }
 
                 return .create

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -15,20 +15,9 @@ class NewOrderViewModelTests: XCTestCase {
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
 
         // Then
-        XCTAssertEqual(viewModel.navigationTrailingItem, .none)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .create)
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "pending")
         XCTAssertEqual(viewModel.productRows.count, 0)
-    }
-
-    func test_create_button_is_enabled_when_order_detail_changes_from_default_value() {
-        // Given
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID)
-
-        // When
-        viewModel.updateOrderStatus(newStatus: .processing)
-
-        // Then
-        XCTAssertEqual(viewModel.navigationTrailingItem, .create)
     }
 
     func test_loading_indicator_is_enabled_during_network_request() {


### PR DESCRIPTION
Closes: #6150

## Description

Previously for Order Creation, we checked to see if any order details had changed before enabling the Create button. However, this meant it was not possible to create an empty order with `pending` status, but it was possible for other order statuses.

This enables the Create button by default for new orders, including orders with the `pending` status, to match Core behavior. The Create button is now always available, unless the order is already being created remotely.

## Changes

* Removes the `none` case for the `NavigationItem` enum in `NewOrderViewModel`.
* Sets `navigationTrailingItem` to `.create` by default.
* Updates unit tests.

## Testing

1. Build and run the app.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. Confirm the "Create" button is immediately visible, and you can create a new order immediately without making any changes.

You can check to make sure the new order is created remotely and appears in the order list as expected.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-24 at 17 45 41](https://user-images.githubusercontent.com/8658164/155578873-76b5a24b-abde-4277-8c13-b2a6c36de112.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-02-24 at 17 36 45](https://user-images.githubusercontent.com/8658164/155578688-26400b43-4121-4d11-accd-485095137f99.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
