### PR TITLE
Show Inbox menu based on WC version

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -69,11 +69,15 @@ final class HubMenuViewModel: ObservableObject {
     /// Resets the menu elements displayed on the menu.
     ///
     func setupMenuElements() {
-        menuElements = [.woocommerceAdmin, .viewStore]
-        if featureFlagService.isFeatureFlagEnabled(.inbox) {
-            menuElements.append(.inbox)
+        menuElements = [.woocommerceAdmin, .viewStore, .reviews]
+
+        let inboxUseCase = InboxEligibilityUseCase(stores: stores, featureFlagService: featureFlagService)
+        inboxUseCase.isEligibleForInbox(siteID: siteID) { [weak self] isInboxMenuShown in
+            guard let self = self else { return }
+            if let index = self.menuElements.firstIndex(of: .viewStore), isInboxMenuShown {
+                self.menuElements.insert(.inbox, at: index + 1)
+            }
         }
-        menuElements.append(.reviews)
 
         let action = AppSettingsAction.loadCouponManagementFeatureSwitchState { [weak self] result in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -1,0 +1,60 @@
+import Foundation
+import enum Yosemite.SystemStatusAction
+import protocol Yosemite.StoresManager
+import Experiments
+
+final class InboxEligibilityUseCase {
+    private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
+
+    init(stores: StoresManager = ServiceLocator.stores, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.stores = stores
+        self.featureFlagService = featureFlagService
+    }
+
+    /// Determines whether the store is eligible for inbox feature.
+    /// - Parameters:
+    ///   - siteID: the ID of the site to check for Inbox eligibility.
+    ///   - completion: called when the Inbox eligibility is determined.
+    func isEligibleForInbox(siteID: Int64, completion: @escaping (Bool) -> Void) {
+        guard featureFlagService.isFeatureFlagEnabled(.inbox) else {
+            return completion(false)
+        }
+
+        // Fetches WC plugin.
+        let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { [weak self] wcPlugin in
+            guard let self = self else { return }
+
+            // WooCommerce plugin is expected to be active in order to use the app/inbox.
+            guard let wcPlugin = wcPlugin, wcPlugin.active else {
+                return completion(false)
+            }
+
+            // Fetches WC Admin plugin. When WC Admin is active, WC Admin overrides the bundled version in WC plugin.
+            let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcAdminPluginName) { wcAdminPlugin in
+                guard let wcAdminPlugin = wcAdminPlugin, wcAdminPlugin.active else {
+                    let isInboxSupportedForWCPlugin = VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                                                        minimumRequired: Constants.wcPluginMinimumVersion)
+                    return completion(isInboxSupportedForWCPlugin)
+                }
+
+                let isInboxSupportedForWCAdminPlugin = VersionHelpers.isVersionSupported(version: wcAdminPlugin.version,
+                                                                                         minimumRequired: Constants.wcAdminPluginMinimumVersion)
+                completion(isInboxSupportedForWCAdminPlugin)
+            }
+            self.stores.dispatch(action)
+        }
+        stores.dispatch(action)
+    }
+}
+
+private extension InboxEligibilityUseCase {
+    enum Constants {
+        static let wcPluginName = "WooCommerce"
+        // TODO: 6148 - Update the minimum WC version with inbox filtering.
+        static let wcPluginMinimumVersion = "5.0.0"
+        static let wcAdminPluginName = "WooCommerce Admin"
+        // TODO: 6148 - Update the minimum WC Admin version with inbox filtering.
+        static let wcAdminPluginMinimumVersion = "2.0.0"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -3,6 +3,8 @@ import enum Yosemite.SystemStatusAction
 import protocol Yosemite.StoresManager
 import Experiments
 
+/// Checks whether a store is eligible for Inbox feature.
+/// Since mobile requires API support for filtering, only stores with a minimum WC plugin version are eligible.
 final class InboxEligibilityUseCase {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -22,27 +22,15 @@ final class InboxEligibilityUseCase {
         }
 
         // Fetches WC plugin.
-        let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { [weak self] wcPlugin in
-            guard let self = self else { return }
-
+        let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
             // WooCommerce plugin is expected to be active in order to use the app/inbox.
             guard let wcPlugin = wcPlugin, wcPlugin.active else {
                 return completion(false)
             }
 
-            // Fetches WC Admin plugin. When WC Admin is active, WC Admin overrides the bundled version in WC plugin.
-            let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcAdminPluginName) { wcAdminPlugin in
-                guard let wcAdminPlugin = wcAdminPlugin, wcAdminPlugin.active else {
-                    let isInboxSupportedForWCPlugin = VersionHelpers.isVersionSupported(version: wcPlugin.version,
-                                                                                        minimumRequired: Constants.wcPluginMinimumVersion)
-                    return completion(isInboxSupportedForWCPlugin)
-                }
-
-                let isInboxSupportedForWCAdminPlugin = VersionHelpers.isVersionSupported(version: wcAdminPlugin.version,
-                                                                                         minimumRequired: Constants.wcAdminPluginMinimumVersion)
-                completion(isInboxSupportedForWCAdminPlugin)
-            }
-            self.stores.dispatch(action)
+            let isInboxSupportedByWCPlugin = VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                                               minimumRequired: Constants.wcPluginMinimumVersion)
+            completion(isInboxSupportedByWCPlugin)
         }
         stores.dispatch(action)
     }
@@ -53,8 +41,5 @@ private extension InboxEligibilityUseCase {
         static let wcPluginName = "WooCommerce"
         // TODO: 6148 - Update the minimum WC version with inbox filtering.
         static let wcPluginMinimumVersion = "5.0.0"
-        static let wcAdminPluginName = "WooCommerce Admin"
-        // TODO: 6148 - Update the minimum WC Admin version with inbox filtering.
-        static let wcAdminPluginMinimumVersion = "2.0.0"
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */; };
 		0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */; };
 		0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */; };
