### PR TITLE
Adding initial view controller for bulk update variations with placeh…

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -140,8 +140,6 @@ private extension BulkUpdateViewController {
     }
 }
 
-// MARK: - Private Types
-//
 extension BulkUpdateViewController {
     struct Section: Equatable {
         let title: String?

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -40,16 +40,14 @@ final class BulkUpdateViewController: UIViewController {
             guard let self = self else { return }
 
             switch state {
+            // `.notStarted` is the initial state of the VM
+            // and transition to this state is not possible
             case .notStarted:
-                fallthrough
+                ()
             case .syncing:
-                self.displayPlaceholder()
-            case .synced:
-                fallthrough
-            case .error:
-                self.removePlaceholder()
-                self.removePlaceholder()
-                self.removePlaceholder()
+                self.displayGhostContent()
+            case .synced, .error:
+                self.removeGhostContent()
             }
         }.store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -150,7 +150,6 @@ extension BulkUpdateViewController {
 
     enum Row: CaseIterable {
         case regularPrice
-        case salePrice
 
         fileprivate var type: UITableViewCell.Type {
             return ValueOneTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -1,0 +1,180 @@
+import UIKit
+import Yosemite
+import WordPressUI
+import Combine
+
+/// Displays a list of settings for the user to choose to bulk update them for all variations
+///
+final class BulkUpdateViewController: UIViewController {
+
+    @IBOutlet private weak var tableView: UITableView!
+
+    private let viewModel: BulkUpdateViewModel
+
+    private var subscriptions = Set<AnyCancellable>()
+
+    init(viewModel: BulkUpdateViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTableView()
+        configureViewModel()
+    }
+
+    /// Setup receiving updates for data changes and actives the view model
+    ///
+    private func configureViewModel() {
+        viewModel.$syncState.sink { [weak self] state in
+            guard let self = self else { return }
+
+            switch state {
+            case .notStarted:
+                fallthrough
+            case .syncing:
+                self.displayPlaceholder()
+            case .synced:
+                fallthrough
+            case .error:
+                self.removePlaceholder()
+                self.removePlaceholder()
+                self.removePlaceholder()
+            }
+        }.store(in: &subscriptions)
+
+        viewModel.activate()
+    }
+
+    /// Renders the placeholders for the the bulk update settings
+    ///
+    func displayPlaceholder() {
+        // We currently support 2 options (Regular & Sale price)
+        let options = GhostOptions(reuseIdentifier: ValueOneTableViewCell.reuseIdentifier, rowsPerSection: [2])
+        tableView.displayGhostContent(options: options,
+                                      style: .wooDefaultGhostStyle)
+    }
+
+    /// Removes the placeholder cells.
+    ///
+    func removePlaceholder() {
+        tableView.removeGhostContent()
+    }
+
+    /// Configures the table view: registers Nibs & setup datasource / delegate
+    ///
+    func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        registerTableViewHeaderSections()
+        registerTableViewCells()
+
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func registerTableViewHeaderSections() {
+        let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
+        tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)
+    }
+
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+    }
+
+    var sections: [Section] {
+        return viewModel.sections
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension BulkUpdateViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension BulkUpdateViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return Constants.sectionHeight
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let leftText = viewModel.sections[section].title else {
+            return nil
+        }
+
+        let reuseIdentifier = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: reuseIdentifier) as? TwoColumnSectionHeaderView else {
+            fatalError("Could not find section header view for reuseIdentifier \(reuseIdentifier)")
+        }
+
+        headerView.leftText = leftText
+        headerView.rightText = nil
+
+        return headerView
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension BulkUpdateViewController {
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+}
+
+// MARK: - Private Types
+//
+extension BulkUpdateViewController {
+    struct Section: Equatable {
+        let title: String?
+        let rows: [Row]
+    }
+
+    enum Row: CaseIterable {
+        case regularPrice
+        case salePrice
+
+        fileprivate var type: UITableViewCell.Type {
+            return ValueOneTableViewCell.self
+        }
+
+        fileprivate var reuseIdentifier: String {
+            return type.reuseIdentifier
+        }
+    }
+}
+
+private struct Constants {
+    static let sectionHeight = CGFloat(44)
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -56,7 +56,7 @@ final class BulkUpdateViewController: UIViewController {
 
     /// Configures the table view: registers Nibs & setup datasource / delegate
     ///
-    func configureTableView() {
+    private func configureTableView() {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
 
@@ -67,18 +67,18 @@ final class BulkUpdateViewController: UIViewController {
         tableView.delegate = self
     }
 
-    func registerTableViewHeaderSections() {
+    private func registerTableViewHeaderSections() {
         let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)
     }
 
-    func registerTableViewCells() {
+    private func registerTableViewCells() {
         for row in Row.allCases {
             tableView.registerNib(for: row.type)
         }
     }
 
-    var sections: [Section] {
+    private var sections: [Section] {
         return viewModel.sections
     }
 }
@@ -167,7 +167,7 @@ private struct Constants {
 }
 
 private extension BulkUpdateViewController {
-    /// Renders Placeholder Content.
+    /// Renders the Placeholder Content.
     ///
     func displayGhostContent() {
         guard let ghostView = ghostTableViewController.view else {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BulkUpdateViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="fCF-yK-YZD" id="o1B-1P-QyV"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fCF-yK-YZD">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="fCF-yK-YZD" secondAttribute="trailing" id="9Tw-76-jV7"/>
+                <constraint firstItem="fCF-yK-YZD" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="LpE-Hf-Tza"/>
+                <constraint firstAttribute="bottom" secondItem="fCF-yK-YZD" secondAttribute="bottom" id="bPq-aC-chC"/>
+                <constraint firstItem="fCF-yK-YZD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="gfX-HE-oqD"/>
+            </constraints>
+            <point key="canvasLocation" x="-214" y="38"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.xib
@@ -33,7 +33,7 @@
                 <constraint firstAttribute="bottom" secondItem="fCF-yK-YZD" secondAttribute="bottom" id="bPq-aC-chC"/>
                 <constraint firstItem="fCF-yK-YZD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="gfX-HE-oqD"/>
             </constraints>
-            <point key="canvasLocation" x="-214" y="38"/>
+            <point key="canvasLocation" x="-272" y="32"/>
         </view>
     </objects>
     <resources>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -5,6 +5,9 @@ import protocol Storage.StorageManagerType
 /// View Model logic for the Bulk Variations Update
 final class BulkUpdateViewModel {
 
+    typealias Section = BulkUpdateViewController.Section
+    typealias Row = BulkUpdateViewController.Row
+
     /// Represents possible states for syncing product variations.
     enum SyncState: Equatable {
         case syncing
@@ -20,6 +23,12 @@ final class BulkUpdateViewModel {
 
     /// The state of synching all variations
     @Published private(set) var syncState: SyncState
+
+    var sections: [Section] {
+        let priceSection = Section(title: Localization.priceTitle, rows: [])
+
+        return [priceSection]
+    }
 
     init(siteID: Int64,
          productID: Int64,
@@ -64,6 +73,12 @@ final class BulkUpdateViewModel {
             }
 
         storesManager.dispatch(action)
+    }
+}
+
+extension BulkUpdateViewModel {
+    private enum Localization {
+        static let priceTitle = NSLocalizedString("Price", comment: "The title for the price settings section in the product variation bulk update screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -568,7 +568,12 @@ private extension ProductVariationsViewController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
-        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.bulkUpdate) { _ in
+        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.bulkUpdate) { [weak self] _ in
+            guard let self = self else { return }
+
+            let viewModel = BulkUpdateViewModel(siteID: self.siteID, productID: self.productID)
+            let navigationController = WooNavigationController(rootViewController: BulkUpdateViewController(viewModel: viewModel))
+            self.present(navigationController, animated: true)
         }
 
         actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -424,6 +424,8 @@
 		098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */; };
 		09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */; };
 		09E41E1D27B90B3C00BFCB7C /* BulkUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */; };
+		09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA565327C8ACEE00407D40 /* BulkUpdateViewController.swift */; };
+		09EA565627C8ACEE00407D40 /* BulkUpdateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09EA565427C8ACEE00407D40 /* BulkUpdateViewController.xib */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -2090,6 +2092,8 @@
 		098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSourceTests.swift; sourceTree = "<group>"; };
 		09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModelTests.swift; sourceTree = "<group>"; };
 		09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModel.swift; sourceTree = "<group>"; };
+		09EA565327C8ACEE00407D40 /* BulkUpdateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewController.swift; sourceTree = "<group>"; };
+		09EA565427C8ACEE00407D40 /* BulkUpdateViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BulkUpdateViewController.xib; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
@@ -4361,6 +4365,8 @@
 		09E41E1527B7BB7500BFCB7C /* Bulk Update */ = {
 			isa = PBXGroup;
 			children = (
+				09EA565327C8ACEE00407D40 /* BulkUpdateViewController.swift */,
+				09EA565427C8ACEE00407D40 /* BulkUpdateViewController.xib */,
 				09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */,
 			);
 			path = "Bulk Update";
@@ -8010,6 +8016,7 @@
 				028296ED237D28B600E84012 /* TextViewViewController.xib in Resources */,
 				451A04F52386F7C900E368C9 /* AddProductImageCollectionViewCell.xib in Resources */,
 				455DC3A427393C7E00D4644C /* OrderDatesFilterViewController.xib in Resources */,
+				09EA565627C8ACEE00407D40 /* BulkUpdateViewController.xib in Resources */,
 				0211254225778BDF0075AD2A /* ShippingLabelDetailsViewController.xib in Resources */,
 				456396B725C82691001F1A26 /* ShippingLabelFormStepTableViewCell.xib in Resources */,
 				450C2CBB24D3127500D570DD /* ProductReviewsTableViewCell.xib in Resources */,
@@ -9113,6 +9120,7 @@
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
 				DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
+				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,
 				2602A64627BDBEBA00B347F1 /* ProductInputTransformer.swift in Sources */,
 				AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */,
 				0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -23,6 +23,23 @@ final class BulkUpdateViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_number_of_sections() {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+
+        // Then
+        XCTAssertEqual(viewModel.sections.count, 1)
+    }
+
+    func test_first_section_title() throws {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+
+        // Then
+        let sectionTitle = try XCTUnwrap(viewModel.sections.first?.title)
+        XCTAssertEqual(sectionTitle, Localization.priceTitle)
+    }
+
     func test_all_products_are_synchronized_on_the_viewload_event() throws {
         // Given
         let expectedSiteID: Int64 = 42
@@ -106,5 +123,11 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.syncState, .synced)
+    }
+}
+
+private extension BulkUpdateViewModelTests {
+    private enum Localization {
+        static let priceTitle = NSLocalizedString("Price", comment: "The title for the price settings section in the product variation bulk update screen")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -37,7 +37,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
         // Then
         let sectionTitle = try XCTUnwrap(viewModel.sections.first?.title)
-        XCTAssertEqual(sectionTitle, Localization.priceTitle)
+        XCTAssertTrue(sectionTitle.isNotEmpty)
     }
 
     func test_all_products_are_synchronized_on_the_viewload_event() throws {
@@ -123,11 +123,5 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.syncState, .synced)
-    }
-}
-
-private extension BulkUpdateViewModelTests {
-    private enum Localization {
-        static let priceTitle = NSLocalizedString("Price", comment: "The title for the price settings section in the product variation bulk update screen")
     }
 }


### PR DESCRIPTION
Part of: #6239

### Description
This PR adds the initial view controller for the bulk update variations. 
When the BulkUpdateViewController loads it will configure to receive events from the bulkUpdateViewModel. It will show placeholder cells while the data are loading (fetching the first 100 product variations) and then it will display the "Price" section.
A latter PR will add the configuration for the cells & cancel button and add actions for cancel button and tapping on the cells.

### Testing instructions
In a Alpha version release, or in local development:
1. Goto the products tab
3. Select a product with variations
4. Go to the list of variations
6. Tap on the "more" button in the navigation bar
8. Select the "Bulk update"  
9. The new bulk update screen should appear loading (a ghost section and two ghost cells)
10. After the loading finishes an price section should be displayed

### Screenshots
![entry point screen](https://user-images.githubusercontent.com/96764631/155673413-1dfe6877-222d-4b8d-83c0-39f49a802cc0.png)

![loading](https://user-images.githubusercontent.com/96764631/155673423-ef666e7a-4eb9-484a-8f0a-13af2e6d5467.png)

![final screen](https://user-images.githubusercontent.com/96764631/155673427-74450883-9488-4170-829f-d5aaca02ea95.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
