### PR TITLE
Fix locally failing unit tests

### DIFF
--- a/WooCommerce/WooCommerceTests/Mocks/MockImageCache.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockImageCache.swift
@@ -4,6 +4,10 @@ final class MockImageCache: ImageCache {
     // Mocks in-memory cache.
     private var imagesByKey: [String: UIImage] = [:]
 
+    override func imageCachedType(forKey key: String, processorIdentifier identifier: String = DefaultImageProcessor.default.identifier) -> CacheType {
+        imagesByKey[key] != nil ? .memory: .none
+    }
+
     override func retrieveImage(forKey key: String,
                                 options: KingfisherParsedOptionsInfo,
                                 callbackQueue: CallbackQueue = .mainCurrentOrAsync,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -104,7 +104,9 @@ final class ProductDetailsCellViewModelTests: XCTestCase {
                                  attributes: [])
 
         // When
-        let viewModel = ProductDetailsCellViewModel(item: item, currency: "$",
+        let viewModel = ProductDetailsCellViewModel(item: item,
+                                                    currency: "$",
+                                                    formatter: CurrencyFormatter(currencySettings: CurrencySettings()),
                                                     hasAddOns: false)
         let quantity = NumberFormatter.localizedString(from: item.quantity as NSDecimalNumber, number: .decimal)
         let subtitle = String.localizedStringWithFormat(Localization.subtitleFormat, quantity, "$10.00")
@@ -121,7 +123,9 @@ final class ProductDetailsCellViewModelTests: XCTestCase {
                                  attributes: [])
 
         // When
-        let viewModel = ProductDetailsCellViewModel(item: item, currency: "$",
+        let viewModel = ProductDetailsCellViewModel(item: item,
+                                                    currency: "$",
+                                                    formatter: CurrencyFormatter(currencySettings: CurrencySettings()),
                                                     hasAddOns: false)
         let quantity = NumberFormatter.localizedString(from: item.quantity as NSDecimalNumber, number: .decimal)
         let subtitle = String.localizedStringWithFormat(Localization.subtitleFormat, quantity, "-$10.00")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #1687
Closes: #6252
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixed test failures under certain circumstances that we might encounter when running tests locally:

#### `DefaultImageServiceTests`

Thanks @chrisKns for raising these! I saw the same failures and recalled your posting earlier.

- `DefaultImageServiceTests.testDownloadingAndCachingAndRetrievingAnImageForImageView`: Assertion Failure at DefaultImageServiceTests.swift:101: XCTAssertNotNil failed / Assertion Failure at DefaultImageServiceTests.swift:105: XCTAssertNotNil failed
- `DefaultImageServiceTests.testDownloadingAndCachingAndRetrievingAnImageForImageViewFromURLWithSpecialChars` Assertion Failure at DefaultImageServiceTests.swift:137: XCTAssertNotNil failed / Assertion Failure at DefaultImageServiceTests.swift:141: XCTAssertNotNil failed

**When they fail**: these failures happen after the first run.
**Why they fail**: it was a bit hard to track exactly which Kingfisher version, but `MockImageCache` (a subclass of `Kingfisher.ImageCache`) that mocks the local image cache is missing a custom implementation of `imageCachedType` to be based on the internal state. Therefore, the superclass `Kingfisher.ImageCache.imageCachedType` was called instead and it returned an inconsistent state.
**The fix**: after overriding `imageCachedType` in `MockImageCache` by using the internal cache state, the Kingfisher image service was able to download or retrieve cache as expected using our mock implementations.

#### `ProductDetailsCellViewModelTests`

- `ProductDetailsCellViewModelTests.test_if_total_and_subtitle_are_negative_when_product_price_sum_is_negative` Assertion Failure at ProductDetailsCellViewModelTests.swift:129: XCTAssertEqual failed: ("-Sh 25") is not equal to ("-$25.00") / Assertion Failure at ProductDetailsCellViewModelTests.swift:130: XCTAssertEqual failed: ("2.5 x -Sh 10") is not equal to ("2.5 x -$10.00")
- `ProductDetailsCellViewModelTests.test_if_total_and_subtitle_are_positive_when_product_price_sum_is_positive` Assertion Failure at ProductDetailsCellViewModelTests.swift:112: XCTAssertEqual failed: ("Sh 25") is not equal to ("$25.00") / Assertion Failure at ProductDetailsCellViewModelTests.swift:113: XCTAssertEqual failed: ("2.5 x Sh 10") is not equal to ("2.5 x $10.00")

**When they fail**: these failures happen when the simulator was previously run with a store using different currency settings from USD.
**Why they fail**: `ServiceLocator.currencySettings` was used in the view model in these two test cases, and thus the generated values do not match the expected values in USD.
**The fix**: passing a fixed `CurrencySettings` to the view model ensures the expected currency settings are used in the view model.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can run `WooCommerceTests` twice and make sure all tests pass!


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