+		0205021E27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0205021D27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift */; };
 		020624F027951113000D024C /* StoreStatsDataOrRedactedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */; };
 		0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206483923FA4160008441BB /* OrdersRootViewController.swift */; };
 		02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */; };
@@ -1687,6 +1688,7 @@
 		0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsTabProductViewModel+ProductVariation.swift"; sourceTree = "<group>"; };
 		0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooTab+Tag.swift"; sourceTree = "<group>"; };
 		0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Order.swift"; sourceTree = "<group>"; };
+		0205021D27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxEligibilityUseCase.swift; sourceTree = "<group>"; };
 		020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsDataOrRedactedView.swift; sourceTree = "<group>"; };
 		0206483923FA4160008441BB /* OrdersRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRootViewController.swift; sourceTree = "<group>"; };
 		02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+ReadonlyProductTests.swift"; sourceTree = "<group>"; };
@@ -3832,6 +3834,7 @@
 				02645D7A27BA027B0065DC68 /* InboxViewModel.swift */,
 				02645D8427BA2DB40065DC68 /* InboxNoteRow.swift */,
 				02645D8327BA2DB30065DC68 /* InboxNoteRowViewModel.swift */,
+				0205021D27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift */,
 			);
 			path = Inbox;
 			sourceTree = "<group>";
@@ -8374,6 +8377,7 @@
 				D817585E22BB5E8700289CFE /* OrderEmailComposer.swift in Sources */,
 				D8815ADF26383EE700EDAD62 /* CardPresentPaymentsModalViewController.swift in Sources */,
 				57896D6625362B0C000E8C4D /* TitleAndEditableValueTableViewCellViewModel.swift in Sources */,
