### PR TITLE
"more" button in product variations shown only if we have variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -176,12 +176,16 @@ private extension ProductVariationsViewController {
             return
         }
 
-        let moreButton = UIBarButtonItem(image: .moreImage,
-                                     style: .plain,
-                                     target: self,
-                                     action: #selector(presentMoreActionSheet(_:)))
+        var moreButton: UIBarButtonItem? = nil
+        // Do not display the "more" button with the bulk update option if we do not have any variations
+        if self.product.variations.isNotEmpty {
+            moreButton = UIBarButtonItem(image: .moreImage,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(presentMoreActionSheet(_:)))
+        }
 
-        navigationItem.rightBarButtonItems = [moreButton]
+        navigationItem.rightBarButtonItem = moreButton
     }
 
     /// Apply Woo styles.
@@ -536,6 +540,7 @@ private extension ProductVariationsViewController {
             let variationsUpdated = self.product.variations.filter { $0 != variation.productVariationID }
             let updatedProduct = self.product.copy(variations: variationsUpdated)
             self.product = updatedProduct
+            self.configureNavigationBarButtons()
         }
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductVariationFormEventLogger(),
@@ -666,6 +671,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
                 self.noticePresenter.enqueue(notice: .init(title: Localization.variationCreated, feedbackType: .success))
                 self.product = updatedProduct
                 self.navigateToVariationDetail(for: newVariation)
+                self.configureNavigationBarButtons()
             case .failure(let error):
                 self.noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
                 DDLogError("⛔️ Error generating variation: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -172,7 +172,7 @@ private extension ProductVariationsViewController {
     /// Sets the navigation bar buttons
     ///
     func configureNavigationBarButtons() {
-        guard featureFlagService.isFeatureFlagEnabled(.bulkEditProductVariations) && self.product.variations.isNotEmpty else {
+        guard featureFlagService.isFeatureFlagEnabled(.bulkEditProductVariations) && resultsController.fetchedObjects.isNotEmpty else {
             // Do not display the "more" button with the bulk update option if we do not have any variations
             navigationItem.rightBarButtonItem = nil
             return
@@ -361,6 +361,7 @@ private extension ProductVariationsViewController {
     func configureResultsControllerEventHandling(_ resultsController: ResultsController<StorageProductVariation>) {
         let onReload = { [weak self] in
             self?.tableView.reloadData()
+            self?.configureNavigationBarButtons()
         }
 
         resultsController.onDidChangeContent = { [weak tableView] in
@@ -536,7 +537,6 @@ private extension ProductVariationsViewController {
             let variationsUpdated = self.product.variations.filter { $0 != variation.productVariationID }
             let updatedProduct = self.product.copy(variations: variationsUpdated)
             self.product = updatedProduct
-            self.configureNavigationBarButtons()
         }
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductVariationFormEventLogger(),
@@ -667,7 +667,6 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
                 self.noticePresenter.enqueue(notice: .init(title: Localization.variationCreated, feedbackType: .success))
                 self.product = updatedProduct
                 self.navigateToVariationDetail(for: newVariation)
-                self.configureNavigationBarButtons()
             case .failure(let error):
                 self.noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
                 DDLogError("⛔️ Error generating variation: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -172,20 +172,16 @@ private extension ProductVariationsViewController {
     /// Sets the navigation bar buttons
     ///
     func configureNavigationBarButtons() {
-        guard featureFlagService.isFeatureFlagEnabled(.bulkEditProductVariations) else {
+        guard featureFlagService.isFeatureFlagEnabled(.bulkEditProductVariations) && self.product.variations.isNotEmpty else {
+            // Do not display the "more" button with the bulk update option if we do not have any variations
+            navigationItem.rightBarButtonItem = nil
             return
         }
 
-        var moreButton: UIBarButtonItem? = nil
-        // Do not display the "more" button with the bulk update option if we do not have any variations
-        if self.product.variations.isNotEmpty {
-            moreButton = UIBarButtonItem(image: .moreImage,
-                                         style: .plain,
-                                         target: self,
-                                         action: #selector(presentMoreActionSheet(_:)))
-        }
-
-        navigationItem.rightBarButtonItem = moreButton
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: .moreImage,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(presentMoreActionSheet(_:)))
     }
 
     /// Apply Woo styles.


### PR DESCRIPTION
Closes: #6340

### Description
In the `ProductVariationsViewController` we should display the "more" button with the bulk update option only if the product has at least one variation. This PR adds in the method that configures the navigation buttons `configureNavigationBarButtons()` the condition of checking if we have at least one variation in order to add the "more" button. This method is also called also when a variation is created or deleted to make sure the button will be displayed when the first variation is created.

### Testing instructions
1. Go to the products tab
2. Select a product with one variation
3. Go to the list of variations
4. Select the variation and delete it 
5. When you return to the variation list screen the "more" button should not be displayed
6. Select to add a variation
7. When you return to the variation list screen the "more" button should be displayed

### Screenshots

https://user-images.githubusercontent.com/96764631/156644129-4c0f0c85-01e2-4b35-bcb5-9e9c1ea2bd04.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

