### PR TITLE
Remove ghost animations when refreshing products, reviews and plugins

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -104,7 +104,9 @@ private extension PluginListViewController {
     ///
     @objc func syncPlugins() {
         removeErrorStateView()
-        startGhostAnimation()
+        if viewModel.numberOfSections == 0 {
+            startGhostAnimation()
+        }
         viewModel.syncPlugins { [weak self] result in
             guard let self = self else { return }
             self.refreshControl.endRefreshing()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -949,7 +949,10 @@ private extension ProductsViewController {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
         case .syncing(let pageNumber):
-            if pageNumber != SyncingCoordinator.Defaults.pageFirstIndex {
+            let isFirstPage = pageNumber == SyncingCoordinator.Defaults.pageFirstIndex
+            if isFirstPage && resultsController.isEmpty {
+                displayPlaceholderProducts()
+            } else if !isFirstPage {
                 ensureFooterSpinnerIsStarted()
             }
             // Remove error banner when sync starts

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -949,13 +949,13 @@ private extension ProductsViewController {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
         case .syncing(let pageNumber):
-            if pageNumber == SyncingCoordinator.Defaults.pageFirstIndex {
-                displayPlaceholderProducts()
-            } else {
+            if pageNumber != SyncingCoordinator.Defaults.pageFirstIndex {
                 ensureFooterSpinnerIsStarted()
             }
-            // Remove top banner when sync starts
-            hideTopBannerView()
+            // Remove error banner when sync starts
+            if hasErrorLoadingData {
+                hideTopBannerView()
+            }
         case .results:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -443,9 +443,7 @@ private extension ReviewsViewController {
         case .placeholder:
             displayPlaceholderReviews()
         case .syncing(let pageNumber):
-            if pageNumber == SyncingCoordinator.Defaults.pageFirstIndex {
-                displayPlaceholderReviews()
-            } else {
+            if pageNumber != SyncingCoordinator.Defaults.pageFirstIndex {
                 ensureFooterSpinnerIsStarted()
             }
         }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -160,7 +160,6 @@ private extension ProductStore {
                                     guard let self = self else {
                                         return
                                     }
-                                    
                                     let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber && shouldDeleteStoredProductsOnFirstPage
                                     self.upsertStoredProductsInBackground(readOnlyProducts: products,
                                                                           shouldDeleteExistingProducts: shouldDeleteExistingProducts) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #2909
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
It is expected that ghost animations are present only when first loading lists. Currently, we're showing this animation in product, review, and plugin lists even when refreshing content.

This PR cleans this up by removing the redundant animations on those screens.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Refresh product, reviews, and plugin lists after loading their contents. Notice that ghost animations are no longer present.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Product list:
https://user-images.githubusercontent.com/5533851/156491620-c27e8acb-7906-4cfd-aff5-94a3af270728.mp4

Review list:
https://user-images.githubusercontent.com/5533851/156491664-86d9f296-2cdb-45c9-b226-d1340c1b1703.mp4

Plugin list:
https://user-images.githubusercontent.com/5533851/156491706-1baae17b-9911-415f-9a25-1e539f670268.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
