### PR TITLE
Order Creation: Add new items support

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -206,6 +206,13 @@ public class OrdersRemote: Remote {
                     case .shippingLines:
                         let shippingEncoded = try order.shippingLines.map { try $0.toDictionary() }
                         params[Order.CodingKeys.shippingLines.rawValue] = shippingEncoded
+                    case .status:
+                        params[Order.CodingKeys.status.rawValue] = order.status.rawValue
+                    case .items:
+                        params[Order.CodingKeys.items.rawValue] = order.items.map { item in
+                            [OrderItem.CodingKeys.productID.rawValue: item.variationID != 0 ? item.variationID : item.productID,
+                             OrderItem.CodingKeys.quantity.rawValue: Int64(truncating: item.quantity as NSDecimalNumber)]
+                        }
                     }
                 }
             }()
@@ -292,6 +299,8 @@ public extension OrdersRemote {
         case billingAddress
         case fees
         case shippingLines
+        case items
+        case status
     }
 
     /// Order fields supported for create

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -210,8 +210,11 @@ public class OrdersRemote: Remote {
                         params[Order.CodingKeys.status.rawValue] = order.status.rawValue
                     case .items:
                         params[Order.CodingKeys.items.rawValue] = order.items.map { item in
-                            [OrderItem.CodingKeys.productID.rawValue: item.variationID != 0 ? item.variationID : item.productID,
-                             OrderItem.CodingKeys.quantity.rawValue: Int64(truncating: item.quantity as NSDecimalNumber)]
+                            [
+                                OrderItem.CodingKeys.itemID.rawValue: item.itemID,
+                                OrderItem.CodingKeys.productID.rawValue: item.variationID != 0 ? item.variationID : item.productID,
+                                OrderItem.CodingKeys.quantity.rawValue: Int64(truncating: item.quantity as NSDecimalNumber)
+                            ]
                         }
                     }
                 }

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -274,7 +274,7 @@ final class OrdersRemoteTests: XCTestCase {
         // Given
         let remote = OrdersRemote(network: network)
         let expectedQuantity: Int64 = 2
-        let orderItem = OrderItem.fake().copy(productID: 5, quantity: Decimal(expectedQuantity))
+        let orderItem = OrderItem.fake().copy(itemID: 123, productID: 5, quantity: Decimal(expectedQuantity))
         let order = Order.fake().copy(items: [orderItem])
 
         // When
@@ -284,6 +284,7 @@ final class OrdersRemoteTests: XCTestCase {
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
         let received = try XCTUnwrap(request.parameters["line_items"] as? [[String: AnyHashable]]).first
         let expected: [String: Int64] = [
+            "id": orderItem.itemID,
             "product_id": orderItem.productID,
             "quantity": expectedQuantity
         ]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -47,6 +47,7 @@ struct NewOrder: View {
 
                         OrderCustomerSection(viewModel: viewModel)
                     }
+                    .disabled(viewModel.disabled)
                 }
                 .background(Color(.listBackground).ignoresSafeArea())
                 .ignoresSafeArea(.container, edges: [.horizontal])
@@ -60,7 +61,10 @@ struct NewOrder: View {
                 case .create:
                     Button(Localization.createButton) {
                         viewModel.createOrder()
-                    }.id(navigationButtonID)
+                    }
+                    .id(navigationButtonID)
+                    .disabled(viewModel.disabled)
+
                 case .loading:
                     ProgressView()
                 }
@@ -68,7 +72,6 @@ struct NewOrder: View {
         }
         .wooNavigationBarStyle()
         .notice($viewModel.notice)
