### PR TITLE
Added support for new cell style for ValueOneTableViewCell 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -102,22 +102,15 @@ final class BulkUpdateViewModel {
     ///
     func viewModelForDisplayingRegularPrice() -> ValueOneTableViewCell.ViewModel {
         let text = Localization.updateRegularPriceTitle
-        var detailText = ""
-        var style: ValueOneTableViewCell.Style = .primary
 
         switch bulkUpdateFormModel.bulkValueOf(\ProductVariation.regularPrice) {
         case .none:
-            detailText = Localization.noneValue
-            style = .secondary
+            return ValueOneTableViewCell.ViewModel(text: text, detailText: Localization.noneValue, style: .secondary)
         case .mixed:
-            detailText = Localization.mixedValue
+            return ValueOneTableViewCell.ViewModel(text: text, detailText: Localization.mixedValue, style: .primary)
         case let .value(price):
-            detailText = formatPriceString(price)
+            return ValueOneTableViewCell.ViewModel(text: text, detailText: formatPriceString(price), style: .primary)
         }
-
-        return ValueOneTableViewCell.ViewModel(text: text,
-                                               detailText: detailText,
-                                               style: style)
     }
 
     /// It formats a price `String` according to the current price settings.

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -103,7 +103,7 @@ final class BulkUpdateViewModel {
     func viewModelForDisplayingRegularPrice() -> ValueOneTableViewCell.ViewModel {
         let text = Localization.updateRegularPriceTitle
         var detailText = ""
-        var style = ValueOneTableViewCell.Style.primary
+        var style: ValueOneTableViewCell.Style = .primary
 
         switch bulkUpdateFormModel.bulkValueOf(\ProductVariation.regularPrice) {
         case .none:

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -101,21 +101,23 @@ final class BulkUpdateViewModel {
     /// Provides the view model with all user facing data of the option for updating the regular price
     ///
     func viewModelForDisplayingRegularPrice() -> ValueOneTableViewCell.ViewModel {
-        return ValueOneTableViewCell.ViewModel(text: Localization.updateRegularPriceTitle,
-                                               detailText: detailTextforPrice(\ProductVariation.regularPrice))
-    }
+        let text = Localization.updateRegularPriceTitle
+        var detailText = ""
+        var style = ValueOneTableViewCell.Style.primary
 
-    /// Returns the detail text of the option for updating a price
-    ///
-    private func detailTextforPrice(_ priceKeyPath: KeyPath<ProductVariation, String?>) -> String {
-        switch bulkUpdateFormModel.bulkValueOf(priceKeyPath) {
+        switch bulkUpdateFormModel.bulkValueOf(\ProductVariation.regularPrice) {
         case .none:
-            return Localization.noneValue
+            detailText = Localization.noneValue
+            style = .secondary
         case .mixed:
-            return Localization.mixedValue
+            detailText = Localization.mixedValue
         case let .value(price):
-            return formatPriceString(price)
+            detailText = formatPriceString(price)
         }
+
+        return ValueOneTableViewCell.ViewModel(text: text,
+                                               detailText: detailText,
+                                               style: style)
     }
 
     /// It formats a price `String` according to the current price settings.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
@@ -2,17 +2,39 @@ import UIKit
 
 class ValueOneTableViewCell: UITableViewCell {
 
+    /// The style options for the `ValueOneTableViewCell`
+    ///
+    enum Style {
+        /// Uses BodyStyle for the Text  and Subheadline for the DetailText.  This is the default.
+        case primary
+        /// The same as `primary` except that for the DetailText uses a Tertiary text color.
+        case secondary
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        configureBackground()
         configureTextLabel()
         configureDetailTextLabel()
+        apply(style: .primary)
+    }
+
+    /// Change the styling of the UI elements.
+    ///
+    func apply(style: Style) {
+        configureTextLabel()
+        configureDetailTextLabel()
+        configureBackground()
+
+        if style == .secondary {
+            detailTextLabel?.textColor = .textTertiary
+        }
     }
 
     func configure(with viewModel: ViewModel) {
         textLabel?.text = viewModel.text
         detailTextLabel?.text = viewModel.detailText
+        apply(style: viewModel.style)
     }
 }
 
@@ -22,6 +44,13 @@ extension ValueOneTableViewCell {
     struct ViewModel {
         let text: String
         let detailText: String
+        let style: Style
+
+        init(text: String, detailText: String, style: Style = .primary) {
+            self.text = text
+            self.detailText = detailText
+            self.style = style
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -167,6 +167,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let regularPriceViewModel = viewModel.viewModelForDisplayingRegularPrice()
         XCTAssertFalse(regularPriceViewModel.text.isEmpty)
         XCTAssertEqual(regularPriceViewModel.detailText, "$1.00")
+        XCTAssertEqual(regularPriceViewModel.style, .primary)
     }
 
     func test_sale_price_description_when_some_products_have_different_price() {
@@ -198,6 +199,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let regularPriceViewModel = viewModel.viewModelForDisplayingRegularPrice()
         XCTAssertFalse(regularPriceViewModel.text.isEmpty)
         XCTAssertFalse(regularPriceViewModel.detailText.isEmpty)
+        XCTAssertEqual(regularPriceViewModel.style, .primary)
     }
 
     func test_sale_price_description_when_all_products_have_no_price() {
@@ -229,7 +231,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let regularPriceViewModel = viewModel.viewModelForDisplayingRegularPrice()
         XCTAssertFalse(regularPriceViewModel.text.isEmpty)
         XCTAssertFalse(regularPriceViewModel.detailText.isEmpty)
-
+        XCTAssertEqual(regularPriceViewModel.style, .secondary)
     }
 
     func test_sale_price_description_when_some_products_have_no_price() {
@@ -261,6 +263,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let regularPriceViewModel = viewModel.viewModelForDisplayingRegularPrice()
         XCTAssertFalse(regularPriceViewModel.text.isEmpty)
         XCTAssertFalse(regularPriceViewModel.detailText.isEmpty)
+        XCTAssertEqual(regularPriceViewModel.style, .primary)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/ValueOneTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/ValueOneTableViewCellTests.swift
@@ -5,12 +5,21 @@ import XCTest
 /// Tests for `ValueOneTableViewCell`.
 ///
 final class ValueOneTableViewCellTests: XCTestCase {
+    private var cell: ValueOneTableViewCell!
 
-    func test_cell_is_configured_with_correct_values_from_the_view_model() throws {
-        // Given
+    override func setUpWithError() throws {
+        super.setUp()
         let nib = try XCTUnwrap(Bundle.main.loadNibNamed("ValueOneTableViewCell", owner: self, options: nil))
-        let cell = try XCTUnwrap(nib.first as? ValueOneTableViewCell)
+        cell = try XCTUnwrap(nib.first as? ValueOneTableViewCell)
+    }
 
+    override func tearDown() {
+        cell = nil
+        super.tearDown()
+    }
+
+    func test_cell_is_configured_with_correct_values_from_the_view_model() {
+        // Given
         let viewModel = ValueOneTableViewCell.ViewModel(text: "Text", detailText: "DetailText")
 
         // When
@@ -19,5 +28,53 @@ final class ValueOneTableViewCellTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.text, cell.textLabel?.text)
         XCTAssertEqual(viewModel.detailText, cell.detailTextLabel?.text)
+    }
+
+    func test_primary_style_of_text_label() throws {
+        // When
+        cell.apply(style: .primary)
+
+        // Then
+        XCTAssertEqual(cell?.textLabel?.font, UIFont.body)
+        XCTAssertEqual(cell?.textLabel?.textColor, UIColor.text)
+        let adjustsFontForContentSizeCategory = try XCTUnwrap(cell?.textLabel?.adjustsFontForContentSizeCategory)
+        XCTAssertTrue(adjustsFontForContentSizeCategory)
+    }
+
+    func test_secondary_style_of_text_label() throws {
+        // When
+        cell.apply(style: .secondary)
+
+        // Then
+        XCTAssertEqual(cell?.textLabel?.font, UIFont.body)
+        XCTAssertEqual(cell?.textLabel?.textColor, UIColor.text)
+        let adjustsFontForContentSizeCategory = try XCTUnwrap(cell?.textLabel?.adjustsFontForContentSizeCategory)
+        XCTAssertTrue(adjustsFontForContentSizeCategory)
+    }
+
+    func test_primary_style__of_detail_text_label() throws {
+        // When
+        cell.apply(style: .primary)
+
+        // Then
+        XCTAssertEqual(cell?.detailTextLabel?.font, UIFont.subheadline)
+        XCTAssertEqual(cell?.detailTextLabel?.textColor, UIColor.secondaryLabel)
+        let adjustsFontForContentSizeCategory = try XCTUnwrap(cell?.detailTextLabel?.adjustsFontForContentSizeCategory)
+        XCTAssertTrue(adjustsFontForContentSizeCategory)
+        XCTAssertEqual(cell?.detailTextLabel?.lineBreakMode, .byWordWrapping)
+        XCTAssertEqual(cell?.detailTextLabel?.numberOfLines, 0)
+    }
+
+    func test_secondary_style__of_detail_text_label() throws {
+        // When
+        cell.apply(style: .secondary)
+
+        // Then
+        XCTAssertEqual(cell?.detailTextLabel?.font, UIFont.subheadline)
+        XCTAssertEqual(cell?.detailTextLabel?.textColor, UIColor.textTertiary)
+        let adjustsFontForContentSizeCategory = try XCTUnwrap(cell?.detailTextLabel?.adjustsFontForContentSizeCategory)
+        XCTAssertTrue(adjustsFontForContentSizeCategory)
+        XCTAssertEqual(cell?.detailTextLabel?.lineBreakMode, .byWordWrapping)
+        XCTAssertEqual(cell?.detailTextLabel?.numberOfLines, 0)
     }
 }


### PR DESCRIPTION
Part of: #6239

### Description
When displaying the bulk update screen in the case where none of the variations has regular price the style of the "None" text description is different (Tertiary color). This PR adds a style to the `ValueOneTableViewCell ` so that it can apply either the regular current style (called primary) or an other style (called secondary) that uses the Tertiary color color the text of the details label. 

### Testing instructions

1. Go to the products tab
2. Select a product with variations that none has regular price
3. Go to the list of variations
4. Tap on the "more" button in the navigation bar
5. Select the "Bulk update"
6. After the view loads, the description text of the "Regular Price" option should be a more pale grey colour (Tertiary), in comparison with the case where all or some of the variations have regular price.

### Screenshots

![Simulator Screen Shot - iPod touch (7th generation) - 2022-03-03 at 18 55 48](https://user-images.githubusercontent.com/96764631/156637425-af87f096-e759-4bad-9f2b-15989db3cbc1.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2022-03-03 at 18 47 17](https://user-images.githubusercontent.com/96764631/156637432-3f1c32e7-987b-44e9-b229-f5d0f30abe09.png)

![Mixed Prices](https://user-images.githubusercontent.com/96764631/156637525-a1d4990b-99b4-4e04-90fb-228a22fb3305.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
