### PR TITLE
[Mobile Payments] Bump Stripe Terminal SDK to 2.6.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -64,7 +64,7 @@ target 'WooCommerce' do
   pod 'XLPagerTabStrip', '~> 9.0'
   pod 'Charts', '~> 3.6.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
-  pod 'StripeTerminal', '~> 2.5'
+  pod 'StripeTerminal', '~> 2.6'
   pod 'Kingfisher', '~> 6.0.0'
   pod 'Wormholy', '~> 1.6.5', configurations: ['Debug']
 
@@ -81,7 +81,7 @@ end
 #
 def yosemite_pods
   pod 'Alamofire', '~> 4.8'
-  pod 'StripeTerminal', '~> 2.5'
+  pod 'StripeTerminal', '~> 2.6'
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 
@@ -169,7 +169,7 @@ end
 # =================
 #
 def hardware_pods
-  pod 'StripeTerminal', '~> 2.5'
+  pod 'StripeTerminal', '~> 2.6'
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - Sentry/Core (6.2.1)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (2.5.0)
+  - StripeTerminal (2.6.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.7.1)
   - WordPress-Aztec-iOS (1.11.0)
@@ -98,7 +98,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 6.0.0)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 2.5)
+  - StripeTerminal (~> 2.6)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.43.1)
   - WordPressKit (~> 4.46.0)
@@ -172,7 +172,7 @@ SPEC CHECKSUMS:
   Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: 2c7d261881b0039693a6ba30c00e1e6133e6d393
+  StripeTerminal: c75c9d5be371a0e292a829f56860fc98ed5a3149
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: d0fee204f467dacf8808b7ac14ce43affeb271a5
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -193,6 +193,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 8238650e6eb6a67c58c5626cf8d12ede15dcafb5
+PODFILE CHECKSUM: 6a578f9f9306d5a23c420153e878231942400068
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6336 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Bump the Stripe Terminal SDK to 2.6.0: https://github.com/stripe/stripe-terminal-ios/releases/tag/v2.6.0

Mostly because of this fix:
> Addressses https://github.com/stripe/stripe-terminal-ios/issues/133: Fixes a bug where connecting to an internet reader then calling cancel() on the discovery cancelable would cause the SCPTerminal singleton to not reset state properly if that connection fails. As a result, the SCPTerminal singleton would prevent you from restarting discovery.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

CI passing should be enough, but a quick smoke test of the branch (capturing a payment) would not hurt.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
