### PR TITLE
Order Creation: Handle empty (non-nil) addresses in Customer section

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -133,7 +133,6 @@ struct OrderCustomerSection_Previews: PreviewProvider {
     static var previews: some View {
         let emptyViewModel = NewOrderViewModel.CustomerDataViewModel(billingAddress: nil, shippingAddress: nil)
         let addressViewModel = NewOrderViewModel.CustomerDataViewModel(fullName: "Johnny Appleseed",
-                                                                       email: "scrambled@scrambled.com",
                                                                        billingAddressFormatted: nil,
                                                                        shippingAddressFormatted: """
                                                                             Johnny Appleseed

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -318,7 +318,10 @@ extension NewOrderViewModel {
         let shippingAddressFormatted: String?
 
         init(fullName: String? = nil, email: String? = nil, billingAddressFormatted: String? = nil, shippingAddressFormatted: String? = nil) {
-            self.isDataAvailable = fullName != nil || email != nil || billingAddressFormatted != nil || shippingAddressFormatted != nil
+            self.isDataAvailable = !fullName.isNilOrEmpty
+                || !email.isNilOrEmpty
+                || !billingAddressFormatted.isNilOrEmpty
+                || !shippingAddressFormatted.isNilOrEmpty
             self.fullName = fullName
             self.email = email
             self.billingAddressFormatted = billingAddressFormatted
@@ -326,7 +329,7 @@ extension NewOrderViewModel {
         }
 
         init(billingAddress: Address?, shippingAddress: Address?) {
-            let availableFullName = billingAddress?.fullName ?? shippingAddress?.fullName
+            let availableFullName = billingAddress?.fullName.isNotEmpty == true ? billingAddress?.fullName : shippingAddress?.fullName
 
             self.init(fullName: availableFullName?.isNotEmpty == true ? availableFullName : nil,
                       email: billingAddress?.hasEmailAddress == true ? billingAddress?.email : nil,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -313,22 +313,20 @@ extension NewOrderViewModel {
     struct CustomerDataViewModel {
         let isDataAvailable: Bool
         let fullName: String?
-        let email: String?
         let billingAddressFormatted: String?
         let shippingAddressFormatted: String?
 
         init(fullName: String? = nil,
-             email: String? = nil,
+             hasEmail: Bool = false,
              hasPhone: Bool = false,
              billingAddressFormatted: String? = nil,
              shippingAddressFormatted: String? = nil) {
             self.isDataAvailable = !fullName.isNilOrEmpty
-                || !email.isNilOrEmpty
+                || hasEmail
                 || hasPhone
                 || !billingAddressFormatted.isNilOrEmpty
                 || !shippingAddressFormatted.isNilOrEmpty
             self.fullName = fullName
-            self.email = email
             self.billingAddressFormatted = billingAddressFormatted
             self.shippingAddressFormatted = shippingAddressFormatted
         }
@@ -337,7 +335,7 @@ extension NewOrderViewModel {
             let availableFullName = billingAddress?.fullName.isNotEmpty == true ? billingAddress?.fullName : shippingAddress?.fullName
 
             self.init(fullName: availableFullName?.isNotEmpty == true ? availableFullName : nil,
-                      email: billingAddress?.hasEmailAddress == true ? billingAddress?.email : nil,
+                      hasEmail: billingAddress?.hasEmailAddress == true,
                       hasPhone: billingAddress?.hasPhoneNumber == true || shippingAddress?.hasPhoneNumber == true,
                       billingAddressFormatted: billingAddress?.fullNameWithCompanyAndAddress,
                       shippingAddressFormatted: shippingAddress?.fullNameWithCompanyAndAddress)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -317,9 +317,14 @@ extension NewOrderViewModel {
         let billingAddressFormatted: String?
         let shippingAddressFormatted: String?
 
-        init(fullName: String? = nil, email: String? = nil, billingAddressFormatted: String? = nil, shippingAddressFormatted: String? = nil) {
+        init(fullName: String? = nil,
+             email: String? = nil,
+             hasPhone: Bool = false,
+             billingAddressFormatted: String? = nil,
+             shippingAddressFormatted: String? = nil) {
             self.isDataAvailable = !fullName.isNilOrEmpty
                 || !email.isNilOrEmpty
+                || hasPhone
                 || !billingAddressFormatted.isNilOrEmpty
                 || !shippingAddressFormatted.isNilOrEmpty
             self.fullName = fullName
@@ -333,6 +338,7 @@ extension NewOrderViewModel {
 
             self.init(fullName: availableFullName?.isNotEmpty == true ? availableFullName : nil,
                       email: billingAddress?.hasEmailAddress == true ? billingAddress?.email : nil,
+                      hasPhone: billingAddress?.hasPhoneNumber == true || shippingAddress?.hasPhoneNumber == true,
                       billingAddressFormatted: billingAddress?.fullNameWithCompanyAndAddress,
                       shippingAddressFormatted: shippingAddress?.fullNameWithCompanyAndAddress)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -315,6 +315,21 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(customerDataViewModel.shippingAddressFormatted, "")
     }
 
+    func test_customer_data_view_model_is_initialized_correctly_with_only_phone() {
+        // Given
+        let addressWithOnlyPhone = Address.fake().copy(phone: "123-456-7890")
+
+        // When
+        let customerDataViewModel = NewOrderViewModel.CustomerDataViewModel(billingAddress: addressWithOnlyPhone, shippingAddress: Address.empty)
+
+        // Then
+        XCTAssertTrue(customerDataViewModel.isDataAvailable)
+        XCTAssertNil(customerDataViewModel.fullName)
+        XCTAssertNil(customerDataViewModel.email)
+        XCTAssertEqual(customerDataViewModel.billingAddressFormatted, "")
+        XCTAssertEqual(customerDataViewModel.shippingAddressFormatted, "")
+    }
+
     func test_payment_data_view_model_is_initialized_with_expected_values() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -298,7 +298,6 @@ class NewOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(customerDataViewModel.isDataAvailable)
         XCTAssertNil(customerDataViewModel.fullName)
-        XCTAssertNil(customerDataViewModel.email)
         XCTAssertNotNil(customerDataViewModel.billingAddressFormatted)
         XCTAssertNil(customerDataViewModel.shippingAddressFormatted)
     }
@@ -310,7 +309,6 @@ class NewOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(customerDataViewModel.isDataAvailable)
         XCTAssertNil(customerDataViewModel.fullName)
-        XCTAssertNil(customerDataViewModel.email)
         XCTAssertEqual(customerDataViewModel.billingAddressFormatted, "")
         XCTAssertEqual(customerDataViewModel.shippingAddressFormatted, "")
     }
@@ -325,7 +323,6 @@ class NewOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(customerDataViewModel.isDataAvailable)
         XCTAssertNil(customerDataViewModel.fullName)
-        XCTAssertNil(customerDataViewModel.email)
         XCTAssertEqual(customerDataViewModel.billingAddressFormatted, "")
         XCTAssertEqual(customerDataViewModel.shippingAddressFormatted, "")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -303,6 +303,18 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertNil(customerDataViewModel.shippingAddressFormatted)
     }
 
+    func test_customer_data_view_model_is_initialized_correctly_from_empty_input() {
+        // Given
+        let customerDataViewModel = NewOrderViewModel.CustomerDataViewModel(billingAddress: Address.empty, shippingAddress: Address.empty)
+
+        // Then
+        XCTAssertFalse(customerDataViewModel.isDataAvailable)
+        XCTAssertNil(customerDataViewModel.fullName)
+        XCTAssertNil(customerDataViewModel.email)
+        XCTAssertEqual(customerDataViewModel.billingAddressFormatted, "")
+        XCTAssertEqual(customerDataViewModel.shippingAddressFormatted, "")
+    }
+
     func test_payment_data_view_model_is_initialized_with_expected_values() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)


### PR DESCRIPTION
Closes: #6230

## Description

In Order Creation, this updates how empty (non-nil) addresses are handled in the Customer section. Now, instead of showing them as empty addresses, we show the prompt to add customer details.

This resolves the issue where we create an order as part of the `RemoteOrderSynchronizer` logic, and the remote order is returned with empty (non-nil) addresses.

## Changes

* When setting `isDataAvailable` for `CustomerDataViewModel`, it now checks that the details are not nil or empty (not just non-nil), so that empty addresses are handled as not having data available.
* Adds a check for `hasPhone` when setting `isDataAvailable`, for the case where only a phone number is entered in the address form. (In this case we expect to display "No address specified" in the Customer section on the New Order screen, since we don't show the phone number there but there are still details entered.)

## Testing

### Prerequisites

- Set your store to WC 6.3.0-beta.1.
- Enable the `orderCreationRemoteSynchronizer` local feature flag.

### Steps

1. Build and run the app.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. Select a product or add shipping/fee.
5. See that after 1s the order is synced (see visible loading indicator).
6. Confirm the Customer section still shows the prompt "Add Customer Details" after the sync is done.
7. Tap "Add Customer Details" and add only a phone number.
8. Confirm the Customer section now shows "No address specified."

## Screenshots

https://user-images.githubusercontent.com/8658164/155732107-c1058e52-674b-426e-8ac6-b3bfc235d3ce.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
