### PR TITLE
Notifications: Dismiss presented view before presenting content from notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [internal] Removed all feature flags for Shipping Labels. Please smoke test all parts of Shipping Labels to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6270]
 - [*] In-Person Payments: Localized messages and UI [https://github.com/woocommerce/woocommerce-ios/pull/6317]
 - [*] My Store: Fixed incorrect currency symbol of revenue text for stores with non-USD currency. [https://github.com/woocommerce/woocommerce-ios/pull/6335]
+- [*] Notifications: Dismiss presented view before presenting content from notifications [https://github.com/woocommerce/woocommerce-ios/pull/6354]
 - [internal] Removed the feature flag for My store tab UI updates. Please smoke test the store stats and top performers in the "My store" tab to make sure everything works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6334]
 
 8.6

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -161,9 +161,12 @@ final class MainTabBarController: UITabBarController {
 
     // MARK: - Public Methods
 
-    /// Switches the TabBarcController to the specified Tab
+    /// Switches the TabBarController to the specified Tab
     ///
     func navigateTo(_ tab: WooTab, animated: Bool = false, completion: (() -> Void)? = nil) {
+        if let presentedController = Self.childViewController()?.presentedViewController {
+            presentedController.dismiss(animated: true)
+        }
         selectedIndex = tab.visibleIndex(isHubMenuFeatureFlagOn)
         if let navController = selectedViewController as? UINavigationController {
             navController.popToRootViewController(animated: animated) {
@@ -455,7 +458,7 @@ private extension MainTabBarController {
     func createReviewsTabCoordinator() -> ReviewsCoordinator {
         ReviewsCoordinator(navigationController: reviewsNavigationController,
                            willPresentReviewDetailsFromPushNotification: { [weak self] in
-                            self?.navigateTo(.reviews)
+            self?.navigateTo(.reviews)
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -117,6 +117,11 @@ final class OrdersRootViewController: UIViewController {
             return
         }
 
+        // dismiss any presented controller before pushing the detail view.
+        if let presentedVC = presentedViewController {
+            presentedVC.dismiss(animated: true, completion: nil)
+        }
+
         let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
         navigationController?.pushViewController(loaderViewController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -117,11 +117,6 @@ final class OrdersRootViewController: UIViewController {
             return
         }
 
-        // dismiss any presented controller before pushing the detail view.
-        if let presentedVC = presentedViewController {
-            presentedVC.dismiss(animated: true, completion: nil)
-        }
-
         let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
         navigationController?.pushViewController(loaderViewController, animated: true)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #2823 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes issue when the presented modal is still present after tapping a notification when the app is in background mode.

The solution is simply to dismiss any presented modal before pushing new content from notification. Since we are switching tabs on the `MainTabBarController` when handling navigation for notifications, the dismissal for presented modals is handled here. Let me know if this solution is too hacky and please feel free to suggest a cleaner strategy is possible.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Test order notifications
- Build the app to a physical device (so that notifications are available) > proceed to a flow that ends with a screen presented modally (e.g Orders > Search).
- Background the app, then place an order on your test store.
- When a notification comes on your device, tap on it. Notice that the presented modal is dismissed and the detail screen for the new order is presented properly.

#### Test review notifications
- Build the app to a physical device (so that notifications are available) > proceed to a flow that ends with a screen presented modally (e.g Orders > Search).
- Background the app, then submit a review for a product on your test store.
- When a notification comes on your device, tap on it. Notice that the presented modal is dismissed and the detail screen for the new review is presented properly.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

#### Order notification
https://user-images.githubusercontent.com/5533851/156486275-9047019d-9e3a-4ee8-a130-68a17511166a.MP4

#### Review notification
https://user-images.githubusercontent.com/5533851/156486333-6fcf1ae6-bb81-41b5-887d-d05950618241.MP4


---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
