### PR TITLE
[Mobile Payments] Show unsupported country error if store has Stripe set up in Canada

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -142,16 +142,28 @@ private extension CardPresentPaymentsOnboardingUseCase {
         }
 
         let configuration = configurationLoader.configuration
+
+        let wcPay = getWCPayPlugin()
+        let stripe = getStripePlugin()
+        let isStripeSupported = configuration.paymentGateways.contains(StripeAccount.gatewayID)
+
+        // If isSupportedCountry is false, IPP is not supported in the country through any
+        // payment gateway
         guard configuration.isSupportedCountry else {
             return .countryNotSupported(countryCode: countryCode)
         }
 
-        let wcPay = getWCPayPlugin()
-        guard configuration.paymentGateways.contains(StripeAccount.gatewayID) == true else {
-            return wcPayOnlyOnboardingState(plugin: wcPay)
+        // If it is supported in the country, we might or might not support Stripe yet, only WCPay
+        guard isStripeSupported else {
+            // If we only support WCPay, we don't want to ask users to set up WCPay if they already
+            // have Stripe. In that case, we can tell them that IPP is not supported for Stripe in
+            // their country yet.
+            if stripeInstalledAndActive(wcPay: wcPay, stripe: stripe) {
+                return .countryNotSupportedStripe(countryCode: countryCode)
+            } else {
+                return wcPayOnlyOnboardingState(plugin: wcPay)
+            }
         }
-
-        let stripe = getStripePlugin()
 
         // If both the Stripe plugin and WCPay are installed and activated, the user needs
         // to deactivate one: pdfdoF-fW-p2#comment-683
@@ -270,7 +282,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         return wcPay.active && stripe.active
     }
 
-    func wcPayInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin) -> Bool {
+    func wcPayInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin?) -> Bool {
         // If the WCPay plugin is not installed, immediately return false
         guard let wcPay = wcPay else {
             return false
@@ -278,6 +290,16 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         return wcPay.active
     }
+
+    func stripeInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin?) -> Bool {
+        // If the Stripe plugin is not installed, immediately return false
+        guard let stripe = stripe else {
+            return false
+        }
+
+        return stripe.active
+    }
+
 
     func isWCPayVersionSupported(plugin: SystemPlugin) -> Bool {
         VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: CardPresentPaymentsPlugins.wcPay.minimumSupportedPluginVersion)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -158,7 +158,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             // If we only support WCPay, we don't want to ask users to set up WCPay if they already
             // have Stripe. In that case, we can tell them that IPP is not supported for Stripe in
             // their country yet.
-            if stripeInstalledAndActive(wcPay: wcPay, stripe: stripe) {
+            if stripeInstalledAndActive(stripe: stripe) {
                 return .countryNotSupportedStripe(countryCode: countryCode)
             } else {
                 return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -173,7 +173,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // If only the Stripe extension is installed, skip to checking Stripe activation and version
         if let stripe = stripe,
-            wcPayInstalledAndActive(wcPay: wcPay, stripe: stripe) == false {
+            wcPayInstalledAndActive(wcPay: wcPay) == false {
             return stripeGatewayOnlyOnboardingState(plugin: stripe)
         } else {
             return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -282,7 +282,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         return wcPay.active && stripe.active
     }
 
-    func wcPayInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin?) -> Bool {
+    func wcPayInstalledAndActive(wcPay: SystemPlugin?) -> Bool {
         // If the WCPay plugin is not installed, immediately return false
         guard let wcPay = wcPay else {
             return false
@@ -291,7 +291,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         return wcPay.active
     }
 
-    func stripeInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin?) -> Bool {
+    func stripeInstalledAndActive(stripe: SystemPlugin?) -> Bool {
         // If the Stripe plugin is not installed, immediately return false
         guard let stripe = stripe else {
             return false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -37,6 +37,8 @@ struct InPersonPaymentsView: View {
                 }
             case .countryNotSupported(let countryCode):
                 InPersonPaymentsCountryNotSupported(countryCode: countryCode)
+            case .countryNotSupportedStripe(let countryCode):
+                InPersonPaymentsCountryNotSupportedStripe(countryCode: countryCode)
             case .pluginNotInstalled:
                 InPersonPaymentsPluginNotInstalled(onRefresh: viewModel.refresh)
             case .pluginUnsupportedVersion(let plugin):

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct InPersonPaymentsCountryNotSupportedStripe: View {
+    let countryCode: String
+
+    var body: some View {
+        InPersonPaymentsOnboardingError(
+            title: title,
+            message: Localization.message,
+            image: InPersonPaymentsOnboardingError.ImageInfo(
+                image: .paymentErrorImage,
+                height: 180.0
+            ),
+            supportLink: true,
+            learnMore: true
+        )
+    }
+
+    var title: String {
+        guard let countryName = Locale.current.localizedString(forRegionCode: countryCode) else {
+            DDLogError("In-Person Payments unsupported in country code \(countryCode), which can't be localized")
+            return Localization.titleUnknownCountry
+        }
+        return String(format: Localization.title, countryName)
+    }
+}
+
+private enum Localization {
+    static let title = NSLocalizedString(
+        "We don’t support In-Person Payments with Stripe in %1$@",
+        comment: "Title for the error screen when In-Person Payments is not supported in a specific country"
+    )
+
+    static let titleUnknownCountry = NSLocalizedString(
+        "We don’t support In-Person Payments with Stripe in your country",
+        comment: "Title for the error screen when In-Person Payments is not supported because we don't know the name of the country"
+    )
+
+    static let message = NSLocalizedString(
+        "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
+        comment: "Error message when In-Person Payments is not supported in a specific country"
+    )
+}
+
+struct InPersonPaymentsCountryNotSupportedStripe_Previews: PreviewProvider {
+    static var previews: some View {
+        // Valid country code
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES")
+        // Invalid country code
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -423,9 +423,9 @@
 		094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */; };
 		09885C8727C6947A00910A62 /* ProductPriceSettingsValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09885C8627C6947A00910A62 /* ProductPriceSettingsValidator.swift */; };
 		098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */; };
-		09EA565227C8235200407D40 /* ProductPriceSettingsValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */; };
 		09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */; };
 		09E41E1D27B90B3C00BFCB7C /* BulkUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */; };
+		09EA565227C8235200407D40 /* ProductPriceSettingsValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */; };
 		09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA565327C8ACEE00407D40 /* BulkUpdateViewController.swift */; };
 		09EA565627C8ACEE00407D40 /* BulkUpdateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09EA565427C8ACEE00407D40 /* BulkUpdateViewController.xib */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -1564,6 +1564,7 @@
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
 		E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */; };
 		E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */; };
