### PR TITLE
Order Creation: Use specific local IDs on RemoteOrderSynchronizer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -19,9 +19,13 @@ struct OrderSyncProductInput {
         case product(Product)
         case variation(ProductVariation)
     }
-    var id = Int64(UUID().uuidString.hashValue)
+    var id: Int64 = .zero
     let product: ProductType
     let quantity: Decimal
+
+    func updating(id: Int64) -> OrderSyncProductInput {
+        .init(id: id, product: self.product, quantity: self.quantity)
+    }
 }
 
 /// Addresses input for an `OrderSynchronizer` type.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -46,6 +46,10 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
     ///
     private var subscriptions = Set<AnyCancellable>()
 
+    /// Store to serve local IDs.
+    ///
+    private let localIDStore = LocalIDStore()
+
     // MARK: Initializers
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
@@ -282,6 +286,24 @@ private extension RemoteOrderSynchronizer {
         ///
         func copy(order: Order) -> SyncOperation {
             SyncOperation(id: id, order: order)
+        }
+    }
+
+    /// Simple type to serve negative IDs.
+    /// This is needed to differentiate if an item ID has been synced remotely while providing a unique ID to consumers.
+    /// If the ID is a negative number we assume that it's a local ID.
+    /// Warning: This is not thread safe.
+    ///
+    final class LocalIDStore {
+        /// Last used ID
+        ///
+        private var currentID: Int64 = 0
+
+        /// Creates a new and unique local ID for this session.
+        ///
+        func dispatchLocalID() -> Int64 {
+            currentID -= 1
+            return currentID
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -52,11 +52,11 @@ class ProductInputTransformerTests: XCTestCase {
     func test_sending_a_new_product_input_twice_adds_adds_two_items_to_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
-        let input1 = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input1 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
         let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder)
 
         // When
-        let input2 = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input2 = OrderSyncProductInput(id: sampleInputID + 1, product: .product(product), quantity: 1)
         let update2 = ProductInputTransformer.update(input: input2, on: update1)
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -39,7 +39,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
 
         // When
-        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
         synchronizer.setProduct.send(input)
 
         // Then


### PR DESCRIPTION
# Why

While I was working on adding the "update order items" support to the `OrdersRemote` class. I found out that our random generated IDs (that are needed to differentiate orders on the UI) do not play well with the API request.

I assumed that if we sent a random ID to the API, the ID would get ignored, but in fact the API errors out.

In order to not send that ID, we need to differentiate when an ID has been randomly generated and when it has been created by the API, which is not possible for random IDs.

This PR fixes that situation by defining a concrete set of "local ids" so we can differentiate later (in a future PR) when an ID is a local ID and when it is a remote ID.

# How

- Adds a private `LocalIDStore` which will dispatch negative numbers by decreasing them 1 by 1. This type is really simple & not thread-safe but It works well enough for our current needs. There is no need to overcomplicate it right now.

- Updates `RemoteOrderSynchronizer` to update product inputs with a "local id" when the provided id is `zero`

- Updates `LocalOrderSynchronizer` to update product inputs with a randomly generated ID, the same way it was working before.

---

# Testing Steps

- Just make sure the app with the LocalOrderSynchronizer keeps working as expected. Testing steps for "RemoteOrderSynchronizer" will be more testable in a later PR.

