### PR TITLE
Shipping Label: Fix incorrect tracks for origin and destination address steps of the creation flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -100,12 +100,6 @@ final class ShippingLabelAddressFormViewController: UIViewController {
                                                       countries: countries)
         onCompletion = completion
         super.init(nibName: nil, bundle: nil)
-        switch type {
-        case .origin:
-            ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "origin_address_started"])
-        case .destination:
-            ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "destination_address_started"])
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -213,6 +213,8 @@ private extension ShippingLabelFormViewController {
                        body: viewModel.originAddress?.fullNameWithCompanyAndAddress,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
+            ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "origin_address_started"])
+
             // Skip remote validation and navigate to edit address
             // if customs form is required and phone number is not found.
             if self.viewModel.customsFormRequired,
@@ -246,6 +248,7 @@ private extension ShippingLabelFormViewController {
                        body: viewModel.destinationAddress?.fullNameWithCompanyAndAddress,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
+            ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "destination_address_started"])
 
             // Skip remote validation and navigate to edit address
             // if customs form is required and phone number is not found.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6345 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the way the start of the origin and destination addresses steps are tracked.
Previously we're tracking these events only when the Edit Address form is presented. But there are cases when addresses can be successfully auto-validated so the start of these steps are missing.

This PR fixes that by tracking the events right when the Continue buttons on the Ship To and Ship From are tapped.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that your test store has WCShip installed and activated. The store address should be in the US to avoid the international shipping case.
- Place an order in the store with the shipping address within the US.
- On the app: navigate to Orders > select the created order > tap Create Shipping Label. If the order's payment method is COD and you have WCPay set up, make sure to collect payment first before the order is eligible for creating shipping labels.
- Tap Continue on the Ship From row. Notice in the console there's an event: `🔵 Tracked shipping_label_purchase_flow, properties: [AnyHashable("state"): "origin_address_started"...]`
- Tap Continue on the Ship To row. Notice in the console there's an event: `🔵 Tracked shipping_label_purchase_flow, properties: [AnyHashable("state"): "destination_address_started"...]`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