+		E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BD16C27CF890700CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift */; };
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
 		E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC792673595A0083AFF2 /* ShareSheet.swift */; };
 		E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */; };
@@ -2094,9 +2095,9 @@
 		094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModelTests.swift; sourceTree = "<group>"; };
 		09885C8627C6947A00910A62 /* ProductPriceSettingsValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsValidator.swift; sourceTree = "<group>"; };
 		098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSourceTests.swift; sourceTree = "<group>"; };
-		09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsValidatorTests.swift; sourceTree = "<group>"; };
 		09C6A26127C01166001FAD73 /* BulkUpdateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModelTests.swift; sourceTree = "<group>"; };
 		09E41E1C27B90B3B00BFCB7C /* BulkUpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewModel.swift; sourceTree = "<group>"; };
+		09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsValidatorTests.swift; sourceTree = "<group>"; };
 		09EA565327C8ACEE00407D40 /* BulkUpdateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BulkUpdateViewController.swift; sourceTree = "<group>"; };
 		09EA565427C8ACEE00407D40 /* BulkUpdateViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BulkUpdateViewController.xib; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
@@ -3239,6 +3240,7 @@
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
 		E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsSupportLink.swift; sourceTree = "<group>"; };
 		E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableVStack.swift; sourceTree = "<group>"; };
+		E10BD16C27CF890700CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupportedStripe.swift; sourceTree = "<group>"; };
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
 		E10DFC792673595A0083AFF2 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalUpdateFailed.swift; sourceTree = "<group>"; };
@@ -7565,6 +7567,7 @@
 				D85A3C5126C15DE200C0E026 /* InPersonPaymentsPluginNotSupportedVersionView.swift */,
 				D85A3C5526C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift */,
 				E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */,
+				E10BD16C27CF890700CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift */,
 				D85A3C4F26C153A500C0E026 /* InPersonPaymentsPluginNotActivatedView.swift */,
 				D8B4D5F126C2CF5B00F34E94 /* InPersonPaymentsStripeAccountOverdueView.swift */,
 				D8B4D5EF26C2C7EC00F34E94 /* InPersonPaymentsStripeAccountPendingView.swift */,
@@ -9141,6 +9144,7 @@
 				0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
+				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,
 				4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */,
 				77E53EBF2510C153003D385F /* ProductDownloadListViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -77,6 +77,19 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
     }
 
+    func test_onboarding_returns_country_unsupported_with_canada_when_stripe_plugin_installed() {
+        // Given
+        setupCountry(country: .ca)
+        setupStripePlugin(status: .active, version: .minimumSupportedVersion)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .countryNotSupportedStripe(countryCode: "CA"))
+    }
+
     func test_onboarding_does_not_return_country_unsupported_with_canada_for_wcpay() {
         // Given
         setupCountry(country: .ca)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -16,6 +16,10 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     ///
     case countryNotSupported(countryCode: String)
 
+    /// Store is not located in one of the supported countries for Stripe (but it is for WCPay).
+    ///
+    case countryNotSupportedStripe(countryCode: String)
+
     /// No CPP plugin is installed on the store.
     ///
     case pluginNotInstalled
@@ -74,6 +78,8 @@ extension CardPresentPaymentOnboardingState {
         case .selectPlugin:
             return "multiple_plugins_installed"
         case .countryNotSupported(countryCode: _):
+            return "country_not_supported"
+        case .countryNotSupportedStripe(countryCode: _):
             return "country_not_supported"
         case .pluginNotInstalled:
             return "wcpay_not_installed"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6233 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR shows a new specific error in the case where a store is based on Canada and already has the Stripe extension installed. Since we don't support IPP with Stripe in Canada yet, we want to show an error, but not direct merchants to replace Stripe with WCPay.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Switch to a store in Canada that has Stripe installed but not WCPay2. 
2. Go to Settings -> In-Person Payments
3. Verify there's an error saying that In-Person Payments are not supported for Stripe in Canada

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After
-|-
![before](https://user-images.githubusercontent.com/8739/156742462-74f8ec97-4d4f-4fa7-87e3-593a245d0459.png)|![after](https://user-images.githubusercontent.com/8739/156742479-ddc40ba2-3d46-4985-a45d-62e214d76c8a.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
