### PR TITLE
Order Creation: Show tax row in Payment section on new order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -351,6 +351,9 @@ extension NewOrderViewModel {
         let feesBaseAmountForPercentage: Decimal
         let feesTotal: String
 
+        let shouldShowTaxes: Bool
+        let taxesTotal: String
+
         /// Whether payment data is being reloaded (during remote sync)
         ///
         let isLoading: Bool
@@ -365,6 +368,8 @@ extension NewOrderViewModel {
              shouldShowFees: Bool = false,
              feesBaseAmountForPercentage: Decimal = 0,
              feesTotal: String = "",
+             shouldShowTaxes: Bool = false,
+             taxesTotal: String = "",
              orderTotal: String = "",
              isLoading: Bool = false,
              saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
@@ -377,6 +382,8 @@ extension NewOrderViewModel {
             self.shouldShowFees = shouldShowFees
             self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? ""
+            self.shouldShowTaxes = shouldShowTaxes
+            self.taxesTotal = currencyFormatter.formatAmount(taxesTotal) ?? ""
             self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? ""
             self.isLoading = isLoading
             self.shippingLineViewModel = ShippingLineDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
@@ -509,6 +516,8 @@ private extension NewOrderViewModel {
                                             shouldShowFees: order.fees.isNotEmpty,
                                             feesBaseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
                                             feesTotal: orderTotals.feesTotal.stringValue,
+                                            shouldShowTaxes: order.totalTax.isNotEmpty,
+                                            taxesTotal: order.totalTax,
                                             orderTotal: order.total,
                                             isLoading: isDataSyncing,
                                             saveShippingLineClosure: self.saveShippingLine,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -49,9 +49,11 @@ struct OrderPaymentSection: View {
 
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}
 
-            Text(Localization.taxesInfo)
-                .footnoteStyle()
-                .padding([.horizontal, .bottom])
+            if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) {
+                Text(Localization.taxesInfo)
+                    .footnoteStyle()
+                    .padding([.horizontal, .bottom])
+            }
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.listForeground))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -47,9 +47,13 @@ struct OrderPaymentSection: View {
                     }
             }
 
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreationRemoteSynchronizer) { // TODO: Also check if the taxes row should be shown
+                TitleAndValueRow(title: Localization.taxesTotal, value: .content("$0.00")) // TODO: Add real tax value from synchronizer
+            }
+
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}
 
-            if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) {
+            if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreationRemoteSynchronizer) {
                 Text(Localization.taxesInfo)
                     .footnoteStyle()
                     .padding([.horizontal, .bottom])
@@ -102,6 +106,7 @@ private extension OrderPaymentSection {
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
         static let addFees = NSLocalizedString("Add Fees", comment: "Title text of the button that adds fees when creating a new order")
         static let feesTotal = NSLocalizedString("Fees", comment: "Label for the row showing the cost of fees in the order")
+        static let taxesTotal = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -47,8 +47,8 @@ struct OrderPaymentSection: View {
                     }
             }
 
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreationRemoteSynchronizer) { // TODO: Also check if the taxes row should be shown
-                TitleAndValueRow(title: Localization.taxesTotal, value: .content("$0.00")) // TODO: Add real tax value from synchronizer
+            if viewModel.shouldShowTaxes {
+                TitleAndValueRow(title: Localization.taxesTotal, value: .content(viewModel.taxesTotal))
             }
 
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -319,16 +319,20 @@ class NewOrderViewModelTests: XCTestCase {
     func test_payment_data_view_model_is_initialized_with_expected_values() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
-        let itemsTotal = "20.00"
-        let orderTotal = "30.00"
 
         // When
-        let paymentDataViewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: itemsTotal,
-                                                                          orderTotal: orderTotal,
+        let paymentDataViewModel = NewOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00",
+                                                                          shippingTotal: "3.00",
+                                                                          feesTotal: "2.00",
+                                                                          taxesTotal: "5.00",
+                                                                          orderTotal: "30.00",
                                                                           currencyFormatter: CurrencyFormatter(currencySettings: currencySettings))
 
         // Then
         XCTAssertEqual(paymentDataViewModel.itemsTotal, "£20.00")
+        XCTAssertEqual(paymentDataViewModel.shippingTotal, "£3.00")
+        XCTAssertEqual(paymentDataViewModel.feesTotal, "£2.00")
+        XCTAssertEqual(paymentDataViewModel.taxesTotal, "£5.00")
         XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
     }
 
