### PR TITLE
Order Creation - Product Sync: Don't die after errors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -48,6 +48,10 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
     ///
     private var subscriptions = Set<AnyCancellable>()
 
+    /// Store to serve local IDs.
+    ///
+    private let localIDStore = LocalIDStore()
+
     // MARK: Initializers
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
@@ -286,5 +290,23 @@ private extension Order {
             return item.copy(subtotal: "", total: "")
         }
         return copy(items: sanitizedItems)
+    }
+
+    /// Simple type to serve negative IDs.
+    /// This is needed to differentiate if an item ID has been synced remotely while providing a unique ID to consumers.
+    /// If the ID is a negative number we assume that it's a local ID.
+    /// Warning: This is not thread safe.
+    ///
+    final class LocalIDStore {
+        /// Last used ID
+        ///
+        private var currentID: Int64 = 0
+
+        /// Creates a new and unique local ID for this session.
+        ///
+        func dispatchLocalID() -> Int64 {
+            currentID -= 1
+            return currentID
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -411,6 +411,48 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(states, [.syncing(blocking: false), .synced])
     }
 
+    func test_order_creation_can_resume_after_receiving_errors() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let error = NSError(domain: "", code: 0, userInfo: nil)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let receivedError: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder(_, _, let completion):
+                    completion(.failure(error))
+                    promise(true)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            synchronizer.setProduct.send(input)
+        }
+        XCTAssertTrue(receivedError)
+
+        let receivedCreationRequest: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder:
+                    promise(true)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            synchronizer.setProduct.send(input)
+        }
+
+        // Then
+        XCTAssertTrue(receivedCreationRequest)
+    }
+
     func test_states_are_properly_set_upon_failing_order_creation() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)


### PR DESCRIPTION
Closes: #6329 

# Why

Previously if an error occurred while creating or updating an order, the whole synchronizer stopped working.
Why? Because we were catching the error in the main reactive stream and catching the error causes the whole stream to complete.

Additionally, upon fixing the issue described above, another issue became apparent, which is that if the order fails to sync, we can't have multiple pending items to submit, because we removed the ability to have local ids when we decided to [disable user input while an item was created](https://github.com/woocommerce/woocommerce-ios/pull/6327).

# How

- Move the error `catch` from the main reactive stream, to the sub-stream when the order is created or updated.

- Bring back `LocalIDStore`, update new items to have local ids(to allow multiple local items), and make sure we remove that local ID when submitting the order to the remote source.

# Demo

https://user-images.githubusercontent.com/562080/156655176-4d731db4-f89e-4f3d-bac2-f54e0a943e52.mov

# Testing Steps
- Enable `orderCreationRemoteSynchronizer`
- Open the app and load the product list
- Turn off your wifi 
- Go to the order creation screen & add a product
- See that the order failed to get updated (no taxes available)
- Turn on your wifi
- Select a new product or update the current item quantity
- See the order being correctly synced. 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
