### PR TITLE
Coupons: Hotfix empty state view for the coupon list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -7,6 +7,7 @@ struct CouponListView: UIViewControllerRepresentable {
 
     class Coordinator {
         var parentObserver: NSKeyValueObservation?
+        var rightBarButtonItemsObserver: NSKeyValueObservation?
     }
 
     /// This is a UIKit solution for fixing Navigation Title and Bar Button Items ignored in NavigationView.
@@ -18,6 +19,12 @@ struct CouponListView: UIViewControllerRepresentable {
         let viewController = CouponListViewController(siteID: siteID)
         context.coordinator.parentObserver = viewController.observe(\.parent, changeHandler: { vc, _ in
             vc.parent?.navigationItem.title = vc.title
+            vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
+        })
+
+        // This fixes the issue when `rightBarButtonItem` is updated in `CouponListViewController`,
+        // the hosting controller should be updated to reflect the change.
+        context.coordinator.rightBarButtonItemsObserver = viewController.observe(\.navigationItem.rightBarButtonItems, changeHandler: { vc, _ in
             vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
         })
         return viewController

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -221,11 +221,10 @@ extension CouponListViewController {
     ///
     func displayNoResultsOverlay() {
         let emptyStateViewController = EmptyStateViewController(style: .list)
-        let config = EmptyStateViewController.Config.withButton(
+        let config = EmptyStateViewController.Config.simple(
             message: .init(string: Localization.emptyStateMessage),
-            image: .emptyCouponsImage,
-            details: "",
-            buttonTitle: Localization.addCouponButton) { _ in }
+            image: .emptyCouponsImage
+        )
 
         displayEmptyStateViewController(emptyStateViewController)
         emptyStateViewController.configure(config)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -299,8 +299,6 @@ private extension CouponListViewController {
             "No coupons found",
             comment: "The title on the placeholder overlay when there are no coupons on the coupon list screen.")
 
-        static let addCouponButton = NSLocalizedString("Add Coupon", comment: "Title for the action button to add coupon on the coupon list screen.")
-
         static let accessibilityLabelSearchCoupons = NSLocalizedString("Search coupons", comment: "Accessibility label for the Search Coupons button")
         static let accessibilityHintSearchCoupons = NSLocalizedString(
             "Retrieves a list of coupons that contain a given keyword.",

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -85,6 +85,16 @@ final class CouponListViewController: UIViewController {
             }
             .store(in: &subscriptions)
 
+        viewModel.$couponViewModels
+            .map { viewModels -> Bool in
+                viewModels.isNotEmpty
+            }
+            .removeDuplicates()
+            .sink { [weak self] hasData in
+                self?.configureNavigationBarItems(hasCoupons: hasData)
+            }
+            .store(in: &subscriptions)
+
         // Call this after the state subscription for extra safety
         viewModel.viewDidLoad()
     }
@@ -148,7 +158,10 @@ extension CouponListViewController: UITableViewDelegate {
 private extension CouponListViewController {
     func configureNavigation() {
         title = Localization.title
-        navigationItem.rightBarButtonItem = searchBarButtonItem
+    }
+
+    func configureNavigationBarItems(hasCoupons: Bool) {
+        navigationItem.rightBarButtonItems = hasCoupons ? [searchBarButtonItem] : []
     }
 
     func configureTableView() {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -224,7 +224,7 @@ extension CouponListViewController {
         let config = EmptyStateViewController.Config.withButton(
             message: .init(string: Localization.emptyStateMessage),
             image: .emptyCouponsImage,
-            details: Localization.emptyStateDetails,
+            details: "",
             buttonTitle: Localization.addCouponButton) { _ in }
 
         displayEmptyStateViewController(emptyStateViewController)
@@ -297,12 +297,8 @@ private extension CouponListViewController {
             comment: "Coupon management coupon list screen title")
 
         static let emptyStateMessage = NSLocalizedString(
-            "Everyone loves a deal",
+            "No coupons found",
             comment: "The title on the placeholder overlay when there are no coupons on the coupon list screen.")
-
-        static let emptyStateDetails = NSLocalizedString(
-            "Boost your business by sending customers special offers and discounts.",
-            comment: "The description on the placeholder overlay when there are no coupons on the coupon list screen.")
 
         static let addCouponButton = NSLocalizedString("Add Coupon", comment: "Title for the action button to add coupon on the coupon list screen.")
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -23,7 +23,7 @@ final class CouponListViewModel {
 
     /// couponViewModels: ViewModels for the cells representing Coupons
     ///
-    var couponViewModels: [CouponListCellViewModel] = []
+    @Published private(set) var couponViewModels: [CouponListCellViewModel] = []
 
     /// siteID: siteID of the currently active site, used for fetching and storing coupons
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6324 
(This PR is a clone of #6325, but to merge into release/8.6. I mistakenly set the base of #6325 to trunk so this is to fix that 😓 )
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the empty state view for the coupon list:
- Hides search button if no coupons are found for the store.
- Removes the Add Coupon button since we are not enabling coupon creation in M1.
- Updates message copy for the empty state view.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that your test store enables coupons and doesn't have any coupons set up yet.
- On the app, turn on Coupon Management in Experimental Features.
- Navigate to Menu > Coupons. Notice that the search button or Add Coupon button is not present.
- Add a coupon to the store in WP Admin > Marketing > Coupons or switch to a store with at least one coupon. Notice that after fetching coupon, the list should show the search button on the navigation bar.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After | 
| ----- | ----- | 
| <img src="https://user-images.githubusercontent.com/5533851/155927220-63590f78-6492-4e7b-a453-371093a308a0.jpeg" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/155927246-f230cd5c-8227-4068-8c26-954481701474.png" width=320 /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
