### PR TITLE
Update inbox note row UI based on `isRead` state

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -21,17 +21,11 @@ struct InboxNoteRow: View {
                 VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
 
 
-                    // Title Unread (unactioned)
+                    // Title with status read or unread.
                     Text(viewModel.title)
-                        .headlineStyle()
+                        .if(viewModel.isRead) { $0.bodyStyle() }
+                        .if(!viewModel.isRead) { $0.headlineStyle() }
                         .fixedSize(horizontal: false, vertical: true)
-                        .renderedIf(!viewModel.isRead)
-
-                    // Title Read (actioned)
-                    Text(viewModel.title)
-                        .bodyStyle()
-                        .fixedSize(horizontal: false, vertical: true)
-                        .renderedIf(viewModel.isRead)
 
                     // Content.
                     // Showing `AttributedText` in placeholder state results in animated height changes, thus a `Text` is shown instead.

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -169,7 +169,8 @@ struct InboxNoteRow_Previews: PreviewProvider {
                                                          attributedContent: .init(),
                                                          actions: [],
                                                          siteID: 1,
-                                                         isPlaceholder: true)
+                                                         isPlaceholder: true,
+                                                         isRead: true)
         Group {
             VStack {
                 InboxNoteRow(viewModel: .init(note: note.copy(type: "marketing", dateCreated: today), today: today))

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -19,10 +19,19 @@ struct InboxNoteRow: View {
                     .foregroundColor(Color(Constants.dateTextColor))
 
                 VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
-                    // Title.
+
+
+                    // Title Unread (unactioned)
+                    Text(viewModel.title)
+                        .headlineStyle()
+                        .fixedSize(horizontal: false, vertical: true)
+                        .renderedIf(!viewModel.isRead)
+
+                    // Title Read (actioned)
                     Text(viewModel.title)
                         .bodyStyle()
                         .fixedSize(horizontal: false, vertical: true)
+                        .renderedIf(viewModel.isRead)
 
                     // Content.
                     // Showing `AttributedText` in placeholder state results in animated height changes, thus a `Text` is shown instead.

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -81,7 +81,8 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
 
     static func == (lhs: InboxNoteRowViewModel, rhs: InboxNoteRowViewModel) -> Bool {
         lhs.id == rhs.id &&
-        lhs.siteID == rhs.siteID
+        lhs.siteID == rhs.siteID &&
+        lhs.isRead == rhs.isRead
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -26,7 +26,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Whether the row is shown in placeholder state.
     let isPlaceholder: Bool
 
-    /// Indicate if the note was read or not (read = actioned).
+    /// Indicate if the note was actioned or not (the user did an action, so the note will be considered as read).
     let isRead: Bool
 
     init(note: InboxNote,
@@ -88,7 +88,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
 extension InboxNoteRowViewModel {
     func markInboxNoteAsActioned(actionID: Int64) {
         let action = InboxNotesAction.markInboxNoteAsActioned(siteID: siteID,
-                                                              noteID: actionID,
+                                                              noteID: id,
                                                               actionID: actionID) { result in
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -26,6 +26,9 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Whether the row is shown in placeholder state.
     let isPlaceholder: Bool
 
+    /// Indicate if the note was read or not (read = actioned).
+    let isRead: Bool
+
     init(note: InboxNote,
          today: Date = .init(),
          locale: Locale = .current,
@@ -52,7 +55,8 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
                   actions: actions,
                   siteID: note.siteID,
                   stores: stores,
-                  isPlaceholder: false)
+                  isPlaceholder: false,
+                  isRead: note.isRead)
     }
 
     init(id: Int64,
@@ -62,7 +66,8 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
          actions: [InboxNoteRowActionViewModel],
          siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
-         isPlaceholder: Bool) {
+         isPlaceholder: Bool,
+         isRead: Bool) {
         self.id = id
         self.date = date
         self.title = title
@@ -71,6 +76,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
         self.siteID = siteID
         self.stores = stores
         self.isPlaceholder = isPlaceholder
+        self.isRead = isRead
     }
 
     static func == (lhs: InboxNoteRowViewModel, rhs: InboxNoteRowViewModel) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -21,7 +21,8 @@ final class InboxViewModel: ObservableObject {
                               attributedContent: .init(),
                               actions: [.init(id: 0, title: "Placeholder", url: nil)],
                               siteID: 123,
-                              isPlaceholder: true)
+                              isPlaceholder: true,
+                              isRead: true)
     }
 
     // MARK: Sync


### PR DESCRIPTION
Closes #6251 

### Description
In this PR I updated the row logic in the inbox note for displaying a bold title or a regular title based on `isRead` property of the note.

### Testing instructions
1. Open the Inbox Notes 
2. The notes status should match the status `isRead`, like on the web. If the note is read, the title should be `regular`, instead it will be bold if unread.3. 

Note: while I was testing this PR, I discovered [this bug](https://github.com/woocommerce/woocommerce-ios/issues/6318) (so, If you mark do an action on an inbox note, you should close the inbox notes list and reopen it to see the state `isRead` updated) 


### Screenshots
<img src="https://user-images.githubusercontent.com/495617/155727161-30d332f6-96c4-4af7-a5f7-e9c6ade8775c.png" width=300 />




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
