### PR TITLE
[Mobile Payments] Accept IPP for confirmed bookings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] My Store: Fixed incorrect currency symbol of revenue text for stores with non-USD currency. [https://github.com/woocommerce/woocommerce-ios/pull/6335]
 - [*] Notifications: Dismiss presented view before presenting content from notifications [https://github.com/woocommerce/woocommerce-ios/pull/6354]
 - [internal] Removed the feature flag for My store tab UI updates. Please smoke test the store stats and top performers in the "My store" tab to make sure everything works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6334]
+- [*] In-Person Payments: Add support for accepting payments on bookable products [https://github.com/woocommerce/woocommerce-ios/pull/6364]
 
 8.6
 -----

--- a/WooCommerce/Classes/Model/OrderPaymentMethod.swift
+++ b/WooCommerce/Classes/Model/OrderPaymentMethod.swift
@@ -1,5 +1,8 @@
 /// Order Payment methods
 enum OrderPaymentMethod: RawRepresentable {
+    /// Booking (confirmed by Shop manager)
+    case booking
+
     /// Cash on Delivery
     case cod
 
@@ -16,6 +19,8 @@ enum OrderPaymentMethod: RawRepresentable {
     ///
     public init(rawValue: String) {
         switch rawValue {
+        case Keys.booking:
+            self = .booking
         case Keys.cod:
             self = .cod
         case Keys.woocommercePayments:
@@ -29,6 +34,8 @@ enum OrderPaymentMethod: RawRepresentable {
 
     public var rawValue: String {
         switch self {
+        case .booking:
+            return Keys.booking
         case .cod:
             return Keys.cod
         case .woocommercePayments:
@@ -43,6 +50,7 @@ enum OrderPaymentMethod: RawRepresentable {
 
 
 private enum Keys {
+    static let booking = "wc-booking-gateway"
     static let cod = "cod"
     static let woocommercePayments = "woocommerce_payments"
     static let none = ""

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1513,7 +1513,12 @@ private extension OrderDetailsDataSource {
 
     func isOrderPaymentMethodEligibleForCardPayment() -> Bool {
         let paymentMethod = OrderPaymentMethod(rawValue: order.paymentMethodID)
-        return paymentMethod == .cod || paymentMethod == .woocommercePayments || paymentMethod == .none
+        switch paymentMethod {
+        case .booking, .cod, .woocommercePayments, .none:
+            return true
+        case .unknown:
+            return false
+        }
     }
 
     func hasCardPresentEligiblePaymentGatewayAccount() -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -259,6 +259,51 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
     }
 
+    func test_collect_payment_button_is_not_visible_if_order_is_a_confirmed_booking_and_total_amount_is_zero() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "wc-booking-gateway")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+    func test_collect_payment_button_is_visible_if_order_is_a_confirmed_booking_and_total_amount_is_greater_than_zero() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "1", paymentMethodID: "wc-booking-gateway")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+
     func test_collect_payment_button_is_not_visible_if_date_paid_is_not_nil() throws {
         // Setup
         let account = storageManager.insertCardPresentEligibleAccount()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6357
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Bookings which have been confirmed by an admin have a specific payment method name on the order, `wc-booking-gateway`.

This meant that they could not be paid for with a card reader, as the only payment methods supported were `cod, woocommerce-payments, none`.

This adds the `booking` payment type to the supported payment methods eligible for IPP.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Setup
1. Add the [Woocommerce Bookings plugin](https://woocommerce.com/products/woocommerce-bookings/) to a test store which is set up for In Person Payments. PdfdoF-D-p2
2. Add two [test booking products](https://woocommerce.com/document/creating-a-bookable-product/), one which requires admin confirmation, and one which doesn't. 
3. As a customer, place two orders, one for the confirmation-required product, one for the other. (For the confirmation-required product, just use "Request Confirmation" at checkout, otherwise "Cash on Delivery" or the label you've used for IPP.)

#### Testing in the app
1. In each order, check that you can take payment using the `Collect Payment` button on the Order Details screen.

#### Unaddressed issues
- Requires-confirmation orders do not enforce confirmation before payment is taken, nor do they get confirmed by taking payment: pdfdoF-x7-p2#comment-1054
- Requires-confirmation orders are listed as `Awaiting payment via Check booking availability` in the Order Details screen. This comes from the API in the `payment_method_title` field on Order, and is [set by the Bookings plugin's payment gateway](https://github.com/woocommerce/woocommerce-bookings/blob/de123ce559f91c32b5b730e58ee9a91a8612c30f/includes/gateways/class-wc-bookings-gateway.php#L15). If this is an issue, we could override it in the app, but I don't think that's required.


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![support-confirmed-bookings](https://user-images.githubusercontent.com/2472348/156656619-352017ae-7367-4c64-83fd-31f61954ad95.jpg)

https://user-images.githubusercontent.com/2472348/156756370-39fc1af8-94b4-4766-94f6-acad2bd4e064.mp4

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
