### PR TITLE
Order Creation: Maintain state on shipping & fees detail screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -39,8 +39,7 @@ struct NewOrder: View {
 
                         Spacer(minLength: Layout.sectionSpacing)
 
-                        OrderPaymentSection(viewModel: viewModel.paymentDataViewModel,
-                                            saveFeeLineClosure: viewModel.saveFeeLine)
+                        OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
 
                         Spacer(minLength: Layout.sectionSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -40,7 +40,6 @@ struct NewOrder: View {
                         Spacer(minLength: Layout.sectionSpacing)
 
                         OrderPaymentSection(viewModel: viewModel.paymentDataViewModel,
-                                            saveShippingLineClosure: viewModel.saveShippingLine,
                                             saveFeeLineClosure: viewModel.saveFeeLine)
 
                         Spacer(minLength: Layout.sectionSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -341,7 +341,6 @@ extension NewOrderViewModel {
 
         let shouldShowShippingTotal: Bool
         let shippingTotal: String
-        let shippingMethodTitle: String
 
         let shouldShowFees: Bool
         let feesBaseAmountForPercentage: Decimal
@@ -350,6 +349,8 @@ extension NewOrderViewModel {
         /// Whether payment data is being reloaded (during remote sync)
         ///
         let isLoading: Bool
+
+        let shippingLineViewModel: ShippingLineDetailsViewModel
 
         init(itemsTotal: String = "",
              shouldShowShippingTotal: Bool = false,
@@ -360,16 +361,20 @@ extension NewOrderViewModel {
              feesTotal: String = "",
              orderTotal: String = "",
              isLoading: Bool = false,
+             saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
             self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? ""
             self.shouldShowShippingTotal = shouldShowShippingTotal
             self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? ""
-            self.shippingMethodTitle = shippingMethodTitle
             self.shouldShowFees = shouldShowFees
             self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? ""
             self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? ""
             self.isLoading = isLoading
+            self.shippingLineViewModel = ShippingLineDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
+                                                                      initialMethodTitle: shippingMethodTitle,
+                                                                      shippingTotal: self.shippingTotal,
+                                                                      didSelectSave: saveShippingLineClosure)
         }
     }
 }
@@ -496,6 +501,7 @@ private extension NewOrderViewModel {
                                             feesTotal: feesTotal.stringValue,
                                             orderTotal: orderTotal.stringValue,
                                             isLoading: isDataSyncing,
+                                            saveShippingLineClosure: self.saveShippingLine,
                                             currencyFormatter: self.currencyFormatter)
             }
             .assign(to: &$paymentDataViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -341,6 +341,7 @@ extension NewOrderViewModel {
 
         let shouldShowShippingTotal: Bool
         let shippingTotal: String
+        let shippingMethodTitle: String
 
         let shouldShowFees: Bool
         let feesBaseAmountForPercentage: Decimal
@@ -351,6 +352,7 @@ extension NewOrderViewModel {
         let isLoading: Bool
 
         let shippingLineViewModel: ShippingLineDetailsViewModel
+        let feeLineViewModel: FeeLineDetailsViewModel
 
         init(itemsTotal: String = "",
              shouldShowShippingTotal: Bool = false,
@@ -362,10 +364,12 @@ extension NewOrderViewModel {
              orderTotal: String = "",
              isLoading: Bool = false,
              saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
+             saveFeeLineClosure: @escaping (OrderFeeLine?) -> Void = { _ in },
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
             self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? ""
             self.shouldShowShippingTotal = shouldShowShippingTotal
             self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? ""
+            self.shippingMethodTitle = shippingMethodTitle
             self.shouldShowFees = shouldShowFees
             self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? ""
@@ -375,6 +379,10 @@ extension NewOrderViewModel {
                                                                       initialMethodTitle: shippingMethodTitle,
                                                                       shippingTotal: self.shippingTotal,
                                                                       didSelectSave: saveShippingLineClosure)
+            self.feeLineViewModel = FeeLineDetailsViewModel(isExistingFeeLine: shouldShowFees,
+                                                            baseAmountForPercentage: feesBaseAmountForPercentage,
+                                                            feesTotal: self.feesTotal,
+                                                            didSelectSave: saveFeeLineClosure)
         }
     }
 }
@@ -502,6 +510,7 @@ private extension NewOrderViewModel {
                                             orderTotal: orderTotal.stringValue,
                                             isLoading: isDataSyncing,
                                             saveShippingLineClosure: self.saveShippingLine,
+                                            saveFeeLineClosure: self.saveFeeLine,
                                             currencyFormatter: self.currencyFormatter)
             }
             .assign(to: &$paymentDataViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -168,9 +168,10 @@ private extension FeeLineDetails {
 
 struct FeeLineDetails_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
-                                                               feesBaseAmountForPercentage: 200,
-                                                               feesTotal: "10")
-        FeeLineDetails(viewModel: .init(inputData: viewModel, didSelectSave: { _ in }))
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: true,
+                                                baseAmountForPercentage: 200,
+                                                feesTotal: "10",
+                                                didSelectSave: { _ in })
+        FeeLineDetails(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -100,7 +100,9 @@ class FeeLineDetailsViewModel: ObservableObject {
 
     @Published var feeType: FeeType = .fixed
 
-    init(inputData: NewOrderViewModel.PaymentDataViewModel,
+    init(isExistingFeeLine: Bool,
+         baseAmountForPercentage: Decimal,
+         feesTotal: String,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          didSelectSave: @escaping ((OrderFeeLine?) -> Void)) {
@@ -111,10 +113,10 @@ class FeeLineDetailsViewModel: ObservableObject {
         self.currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
         self.amountPlaceholder = priceFieldFormatter.formatAmount("0")
 
-        self.isExistingFeeLine = inputData.shouldShowFees
-        self.baseAmountForPercentage = inputData.feesBaseAmountForPercentage
+        self.isExistingFeeLine = isExistingFeeLine
+        self.baseAmountForPercentage = baseAmountForPercentage
 
-        if let initialAmount = currencyFormatter.convertToDecimal(from: inputData.feesTotal) {
+        if let initialAmount = currencyFormatter.convertToDecimal(from: feesTotal) {
             self.initialAmount = initialAmount as Decimal
         } else {
             self.initialAmount = .zero

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -7,8 +7,6 @@ struct OrderPaymentSection: View {
     /// View model to drive the view content
     let viewModel: NewOrderViewModel.PaymentDataViewModel
 
-    let saveFeeLineClosure: (OrderFeeLine?) -> Void
-
     /// Indicates if the shipping line details screen should be shown or not.
     ///
     @State private var shouldShowShippingLineDetails: Bool = false
@@ -45,9 +43,7 @@ struct OrderPaymentSection: View {
                     }
                 feesRow
                     .sheet(isPresented: $shouldShowFeeLineDetails) {
-                        FeeLineDetails(viewModel: .init(inputData: viewModel, didSelectSave: { newFeeLine in
-                            saveFeeLineClosure(newFeeLine)
-                        }))
+                        FeeLineDetails(viewModel: viewModel.feeLineViewModel)
                     }
             }
 
@@ -111,7 +107,7 @@ struct OrderPaymentSection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00", orderTotal: "20.00")
 
-        OrderPaymentSection(viewModel: viewModel, saveFeeLineClosure: { _ in })
+        OrderPaymentSection(viewModel: viewModel)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -7,8 +7,6 @@ struct OrderPaymentSection: View {
     /// View model to drive the view content
     let viewModel: NewOrderViewModel.PaymentDataViewModel
 
-    /// Closure to create/update the shipping line object
-    let saveShippingLineClosure: (ShippingLine?) -> Void
     let saveFeeLineClosure: (OrderFeeLine?) -> Void
 
     /// Indicates if the shipping line details screen should be shown or not.
@@ -43,9 +41,7 @@ struct OrderPaymentSection: View {
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) {
                 shippingRow
                     .sheet(isPresented: $shouldShowShippingLineDetails) {
-                        ShippingLineDetails(viewModel: .init(inputData: viewModel, didSelectSave: { newShippingLine in
-                            saveShippingLineClosure(newShippingLine)
-                        }))
+                        ShippingLineDetails(viewModel: viewModel.shippingLineViewModel)
                     }
                 feesRow
                     .sheet(isPresented: $shouldShowFeeLineDetails) {
@@ -115,7 +111,7 @@ struct OrderPaymentSection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00", orderTotal: "20.00")
 
-        OrderPaymentSection(viewModel: viewModel, saveShippingLineClosure: { _ in }, saveFeeLineClosure: { _ in })
+        OrderPaymentSection(viewModel: viewModel, saveFeeLineClosure: { _ in })
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -123,11 +123,10 @@ private extension ShippingLineDetails {
 
 struct ShippingLineDetails_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: "5",
-                                                               shouldShowShippingTotal: true,
-                                                               shippingTotal: "10",
-                                                               shippingMethodTitle: "Shipping",
-                                                               orderTotal: "15")
-        ShippingLineDetails(viewModel: .init(inputData: viewModel, didSelectSave: { _ in }))
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: true,
+                                                     initialMethodTitle: "Shipping",
+                                                     shippingTotal: "10",
+                                                     didSelectSave: { _ in })
+        ShippingLineDetails(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
@@ -62,7 +62,9 @@ class ShippingLineDetailsViewModel: ObservableObject {
         return !(amountUpdated || methodTitleUpdated)
     }
 
-    init(inputData: NewOrderViewModel.PaymentDataViewModel,
+    init(isExistingShippingLine: Bool,
+         initialMethodTitle: String,
+         shippingTotal: String,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          didSelectSave: @escaping ((ShippingLine?) -> Void)) {
@@ -71,12 +73,12 @@ class ShippingLineDetailsViewModel: ObservableObject {
         self.currencyPosition = storeCurrencySettings.currencyPosition
         self.amountPlaceholder = priceFieldFormatter.formatAmount("0")
 
-        self.isExistingShippingLine = inputData.shouldShowShippingTotal
-        self.initialMethodTitle = inputData.shippingMethodTitle
+        self.isExistingShippingLine = isExistingShippingLine
+        self.initialMethodTitle = initialMethodTitle
         self.methodTitle = initialMethodTitle
 
        let currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
-        if let initialAmount = currencyFormatter.convertToDecimal(from: inputData.shippingTotal) {
+        if let initialAmount = currencyFormatter.convertToDecimal(from: shippingTotal) {
             self.initialAmount = initialAmount as Decimal
         } else {
             self.initialAmount = .zero

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -11,7 +11,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_formats_amount_correctly() {
         // Given
-        let viewModel = FeeLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 0,
+                                                feesTotal: "",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
 
         // When
         viewModel.amount = "hi:11.3005.02-"
@@ -31,7 +36,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
                                               decimalSeparator: ".",
                                               numberOfDecimals: 3)
 
-        let viewModel = FeeLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: customSettings, didSelectSave: { _ in })
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 0,
+                                                feesTotal: "",
+                                                locale: usLocale,
+                                                storeCurrencySettings: customSettings,
+                                                didSelectSave: { _ in })
 
         // When
         viewModel.amount = "12.203"
@@ -45,7 +55,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_formats_percentage_correctly() {
         // Given
-        let viewModel = FeeLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 0,
+                                                feesTotal: "",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
 
         // When
         viewModel.percentage = "hi:11.3005.02-"
@@ -56,11 +71,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_prefills_input_data_correctly() {
         // Given
-        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
-                                                               feesBaseAmountForPercentage: 200,
-                                                               feesTotal: "10")
-
-        let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: true,
+                                                baseAmountForPercentage: 200,
+                                                feesTotal: "10",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isPercentageOptionAvailable)
@@ -72,9 +88,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_empty_state_and_enables_with_input() {
         // Given
-        let inputData = NewOrderViewModel.PaymentDataViewModel(feesBaseAmountForPercentage: 200)
-
-        let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 200,
+                                                feesTotal: "",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
 
         // When & Then
@@ -104,11 +123,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_changes() {
         // Given
-        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
-                                                               feesBaseAmountForPercentage: 100,
-                                                               feesTotal: "11.30")
-
-        let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: true,
+                                                baseAmountForPercentage: 100,
+                                                feesTotal: "11.30",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
 
         // When & Then
@@ -127,11 +147,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
     func test_view_model_disables_done_button_for_matched_percentage_value() {
         // Given
         // Initial fee is $10/5%
-        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: true,
-                                                               feesBaseAmountForPercentage: 200,
-                                                               feesTotal: "10")
-
-        let viewModel = FeeLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: true,
+                                                baseAmountForPercentage: 200,
+                                                feesTotal: "10",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
 
         // When & Then
@@ -149,10 +170,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
     func test_view_model_creates_fee_line_with_fixed_amount() {
         // Given
         var savedFeeLine: OrderFeeLine?
-        let viewModel = FeeLineDetailsViewModel(inputData: .init(),
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { newFeeLine in
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 0,
+                                                feesTotal: "",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { newFeeLine in
             savedFeeLine = newFeeLine
         })
 
@@ -167,13 +190,12 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
     func test_view_model_creates_fee_line_with_percentage_amount() {
         // Given
         var savedFeeLine: OrderFeeLine?
-        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowFees: false,
-                                                               feesBaseAmountForPercentage: 200,
-                                                               feesTotal: "0")
-        let viewModel = FeeLineDetailsViewModel(inputData: inputData,
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { newFeeLine in
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 200,
+                                                feesTotal: "0",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { newFeeLine in
             savedFeeLine = newFeeLine
         })
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
@@ -11,7 +11,12 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_formats_amount_correctly() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
 
         // When
         viewModel.amount = "hi:11.3005.02-"
@@ -28,7 +33,12 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
                                               decimalSeparator: ",",
                                               numberOfDecimals: 3)
 
-        let viewModel = ShippingLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: customSettings, didSelectSave: { _ in })
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: customSettings,
+                                                     didSelectSave: { _ in })
 
         // When
         viewModel.amount = "12.203"
@@ -41,11 +51,12 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_prefills_input_data_correctly() {
         // Given
-        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowShippingTotal: true,
-                                                               shippingTotal: "$11.30",
-                                                               shippingMethodTitle: "Flat Rate")
-
-        let viewModel = ShippingLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: true,
+                                                     initialMethodTitle: "Flat Rate",
+                                                     shippingTotal: "$11.30",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
@@ -55,7 +66,12 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_empty_state_and_enables_with_input() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(inputData: .init(), locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
 
         // When
@@ -73,11 +89,12 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_changes() {
         // Given
-        let inputData = NewOrderViewModel.PaymentDataViewModel(shouldShowShippingTotal: true,
-                                                               shippingTotal: "$11.30",
-                                                               shippingMethodTitle: "Flat Rate")
-
-        let viewModel = ShippingLineDetailsViewModel(inputData: inputData, locale: usLocale, storeCurrencySettings: usStoreSettings, didSelectSave: { _ in })
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: true,
+                                                     initialMethodTitle: "Flat Rate",
+                                                     shippingTotal: "$11.30",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
 
         // When
@@ -96,7 +113,9 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
     func test_view_model_creates_shippping_line_with_data_from_fields() {
         // Given
         var savedShippingLine: ShippingLine?
-        let viewModel = ShippingLineDetailsViewModel(inputData: .init(),
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
                                                      didSelectSave: { newShippingLine in
@@ -116,7 +135,9 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
     func test_view_model_creates_shippping_line_with_placeholder_for_method_title() {
         // Given
         var savedShippingLine: ShippingLine?
-        let viewModel = ShippingLineDetailsViewModel(inputData: .init(),
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
                                                      didSelectSave: { newShippingLine in


### PR DESCRIPTION
Closes: #6322

## Description

During Order Creation, the Add Shipping and Add Fee screens were losing state e.g. on device rotation. The view models for those views were initialized directly in the `OrderPaymentSection` view, so whenever that section was redrawn their state was lost.

Now, instead of initializing those view models in the `OrderPaymentSection` view (and passing in that parent view's view model to extract the input data for each subview), those view models are initialized in the `PaymentDataViewModel` struct with the relevant data and passed from there to the views.

## Changes

* `FeeLineDetailsViewModel` and `ShippingLineDetailsViewModel` now take each piece of input data as a separate parameter, instead of taking `NewOrderViewModel.PaymentDataViewModel` as input data.
* Those view models are initialized and stored as properties in `NewOrderViewModel.PaymentDataViewModel`.
* `OrderPaymentSection` passes those view models to their views, instead of initializing them within the view.
* Updated unit tests.

## Testing

1. Build and run the app.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab, tap the + button, and select "Create order."
4. Add a product to the order.
5. Select "Add Shipping."
6. Enter a shipping amount and (optionally) a name.
7. Rotate your device and confirm the entered amount/name are retained.
8. Tap "Done" and confirm the shipping you entered is reflected in the Payment section.
9. Repeat steps 5-8 with a fee ("Add Fee").

## Screenshots

https://user-images.githubusercontent.com/8658164/156011597-fc319590-ac73-40c4-a6e7-ef7c57aeee31.mp4


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
