### PR TITLE
[Mobile Payments] Localization fixes

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		039D948B2760C0660044EF38 /* NoOpCardReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948A2760C0660044EF38 /* NoOpCardReaderService.swift */; };
 		03B440AA2754DFC400759429 /* UnderlyingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B440A92754DFC400759429 /* UnderlyingError.swift */; };
 		03CF78D327C6710C00523706 /* interac.svg in Resources */ = {isa = PBXBuildFile; fileRef = 03CF78D227C6710B00523706 /* interac.svg */; };
+		03CF78D527C92FF900523706 /* ReaderDisplayMessage+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D427C92FF900523706 /* ReaderDisplayMessage+Localization.swift */; };
 		311889EB2653286B0080AEA2 /* PaymentIntentMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */; };
 		317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975BF274EB1F9004357B1 /* DeclineReason.swift */; };
 		317975C2274EBC1F004357B1 /* DeclineReason+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */; };
@@ -138,6 +139,7 @@
 		039D948A2760C0660044EF38 /* NoOpCardReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpCardReaderService.swift; sourceTree = "<group>"; };
 		03B440A92754DFC400759429 /* UnderlyingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlyingError.swift; sourceTree = "<group>"; };
 		03CF78D227C6710B00523706 /* interac.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = interac.svg; sourceTree = "<group>"; };
+		03CF78D427C92FF900523706 /* ReaderDisplayMessage+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderDisplayMessage+Localization.swift"; sourceTree = "<group>"; };
 		0C16E0AAFF5A7B364BD4E171 /* Pods-Hardware.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.release-alpha.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		1CC96A71F2937BCB7432766F /* Pods-HardwareTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HardwareTests.debug.xcconfig"; path = "Target Support Files/Pods-HardwareTests/Pods-HardwareTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleReceiptPrinter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -449,6 +451,7 @@
 				D845BDDD262DAB8300A3E40F /* PaymentMethod+Stripe.swift */,
 				E1E125AF26EB66EA0068A9B0 /* Cancelable+Stripe.swift */,
 				317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */,
+				03CF78D427C92FF900523706 /* ReaderDisplayMessage+Localization.swift */,
 			);
 			path = StripeCardReader;
 			sourceTree = "<group>";
@@ -785,6 +788,7 @@
 				E1E125B026EB66EA0068A9B0 /* Cancelable+Stripe.swift in Sources */,
 				D80B4656260E1B290092EDC0 /* CurrencyCode.swift in Sources */,
 				D81AE86425E6B77F00D9CFD3 /* CardReaderServiceError.swift in Sources */,
+				03CF78D527C92FF900523706 /* ReaderDisplayMessage+Localization.swift in Sources */,
 				317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */,
 				D8DF5F4E25DD9F91008AFE25 /* CardReaderType+Stripe.swift in Sources */,
 				D89B8F1225DDCBCD0001C726 /* Charge+Stripe.swift in Sources */,

--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderEvent+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderEvent+Stripe.swift
@@ -11,7 +11,7 @@ extension CardReaderEvent {
     /// Factory method
     /// - Parameter readerInputOptions: An instance of a StripeTerminal.ReaderDisplayMessage
     static func make(displayMessage: ReaderDisplayMessage) -> Self {
-         .displayMessage(Terminal.stringFromReaderDisplayMessage(displayMessage))
+        return .displayMessage(displayMessage.localizedMessage)
     }
 }
 #endif

