### PR TITLE
Order Creation - Product Sync: Adds update quantity support

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Order's Item Entity.
 ///
-public struct OrderItem: Decodable, Equatable, Hashable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, GeneratedCopiable {
     public let itemID: Int64
     public let name: String
     public let productID: Int64
@@ -113,6 +113,28 @@ public struct OrderItem: Decodable, Equatable, Hashable, GeneratedFakeable, Gene
                   total: total,
                   totalTax: totalTax,
                   attributes: attributes)
+    }
+
+    /// Encodes an order item.
+    ///
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(itemID, forKey: .itemID)
+
+        let parentID = variationID != 0 ? variationID : productID
+        try container.encode(parentID, forKey: .productID)
+
+        let nonDecimalQuantity = (quantity as NSDecimalNumber).int64Value
+        try container.encode(nonDecimalQuantity, forKey: .quantity)
+
+        if !subtotal.isEmpty {
+            try container.encode(subtotal, forKey: .subtotal)
+        }
+
+        if !total.isEmpty {
+            try container.encode(total, forKey: .total)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -135,10 +135,7 @@ public class OrdersRemote: Remote {
                     case .status:
                         params[Order.CodingKeys.status.rawValue] = order.status.rawValue
                     case .items:
-                        params[Order.CodingKeys.items.rawValue] = order.items.map { item in
-                            [OrderItem.CodingKeys.productID.rawValue: item.variationID != 0 ? item.variationID : item.productID,
-                             OrderItem.CodingKeys.quantity.rawValue: Int64(truncating: item.quantity as NSDecimalNumber)]
-                        }
+                        params[Order.CodingKeys.items.rawValue] = try order.items.map { try $0.toDictionary() }
                     case .billingAddress:
                         if let billingAddress = order.billingAddress {
                             params[Order.CodingKeys.billingAddress.rawValue] = try billingAddress.toDictionary()
@@ -209,13 +206,7 @@ public class OrdersRemote: Remote {
                     case .status:
                         params[Order.CodingKeys.status.rawValue] = order.status.rawValue
                     case .items:
-                        params[Order.CodingKeys.items.rawValue] = order.items.map { item in
-                            [
-                                OrderItem.CodingKeys.itemID.rawValue: item.itemID,
-                                OrderItem.CodingKeys.productID.rawValue: item.variationID != 0 ? item.variationID : item.productID,
-                                OrderItem.CodingKeys.quantity.rawValue: Int64(truncating: item.quantity as NSDecimalNumber)
-                            ]
-                        }
+                        params[Order.CodingKeys.items.rawValue] = try order.items.map { try $0.toDictionary() }
                     }
                 }
             }()

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -274,7 +274,7 @@ final class OrdersRemoteTests: XCTestCase {
         // Given
         let remote = OrdersRemote(network: network)
         let expectedQuantity: Int64 = 2
-        let orderItem = OrderItem.fake().copy(itemID: 123, productID: 5, quantity: Decimal(expectedQuantity))
+        let orderItem = OrderItem.fake().copy(itemID: 123, productID: 5, quantity: Decimal(expectedQuantity), subtotal: "3", total: "15")
         let order = Order.fake().copy(items: [orderItem])
 
         // When
@@ -283,10 +283,12 @@ final class OrdersRemoteTests: XCTestCase {
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
         let received = try XCTUnwrap(request.parameters["line_items"] as? [[String: AnyHashable]]).first
-        let expected: [String: Int64] = [
+        let expected: [String: AnyHashable] = [
             "id": orderItem.itemID,
             "product_id": orderItem.productID,
-            "quantity": expectedQuantity
+            "quantity": expectedQuantity,
+            "subtotal": orderItem.subtotal,
+            "total": orderItem.total
         ]
         assertEqual(received, expected)
     }
@@ -413,6 +415,7 @@ final class OrdersRemoteTests: XCTestCase {
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
         let received = try XCTUnwrap(request.parameters["line_items"] as? [[String: AnyHashable]]).first
         let expected: [String: Int64] = [
+            "id": 0,
             "product_id": orderItem.productID,
             "quantity": expectedQuantity
         ]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -28,11 +28,12 @@ struct ProductInputTransformer {
         }
 
         // Add or update the order items with the new input.
-        let newItem = createOrderItem(using: input)
         var items = order.items
-        if let itemIndex = order.items.firstIndex(where: { $0.itemID == newItem.itemID }) {
+        if let itemIndex = order.items.firstIndex(where: { $0.itemID == input.id }) {
+            let newItem = createOrderItem(using: input, usingPriceFrom: items[itemIndex])
             items[itemIndex] = newItem
         } else {
+            let newItem = createOrderItem(using: input, usingPriceFrom: nil)
             items.append(newItem)
         }
 
@@ -48,15 +49,17 @@ struct ProductInputTransformer {
     }
 
     /// Creates and order item by using the `input.id` as the `item.itemID`.
+    /// When `usingPriceFrom` is set, the price from the item will be used instead of the price of the product.
     ///
-    private static func createOrderItem(using input: OrderSyncProductInput) -> OrderItem {
+    private static func createOrderItem(using input: OrderSyncProductInput, usingPriceFrom existingItem: OrderItem?) -> OrderItem {
         let parameters: OrderItemParameters = {
+            // Prefer the item price as it should have been properly sanitized by the remote source.
             switch input.product {
             case .product(let product):
-                let price = Decimal(string: product.price) ?? .zero
+                let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: product.price) ?? .zero
                 return OrderItemParameters(quantity: input.quantity, price: price, productID: product.productID, variationID: nil)
             case .variation(let variation):
-                let price = Decimal(string: variation.price) ?? .zero
+                let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: variation.price) ?? .zero
                 return OrderItemParameters(quantity: input.quantity, price: price, productID: variation.productID, variationID: variation.productVariationID)
             }
         }()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -14,6 +14,9 @@ struct ProductInputTransformer {
         var subtotal: String {
             "\(price * quantity)"
         }
+        var total: String {
+            subtotal
+        }
     }
 
     /// Adds, deletes, or updates order items based on the given product input.
@@ -69,7 +72,7 @@ struct ProductInputTransformer {
                          subtotalTax: "",
                          taxClass: "",
                          taxes: [],
-                         total: "",
+                         total: parameters.total,
                          totalTax: "",
                          attributes: [])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -85,6 +85,23 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.total, "19.98")
     }
 
+    func test_sending_an_update_product_input_uses_item_price_from_order() throws {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
+        let item = OrderItem.fake().copy(itemID: sampleInputID, price: 8.00)
+        let order = Order.fake().copy(items: [item])
+
+        // When
+        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
+        let updatedOrder = ProductInputTransformer.update(input: input, on: order)
+
+        // Then
+        let updatedItem = try XCTUnwrap(updatedOrder.items.first)
+        XCTAssertEqual(updatedItem.price, 8.00) // Existing item price from order.
+        XCTAssertEqual(updatedItem.subtotal, "16")
+        XCTAssertEqual(updatedItem.total, "16")
+    }
+
     func test_sending_an_zero_quantity_update_product_input_deletes_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -28,6 +28,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.variationID, 0)
         XCTAssertEqual(item.price, 9.99)
         XCTAssertEqual(item.subtotal, "9.99")
+        XCTAssertEqual(item.total, "9.99")
     }
 
     func test_sending_a_new_product_variation_input_adds_an_item_to_order() throws {
@@ -47,6 +48,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.variationID, productVariation.productVariationID)
         XCTAssertEqual(item.price, 9.99)
         XCTAssertEqual(item.subtotal, "9.99")
+        XCTAssertEqual(item.total, "9.99")
     }
 
     func test_sending_a_new_product_input_twice_adds_adds_two_items_to_order() throws {
@@ -80,6 +82,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.productID, product.productID)
         XCTAssertEqual(item.price, 9.99)
         XCTAssertEqual(item.subtotal, "19.98")
