### PR TITLE
Added cancel button and navigation bar title for bulk update screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -31,9 +31,21 @@ final class BulkUpdateViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        configureNavigationBar()
         configureTableView()
         configureGhostTableView()
         configureViewModel()
+    }
+
+    /// Configures the  title and navigation bar button
+    ///
+    private func configureNavigationBar() {
+        title = Localization.screenTitle
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancelButtonTitle,
+                                                           style: .plain,
+                                                           target: self,
+                                                           action: #selector(cancelButtonTapped))
     }
 
     /// Setup receiving updates for data changes and actives the view model
@@ -114,6 +126,12 @@ final class BulkUpdateViewController: UIViewController {
         for row in Row.allCases {
             tableView.registerNib(for: row.type)
         }
+    }
+
+    /// Action handler for the cancel button
+    ///
+    @objc private func cancelButtonTapped() {
+        viewModel.handleTapCancel()
     }
 }
 
@@ -214,6 +232,13 @@ extension BulkUpdateViewController {
         fileprivate var reuseIdentifier: String {
             return type.reuseIdentifier
         }
+    }
+}
+
+private extension BulkUpdateViewController {
+    enum Localization {
+        static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Button title that closes the presented screen")
+        static let screenTitle = NSLocalizedString("Bulk Update", comment: "Title that appears on top of the bulk update of product variations screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -23,6 +23,7 @@ final class BulkUpdateViewModel {
     private let productID: Int64
     private var bulkUpdateFormModel = BulkUpdateOptionsModel(productVariations: [])
     private let currencyFormatter: CurrencyFormatter
+    private var onCancelButtonTapped: () -> Void
 
     /// Product Variations Controller.
     ///
@@ -46,11 +47,13 @@ final class BulkUpdateViewModel {
 
     init(siteID: Int64,
          productID: Int64,
+         onCancelButtonTapped: @escaping () -> Void,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          storesManager: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.siteID = siteID
         self.productID = productID
+        self.onCancelButtonTapped = onCancelButtonTapped
         self.storageManager = storageManager
         self.storesManager = storesManager
         self.currencySettings = currencySettings
@@ -96,6 +99,10 @@ final class BulkUpdateViewModel {
             }
 
         storesManager.dispatch(action)
+    }
+
+    func handleTapCancel() {
+        onCancelButtonTapped()
     }
 
     /// Provides the view model with all user facing data of the option for updating the regular price

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -571,9 +571,9 @@ private extension ProductVariationsViewController {
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.bulkUpdate) { [weak self] _ in
             guard let self = self else { return }
 
-            let viewModel = BulkUpdateViewModel(siteID: self.siteID, productID: self.productID) { [weak self] in
+            let viewModel = BulkUpdateViewModel(siteID: self.siteID, productID: self.productID, onCancelButtonTapped: { [weak self] in
                 self?.dismiss(animated: true)
-            }
+            })
             let navigationController = WooNavigationController(rootViewController: BulkUpdateViewController(viewModel: viewModel))
             self.present(navigationController, animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -571,7 +571,9 @@ private extension ProductVariationsViewController {
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.bulkUpdate) { [weak self] _ in
             guard let self = self else { return }
 
-            let viewModel = BulkUpdateViewModel(siteID: self.siteID, productID: self.productID)
+            let viewModel = BulkUpdateViewModel(siteID: self.siteID, productID: self.productID) { [weak self] in
+                self?.dismiss(animated: true)
+            }
             let navigationController = WooNavigationController(rootViewController: BulkUpdateViewController(viewModel: viewModel))
             self.present(navigationController, animated: true)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -30,7 +30,11 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let expectedProductID: Int64 = 19
         let expectedPageSize = 100
         let expectedPageNumber = 1
-        let viewModel = BulkUpdateViewModel(siteID: expectedSiteID, productID: expectedProductID, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: expectedSiteID,
+                                            productID: expectedProductID,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
 
         // When
         viewModel.activate()
@@ -51,7 +55,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_initial_sync_state() throws {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
 
         // Then
         XCTAssertEqual(viewModel.syncState, .notStarted)
@@ -59,7 +63,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_sync_state_updates_to_loading_when_product_variations_syncing_starts() {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { _ in
             // do nothing to stay in "syncing" state
         }
@@ -73,7 +77,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_sync_state_updates_to_syncerror_when_product_variations_syncing_fails() {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
@@ -92,7 +96,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_sync_state_updates_to_syncResults_when_product_variations_syncing_is_successful() {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
@@ -123,7 +127,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
 
         // When
         viewModel.activate()
@@ -154,7 +158,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
 
         // When
         viewModel.activate()
@@ -185,7 +189,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
 
         // When
         viewModel.activate()
@@ -216,7 +220,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
 
         // When
         viewModel.activate()
@@ -248,7 +252,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
 
         // When
         viewModel.activate()
@@ -261,6 +265,24 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let regularPriceViewModel = viewModel.viewModelForDisplayingRegularPrice()
         XCTAssertFalse(regularPriceViewModel.text.isEmpty)
         XCTAssertFalse(regularPriceViewModel.detailText.isEmpty)
+    }
+
+    func test_tapped_cancel_button_invokes_closure() {
+        // Given
+        var onCancelButtonTappedInvoked = false
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            onCancelButtonTapped: {
+                                                onCancelButtonTappedInvoked = true
+                                            },
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
+
+        // When
+        viewModel.handleTapCancel()
+
+        // Then
+        XCTAssertTrue(onCancelButtonTappedInvoked)
     }
 }
 


### PR DESCRIPTION
Part of: #6239

### Description
This PR adds a cancel button & title to the bulk update screen. Tapping the button dismisses the modally presented screen.

Notes:
I couldn't find a way to cancel an dispatched Action, so if you dismiss the controller before the loading is completed, previous controller (displaying the list of variations) will show a refresh animation when the synch of the bulk update completes:

https://user-images.githubusercontent.com/96764631/156633174-bad76e50-938a-4613-9302-18373e8fc2f7.mp4


### Testing instructions

1. Go to the products tab
2. Select a product with variations
3. Tap on the "more" button in the navigation bar 
4. Select the "Bulk update"
5. The screen should have a title 
6. The screen should display a "cancel" button left of the title 
8. Tapping the cancel button closes the screen

### Screenshots

![Simulator Screen Shot - iPod touch (7th generation) - 2022-03-03 at 20 45 24](https://user-images.githubusercontent.com/96764631/156632136-fd1423af-b689-40d2-b456-976595c26393.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

