### PR TITLE
Attempted crash fix on order stats intervals usage

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -63,9 +63,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
         return ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
     }
 
-    private var orderStatsIntervals: [OrderStatsV4Interval] {
-        viewModel.orderStatsIntervals
-    }
+    private var orderStatsIntervals: [OrderStatsV4Interval] = []
 
     private var revenueItems: [Double] {
         orderStatsIntervals.map({ ($0.revenueValue as NSDecimalNumber).doubleValue })
@@ -153,7 +151,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
         observeStatsLabels()
         observeSelectedBarIndex()
         observeTimeRangeBarViewModel()
-        observeReloadChartAnimated()
+        observeOrderStatsIntervals()
         observeVisitorStatsViewState()
         observeConversionStatsViewState()
         observeYAxisMaximum()
@@ -217,9 +215,15 @@ private extension StoreStatsV4PeriodViewController {
         }.store(in: &cancellables)
     }
 
-    func observeReloadChartAnimated() {
-        viewModel.reloadChartAnimated.sink { [weak self] animated in
-            self?.reloadChart(animateChart: animated)
+    func observeOrderStatsIntervals() {
+        viewModel.orderStatsIntervals.sink { [weak self] orderStatsIntervals in
+            guard let self = self else { return }
+
+            self.orderStatsIntervals = orderStatsIntervals
+
+            // Don't animate the chart here - this helps avoid a "double animation" effect if a
+            // small number of values change (the chart WILL be updated correctly however)
+            self.reloadChart(animateChart: false)
         }.store(in: &cancellables)
     }
 

--- a/Yosemite/Yosemite/Model/Storage/OrderStatsV4Totals+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatsV4Totals+ReadOnlyConvertible.swift
@@ -18,6 +18,7 @@ extension Storage.OrderStatsV4Totals: ReadOnlyConvertible {
         taxes = NSDecimalNumber(decimal: statsTotals.taxes)
         shipping = NSDecimalNumber(decimal: statsTotals.shipping)
         netRevenue = NSDecimalNumber(decimal: statsTotals.netRevenue)
+        totalProducts = Int64(statsTotals.totalProducts ?? 0)
     }
 
     /// Returns a ReadOnly version of the receiver.

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -64,7 +64,7 @@ final class StatsStoreV4Tests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatsV4.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatsV4Interval.self), 1)
         let readOnlyOrderStats = viewStorage.firstObject(ofType: Storage.OrderStatsV4.self)?.toReadOnly()
-        XCTAssertEqual(readOnlyOrderStats, sampleStats())
+        assertEqual(sampleStats(), readOnlyOrderStats)
     }
 
     /// Verifies that `StatsActionV4.retrieveStats` returns an error whenever there is an error response from the backend.
@@ -440,6 +440,20 @@ private extension StatsStoreV4Tests {
                                   taxes: 0,
                                   shipping: 0,
                                   netRevenue: 800,
+                                  totalProducts: 2)
+    }
+
+    /// Matches the first interval's `subtotals` field in `order-stats-v4-year` response.
+    func sampleIntervalSubtotals() -> Networking.OrderStatsV4Totals {
+        return OrderStatsV4Totals(totalOrders: 3,
+                                  totalItemsSold: 5,
+                                  grossRevenue: 800,
+                                  couponDiscount: 0,
+                                  totalCoupons: 0,
+                                  refunds: 0,
+                                  taxes: 0,
+                                  shipping: 0,
+                                  netRevenue: 800,
                                   totalProducts: 0)
     }
 
@@ -451,7 +465,7 @@ private extension StatsStoreV4Tests {
         return OrderStatsV4Interval(interval: "2019",
                                     dateStart: "2019-07-09 00:00:00",
                                     dateEnd: "2019-07-09 23:59:59",
-                                    subtotals: sampleTotals())
+                                    subtotals: sampleIntervalSubtotals())
     }
 
     func sampleStatsMutated() -> Networking.OrderStatsV4 {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

For #6333 (won't close the issue until the crashes disappear since I can't reproduce the crash)
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In release 8.5, a new crash came in with the following stack trace:

```
range (StoreStatsV4PeriodViewController.swift)
_ArrayBuffer._checkInoutAndNativeTypeCheckedBounds
...
Array.subscript.getter
StoreStatsV4PeriodViewController.stringForValue (StoreStatsV4PeriodViewController.swift:467)
[Charts]()AxisBase.getFormattedLabel (AxisBase.swift:159)
[Charts]()AxisBase.getLongestLabel (AxisBase.swift:140)
...
[Charts]()BarLineChartViewBase.notifyDataSetChanged (BarLineChartViewBase.swift:349)
[Charts]()ChartViewBase.data.setter (ChartViewBase.swift:232)
StoreStatsV4PeriodViewController.reloadChart (StoreStatsV4PeriodViewController.swift:586)
StoreStatsV4PeriodViewController.observeReloadChartAnimated (StoreStatsV4PeriodViewController.swift:222)
thunk for closure
...
StoreStatsPeriodViewModel.updateOrderDataIfNeeded (StoreStatsPeriodViewModel.swift:373)
...
[Storage]()NSManagedObjectContext.saveIfNeeded (NSManagedObjectContext+Storage.swift:137)
[Yosemite]()StatsStoreV4.upsertStoredOrderStats (StatsStoreV4.swift:194)
[Yosemite]()StatsStoreV4.retrieveStats (StatsStoreV4.swift:109)
[Networking]()Remote.enqueue<T>
...
AlamofireNetwork.responseData (AlamofireNetwork.swift:68)
```

I cannot reproduce the crash to debug further, the crash is from out of bound access to `orderStatsIntervals` array which is a derived variable from `viewModel.orderStatsIntervals`. In `StoreStatsV4PeriodViewController`, `orderStatsIntervals` array is used to generate chart data which then triggers axis label updates that call `stringForValue`. `stringForValue` then uses `orderStatsIntervals` to generate the x-axis labels. My guess is that somehow `orderStatsIntervals` size changes between these two use cases (chart data and x-axis labels) like from other Core Data calls to save the context.

This PR attempted to fix the crash by changing `orderStatsIntervals` from a derived variable to an observable in the view model. The view controller keeps an internal variable `orderStatsIntervals` that is updated based on the view model, and is fixed until the next change which then triggers the chart reload.

### Fixing a side issue in `OrderStatsV4Totals` storage update

While updating the unit test case `test_orderStatsIntervals_is_emitted_once_after_order_stats_are_updated`, I noticed the test failed due to the mismatch on `OrderStatsV4.intervals.subtotals`. After some debugging, the `OrderStatsV4Totals.update(with:)` function in the `ReadOnlyConvertible` extension to update the storage entity didn't set `totalProducts`. This PR updated this to set `totalProducts`, and a related test case in `StatsStoreV4Tests.test_retrieveStats_effectively_persists_retrieved_stats`. The interval's `totalProducts` isn't currently used.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I haven't found a way to repro the crash, feel free to just smoke test the PR by:

- Launch the app
- Tap on each stats time range tab --> the store stats charts and top performers data should be shown without crashing

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