+				0205021E27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
 				DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */,
 				02645D8827BA2E820065DC68 /* NSAttributedString+Attributes.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -168,7 +168,7 @@ private extension HubMenuViewModelTests {
     }
 
     enum Fixtures {
-        // WooCommerce plugin.
+        // TODO: 6148 - Update the minimum WC version with inbox filtering.
         static let wcPluginIneligibleForInbox = SystemPlugin.fake().copy(version: "3.0.0", active: true)
         static let wcPluginEligibleForInbox = SystemPlugin.fake().copy(version: "6.1.0", active: true)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -52,7 +52,7 @@ final class HubMenuViewModelTests: XCTestCase {
     }
 
     func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version() {
-        // Given the store is ineligible for inbox with WC version and coupons feature is enabled in app settings
+        // Given the store is ineligible WC version for inbox and coupons feature is enabled in app settings
         let featureFlagService = MockFeatureFlagService(isInboxOn: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
@@ -81,12 +81,12 @@ final class HubMenuViewModelTests: XCTestCase {
         let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
         viewModel.setupMenuElements()
 
-        // Then both inbox and coupons are in the menu
+        // Then only coupons is in the menu
         XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .coupons, .reviews])
     }
 
     func test_menuElements_do_not_include_inbox_and_coupons_when_store_has_ineligible_wc_version_and_coupons_disabled() {
-        // Given the store is ineligible for inbox with WC version and coupons feature is enabled in app settings
+        // Given the store is ineligible WC version for inbox and coupons feature is disabled in app settings
         let featureFlagService = MockFeatureFlagService(isInboxOn: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
@@ -115,7 +115,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
         viewModel.setupMenuElements()
 
-        // Then both inbox and coupons are in the menu
+        // Then neither inbox nor coupons is in the menu
         XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -17,22 +17,154 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.menuElements.contains(.inbox))
     }
 
-    func test_menuElements_include_inbox_when_feature_flag_is_on() {
-        // Given
+    func test_menuElements_include_inbox_and_coupons_when_store_has_eligible_wc_version_and_coupons_enabled() {
+        // Given the store is eligible for inbox with only WC plugin and coupons feature is enabled in app settings
         let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                switch systemPluginName {
+                case PluginName.wooCommerce:
+                    onCompletion(Fixtures.wcPluginEligibleForInbox)
+                default:
+                    onCompletion(nil)
+                }
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadCouponManagementFeatureSwitchState(let onCompletion):
+                onCompletion(.success(true))
+            default:
+                break
+            }
+        }
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService)
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
         viewModel.setupMenuElements()
 
-        // Then
+        // Then both inbox and coupons are in the menu
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .coupons, .reviews])
+    }
+
+    func test_menuElements_include_inbox_when_store_has_min_wcAdmin_version_while_wc_version_is_ineligible() {
+        // Given the store is eligible for inbox with WC Admin and coupons feature is enabled in app settings
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                switch systemPluginName {
+                case PluginName.wooCommerce:
+                    onCompletion(Fixtures.wcPluginIneligibleForInbox)
+                case PluginName.wooCommerceAdmin:
+                    onCompletion(Fixtures.wcAdminPluginEligibleForInbox)
+                default:
+                    onCompletion(nil)
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
+        viewModel.setupMenuElements()
+
+        // Then both inbox and coupons are in the menu
         XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .reviews])
+    }
+
+    func test_menuElements_do_not_include_inbox_when_store_has_eligible_wc_version_but_ineliglbe_wcAdmin_version() {
+        // Given the store is eligible for inbox with only WC plugin
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                switch systemPluginName {
+                case PluginName.wooCommerce:
+                    onCompletion(Fixtures.wcPluginEligibleForInbox)
+                case PluginName.wooCommerceAdmin:
+                    onCompletion(Fixtures.wcAdminPluginIneligibleForInbox)
+                default:
+                    onCompletion(nil)
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
+        viewModel.setupMenuElements()
+
+        // Then both inbox and coupons are in the menu
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
+    }
+
+    func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version_and_no_wcAdmin_plugin() {
+        // Given the store is eligible for inbox with WC Admin and coupons feature is enabled in app settings
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                switch systemPluginName {
+                case PluginName.wooCommerce:
+                    onCompletion(Fixtures.wcPluginIneligibleForInbox)
+                default:
+                    onCompletion(nil)
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
+        viewModel.setupMenuElements()
+
+        // Then both inbox and coupons are in the menu
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
+    }
+
+    func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version_and_inactive_wcAdmin_plugin() {
+        // Given the store is eligible for inbox with WC Admin and coupons feature is enabled in app settings
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                switch systemPluginName {
+                case PluginName.wooCommerce:
+                    onCompletion(Fixtures.wcPluginIneligibleForInbox)
+                case PluginName.wooCommerceAdmin:
+                    onCompletion(Fixtures.inactiveWCAdminPluginEligibleForInbox)
+                default:
+                    onCompletion(nil)
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
+        viewModel.setupMenuElements()
+
+        // Then both inbox and coupons are in the menu
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
     }
 
     func test_menuElements_include_coupons_when_couponManagement_is_enabled_in_app_settings() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let featureFlagService = MockFeatureFlagService(isInboxOn: false)
 
         // When
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
@@ -47,7 +179,7 @@ final class HubMenuViewModelTests: XCTestCase {
         viewModel.setupMenuElements()
 
         // Then
-        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .coupons, .reviews])
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .coupons, .reviews])
     }
 
     func test_menuElements_do_not_include_coupons_when_couponManagement_is_not_enabled_in_app_settings() {
@@ -69,5 +201,23 @@ final class HubMenuViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
+    }
+}
+
+private extension HubMenuViewModelTests {
+    enum PluginName {
+        static let wooCommerce = "WooCommerce"
+        static let wooCommerceAdmin = "WooCommerce Admin"
+    }
+
+    enum Fixtures {
+        // WooCommerce plugin.
+        static let wcPluginIneligibleForInbox = SystemPlugin.fake().copy(version: "3.0.0", active: true)
+        static let wcPluginEligibleForInbox = SystemPlugin.fake().copy(version: "6.1.0", active: true)
+
+        // WooCommerce Admin plugin.
+        static let wcAdminPluginIneligibleForInbox = SystemPlugin.fake().copy(version: "1.0.0", active: true)
+        static let wcAdminPluginEligibleForInbox = SystemPlugin.fake().copy(version: "3.1.0", active: true)
+        static let inactiveWCAdminPluginEligibleForInbox = SystemPlugin.fake().copy(version: "6.0.0", active: false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -17,8 +17,42 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.menuElements.contains(.inbox))
     }
 
-    func test_menuElements_include_inbox_and_coupons_when_store_has_eligible_wc_version_and_coupons_enabled() {
+    func test_menuElements_include_inbox_and_coupons_when_store_has_eligible_wc_version() {
         // Given the store is eligible for inbox with only WC plugin and coupons feature is enabled in app settings
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadCouponManagementFeatureSwitchState(let onCompletion):
+                onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                switch systemPluginName {
+                case PluginName.wooCommerce:
+                    onCompletion(Fixtures.wcPluginEligibleForInbox)
+                default:
+                    onCompletion(nil)
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
+        viewModel.setupMenuElements()
+
+        // Then both inbox and coupons are in the menu
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .coupons, .reviews])
+    }
+
+    func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version() {
+        // Given the store is ineligible for inbox with WC version and coupons feature is enabled in app settings
         let featureFlagService = MockFeatureFlagService(isInboxOn: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
@@ -26,7 +60,7 @@ final class HubMenuViewModelTests: XCTestCase {
             case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
                 switch systemPluginName {
                 case PluginName.wooCommerce:
-                    onCompletion(Fixtures.wcPluginEligibleForInbox)
+                    onCompletion(Fixtures.wcPluginIneligibleForInbox)
                 default:
                     onCompletion(nil)
                 }
@@ -48,67 +82,11 @@ final class HubMenuViewModelTests: XCTestCase {
         viewModel.setupMenuElements()
 
         // Then both inbox and coupons are in the menu
-        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .coupons, .reviews])
+        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .coupons, .reviews])
     }
 
-    func test_menuElements_include_inbox_when_store_has_min_wcAdmin_version_while_wc_version_is_ineligible() {
-        // Given the store is eligible for inbox with WC Admin and coupons feature is enabled in app settings
-        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
-            switch action {
-            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
-                switch systemPluginName {
-                case PluginName.wooCommerce:
-                    onCompletion(Fixtures.wcPluginIneligibleForInbox)
-                case PluginName.wooCommerceAdmin:
-                    onCompletion(Fixtures.wcAdminPluginEligibleForInbox)
-                default:
-                    onCompletion(nil)
-                }
-            default:
-                break
-            }
-        }
-
-        // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
-        viewModel.setupMenuElements()
-
-        // Then both inbox and coupons are in the menu
-        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .inbox, .reviews])
-    }
-
-    func test_menuElements_do_not_include_inbox_when_store_has_eligible_wc_version_but_ineliglbe_wcAdmin_version() {
-        // Given the store is eligible for inbox with only WC plugin
-        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
-            switch action {
-            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
-                switch systemPluginName {
-                case PluginName.wooCommerce:
-                    onCompletion(Fixtures.wcPluginEligibleForInbox)
-                case PluginName.wooCommerceAdmin:
-                    onCompletion(Fixtures.wcAdminPluginIneligibleForInbox)
-                default:
-                    onCompletion(nil)
-                }
-            default:
-                break
-            }
-        }
-
-        // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
-        viewModel.setupMenuElements()
-
-        // Then both inbox and coupons are in the menu
-        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
-    }
-
-    func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version_and_no_wcAdmin_plugin() {
-        // Given the store is eligible for inbox with WC Admin and coupons feature is enabled in app settings
+    func test_menuElements_do_not_include_inbox_and_coupons_when_store_has_ineligible_wc_version_and_coupons_disabled() {
+        // Given the store is ineligible for inbox with WC version and coupons feature is enabled in app settings
         let featureFlagService = MockFeatureFlagService(isInboxOn: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
@@ -124,30 +102,10 @@ final class HubMenuViewModelTests: XCTestCase {
                 break
             }
         }
-
-        // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService, stores: stores)
-        viewModel.setupMenuElements()
-
-        // Then both inbox and coupons are in the menu
-        XCTAssertEqual(viewModel.menuElements, [.woocommerceAdmin, .viewStore, .reviews])
-    }
-
-    func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version_and_inactive_wcAdmin_plugin() {
-        // Given the store is eligible for inbox with WC Admin and coupons feature is enabled in app settings
-        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
-                switch systemPluginName {
-                case PluginName.wooCommerce:
-                    onCompletion(Fixtures.wcPluginIneligibleForInbox)
-                case PluginName.wooCommerceAdmin:
-                    onCompletion(Fixtures.inactiveWCAdminPluginEligibleForInbox)
-                default:
-                    onCompletion(nil)
-                }
+            case .loadCouponManagementFeatureSwitchState(let onCompletion):
+                onCompletion(.success(false))
             default:
                 break
             }
@@ -207,17 +165,11 @@ final class HubMenuViewModelTests: XCTestCase {
 private extension HubMenuViewModelTests {
     enum PluginName {
         static let wooCommerce = "WooCommerce"
-        static let wooCommerceAdmin = "WooCommerce Admin"
     }
 
     enum Fixtures {
         // WooCommerce plugin.
         static let wcPluginIneligibleForInbox = SystemPlugin.fake().copy(version: "3.0.0", active: true)
         static let wcPluginEligibleForInbox = SystemPlugin.fake().copy(version: "6.1.0", active: true)
-
-        // WooCommerce Admin plugin.
-        static let wcAdminPluginIneligibleForInbox = SystemPlugin.fake().copy(version: "1.0.0", active: true)
-        static let wcAdminPluginEligibleForInbox = SystemPlugin.fake().copy(version: "3.1.0", active: true)
-        static let inactiveWCAdminPluginEligibleForInbox = SystemPlugin.fake().copy(version: "6.0.0", active: false)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6148 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Due to App Store guidelines that disallow upsells for payments outside of In-App Purchase, the mobile apps cannot show all the inbox notes as in core where some notes have actions that link to pages with payment CTAs. The API work https://github.com/woocommerce/woocommerce-ios/issues/5950 has yet begun, and might take a while after our API team has bandwidth and after the merging of WC Admin to core is done (ref pbIJXs-1iI-p2).

For stores with a lower WC version, we are going to hide the Inbox menu. This PR added an eligibility use case to check the WC plugin version and only show the Inbox menu when the WC version is above a minimum version (TBD) and the feature flag is enabled. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: has two stores have different WC versions

#### Ineligible case

* If the minimum WC version of the store you have is above 5.0.0: In code `InboxEligibilityUseCase.swift`, update the `wcPluginMinimumVersion` constant to be higher than the minimum WC version of your store
* Log in or switch to the store with the minimum WC version
* Launch the app
* Go to the Menu tab --> the Inbox tab should not be shown

#### Eligible case

* Continue from the ineligible case above
* Log in or switch to the store with the maximum WC version
* Launch the app
* Go to the Menu tab --> the Inbox tab should be shown

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->