+        XCTAssertEqual(item.total, "19.98")
     }
 
     func test_sending_an_zero_quantity_update_product_input_deletes_item_on_order() throws {


### PR DESCRIPTION
Closes: #6138

# Why 

After adding support to add new items on #6327, this PR adds support to update quantities to such items.

**Note:** Deleting items will be tackled in another PR #6137 

The tricky bit here is that we need to differentiate when an item is a new item(local item with id .zero) and when it is an existing item.

- New items are sent **WITHOUT** `total` & `subtotal` values to allow the remote source to return the proper/initial item value.

- Existing items are sent **WITH**  `total` & `subtotal` values because updating only the `quantity` values does update the item totals.

# How 

- Added `encode` function to `OrderItem` which only encodes `total` & `subtotal` if they are provided.

- Updated `OrdersRemote` to use ☝️

- Updated `ProductInputTransformer` to replicate the `subtotal` as `total` when creating new items.

- Updated `RemoteOrderSynchronizer` to remove `total` & `subtotal` values from local items just before syncing the order.

# Demo

https://user-images.githubusercontent.com/562080/156257600-3ddaf02e-e7cc-4c90-a4e6-1b9ff3843111.mov

# Testing

## Prerequisites

- Set your store to wc 6.3.0-rc.1
- Enable the `orderCreationRemoteSynchronizer` local feature flag
- Comment the code on `OrderStore` that prevents auto-draft orders to be saved. (This, in order to see the orders after they are being updated)

https://github.com/woocommerce/woocommerce-ios/blob/07fdba67367f3127bcbf16151737d9204d9ccc11/Yosemite/Yosemite/Stores/OrderStore.swift#L361-L364

## Steps

- Navigate to the create order screen
- Add a new item and see the order being created.
- Modify the order quantity.
- See that the totals update appropriate before & after the order is synced.

**Note:** Removing products is still not supported.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