@@ -448,6 +452,35 @@ class NewOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(isLoadingDuringSync)
         XCTAssertFalse(viewModel.paymentDataViewModel.isLoading) // Disabled after sync ends
+    }
+
+    func test_payment_section_is_updated_when_order_has_taxes() {
+        // Given
+        let expectation = expectation(description: "Order with taxes is synced")
+        let currencySettings = CurrencySettings()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores, currencySettings: currencySettings, enableRemoteSync: true)
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .createOrder(_, _, onCompletion):
+                let order = Order.fake().copy(siteID: self.sampleSiteID, totalTax: "2.50")
+                onCompletion(.success(order))
+                expectation.fulfill()
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+        // Trigger remote sync
+        viewModel.saveShippingLine(ShippingLine.fake())
+
+        // Then
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowTaxes)
+        XCTAssertEqual(viewModel.paymentDataViewModel.taxesTotal, "$2.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 2.50)
+
     }
 }
 


### PR DESCRIPTION
Closes: #6029

## Description

During Order Creation, we now show a tax row in the Payment section if the order has taxes:

- If the `orderCreationRemoteSynchronizer` feature flag is disabled, there will be no tax row and the info text about taxes will continue to be displayed under the order total.
- With `orderCreationRemoteSynchronizer` enabled, and before the draft order has been created remotely, there is no tax information displayed.
- Once the draft order is created remotely and synced, the total tax amount for the order (calculated on the backend and provided by the API) is displayed as "Taxes" and the amount.

## Changes

* Updated `NewOrderViewModel.PaymentDataViewModel` to include properties `shouldShowTaxes` and `taxesTotal` (taken directly from the order).
* Updated `OrderPaymentSection` to show the tax row if `shouldShowTaxes` is true (if there are taxes to display), and to show the existing tax info text if `orderCreationRemoteSynchronizer` is disabled.
* Updates unit tests.

## Testing

With the `orderCreationRemoteSynchronizer` flag **disabled** in `DefaultFeatureFlagService`:

1. Build and run the app.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Confirm the tax info text ("Taxes will be automatically calculated ...") **does** appear under "Order Total" in the Payment section.
5. Add/remove products, shipping, and/or fees from the order and confirm a Taxes row **doesn't** appear.

With the `orderCreationRemoteSynchronizer` flag **enabled** in `DefaultFeatureFlagService`:

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Confirm there is **no** text under "Order Total" in the Payment section.
5. Add products, shipping, and/or fees from the order and confirm a "Taxes" row **does** appear with the expected amount (if you have taxes set up on your store).


## Screenshots

With the `orderCreationRemoteSynchronizer` flag **disabled**:

New order|After adding a product
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-02 at 14 41 53](https://user-images.githubusercontent.com/8658164/156458783-7e0e65e0-3ff8-4c6d-a154-c7e42aade69d.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-03-02 at 14 42 14](https://user-images.githubusercontent.com/8658164/156458803-9d54cece-cca4-44df-a704-cd3de26e1fd9.png)

With the `orderCreationRemoteSynchronizer` flag **enabled**:

New order|After adding a product
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-02 at 14 51 32](https://user-images.githubusercontent.com/8658164/156458828-6d1027e1-e5a7-4754-92ed-412fdbdd4633.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-03-02 at 14 51 43](https://user-images.githubusercontent.com/8658164/156458845-e8906c60-c045-48a0-846a-048140ca2fb7.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
