### PR TITLE
Adding view model for bulk price update screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Yosemite
+
+/// View Model logic for the bulk price setting screen
+///
+final class BulkUpdatePriceSettingsViewModel {
+    /// Represents possible states for the save button.
+    enum ButtonState: Equatable {
+        case enabled
+        case disabled
+        case loading
+    }
+
+    /// Indicates what price we are editting
+    ///
+    enum EdittingPriceType {
+        case regular
+        case sale
+
+        func keyPathForPriceType() -> KeyPath<ProductVariation, String?> {
+            switch self {
+            case .regular:
+                return \.regularPrice
+            case .sale:
+                return \.salePrice
+            }
+        }
+    }
+
+    /// The state of synching all variations
+    @Published private(set) var buttonState: ButtonState = .disabled
+
+    /// The error state, true if the product bulk update API call failed. Used to trigger related informational notification
+    @Published private(set) var lastUpdateDidFail: Bool = false
+
+    /// The error state, true if the product bulk updat failed
+    @Published private(set) var priceValidationError: ProductPriceSettingsError? = nil
+
+    /// A Closure to be called when the price update is successful
+    private let priceUpdateDidFinish: () -> Void
+
+    private let productVariations: [ProductVariation]
+    private let edittingPriceType: EdittingPriceType
+    private let storesManager: StoresManager
+    private let priceSettingsValidator: ProductPriceSettingsValidator
+    private var currentPrice: String? = nil
+    private let siteID: Int64
+    private let productID: Int64
+
+    init(siteID: Int64,
+         productID: Int64,
+         productVariations: [ProductVariation],
+         edittingPriceType: EdittingPriceType,
+         priceUpdateDidFinish: @escaping () -> Void,
+         storesManager: StoresManager = ServiceLocator.stores,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        self.siteID = siteID
+        self.productID = productID
+        self.productVariations = productVariations
+        self.priceUpdateDidFinish = priceUpdateDidFinish
+        self.edittingPriceType = edittingPriceType
+        self.storesManager = storesManager
+        self.priceSettingsValidator = ProductPriceSettingsValidator(currencySettings: currencySettings)
+    }
+
+    func saveButtonTapped() {
+        priceValidationError = validatePrice()
+        guard priceValidationError == nil else {
+            return
+        }
+
+        buttonState = .loading
+        lastUpdateDidFail = false
+
+        let action = ProductVariationAction.updateProductVariations(siteID: siteID,
+                                                                    productID: productID,
+                                                                    productVariations: productVariations) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(_):
+                self.lastUpdateDidFail = false
+                self.priceUpdateDidFinish()
+            case let .failure(error):
+                DDLogError("⛔️ Error updating product variations: \(error)")
+                self.lastUpdateDidFail = true
+            }
+
+            self.updateButtonStateBasedOnCurrentPrice()
+        }
+
+        storesManager.dispatch(action)
+    }
+
+    func handlePriceChange(_ price: String) {
+        currentPrice = price
+        updateButtonStateBasedOnCurrentPrice()
+    }
+
+    private func updateButtonStateBasedOnCurrentPrice() {
+        guard let price = currentPrice, price.isNotEmpty else {
+            buttonState = .disabled
+            return
+        }
+        buttonState = .enabled
+    }
+
+    private func validatePrice() -> ProductPriceSettingsError? {
+        var error: ProductPriceSettingsError?
+
+        for variation in productVariations {
+            let regularPrice = edittingPriceType == .regular ? currentPrice : variation.regularPrice
+            let salePrice = edittingPriceType == .sale ? currentPrice : variation.salePrice
+
+            error = priceSettingsValidator.validate(regularPrice: regularPrice,
+                                                    salePrice: salePrice,
+                                                    dateOnSaleStart: variation.dateOnSaleStart,
+                                                    dateOnSaleEnd: variation.dateOnSaleEnd)
+            if error != nil {
+                break
+            }
+        }
+
+        return error
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
@@ -63,6 +63,8 @@ final class BulkUpdatePriceSettingsViewModel {
         self.priceSettingsValidator = ProductPriceSettingsValidator(currencySettings: currencySettings)
     }
 
+    /// Called when the save button is tapped
+    ///
     func saveButtonTapped() {
         priceValidationError = validatePrice()
         guard priceValidationError == nil else {
@@ -92,11 +94,15 @@ final class BulkUpdatePriceSettingsViewModel {
         storesManager.dispatch(action)
     }
 
+    /// Called when price changes
+    ///
     func handlePriceChange(_ price: String) {
         currentPrice = price
         updateButtonStateBasedOnCurrentPrice()
     }
 
+    /// Update the button state to enable/disable based on price value
+    ///
     private func updateButtonStateBasedOnCurrentPrice() {
         guard let price = currentPrice, price.isNotEmpty else {
             buttonState = .disabled
@@ -105,6 +111,8 @@ final class BulkUpdatePriceSettingsViewModel {
         buttonState = .enabled
     }
 
+    /// Validates the curre price selection for all variations that will be updated
+    ///
     private func validatePrice() -> ProductPriceSettingsError? {
         var error: ProductPriceSettingsError?
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
@@ -76,7 +76,7 @@ final class BulkUpdatePriceSettingsViewModel {
 
         let action = ProductVariationAction.updateProductVariations(siteID: siteID,
                                                                     productID: productID,
-                                                                    productVariations: productVariations) { [weak self] result in
+                                                                    productVariations: variationsWithUpdatedPrice()) { [weak self] result in
             guard let self = self else { return }
 
             switch result {
@@ -109,6 +109,15 @@ final class BulkUpdatePriceSettingsViewModel {
             return
         }
         saveButtonState = .enabled
+    }
+
+    private func variationsWithUpdatedPrice() -> [ProductVariation] {
+        switch edittingPriceType {
+        case .regular:
+            return productVariations.map { $0.copy(regularPrice: currentPrice) }
+        case .sale:
+            return productVariations.map { $0.copy(salePrice: currentPrice) }
+        }
     }
 
     /// Validates the curre price selection for all variations that will be updated

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
@@ -28,7 +28,7 @@ final class BulkUpdatePriceSettingsViewModel {
     }
 
     /// The state of synching all variations
-    @Published private(set) var buttonState: ButtonState = .disabled
+    @Published private(set) var saveButtonState: ButtonState = .disabled
 
     /// The error state, true if the product bulk update API call failed. Used to trigger related informational notification
     @Published private(set) var lastUpdateDidFail: Bool = false
@@ -71,7 +71,7 @@ final class BulkUpdatePriceSettingsViewModel {
             return
         }
 
-        buttonState = .loading
+        saveButtonState = .loading
         lastUpdateDidFail = false
 
         let action = ProductVariationAction.updateProductVariations(siteID: siteID,
@@ -105,10 +105,10 @@ final class BulkUpdatePriceSettingsViewModel {
     ///
     private func updateButtonStateBasedOnCurrentPrice() {
         guard let price = currentPrice, price.isNotEmpty else {
-            buttonState = .disabled
+            saveButtonState = .disabled
             return
         }
-        buttonState = .enabled
+        saveButtonState = .enabled
     }
 
     /// Validates the curre price selection for all variations that will be updated

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -423,9 +423,11 @@
 		094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */; };
 		09885C8727C6947A00910A62 /* ProductPriceSettingsValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09885C8627C6947A00910A62 /* ProductPriceSettingsValidator.swift */; };
 		098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */; };
-		09EA565227C8235200407D40 /* ProductPriceSettingsValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */; };
+		09BE3A8E27C91E730070B69D /* BulkUpdatePriceSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BE3A8D27C91E730070B69D /* BulkUpdatePriceSettingsViewModel.swift */; };
+		09BE3A9127C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BE3A9027C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift */; };
 		09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */; };
 		09E41E1D27B90B3C00BFCB7C /* BulkUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */; };
+		09EA565227C8235200407D40 /* ProductPriceSettingsValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -2091,9 +2093,11 @@
 		094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModelTests.swift; sourceTree = "<group>"; };
 		09885C8627C6947A00910A62 /* ProductPriceSettingsValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsValidator.swift; sourceTree = "<group>"; };
 		098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSourceTests.swift; sourceTree = "<group>"; };
-		09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsValidatorTests.swift; sourceTree = "<group>"; };
+		09BE3A8D27C91E730070B69D /* BulkUpdatePriceSettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BulkUpdatePriceSettingsViewModel.swift; sourceTree = "<group>"; };
+		09BE3A9027C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdatePriceSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModelTests.swift; sourceTree = "<group>"; };
 		09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModel.swift; sourceTree = "<group>"; };
+		09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsValidatorTests.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
@@ -4158,6 +4162,7 @@
 		02C2756924F4EE6F00286C04 /* Edit Price */ = {
 			isa = PBXGroup;
 			children = (
+				09BE3A8F27C921980070B69D /* Bulk Edit Price */,
 				02153210242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift */,
 				02BAB02024D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift */,
 				09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */,
@@ -4353,6 +4358,22 @@
 				098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */,
 			);
 			path = "Edit Order Status";
+			sourceTree = "<group>";
+		};
+		09BE3A8C27C91E610070B69D /* Bulk Edit Price */ = {
+			isa = PBXGroup;
+			children = (
+				09BE3A8D27C91E730070B69D /* BulkUpdatePriceSettingsViewModel.swift */,
+			);
+			path = "Bulk Edit Price";
+			sourceTree = "<group>";
+		};
+		09BE3A8F27C921980070B69D /* Bulk Edit Price */ = {
+			isa = PBXGroup;
+			children = (
+				09BE3A9027C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift */,
+			);
+			path = "Bulk Edit Price";
 			sourceTree = "<group>";
 		};
 		09C6A26027C01151001FAD73 /* Bulk Update */ = {
@@ -5090,6 +5111,7 @@
 		45B9C63B23A8E4DB007FC4C5 /* Edit Price */ = {
 			isa = PBXGroup;
 			children = (
+				09BE3A8C27C91E610070B69D /* Bulk Edit Price */,
 				45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */,
 				45B9C63D23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib */,
 				45B9C64023A9139A007FC4C5 /* Product+PriceSettingsViewModels.swift */,
@@ -8441,6 +8463,7 @@
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
 				025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */,
 				456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */,
+				09BE3A8E27C91E730070B69D /* BulkUpdatePriceSettingsViewModel.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,
@@ -9309,6 +9332,7 @@
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				023EC2E624DAB1270021DA91 /* EditableProductVariationModelTests.swift in Sources */,
+				09BE3A9127C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift in Sources */,
 				E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				FEEB2F6E268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModelTests.swift
@@ -23,7 +23,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0, productID: 0, productVariations: [], edittingPriceType: .regular, priceUpdateDidFinish: { })
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertEqual(viewModel.saveButtonState, .disabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertNil(viewModel.priceValidationError)
     }
@@ -35,7 +35,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.handlePriceChange("42")
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertEqual(viewModel.saveButtonState, .enabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertNil(viewModel.priceValidationError)
     }
@@ -47,7 +47,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.handlePriceChange("")
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertEqual(viewModel.saveButtonState, .disabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertNil(viewModel.priceValidationError)
     }
@@ -65,7 +65,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertEqual(viewModel.saveButtonState, .disabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertEqual(viewModel.priceValidationError, .salePriceWithoutRegularPrice)
     }
@@ -84,7 +84,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertEqual(viewModel.saveButtonState, .disabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertEqual(viewModel.priceValidationError, .salePriceWithoutRegularPrice)
     }
@@ -102,7 +102,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertEqual(viewModel.saveButtonState, .disabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertEqual(viewModel.priceValidationError, .newSaleWithEmptySalePrice)
     }
@@ -121,7 +121,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertEqual(viewModel.saveButtonState, .disabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertEqual(viewModel.priceValidationError, .newSaleWithEmptySalePrice)
     }
@@ -140,7 +140,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertEqual(viewModel.saveButtonState, .enabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertEqual(viewModel.priceValidationError, .salePriceHigherThanRegularPrice)
     }
@@ -160,7 +160,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertEqual(viewModel.saveButtonState, .enabled)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertEqual(viewModel.priceValidationError, .salePriceHigherThanRegularPrice)
     }
@@ -183,7 +183,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .loading)
+        XCTAssertEqual(viewModel.saveButtonState, .loading)
         XCTAssertFalse(viewModel.lastUpdateDidFail)
         XCTAssertNil(viewModel.priceValidationError)
     }
@@ -211,7 +211,7 @@ final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
         viewModel.saveButtonTapped()
 
         // Then
-        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertEqual(viewModel.saveButtonState, .enabled)
         XCTAssertTrue(viewModel.lastUpdateDidFail)
         XCTAssertNil(viewModel.priceValidationError)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModelTests.swift
@@ -1,0 +1,251 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+/// Tests for `BulkUpdatePriceSettingsViewModel`
+///
+final class BulkUpdatePriceSettingsViewModelTests: XCTestCase {
+
+    private var storesManager: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        super.tearDown()
+    }
+
+    func test_initial_viewModel_state() {
+        // Given
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0, productID: 0, productVariations: [], edittingPriceType: .regular, priceUpdateDidFinish: { })
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertNil(viewModel.priceValidationError)
+    }
+
+    func test_state_when_price_is_changed_from_empty_to_a_value() {
+        // Given
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0, productID: 0, productVariations: [], edittingPriceType: .regular, priceUpdateDidFinish: { })
+
+        viewModel.handlePriceChange("42")
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertNil(viewModel.priceValidationError)
+    }
+
+    func test_state_when_price_is_changed_from_a_value_to_empty() {
+        // Given
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0, productID: 0, productVariations: [], edittingPriceType: .regular, priceUpdateDidFinish: { })
+
+        viewModel.handlePriceChange("")
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertNil(viewModel.priceValidationError)
+    }
+
+    func test_state_when_no_regular_price_is_selected_and_save_button_tapped_given_variations_have_sale_price() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), salePrice: "42")]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .regular,
+                                                         priceUpdateDidFinish: { })
+
+        // When
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertEqual(viewModel.priceValidationError, .salePriceWithoutRegularPrice)
+    }
+
+    func test_state_when_no_regular_price_is_selected_and_save_button_tapped_given_with_multiple_variations_having_sale_price() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "43", salePrice: "42"),
+                          MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), salePrice: "42")]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .regular,
+                                                         priceUpdateDidFinish: { })
+
+        // When
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertEqual(viewModel.priceValidationError, .salePriceWithoutRegularPrice)
+    }
+
+    func test_state_when_no_sale_price_is_selected_and_save_button_tapped_given_variations_with_no_prices() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date())]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .sale,
+                                                         priceUpdateDidFinish: { })
+
+        // When
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertEqual(viewModel.priceValidationError, .newSaleWithEmptySalePrice)
+    }
+
+    func test_state_when_no_sale_price_is_selected_and_save_button_tapped_givenwith_multiple_variations_with_no_prices() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date()),
+                          MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date())]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .sale,
+                                                         priceUpdateDidFinish: { })
+
+        // When
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .disabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertEqual(viewModel.priceValidationError, .newSaleWithEmptySalePrice)
+    }
+
+    func test_state_when_selected_sale_price_is_greater_than_regular_price() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "10")]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .sale,
+                                                         priceUpdateDidFinish: { })
+
+        // When
+        viewModel.handlePriceChange("42")
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertEqual(viewModel.priceValidationError, .salePriceHigherThanRegularPrice)
+    }
+
+    func test_state_when_selected_sale_price_is_greater_than_regular_price_with_multiple_variations() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "50"),
+                          MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "10")]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .sale,
+                                                         priceUpdateDidFinish: { })
+
+        // When
+        viewModel.handlePriceChange("42")
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertEqual(viewModel.priceValidationError, .salePriceHigherThanRegularPrice)
+    }
+
+    func test_state_when_selected_valid_price_is_valid_when_action_is_dispatched() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "50")]
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { _ in
+            // do nothing to stay in "syncing" state
+        }
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .sale,
+                                                         priceUpdateDidFinish: { },
+                                                         storesManager: storesManager)
+
+        // When
+        viewModel.handlePriceChange("9")
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .loading)
+        XCTAssertFalse(viewModel.lastUpdateDidFail)
+        XCTAssertNil(viewModel.priceValidationError)
+    }
+
+    func test_state_when_selected_valid_price_is_valid_when_action_fails() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "50")]
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .updateProductVariations(_, _, _, onCompletion):
+                onCompletion(.failure(.unexpected))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .sale,
+                                                         priceUpdateDidFinish: { },
+                                                         storesManager: storesManager)
+
+        // When
+        viewModel.handlePriceChange("9")
+        viewModel.saveButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.buttonState, .enabled)
+        XCTAssertTrue(viewModel.lastUpdateDidFail)
+        XCTAssertNil(viewModel.priceValidationError)
+    }
+
+    func test_callback_is_called_when_update_action_is_successful() {
+        // Given
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "50")]
+        var isCallbackCalled = false
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
+            switch action {
+            case let .updateProductVariations(_, _, _, onCompletion):
+                onCompletion(.success([]))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         productVariations: variations,
+                                                         edittingPriceType: .sale,
+                                                         priceUpdateDidFinish: {
+                                                            isCallbackCalled = true
+                                                         },
+                                                         storesManager: storesManager)
+
+        // When
+        viewModel.handlePriceChange("9")
+        viewModel.saveButtonTapped()
+
+
+        // Then
+        waitUntil {
+            isCallbackCalled
+        }
+        XCTAssertTrue(isCallbackCalled)
+    }
+}


### PR DESCRIPTION
Part of: #6239

### Description
Added view model for the bulk price update screen #6239. This view model handles all view related events (change of price and save button tapped). It holds and updates the state variables of the view based on the actions and network results. The state of the view includes:
* The state of the "save" button `buttonState` (enabled, disabled, loading)
* The state of the validation of the user-typed price (nil for an `ProductPriceSettingsError`)
* If the network call has failed (to display a notice and let the user retry)
 
### Testing instructions
None needed. Just running the unit tests.

### Screenshots
None needed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.