### PR TITLE
Support older WC / WC Admin versions without `is_read` API field

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */ = {isa = PBXBuildFile; fileRef = 020220E123966CD900290165 /* product-shipping-classes-load-one.json */; };
+		0205021C27C86B9700FB1C6B /* inbox-note-without-isRead.json in Resources */ = {isa = PBXBuildFile; fileRef = 0205021B27C86B9700FB1C6B /* inbox-note-without-isRead.json */; };
 		020C907B24C6E108001E2BEB /* product-variation-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 020C907A24C6E108001E2BEB /* product-variation-update.json */; };
 		020C907F24C7D359001E2BEB /* ProductVariationMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */; };
 		020D07B823D852BB00FD9580 /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07B723D852BB00FD9580 /* Media.swift */; };
@@ -684,6 +685,7 @@
 
 /* Begin PBXFileReference section */
 		020220E123966CD900290165 /* product-shipping-classes-load-one.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-one.json"; sourceTree = "<group>"; };
+		0205021B27C86B9700FB1C6B /* inbox-note-without-isRead.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "inbox-note-without-isRead.json"; sourceTree = "<group>"; };
 		020C907A24C6E108001E2BEB /* product-variation-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation-update.json"; sourceTree = "<group>"; };
 		020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationMapperTests.swift; sourceTree = "<group>"; };
 		020D07B723D852BB00FD9580 /* Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
@@ -2030,6 +2032,7 @@
 				0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */,
 				45CCFCE927A2E59B0012E8CB /* inbox-note-list.json */,
 				4513382727A96DE700AE5E78 /* inbox-note.json */,
+				0205021B27C86B9700FB1C6B /* inbox-note-without-isRead.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -2469,6 +2472,7 @@
 				31A451CC27863A2E00FE81AA /* stripe-account-rejected-fraud.json in Resources */,
 				31A451D827863A2E00FE81AA /* stripe-account-restricted-overdue.json in Resources */,
 				D865CE69278CA245002C8520 /* stripe-payment-intent-unknown-status.json in Resources */,
+				0205021C27C86B9700FB1C6B /* inbox-note-without-isRead.json in Resources */,
 				24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */,
 				B58D10C82114D21D00107ED4 /* generic_error.json in Resources */,
 				077F39D826A58EB600ABEADC /* systemStatus.json in Resources */,

--- a/Networking/Networking/Model/InboxNote.swift
+++ b/Networking/Networking/Model/InboxNote.swift
@@ -97,7 +97,7 @@ extension InboxNote: Codable {
         let title = try container.decode(String.self, forKey: .title)
         let content = try container.decode(String.self, forKey: .content)
         let isRemoved = try container.decode(Bool.self, forKey: .isRemoved)
-        let isRead = try container.decode(Bool.self, forKey: .isRead)
+        let isRead = try container.decodeIfPresent(Bool.self, forKey: .isRead) ?? false
         let dateCreated = try container.decode(Date.self, forKey: .dateCreated)
 
         self.init(siteID: siteID,

--- a/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
@@ -50,6 +50,16 @@ final class InboxNoteMapperTests: XCTestCase {
         // Then
         XCTAssertEqual(inboxNote, expectedInboxNote)
     }
+
+    /// Verifies that `isRead` field is set to `false` when the corresponding API field (`is_read`) is not available.
+    ///
+    func test_InboxNoteMapper_sets_isRead_to_false_when_API_field_is_unavailable() throws {
+        // When
+        let inboxNote = try XCTUnwrap(mapLoadInboxNoteWithoutIsReadResponse())
+
+        // Then
+        XCTAssertFalse(inboxNote.isRead)
+    }
 }
 
 
@@ -71,5 +81,11 @@ private extension InboxNoteMapperTests {
     ///
     func mapLoadInboxNoteResponse() throws -> InboxNote? {
         return try mapInboxNote(from: "inbox-note")
+    }
+
+    /// Returns the InboxNoteMapper output from `inbox-note-without-isRead.json`
+    ///
+    func mapLoadInboxNoteWithoutIsReadResponse() throws -> InboxNote? {
+        try mapInboxNote(from: "inbox-note-without-isRead")
     }
 }

--- a/Networking/NetworkingTests/Responses/inbox-note-without-isRead.json
+++ b/Networking/NetworkingTests/Responses/inbox-note-without-isRead.json
@@ -1,0 +1,45 @@
+{
+    "data": {
+        "id": 80,
+        "name": "lead_gen_existing_customers_1",
+        "type": "marketing",
+        "locale": "en_US",
+        "title": "Talk to a consultant",
+        "content": "As your business grows, you want to optimize costs, streamline operations, and sell more. We can help. Talk to us about how you can get the most out of WooCommerce.",
+        "content_data": {},
+        "status": "unactioned",
+        "source": "woocommerce.com",
+        "date_created": "2022-02-13T11:23:51",
+        "date_reminder": null,
+        "is_snoozable": false,
+        "actions": [
+            {
+                "id": 7635,
+                "name": "lead_gen_existing_customers_1",
+                "label": "Yes, please",
+                "query": "https://woocommerce.com/take-your-business-to-the-next-level/",
+                "status": "actioned",
+                "primary": false,
+                "actioned_text": "",
+                "url": "https://woocommerce.com/take-your-business-to-the-next-level/"
+            }
+        ],
+        "layout": "plain",
+        "image": "",
+        "is_deleted": false,
+        "date_created_gmt": "2022-02-13T16:23:51",
+        "date_reminder_gmt": null,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc-analytics/admin/notes/80"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc-analytics/admin/notes"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6300 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We parse `is_read` from the API note response to `isRead: Bool` which is used to show different UI states as in https://github.com/woocommerce/woocommerce-ios/issues/6251. Since `is_read` was recently added in [WC Admin release 3.0.0](https://github.com/woocommerce/woocommerce-admin/commit/aa608396ce1427b58d2573c3971089bf95dc3e5a) in Dec 2021 and [bundled with WC in release 6.1.0](https://github.com/woocommerce/woocommerce/blob/7fdebe1214593ba9dfca57c8d99a1cf069035c8f/changelog.txt#L102-L150) in Jan 2022, stores with older WC or WC Admin versions failed to parse the API response without the `is_read` field.

This PR updated the decoder to parse `is_read` as an optional field, and set the default value to `false` so that we show a bold title.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: having a site with WC version before 6.1.0 or WC Admin version before 3.0.0, and has non-zero inbox notes.

* Launch the app
* Go to the Menu tab
* Tap on "Inbox" --> the notes should be shown after syncing, where it used to show an empty state before this PR

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