--- a/Hardware/Hardware/CardReader/StripeCardReader/ReaderDisplayMessage+Localization.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/ReaderDisplayMessage+Localization.swift
@@ -1,0 +1,61 @@
+#if !targetEnvironment(macCatalyst)
+import StripeTerminal
+
+extension ReaderDisplayMessage {
+    var localizedMessage: String {
+        switch self {
+        case .retryCard:
+            return Localization.retryCard
+        case .insertCard:
+            return Localization.insertCard
+        case .insertOrSwipeCard:
+            return Localization.insertOrSwipeCard
+        case .multipleContactlessCardsDetected:
+            return Localization.multipleContactlessCards
+        case .removeCard:
+            return Localization.removeCard
+        case .swipeCard:
+            return Localization.swipeCard
+        case .tryAnotherCard:
+            return Localization.tryAnotherCard
+        case .tryAnotherReadMethod:
+            return Localization.tryAnotherReadMethod
+        @unknown default:
+            DDLogWarn("Unlocalized IPP ReaderDisplayMessage recieved")
+            return Terminal.stringFromReaderDisplayMessage(self)
+        }
+    }
+
+    enum Localization {
+        /// Strings from `Terminal.stringFromReaderDisplayMessage`
+        static let retryCard = NSLocalizedString(
+            "Retry Card",
+            comment: "Message from the in-person payment card reader prompting user to retry payment with their card")
+        static let insertCard = NSLocalizedString(
+            "Insert Card",
+            comment: "Message from the in-person payment card reader prompting user to insert their card")
+        static let insertOrSwipeCard = NSLocalizedString(
+            "Insert Or Swipe Card",
+            comment: "Message from the in-person payment card reader prompting user to insert or swipe their card")
+        static let multipleContactlessCards = NSLocalizedString(
+            "Multiple Contactless Cards Detected",
+            comment: "Message from the in-person payment card reader when payment could not be taken because " +
+            "multiple cards were detected")
+        static let removeCard = NSLocalizedString(
+            "Remove Card",
+            comment: "Message from the in-person payment card reader prompting user to remove their card")
+        static let swipeCard = NSLocalizedString(
+            "Swipe Card",
+            comment: "Message from the in-person payment card reader prompting user to swipe their card")
+        static let tryAnotherCard = NSLocalizedString(
+            "Try Another Card",
+            comment: "Message from the in-person payment card reader prompting user to retry a payment using a " +
+            "different card")
+        static let tryAnotherReadMethod = NSLocalizedString(
+            "Try Another Read Method",
+            comment: "Message from the in-person payment card reader prompting user to retry a payment using a " +
+            "different method, e.g. swipe, tap, insert")
+    }
+}
+
+#endif

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Coupons: Replace the toggles on Usage Details screen with text for uneditable contents. [https://github.com/woocommerce/woocommerce-ios/pull/6287]
 - [*] Improve image loading for thumbnails especially on the Product list. [https://github.com/woocommerce/woocommerce-ios/pull/6299]
 - [internal] Removed all feature flags for Shipping Labels. Please smoke test all parts of Shipping Labels to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6270]
+- [*] In-Person Payments: Localized messages and UI [https://github.com/woocommerce/woocommerce-ios/pull/6317]
 
 8.6
 -----

--- a/Scripts/localize.py
+++ b/Scripts/localize.py
@@ -173,7 +173,7 @@ def localize(paths, language):
 ## Main
 ##
 if __name__ == '__main__':
-    paths = ['WooCommerce', 'Pods/WordPress*', 'Storage/Storage', 'Networking/Networking']
+    paths = ['WooCommerce', 'Pods/WordPress*', 'Storage/Storage', 'Networking/Networking', 'Hardware/Hardware']
     language = 'WooCommerce/Resources/en.lproj'
 
     localize(paths, language)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -114,7 +114,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
         self.stores = stores
         self.storage = storage
         self.analytics = analytics
-        self.title = Localization.title(total: formattedTotal)
+        self.title = String(format: Localization.title, formattedTotal)
 
         bindStoreCPPState()
         fetchPaymentLink(orderKey: orderKey)
@@ -277,9 +277,9 @@ private extension SimplePaymentsMethodsViewModel {
         static let continueToOrders = NSLocalizedString("Continue To Orders",
                                                         comment: "Button to dismiss modal overlay and go back to the orders list after a sucessful payment")
 
-        static func title(total: String) -> String {
-            NSLocalizedString("Take Payment (\(total))", comment: "Navigation bar title for the Simple Payments Methods screens")
-        }
+        static let title = NSLocalizedString("Take Payment (%1$@)",
+                                             comment: "Navigation bar title for the Simple Payments Methods screens. " +
+                                             "%1$@ is a placeholder for the total amount to collect")
 
         static func markAsPaidInfo(total: String) -> String {
             NSLocalizedString("This will mark your order as complete if you received \(total) outside of WooCommerce",

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -184,7 +184,7 @@ private struct PaymentsSection: View {
                                              selectionStyle: .none) {}
                         }
                     } else {
-                        TitleAndValueRow(title: SimplePaymentsSummary.Localization.taxRate(viewModel.taxRate),
+                        TitleAndValueRow(title: String(format: SimplePaymentsSummary.Localization.taxRate, viewModel.taxRate),
                                          value: .content(viewModel.taxAmount),
                                          selectionStyle: .none) {}
                     }
@@ -287,7 +287,7 @@ private struct TakePaymentSection: View {
             Divider()
                 .ignoresSafeArea()
 
-            Button(SimplePaymentsSummary.Localization.takePayment(total: viewModel.total), action: {
+            Button(String(format: SimplePaymentsSummary.Localization.takePayment, viewModel.total), action: {
                 viewModel.updateOrder()
             })
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
@@ -333,14 +333,13 @@ private extension SimplePaymentsSummary {
         static let taxesDisclaimer = NSLocalizedString("Taxes are automatically calculated based on your store address.",
                                                        comment: "Disclaimer in the simple payments summary screen about taxes.")
 
-        static func taxRate(_ rate: String) -> String {
-            NSLocalizedString("Tax (\(rate)%)", comment: "Tax percentage to be applied to the simple payments order")
-        }
+        static let taxRate = NSLocalizedString("Tax (%1$@%%)",
+                                               comment: "Tax percentage to be applied to the simple payments order. " +
+                                               "%1$@%% is a placeholder for the tax rate as a percentage")
 
-        static func takePayment(total: String) -> String {
-            NSLocalizedString("Take Payment (\(total))",
-                              comment: "Text of the button that creates a simple payment order. Contains the total amount to collect")
-        }
+        static let takePayment = NSLocalizedString("Take Payment (%1$@)",
+                                                   comment: "Text of the button that creates a simple payment order. " +
+                                                   "%1$@ is a placeholder for the total amount to collect")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6278 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#### Format strings for Simple Payments tax/total
Some strings on the Simple Payments screens were not translated, because string interpolation had been used instead of provisional placeholders. This meant that the translations we had weren't shown in the UI. 

This changes these strings to use positional placeholders instead.

#### Localizable.strings for the Hardware project
Previously, none of the NSLocalizedStrings in Hardware were picked up by the scripts and added to the `en.lproj/Localizable.strings` in WooCommerce as they should have been. This resulted in many of the In-Person Payments strings not being translated. A few were translated by chance, because the same string existed elsewhere in the app. 

This adds the `Hardware` project to `localize.py`, so when the script is run the `en.lproj/Localizable.strings` file is correctly generated, and then when translations are added, these strings will be correctly localized in other languages.

#### NSLocalizedString for `ReaderDisplayMessage`
Stripe provide instructional messages to help merchants and their customers complete a card transaction, e.g. “Swipe card”, “Try another read method”, “Multiple contactless cards detected”, “Remove card”. 

Stripe do not provide localizations for these messages, they are provided as an enum, and a method which converts that enum to an English string.

"Remove card" is shown for all IPP transactions, so it was noticeable that it was not localized when testing with a non-English language.

This change copies the current output of Stripe’s `Terminal.stringFromReaderDisplayMessage` for use as the English text when these messages are displayed to the user, but also uses it as the key for localization. There's no change to what’s displayed for merchants using English, likely the vast majority of our IPP merchants.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Format strings for Simple Payments tax/total
1. Add the following to a `Localizable.strings` of your choice, and set the phone to use that language:
```
"Tax (%1$@%%)" = "Taxe (%1$@%%)";
"Take Payment (%1$@)" = "Accepter le paiement (%1$@)";
```
2. Change `SimplePaymentsSummaryViewModel.getter:showTaxBreakup` to `return false` so that the `Tax (amount)` string is used.
3. Go to the orders tab, and add a simple payment order
4. Observe that the localizations you are used for the button, tax row, and when you tap the `Take Payment` button, the title of the following screen.

#### Localizable.strings for the Hardware project

1. In Terminal, in the root of your `woocommerce-ios` directory, run `./Scripts/localize.py`
2. Observe the unstaged changes in `Woocommerce/Resources/en.lproj/Localizable.strings` – there will be around 40 new strings added to the file.
3. Add a translation for one the new receipt strings to a `Localizable.strings` of your choice, and set the phone to use that language, e.g.:
```
/* Line description for 'Amount Paid' cart total on the receipt
   Title of 'Amount Paid' section in the receipt */
"Amount Paid" = "Montant payé";

/* Reads as 'Account Type'. Part of the mandatory data in receipts */
"Account Type" = "Type de compte";

/* Title of 'Date Paid' section in the receipt */
"Date paid" = "Date de paiement";

/* Title of 'Summary' section in the receipt when the order number is unknown */
"Summary" = "Sommaire";

/* Title of 'Summary' section in the receipt. %1$@ is the order number, e.g. 4920 */
"Summary: Order #%1$@" = "Récapitulatif : numéro de commande %1$@";

/* The title of the view containing a receipt preview
   Title of receipt. */
"Receipt" = "Le reçu";

/* Title of receipt. Reads like Receipt from WooCommerce, Inc. */
"Receipt from %1$@" = "Reçu de %1$@";

/* Reads as 'Application name'. Part of the mandatory data in receipts */
"Application Name" = "Nom de l'application";
```
Excuse my French. (Actually, Google's 😬)
4. Open an order which was paid for with IPP on this device
5. Observe that the translations are used.

#### NSLocalizedString for `ReaderDisplayMessage`
1. Add a translation to a strings file of your choice, and set the phone to use that language:
```
/* Message from the in-person payment card reader prompting user to remove their card */
"Remove Card" = "Supprimer la carte";
```
2. In the Orders tab, tap `+` to add a simple payment
3. Set an amount, and go through to take payment 
4. When you've tapped the card, observe that `Remove Card` is not shown during that process, instead your translation is used.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### Format strings for Simple Payments tax/total
Screen | Before | After
---|---|---
`Simple Payments Summary` | ![simple-payments-summary-before](https://user-images.githubusercontent.com/2472348/155712525-c998ba16-7ca9-4e29-ae36-b2a4f8843290.jpg) | ![Simple-payments-summary](https://user-images.githubusercontent.com/2472348/155711828-07fbc375-7da6-4d8c-b343-b3ede4281d8c.jpg)
`SimplePaymentsMethods` | ![payment-method-selection-before](https://user-images.githubusercontent.com/2472348/155712521-31b72c87-1005-4f3f-af79-cf420c399f87.jpg) | ![payment-type-selection](https://user-images.githubusercontent.com/2472348/155711824-29c3a1c4-dd62-442b-8f8d-ebf9691f318e.jpg)
Receipt | ![before-localizable-strings-added](https://user-images.githubusercontent.com/2472348/155753707-30b7cf6c-eb10-4de2-9042-092274b32eb5.jpg) | ![after-localizable-strings-added](https://user-images.githubusercontent.com/2472348/155753711-460de805-17c9-4aca-b3cf-119062d947a2.jpg)
Remove card instruction | ![remove-card-before-localized](https://user-images.githubusercontent.com/2472348/155755336-4982e386-e173-4777-affa-0cdf59e968e9.jpg) | ![remove-card-after-localized](https://user-images.githubusercontent.com/2472348/155755330-4f82cc3a-e5fb-4140-9386-5b4ef63bb6cd.jpg)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