-        .disabled(viewModel.disabled)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -42,6 +42,9 @@ final class NewOrderViewModel: ObservableObject {
     ///
     @Published var shouldShowOrderStatusList: Bool = false
 
+    /// Defines if the view should be disabled.
+    @Published private(set) var disabled: Bool = false
+
     /// Status Results Controller.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
@@ -137,13 +140,6 @@ final class NewOrderViewModel: ObservableObject {
 
     // MARK: -
 
-    /// Defines if the view should be disabled.
-    /// Currently `true` while performing a network request.
-    ///
-    var disabled: Bool {
-        performingNetworkRequest
-    }
-
     /// Defines the current order status.
     ///
     var currentOrderStatus: OrderStatusEnum {
@@ -172,6 +168,7 @@ final class NewOrderViewModel: ObservableObject {
         self.orderSynchronizer = enableRemoteSync ? RemoteOrderSynchronizer(siteID: siteID, stores: stores)
                                                   : LocalOrderSynchronizer(siteID: siteID, stores: stores)
 
+        configureDisabledState()
         configureNavigationTrailingItem()
         configureStatusBadgeViewModel()
         configureProductRowViewModels()
@@ -376,6 +373,23 @@ extension NewOrderViewModel {
 
 // MARK: - Helpers
 private extension NewOrderViewModel {
+
+    /// Sets the view to be `disabled` when `performingNetworkRequest` or when `statePublisher` is `.syncing(blocking: true)`
+    ///
+    func configureDisabledState() {
+        Publishers.CombineLatest(orderSynchronizer.statePublisher, $performingNetworkRequest)
+            .map { state, performingNetworkRequest -> Bool in
+                switch (state, performingNetworkRequest) {
+                case (.syncing(blocking: true), _),
+                     (_, true):
+                    return true
+                default:
+                    return false
+                }
+            }
+            .assign(to: &$disabled)
+    }
+
     /// Calculates what navigation trailing item should be shown depending on our internal state.
     ///
     func configureNavigationTrailingItem() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -5,7 +5,7 @@ import Combine
 /// Possible states of an `OrderSynchronizer` type.
 ///
 enum OrderSyncState {
-    case syncing
+    case syncing(blocking: Bool)
     case synced
     case error(Error)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -121,7 +121,7 @@ private extension RemoteOrderSynchronizer {
             .merge(with: setAddresses.map { _ in () })
             .merge(with: setShipping.map { _ in () })
             .merge(with: setFee.map { _ in () })
-            .debounce(for: 1, scheduler: DispatchQueue.main) // Group & wait for 1s since the last signal was emitted.
+            .debounce(for: 0.5, scheduler: DispatchQueue.main) // Group & wait for 0.5 since the last signal was emitted.
             .compactMap { [weak self] in
                 guard let self = self else { return nil }
                 switch self.state {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -251,6 +251,7 @@ private extension RemoteOrderSynchronizer {
                 .billingAddress,
                 .fees,
                 .shippingLines,
+                .items,
             ]
             let action = OrderAction.updateOrder(siteID: self.siteID, order: request.order, fields: supportedFields) { [weak self] result in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -46,10 +46,6 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
     ///
     private var subscriptions = Set<AnyCancellable>()
 
-    /// Store to serve local IDs.
-    ///
-    private let localIDStore = LocalIDStore()
-
     // MARK: Initializers
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
@@ -93,10 +89,8 @@ private extension RemoteOrderSynchronizer {
             .assign(to: &$order)
 
         setProduct.withLatestFrom(orderPublisher)
-            .map { [weak self] productInput, order in
-                guard let self = self else { return order }
-                let sanitizedInput = self.replaceInputWithLocalIDIfNeeded(productInput)
-                return ProductInputTransformer.update(input: sanitizedInput, on: order)
+            .map { productInput, order in
+                ProductInputTransformer.update(input: productInput, on: order)
             }
             .assign(to: &$order)
 
@@ -123,7 +117,7 @@ private extension RemoteOrderSynchronizer {
     ///
     func bindOrderSync() {
         // Combine inputs that should trigger an order sync operation.
-        let syncTrigger: AnyPublisher<SyncOperation, Never> = setProduct.map { _ in () }
+        let syncTrigger: AnyPublisher<Order, Never> = setProduct.map { _ in () }
             .merge(with: setAddresses.map { _ in () })
             .merge(with: setShipping.map { _ in () })
             .merge(with: setFee.map { _ in () })
@@ -134,8 +128,7 @@ private extension RemoteOrderSynchronizer {
                 case .syncing(blocking: true):
                     return nil // Don't continue if the current state is `blocking`.
                 default:
-                    // TODO: Check if this is needed.
-                    return SyncOperation(order: self.order) // Imperative `withLatestFrom` as it appears to have bugs when assigning a new order value.
+                    return self.order // Imperative `withLatestFrom` as it appears to have bugs when assigning a new order value.
                 }
             }
             .share()
@@ -147,49 +140,49 @@ private extension RemoteOrderSynchronizer {
 
     /// Binds the provided `trigger` and creates an order when needed(order does not exists remotely).
     ///
-    func bindOrderCreation(trigger: AnyPublisher<SyncOperation, Never>) {
+    func bindOrderCreation(trigger: AnyPublisher<Order, Never>) {
         // Creates a "draft" order if the order has not been created yet.
         trigger
             .filter { // Only continue if the order has not been created.
-                $0.order.orderID == .zero
+                $0.orderID == .zero
             }
-            .flatMap(maxPublishers: .max(1)) { [weak self] request -> AnyPublisher<SyncOperation, Error> in // Only allow one request at a time.
+            .flatMap(maxPublishers: .max(1)) { [weak self] request -> AnyPublisher<Order, Error> in // Only allow one request at a time.
                 guard let self = self else { return Empty().eraseToAnyPublisher() }
                 self.state = .syncing(blocking: true) // Creating an oder is always a blocking operation
                 return self.createOrderRemotely(request)
             }
-            .catch { [weak self] error -> AnyPublisher<SyncOperation, Never> in // When an error occurs, update state & finish.
+            .catch { [weak self] error -> AnyPublisher<Order, Never> in // When an error occurs, update state & finish.
                 self?.state = .error(error)
                 return Empty().eraseToAnyPublisher()
             }
-            .sink { [weak self] response in
+            .sink { [weak self] order in
                 self?.state = .synced
-                self?.order = response.order
+                self?.order = order
             }
             .store(in: &subscriptions)
     }
 
     /// Binds the provided `trigger` and updates an order when needed(order already exists remotely).
     ///
-    func bindOrderUpdate(trigger: AnyPublisher<SyncOperation, Never>) {
+    func bindOrderUpdate(trigger: AnyPublisher<Order, Never>) {
         // Updates a "draft" order after it has already been created.
         trigger
             .filter { // Only continue if the order has been created.
-                $0.order.orderID != .zero
+                $0.orderID != .zero
             }
-            .map { [weak self] request -> AnyPublisher<SyncOperation, Error> in // Allow multiple requests, once per update request.
+            .map { [weak self] request -> AnyPublisher<Order, Error> in // Allow multiple requests, once per update request.
                 guard let self = self else { return Empty().eraseToAnyPublisher() }
                 self.state = .syncing(blocking: false) // TODO: Figure out when the request involves an add-item operation.
                 return self.updateOrderRemotely(request)
             }
             .switchToLatest() // Always switch/listen to the latest fired update request.
-            .catch { [weak self] error -> AnyPublisher<SyncOperation, Never> in // When an error occurs, update state & finish.
+            .catch { [weak self] error -> AnyPublisher<Order, Never> in // When an error occurs, update state & finish.
                 self?.state = .error(error)
                 return Empty().eraseToAnyPublisher()
             }
-            .sink { [weak self] response in // When finished, update state & order.
+            .sink { [weak self] order in // When finished, update state & order.
                 self?.state = .synced
-                self?.order = response.order
+                self?.order = order
             }
             .store(in: &subscriptions)
     }
@@ -197,12 +190,12 @@ private extension RemoteOrderSynchronizer {
     /// Returns a publisher that creates an order remotely using the `baseSyncStatus`.
     /// The later emitted order is delivered with the latest selected status.
     ///
-    func createOrderRemotely(_ request: SyncOperation) -> AnyPublisher<SyncOperation, Error> {
-        Future<SyncOperation, Error> { [weak self] promise in
+    func createOrderRemotely(_ order: Order) -> AnyPublisher<Order, Error> {
+        Future<Order, Error> { [weak self] promise in
             guard let self = self else { return }
 
             // Creates the order with the `draft` status
-            let draftOrder = request.order.copy(status: self.baseSyncStatus)
+            let draftOrder = order.copy(status: self.baseSyncStatus)
             let action = OrderAction.createOrder(siteID: self.siteID, order: draftOrder) { [weak self] result in
                 guard let self = self else { return }
 
@@ -210,8 +203,7 @@ private extension RemoteOrderSynchronizer {
                 case .success(let remoteOrder):
                     // Return the order with the current selected status.
                     let newLocalOrder = remoteOrder.copy(status: self.order.status)
-                    let updatedRequest = request.copy(order: newLocalOrder)
-                    promise(.success(updatedRequest))
+                    promise(.success(newLocalOrder))
 
                 case .failure(let error):
                     promise(.failure(error))
@@ -225,8 +217,8 @@ private extension RemoteOrderSynchronizer {
     /// Returns a publisher that updates an order remotely.
     /// The later emitted order is delivered with the latest selected status.
     ///
-    func updateOrderRemotely(_ request: SyncOperation) -> AnyPublisher<SyncOperation, Error> {
-        Future<SyncOperation, Error> { [weak self] promise in
+    func updateOrderRemotely(_ order: Order) -> AnyPublisher<Order, Error> {
+        Future<Order, Error> { [weak self] promise in
             guard let self = self else { return }
 
             // Updates the order supported fields.
@@ -238,15 +230,14 @@ private extension RemoteOrderSynchronizer {
                 .shippingLines,
                 .items,
             ]
-            let action = OrderAction.updateOrder(siteID: self.siteID, order: request.order, fields: supportedFields) { [weak self] result in
+            let action = OrderAction.updateOrder(siteID: self.siteID, order: order, fields: supportedFields) { [weak self] result in
                 guard let self = self else { return }
 
                 switch result {
                 case .success(let remoteOrder):
                     // Return the order with the current selected status.
                     let newLocalOrder = remoteOrder.copy(status: self.order.status)
-                    let updatedRequest = request.copy(order: newLocalOrder)
-                    promise(.success(updatedRequest))
+                    promise(.success(newLocalOrder))
 
                 case .failure(let error):
                     promise(.failure(error))
@@ -255,52 +246,5 @@ private extension RemoteOrderSynchronizer {
             self.stores.dispatch(action)
         }
         .eraseToAnyPublisher()
-    }
-
-    /// Creates a new input with a proper local ID when the given ID is `.zero`.
-    ///
-    func replaceInputWithLocalIDIfNeeded(_ input: OrderSyncProductInput) -> OrderSyncProductInput {
-        guard input.id == .zero else {
-            return input
-        }
-        return input.updating(id: localIDStore.dispatchLocalID())
-    }
-}
-
-// MARK: Definitions
-private extension RemoteOrderSynchronizer {
-    /// Type to represents a sync requests or a sync response.
-    ///
-    struct SyncOperation {
-        /// Autogenerated ID of the operation.
-        ///
-        private(set) var id: String = UUID().uuidString
-
-        /// Order to act upon.
-        let order: Order
-
-        /// Replaces the `order` maintaining the `ID`.
-        ///
-        func copy(order: Order) -> SyncOperation {
-            SyncOperation(id: id, order: order)
-        }
-    }
-
-    /// Simple type to serve negative IDs.
-    /// This is needed to differentiate if an item ID has been synced remotely while providing a unique ID to consumers.
-    /// If the ID is a negative number we assume that it's a local ID.
-    /// Warning: This is not thread safe.
-    ///
-    final class LocalIDStore {
-        /// Last used ID
-        ///
-        private var currentID: Int64 = 0
-
-        /// Creates a new and unique local ID for this session.
-        ///
-        func dispatchLocalID() -> Int64 {
-            currentID -= 1
-            return currentID
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -510,7 +510,8 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(updateFields, [.shippingAddress,
                                       .billingAddress,
                                       .fees,
-                                      .shippingLines])
+                                      .shippingLines,
+                                      .items])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -270,10 +270,10 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(states, [.syncing, .synced])
+        XCTAssertEqual(states, [.syncing(blocking: true), .synced])
     }
 
-    func test_states_are_properly_set_upon_success_order_update() {
+    func test_states_are_properly_set_upon_success_order_update_with_new_items() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -306,7 +306,44 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(states, [.syncing, .synced])
+        XCTAssertEqual(states, [.syncing(blocking: true), .synced])
+    }
+
+    func test_states_are_properly_set_upon_success_order_update_with_no_new_items() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .createOrder(_, _, let completion):
+                completion(.success(.fake().copy(orderID: self.sampleOrderID)))
+            case .updateOrder(_, let order, _, let completion):
+                completion(.success(order))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        createOrder(on: synchronizer, input: input)
+
+        let input2 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
+        synchronizer.setProduct.send(input2)
+
+        let states: [OrderSyncState] = waitFor { promise in
+            synchronizer.statePublisher
+                .dropFirst()
+                .collect(2)
+                .sink { states in
+                    promise(states)
+                }
+                .store(in: &self.subscriptions)
+        }
+
+        // Then
+        XCTAssertEqual(states, [.syncing(blocking: false), .synced])
     }
 
     func test_states_are_properly_set_upon_failing_order_creation() {
@@ -339,7 +376,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Then
-        assertEqual(states, [.syncing, .error(error)])
+        assertEqual(states, [.syncing(blocking: true), .error(error)])
     }
 
     func test_states_are_properly_set_upon_failing_order_update() {
@@ -376,7 +413,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(states, [.syncing, .error(error)])
+        XCTAssertEqual(states, [.syncing(blocking: true), .error(error)])
     }
 
     func test_sending_double_input_triggers_only_one_order_creation() {
@@ -409,14 +446,15 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
 
-    func test_sending_input_while_order_is_being_created_triggers_order_update() {
+    func test_sending_input_while_order_is_being_created_ignores_order_update() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
 
         // When
-        let orderUpdateFired: Bool = waitFor { promise in
+        waitForExpectation { exp in
+            exp.isInverted = true
             stores.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {
                 case .createOrder(_, _, let completion):
@@ -425,10 +463,11 @@ class RemoteOrderSynchronizerTests: XCTestCase {
                     synchronizer.setProduct.send(input2)
 
                     // Complete order creation
-                    completion(.success(.fake().copy(orderID: self.sampleOrderID)))
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        completion(.success(.fake().copy(orderID: self.sampleOrderID)))
+                    }
                 case .updateOrder:
-                    // Update requested
-                    promise(true)
+                    exp.fulfill() // Update should not happen
 
                 default:
                     XCTFail("Unexpected action: \(action)")
@@ -439,9 +478,6 @@ class RemoteOrderSynchronizerTests: XCTestCase {
             let input1 = OrderSyncProductInput(product: .product(product), quantity: 1)
             synchronizer.setProduct.send(input1)
         }
-
-        // Then
-        XCTAssertTrue(orderUpdateFired)
     }
 
     func test_order_is_created_with_draft_status_and_returned_with_selected_status() {


### PR DESCRIPTION
Closes: #6136 

# Why

This PR adds the ability to add new items once an order has been created. **Note that updating quantity is still not supported** #6138 

Additionally, In this PR, I'm changing the behavior of the remote synchronizer to block any input while a new item is being added.
The reason for that change was because it was getting too complex to handle scenarios like:

- Order is created by adding a product | shipping field | fee | address
- Merchant adds a new time & app fires an update request
- While the app is performing the request, the merchant adds a new item & app performs a new update request
- There is no simple way to determine that an item is being synced and the order ends up with duplicated items.

By blocking inputs while the order adds new items we avoid any kind of edge case caused by our API limitations.
Also, this mimics core behavior.

# How

- Updated `OrdersRemote` to send line items data when updating an order

- Updates `OrderSyncState` to add a `blocking` property to the `.syncing`.  `.synching(blocking: true)`

- Updates `RemoteOrderSynchronizer` to: 
    - Set state to `.synching(blocking: true)` when creating an order for the first time.
    - Set state to `.synching(blocking: true)` when updating an order where the update adds new items.
    - Removes `SyncOperation` and `LocalIDStore` types as they are not needed anymore.
    - Removes code that handled firing an update request after the order was being created when needed. Now is not needed because inputs are blocked.

- Updated `NewOrderViewModel` to calculate the `disabled` property using the `synchronizer.statePublisher` property.

- Updated `NewOrder` to disable the internal `VStack` where the inputs are and not the whole view, as disabling the whole view also disables scrolling and makes the app feel broken.


# Demo

https://user-images.githubusercontent.com/562080/156014027-2adf1026-6b4a-4561-adf6-2002b30d5ed0.mov

# Testing

## Prerequisites

- Set your store to wc 6.3.0-rc.1
- Enable the orderCreationRemoteSynchronizer local feature flag
- Comment the code on `OrderStore` that prevents auto-draft orders to be saved. (This, in order to see the orders after they are being updated)

https://github.com/woocommerce/woocommerce-ios/blob/07fdba67367f3127bcbf16151737d9204d9ccc11/Yosemite/Yosemite/Stores/OrderStore.swift#L361-L364

## Steps

- Navigate to the create order screen
- Add a new item and see the order being created.
- While the order is being created, see that all inputs are disabled.
- Add a new item and see the order being updated.
- While the order is being updated, see that all inputs are disabled.
- Add customer details and see that it does not block user input.

**Note:** Updating/Removing products is still not supported.
**Note:** We need to work on properly reflecting the disabled states across the view inputs.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
