### PR TITLE
Order Creation: Display order total (in Payment section) directly from order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -494,10 +494,7 @@ private extension NewOrderViewModel {
                     .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
                     .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
-                let shippingTotal = order.shippingLines
-                    .map { $0.total }
-                    .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
-                    .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
+                let shippingTotal = self.currencyFormatter.convertToDecimal(from: order.shippingTotal) ?? .zero
 
                 let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -166,7 +166,7 @@ final class NewOrderViewModel: ObservableObject {
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.analytics = analytics
         self.orderSynchronizer = enableRemoteSync ? RemoteOrderSynchronizer(siteID: siteID, stores: stores)
-                                                  : LocalOrderSynchronizer(siteID: siteID, stores: stores)
+        : LocalOrderSynchronizer(siteID: siteID, stores: stores, currencySettings: currencySettings)
 
         configureDisabledState()
         configureNavigationTrailingItem()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -498,15 +498,16 @@ private extension NewOrderViewModel {
 
                 let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
 
-                // TODO-6236: move totals calculation to LocalOrderSynchronizer, add tax to feesBaseAmount
-                let feesBaseAmountForPercentage = itemsTotal.adding(shippingTotal)
+                let taxesTotal = self.currencyFormatter.convertToDecimal(from: order.totalTax) ?? .zero
+
+                let feesBaseAmountForPercentage = itemsTotal.adding(shippingTotal).adding(taxesTotal)
 
                 let feesTotal = order.fees
                     .map { $0.total }
                     .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
                     .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
-
+                // TODO: Get this total from the order directly
                 let orderTotal = feesBaseAmountForPercentage.adding(feesTotal)
 
                 let isDataSyncing: Bool = {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -507,9 +507,6 @@ private extension NewOrderViewModel {
                     .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
                     .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
-                // TODO: Get this total from the order directly
-                let orderTotal = feesBaseAmountForPercentage.adding(feesTotal)
-
                 let isDataSyncing: Bool = {
                     switch state {
                     case .syncing:
@@ -521,12 +518,12 @@ private extension NewOrderViewModel {
 
                 return PaymentDataViewModel(itemsTotal: itemsTotal.stringValue,
                                             shouldShowShippingTotal: order.shippingLines.isNotEmpty,
-                                            shippingTotal: shippingTotal.stringValue,
+                                            shippingTotal: order.shippingTotal,
                                             shippingMethodTitle: shippingMethodTitle,
                                             shouldShowFees: order.fees.isNotEmpty,
                                             feesBaseAmountForPercentage: feesBaseAmountForPercentage as Decimal,
                                             feesTotal: feesTotal.stringValue,
-                                            orderTotal: orderTotal.stringValue,
+                                            orderTotal: order.total,
                                             isLoading: isDataSyncing,
                                             saveShippingLineClosure: self.saveShippingLine,
                                             saveFeeLineClosure: self.saveFeeLine,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -166,7 +166,7 @@ final class NewOrderViewModel: ObservableObject {
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.analytics = analytics
         self.orderSynchronizer = enableRemoteSync ? RemoteOrderSynchronizer(siteID: siteID, stores: stores)
-        : LocalOrderSynchronizer(siteID: siteID, stores: stores, currencySettings: currencySettings)
+                                                  : LocalOrderSynchronizer(siteID: siteID, stores: stores, currencySettings: currencySettings)
 
         configureDisabledState()
         configureNavigationTrailingItem()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -489,23 +489,9 @@ private extension NewOrderViewModel {
                     return PaymentDataViewModel()
                 }
 
-                let itemsTotal = order.items
-                    .map { $0.subtotal }
-                    .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
-                    .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
-
-                let shippingTotal = self.currencyFormatter.convertToDecimal(from: order.shippingTotal) ?? .zero
+                let orderTotals = OrderTotalsCalculator(for: order, using: self.currencyFormatter)
 
                 let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
-
-                let taxesTotal = self.currencyFormatter.convertToDecimal(from: order.totalTax) ?? .zero
-
-                let feesBaseAmountForPercentage = itemsTotal.adding(shippingTotal).adding(taxesTotal)
-
-                let feesTotal = order.fees
-                    .map { $0.total }
-                    .compactMap { self.currencyFormatter.convertToDecimal(from: $0) }
-                    .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
                 let isDataSyncing: Bool = {
                     switch state {
@@ -516,13 +502,13 @@ private extension NewOrderViewModel {
                     }
                 }()
 
-                return PaymentDataViewModel(itemsTotal: itemsTotal.stringValue,
+                return PaymentDataViewModel(itemsTotal: orderTotals.itemsTotal.stringValue,
                                             shouldShowShippingTotal: order.shippingLines.isNotEmpty,
                                             shippingTotal: order.shippingTotal,
                                             shippingMethodTitle: shippingMethodTitle,
                                             shouldShowFees: order.fees.isNotEmpty,
-                                            feesBaseAmountForPercentage: feesBaseAmountForPercentage as Decimal,
-                                            feesTotal: feesTotal.stringValue,
+                                            feesBaseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
+                                            feesTotal: orderTotals.feesTotal.stringValue,
                                             orderTotal: order.total,
                                             isLoading: isDataSyncing,
                                             saveShippingLineClosure: self.saveShippingLine,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -85,7 +85,7 @@ private extension LocalOrderSynchronizer {
 
         setShipping.withLatestFrom(orderPublisher)
             .map { shippingLineInput, order in
-                order.copy(shippingLines: shippingLineInput.flatMap { [$0] } ?? [])
+                order.copy(shippingTotal: shippingLineInput?.total ?? "0", shippingLines: shippingLineInput.flatMap { [$0] } ?? [])
             }
             .assign(to: &$order)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Yosemite
+
+/// Helper to calculate the totals on an `Order`.
+///
+final class OrderTotalsCalculator {
+    // MARK: Private properties
+
+    private let order: Order
+
+    private let currencyFormatter: CurrencyFormatter
+
+    /// Total shipping amount on an order.
+    ///
+    private var shippingTotal: NSDecimalNumber {
+        currencyFormatter.convertToDecimal(from: order.shippingTotal) ?? .zero
+    }
+
+    /// Total taxes amount on an order.
+    ///
+    private var taxesTotal: NSDecimalNumber {
+        currencyFormatter.convertToDecimal(from: order.totalTax) ?? .zero
+    }
+
+    // MARK: Calculated totals
+
+    /// Total value of all items on an order.
+    ///
+    var itemsTotal: NSDecimalNumber {
+        order.items
+            .map { $0.subtotal }
+            .compactMap { currencyFormatter.convertToDecimal(from: $0) }
+            .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
+    }
+
+    /// Base amount used to calculate percentage-based fees for an order.
+    ///
+    var feesBaseAmountForPercentage: NSDecimalNumber {
+        itemsTotal.adding(shippingTotal).adding(taxesTotal)
+    }
+
+    /// Total value of all fee lines on an order.
+    ///
+    var feesTotal: NSDecimalNumber {
+        order.fees
+            .map { $0.total }
+            .compactMap { currencyFormatter.convertToDecimal(from: $0) }
+            .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
+    }
+
+    init(for order: Order, using currencyFormatter: CurrencyFormatter) {
+        self.order = order
+        self.currencyFormatter = currencyFormatter
+    }
+
+    /// Returns a copy of the order with a new, locally calculated order total.
+    ///
+    func updateOrderTotal() -> Order {
+        let orderTotal = itemsTotal.adding(shippingTotal).adding(feesTotal).adding(taxesTotal)
+        return order.copy(total: orderTotal.stringValue)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1197,6 +1197,8 @@
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
 		CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */; };
 		CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */; };
+		CC4B252B27CFCEE2008D2E6E /* OrderTotalsCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4B252A27CFCEE2008D2E6E /* OrderTotalsCalculator.swift */; };
+		CC4B252D27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4B252C27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift */; };
 		CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */; };
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
 		CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3427551A6E00C4CA4F /* ProductRow.swift */; };
@@ -2855,6 +2857,8 @@
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
 		CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndToggleRow.swift; sourceTree = "<group>"; };
+		CC4B252A27CFCEE2008D2E6E /* OrderTotalsCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTotalsCalculator.swift; sourceTree = "<group>"; };
+		CC4B252C27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTotalsCalculatorTests.swift; sourceTree = "<group>"; };
 		CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModel.swift; sourceTree = "<group>"; };
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		CC53FB3427551A6E00C4CA4F /* ProductRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRow.swift; sourceTree = "<group>"; };
@@ -4366,6 +4370,7 @@
 				2602A64127BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift */,
 				2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */,
 				2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */,
+				CC4B252C27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift */,
 			);
 			path = Synchronizer;
 			sourceTree = "<group>";
@@ -4610,6 +4615,7 @@
 				2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */,
 				2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */,
 				2602A64527BDBEBA00B347F1 /* ProductInputTransformer.swift */,
+				CC4B252A27CFCEE2008D2E6E /* OrderTotalsCalculator.swift */,
 			);
 			path = Synchronizer;
 			sourceTree = "<group>";
@@ -8801,6 +8807,7 @@
 				AEC95D412774C5AE001571F5 /* AddressFormViewModelProtocol.swift in Sources */,
 				B6E851F5276330200041D1BA /* RefundFeesDetailsTableViewCell.swift in Sources */,
 				2602A63D27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift in Sources */,
+				CC4B252B27CFCEE2008D2E6E /* OrderTotalsCalculator.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				45DB70602614C7E80064A6CF /* ShippingLabelPackageDetailsResultsControllers.swift in Sources */,
 				027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */,
@@ -9448,6 +9455,7 @@
 				021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */,
 				024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */,
 				B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */,
+				CC4B252D27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift in Sources */,
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import WooCommerce
+@testable import Yosemite
+
+class OrderTotalsCalculatorTests: XCTestCase {
+
+    func test_itemsTotal_includes_all_item_subtotals() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let order = Order.fake().copy(items: [OrderItem.fake().copy(subtotal: "2.00"), OrderItem.fake().copy(subtotal: "8.00")])
+
+        // When
+        let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
+
+        // Then
+        XCTAssertEqual(orderTotalsCalculator.itemsTotal, 10)
+    }
+
+    func test_feesTotal_includes_all_fee_line_totals() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let order = Order.fake().copy(fees: [OrderFeeLine.fake().copy(total: "2.00"), OrderFeeLine.fake().copy(total: "8.00")])
+
+        // When
+        let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
+
+        // Then
+        XCTAssertEqual(orderTotalsCalculator.feesTotal, 10)
+    }
+
+    func test_feesBaseAmountForPercentage_includes_expected_totals() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let order = Order.fake().copy(shippingTotal: "5.00",
+                                      totalTax: "3.00",
+                                      items: [OrderItem.fake().copy(subtotal: "2.00"), OrderItem.fake().copy(subtotal: "8.00")],
+                                      fees: [OrderFeeLine.fake().copy(total: "2.00"), OrderFeeLine.fake().copy(total: "8.00")])
+
+        // When
+        let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
+
+        // Then
+        XCTAssertEqual(orderTotalsCalculator.feesBaseAmountForPercentage, 18)
+    }
+
+    func test_updateOrderTotal_returns_order_with_expected_total() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let order = Order.fake().copy(shippingTotal: "5.00",
+                                      totalTax: "3.00",
+                                      items: [OrderItem.fake().copy(subtotal: "2.00"), OrderItem.fake().copy(subtotal: "8.00")],
+                                      fees: [OrderFeeLine.fake().copy(total: "2.00"), OrderFeeLine.fake().copy(total: "8.00")])
+
+        // When
+        let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
+        let updatedOrder = orderTotalsCalculator.updateOrderTotal()
+
+        // Then
+        XCTAssertEqual(updatedOrder.total, "28")
+    }
+}


### PR DESCRIPTION
Closes: #6236

## Description

In Order Creation, we were calculating the order total based on all of the items in the order. We now read the order total directly from the order, which supports the upcoming change to a remote order synchronizer.

## Changes

* The calculations for an order's items total, fees total, and order total are extracted into a new class `OrderTotalsCalculator`:
   * The items total and fees total are used to calculate and update the order total, and they are used in `NewOrderViewModel` to display those totals in the Payment section.
   * The order can be updated with `updateOrderTotal()` to use the locally calculated order total. This is now used in both the local and remote synchronizer to set the order total whenever the order items, shipping, or fees are updated.
   * The base amount used to calculate percentage-based fees is also extracted to this class, since it is based on totals calculated in this class and for ease of testing.
   * This class has a set of unit tests to check that the calculations are performed as expected.
* In `NewOrderViewModel`, there are a few changes to the payment data view model:
   * The order total now comes directly from the `Order`.
   * The shipping total now comes directly from the order's `shippingTotal` property instead of being calculated from the shipping lines.

## Testing

There should be no visible changes when orders are synced locally (with the `.orderCreationRemoteSynchronizer` feature flag disabled):

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Add and remove products, shipping, and fees. Each time, confirm the Payment section reflects the expected totals for each change.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
