### PR TITLE
Order Creation: Update product rows when the order changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -607,6 +607,7 @@ private extension NewOrderViewModel {
 
             // Observe changes to the product quantity
             productRowViewModel.$quantity
+                .dropFirst() // Omit the default/initial quantity to prevent a double trigger.
                 .sink { [weak self] newQuantity in
                     guard let self = self, let newInput = self.createUpdateProductInput(item: item, quantity: newQuantity) else {
                         return


### PR DESCRIPTION
# Why

While I was working on adding the "update order items" support to the OrdersRemote class. I found out the item rows in the new order screen were not being updated after the order finishes syncing.

This turns out to be a problem because the row item ID does not get updated with the item id provided by the remote server.

This PR fixes that by always reloading the products rows by observing the `orderSynchronizer.orderPublisher` property.


# Testing Steps

Just make sure the app with the LocalOrderSynchronizer keeps working as expected. 