### PR TITLE
Add in the Yosemite layer a bulk update variations action

### DIFF
--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -25,6 +25,13 @@ public enum ProductVariationAction: Action {
     ///
     case updateProductVariation(productVariation: ProductVariation, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)
 
+    /// Updates the provided ProductVariations.
+    ///
+    case updateProductVariations(siteID: Int64,
+                                 productID: Int64,
+                                 productVariations: [ProductVariation],
+                                 onCompletion: (Result<[ProductVariation], ProductUpdateError>) -> Void)
+
     /// Requests the variations in a specified Order that have not been fetched.
     ///
     case requestMissingVariations(for: Order, onCompletion: (Error?) -> Void)

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -188,7 +188,7 @@ private extension ProductVariationStore {
                                                                                             onCompletion(.failure(.notFoundInStorage))
                                                                                             return
                                                                 }
-                    onCompletion(.success(storageProductVariation.map({ $0.toReadOnly() })))
+                    onCompletion(.success(storageProductVariation.map { $0.toReadOnly() }))
                 }
             }
         }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -730,7 +730,7 @@ final class ProductVariationStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
     }
 
-    /// Verifies that `ProductVariationAction.updateProductVariation` returns the expected `ProductVariation`.
+    /// Verifies that `ProductVariationAction.updateProductVariations` returns the expected `ProductVariations`.
     ///
     func test_updateProductVariations_is_correctly_updating_productVariation() throws {
         // Given

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -729,6 +729,91 @@ final class ProductVariationStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
     }
+
+    /// Verifies that `ProductVariationAction.updateProductVariation` returns the expected `ProductVariation`.
+    ///
+    func test_updateProductVariations_is_correctly_updating_productVariation() throws {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let variationIDs: [Int64] = [17, 42]
+        let variationA = MockProductVariation().productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: variationIDs[0])
+        let variationB = MockProductVariation().productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: variationIDs[1])
+
+        let expectedVariations = [variationA.copy(dateCreated: Date.distantFuture),
+                                  variationB.copy(dateCreated: Date.distantPast)]
+
+
+        let variations = expectedVariations.map({ $0.copy(regularPrice: "1") })
+
+        remote.whenUpdatingProductVariations(siteID: sampleSiteID,
+                                             productID: sampleProductID,
+                                             productVariationIDs: variationIDs,
+                                             thenReturn: .success(expectedVariations))
+
+        // Saves an existing ProductVariations into storage
+        // The regular price is expected to be updated
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[0])
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1])
+        assertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 2)
+
+        // When
+        var result: Result<[Yosemite.ProductVariation], ProductUpdateError>?
+        waitForExpectation { expectation in
+            let action = ProductVariationAction.updateProductVariations(siteID: sampleSiteID,
+                                                                        productID: sampleProductID,
+                                                                        productVariations: variations) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let updatedVariations = try? result?.get()
+        assertEqual(updatedVariations, expectedVariations)
+
+        let storedVariations = viewStorage.loadProductVariations(siteID: sampleSiteID, productID: sampleProductID)
+        let readOnlyVariations = try XCTUnwrap(storedVariations?.map({ $0.toReadOnly() }))
+        assertEqual(readOnlyVariations, expectedVariations)
+    }
+
+    /// Verifies that `ProductVariationAction.updateProductVariations` returns an error whenever there is an error response from the backend.
+    ///
+    func test_updateProductVariations_returns_error_upon_response_error() {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let variationIDs: [Int64] = [17, 42]
+        remote.whenUpdatingProductVariations(siteID: sampleSiteID,
+                                             productID: sampleProductID,
+                                             productVariationIDs: variationIDs,
+                                             thenReturn: .failure(NSError(domain: "", code: 400, userInfo: nil)))
+        // Saves an existing ProductVariations into storage.
+        let productVariations = [MockProductVariation().productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: variationIDs[0]),
+                                 MockProductVariation().productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: variationIDs[1])]
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariations[0])
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariations[1])
+        assertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 2)
+
+        // When
+        var result: Result<[Yosemite.ProductVariation], ProductUpdateError>?
+        waitForExpectation { expectation in
+            let action = ProductVariationAction.updateProductVariations(siteID: sampleSiteID,
+                                                                        productID: sampleProductID,
+                                                                        productVariations: productVariations) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isFailure)
+
+        // The existing ProductVariations should not be deleted.
+        assertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 2)
+    }
 }
 
 


### PR DESCRIPTION
Closes: #6240

### Description
Added in the Yosemite layer a bulk update action for the product variations, uses the bulk update API Call in the networking layer #6266, then updates the storage with the results.

### Testing instructions
No special testing needed. Just running the unit tests

### Screenshots
Non needed


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
