### PR TITLE
Reviews: Fix missing product information on first load

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -979,6 +979,48 @@ extension ProductImage {
     }
 }
 
+extension ProductReview {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        reviewID: CopiableProp<Int64> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        statusKey: CopiableProp<String> = .copy,
+        reviewer: CopiableProp<String> = .copy,
+        reviewerEmail: CopiableProp<String> = .copy,
+        reviewerAvatarURL: NullableCopiableProp<String> = .copy,
+        review: CopiableProp<String> = .copy,
+        rating: CopiableProp<Int> = .copy,
+        verified: CopiableProp<Bool> = .copy
+    ) -> ProductReview {
+        let siteID = siteID ?? self.siteID
+        let reviewID = reviewID ?? self.reviewID
+        let productID = productID ?? self.productID
+        let dateCreated = dateCreated ?? self.dateCreated
+        let statusKey = statusKey ?? self.statusKey
+        let reviewer = reviewer ?? self.reviewer
+        let reviewerEmail = reviewerEmail ?? self.reviewerEmail
+        let reviewerAvatarURL = reviewerAvatarURL ?? self.reviewerAvatarURL
+        let review = review ?? self.review
+        let rating = rating ?? self.rating
+        let verified = verified ?? self.verified
+
+        return ProductReview(
+            siteID: siteID,
+            reviewID: reviewID,
+            productID: productID,
+            dateCreated: dateCreated,
+            statusKey: statusKey,
+            reviewer: reviewer,
+            reviewerEmail: reviewerEmail,
+            reviewerAvatarURL: reviewerAvatarURL,
+            review: review,
+            rating: rating,
+            verified: verified
+        )
+    }
+}
+
 extension ProductVariation {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a ProductReview Entity.
 ///
-public struct ProductReview: Decodable, Equatable, GeneratedFakeable {
+public struct ProductReview: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     public let siteID: Int64
     public let reviewID: Int64
     public let productID: Int64

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -35,7 +35,7 @@ public final class ProductReviewsRemote: Remote, ProductReviewsRemoteProtocol {
                                 pageSize: Int = Default.pageSize,
                                 products: [Int64]? = nil,
                                 status: ProductReviewStatus? = nil,
-                                completion: @escaping ([ProductReview]?, Error?) -> Void) {
+                                completion: @escaping (Result<[ProductReview], Error>) -> Void) {
 
 
         let stringOfProductIDs = products?.map { String($0) }.joined(separator: ",") ?? ""

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -37,23 +37,19 @@ final class ProductReviewsRemoteTests: XCTestCase {
     func testLoadAllProductReviewsProperlyReturnsParsedProductReviews() throws {
         // Given
         let remote = ProductReviewsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Product Reviews")
 
         network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-all")
 
         // When
-        var result: Result<[ProductReview], Error>?
-        remote.loadAllProductReviews(for: sampleSiteID) { loadResult in
-            result = loadResult
-            expectation.fulfill()
+        let result: Result<[ProductReview], Error> = waitFor { promise in
+            remote.loadAllProductReviews(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        let testResult = try XCTUnwrap(result)
-        XCTAssertTrue(testResult.isSuccess)
-        let reviews = try XCTUnwrap(testResult.get())
+        XCTAssertTrue(result.isSuccess)
+        let reviews = try XCTUnwrap(result.get())
         XCTAssertEqual(reviews.count, 2)
 
         // Assert proper parsing of reviewer_avatar_urls
@@ -67,20 +63,16 @@ final class ProductReviewsRemoteTests: XCTestCase {
     func testLoadAllProductReviewsProperlyRelaysNetwokingErrors() throws {
         // Given
         let remote = ProductReviewsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Product Reviews returns error")
 
         // When
-        var result: Result<[ProductReview], Error>?
-        remote.loadAllProductReviews(for: sampleSiteID) { loadResult in
-            result = loadResult
-            expectation.fulfill()
+        let result: Result<[ProductReview], Error> = waitFor { promise in
+            remote.loadAllProductReviews(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        let testResult = try XCTUnwrap(result)
-        XCTAssertTrue(testResult.isFailure)
+        XCTAssertTrue(result.isFailure)
     }
 
     /// Tests that loadAllProductReviews can handle responses with missing `reviewer_avatar_urls`.
@@ -88,23 +80,18 @@ final class ProductReviewsRemoteTests: XCTestCase {
     func testLoadAllCanHandleMissingReviewerAvatarURLs() throws {
         // Given
         let remote = ProductReviewsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Product Reviews")
-
         network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-missing-avatar-urls")
 
         // When
-        var result: Result<[ProductReview], Error>?
-        remote.loadAllProductReviews(for: sampleSiteID) { loadResult in
-            result = loadResult
-            expectation.fulfill()
+        let result: Result<[ProductReview], Error> = waitFor { promise in
+            remote.loadAllProductReviews(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        let testResult = try XCTUnwrap(result)
-        XCTAssertTrue(testResult.isSuccess)
-        let reviews = try XCTUnwrap(testResult.get())
+        XCTAssertTrue(result.isSuccess)
+        let reviews = try XCTUnwrap(result.get())
         XCTAssertEqual(reviews.count, 2)
 
         // Assert proper parsing of reviewer_avatar_urls
@@ -120,21 +107,17 @@ final class ProductReviewsRemoteTests: XCTestCase {
     func testLoadProductReviewProperlyReturnsParsedProductReviews() throws {
         // Given
         let remote = ProductReviewsRemote(network: network)
-        let expectation = self.expectation(description: "Load Single Product Review")
 
         network.simulateResponse(requestUrlSuffix: "products/reviews/\(sampleReviewID)", filename: "reviews-single")
 
         // When
-        var resultMaybe: Result<ProductReview, Error>?
-        remote.loadProductReview(for: sampleSiteID, reviewID: sampleReviewID) { aResult in
-            resultMaybe = aResult
-            expectation.fulfill()
+        let result: Result<ProductReview, Error> = waitFor { promise in
+            remote.loadProductReview(for: self.sampleSiteID, reviewID: self.sampleReviewID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        let result = try XCTUnwrap(resultMaybe)
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(try result.get())
     }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] In-Person Payments: Localized messages and UI [https://github.com/woocommerce/woocommerce-ios/pull/6317]
 - [*] My Store: Fixed incorrect currency symbol of revenue text for stores with non-USD currency. [https://github.com/woocommerce/woocommerce-ios/pull/6335]
 - [*] Notifications: Dismiss presented view before presenting content from notifications [https://github.com/woocommerce/woocommerce-ios/pull/6354]
+- [*] Reviews: Fixed missing product information on first load [https://github.com/woocommerce/woocommerce-ios/pull/6367]
 - [internal] Removed the feature flag for My store tab UI updates. Please smoke test the store stats and top performers in the "My store" tab to make sure everything works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6334]
 
 8.6

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
@@ -45,16 +45,6 @@ final class ProductReviewsDataSource: NSObject, ReviewsDataSource {
         return []
     }
 
-    /// Identifiers of the Products mentioned in the reviews.
-    /// Guaranteed to be uniqued (does not contain duplicates)
-    ///
-    var reviewsProductsIDs: [Int64] {
-        return reviewsResultsController
-            .fetchedObjects
-            .map { return $0.productID }
-            .uniqued()
-    }
-
     var reviewCount: Int {
         return reviewsResultsController.numberOfObjects
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -84,15 +84,15 @@ extension ProductReviewsViewModel {
                                                                    pageNumber: pageNumber,
                                                                    pageSize: pageSize,
                                                                    products: [productID],
-                                                                   status: .approved) { error in
-                                                                    if let error = error {
-            DDLogError("⛔️ Error synchronizing reviews for product ID :\(productID). Error: \(error)")
-                                                                        ServiceLocator.analytics.track(.productReviewListLoadFailed, withError: error)
-                                                                    } else {
-                                                                        ServiceLocator.analytics.track(.productReviewListLoaded)
-                                                                    }
-
-                                                                    onCompletion?()
+                                                                   status: .approved) { result in
+            switch result {
+            case .failure(let error):
+                DDLogError("⛔️ Error synchronizing reviews for product ID :\(productID). Error: \(error)")
+                ServiceLocator.analytics.track(.productReviewListLoadFailed, withError: error)
+            case .success:
+                ServiceLocator.analytics.track(.productReviewListLoaded)
+            }
+            onCompletion?()
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Reviews/DefaultReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/DefaultReviewsDataSource.swift
@@ -74,16 +74,6 @@ final class DefaultReviewsDataSource: NSObject, ReviewsDataSource {
         return notificationsResultsController.fetchedObjects
     }
 
-    /// Identifiers of the Products mentioned in the reviews.
-    /// Guaranteed to be uniqued (does not contain duplicates)
-    ///
-    var reviewsProductsIDs: [Int64] {
-        return reviewsResultsController
-            .fetchedObjects
-            .map { return $0.productID }
-            .uniqued()
-    }
-
     var reviewCount: Int {
         return reviewsResultsController.numberOfObjects
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
@@ -23,11 +23,6 @@ protocol ReviewsDataSource: UITableViewDataSource, ReviewsInteractionDelegate {
     ///
     var isEmpty: Bool { get }
 
-    /// Identifiers of the Products mentioned in the reviews.
-    /// Guaranteed to be uniqued (does not contain duplicates)
-    ///
-    var reviewsProductsIDs: [Int64] { get }
-
     /// Number of reviews in memory
     ///
     var reviewCount: Int { get }
@@ -45,7 +40,7 @@ protocol ReviewsDataSource: UITableViewDataSource, ReviewsInteractionDelegate {
     ///
     func startForwardingEvents(to tableView: UITableView)
 
-    /// Force a refresh of entities obeserving data collections
+    /// Force a refresh of entities observing data collections
     ///
     func refreshDataObservers()
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -50,6 +50,7 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
     private let siteID: Int64
 
     private let data: ReviewsDataSource
+    private let stores: StoresManager
 
     var isEmpty: Bool {
         return data.isEmpty
@@ -81,9 +82,10 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
     ///
     var hasErrorLoadingData: Bool = false
 
-    init(siteID: Int64, data: ReviewsDataSource) {
+    init(siteID: Int64, data: ReviewsDataSource, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.data = data
+        self.stores = stores
     }
 
     func displayPlaceholderReviews(tableView: UITableView) {
@@ -183,7 +185,7 @@ extension ReviewsViewModel {
             onCompletion?()
         }
 
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 
     private func synchronizeProductsReviewed(onCompletion: @escaping () -> Void) {
@@ -203,7 +205,7 @@ extension ReviewsViewModel {
             onCompletion()
         }
 
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 
     /// Synchronizes the Notifications associated to the active WordPress.com account.
@@ -222,7 +224,7 @@ extension ReviewsViewModel {
             onCompletion?()
         }
 
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 }
 
@@ -233,7 +235,7 @@ private extension ReviewsViewModel {
         let identifiers = notes.map { $0.noteID }
         let action = NotificationAction.updateMultipleReadStatus(noteIDs: identifiers, read: true, onCompletion: onCompletion)
 
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -152,18 +152,13 @@ extension ReviewsViewModel {
         }
 
         group.enter()
-        synchronizeProductsReviewed {
-            group.leave()
-        }
-
-        group.enter()
         synchronizeNotifications {
             group.leave()
         }
 
-        group.notify(queue: .main) {
-            if let completionBlock = onCompletion {
-                completionBlock()
+        group.notify(queue: .main) { [weak self] in
+            self?.synchronizeProductsReviewed {
+                onCompletion?()
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -18,10 +18,10 @@ final class MockReviews {
 
     let sampleVariationTypeProductID: Int64 = 295
 
-    func review(injectedReviewID: Int64? = nil, injectedProductID: Int64? = nil) -> Networking.ProductReview {
+    func review() -> Networking.ProductReview {
         return ProductReview(siteID: siteID,
-                             reviewID: injectedReviewID ?? reviewID,
-                             productID: injectedProductID ?? productID,
+                             reviewID: reviewID,
+                             productID: productID,
                              dateCreated: dateCreated,
                              statusKey: statusKey,
                              reviewer: reviewer,

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -18,10 +18,10 @@ final class MockReviews {
 
     let sampleVariationTypeProductID: Int64 = 295
 
-    func review() -> Networking.ProductReview {
+    func review(injectedReviewID: Int64? = nil, injectedProductID: Int64? = nil) -> Networking.ProductReview {
         return ProductReview(siteID: siteID,
-                             reviewID: reviewID,
-                             productID: productID,
+                             reviewID: injectedReviewID ?? reviewID,
+                             productID: injectedProductID ?? productID,
                              dateCreated: dateCreated,
                              statusKey: statusKey,
                              reviewer: reviewer,

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -104,7 +104,7 @@ final class ReviewsViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductReviewAction.self) { action in
             switch action {
             case .synchronizeProductReviews(_, _, _, _, _, let onCompletion):
-                onCompletion(.success([MockReviews().review()]))
+                onCompletion(.success([ProductReview.fake()]))
             default:
                 return
             }
@@ -144,12 +144,10 @@ final class ReviewsViewModelTests: XCTestCase {
     func test_synchronizeReviews_triggers_retrieveProducts_with_all_reviewsProductIDs() {
         // Given
         let mockDataSource = MockReviewsDataSource()
-        let mocks = MockReviews()
         let sampleReviews: [ProductReview] = [
-            mocks.review(injectedReviewID: sampleSiteID, injectedProductID: 55),
-            mocks.review(injectedReviewID: sampleSiteID, injectedProductID: 668),
-            mocks.review(injectedReviewID: sampleSiteID, injectedProductID: 789)
-        ]
+            .fake().copy(productID: 55),
+            .fake().copy(productID: 668),
+            .fake().copy(productID: 789)        ]
 
         let mockStores = MockStoresManager(sessionManager: .makeForTesting())
         mockStores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
@@ -286,7 +284,7 @@ final class MockReviewsStoresManager: DefaultStoresManager {
         switch action {
         case .synchronizeProductReviews(_, _, _, _, _, let onCompletion):
             syncReviewsIsHit = true
-            onCompletion(.success([MockReviews().review()]))
+            onCompletion(.success([ProductReview.fake()]))
         default:
             return
         }

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -104,7 +104,7 @@ final class ReviewsViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductReviewAction.self) { action in
             switch action {
             case .synchronizeProductReviews(_, _, _, _, _, let onCompletion):
-                onCompletion(nil)
+                onCompletion(.success([MockReviews().review()]))
             default:
                 return
             }
@@ -126,7 +126,7 @@ final class ReviewsViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductReviewAction.self) { action in
             switch action {
             case .synchronizeProductReviews(_, _, _, _, _, let onCompletion):
-                onCompletion(SampleError.first)
+                onCompletion(.failure(SampleError.first))
             default:
                 return
             }
@@ -155,11 +155,7 @@ final class ReviewsViewModelTests: XCTestCase {
         mockStores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
             switch action {
             case let .synchronizeProductReviews(_, _, _, _, _, onCompletion):
-                // simulate the delay in persisting reviews locally
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    onCompletion(nil)
-                    mockDataSource.reviews = sampleReviews
-                }
+                onCompletion(.success(sampleReviews))
             default:
                 break
             }
@@ -290,7 +286,7 @@ final class MockReviewsStoresManager: DefaultStoresManager {
         switch action {
         case .synchronizeProductReviews(_, _, _, _, _, let onCompletion):
             syncReviewsIsHit = true
-            onCompletion(nil)
+            onCompletion(.success([MockReviews().review()]))
         default:
             return
         }

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -4,86 +4,113 @@ import XCTest
 @testable import Yosemite
 
 final class ReviewsViewModelTests: XCTestCase {
-    private var mockDataSource: ReviewsDataSource!
-    private var viewModel: ReviewsViewModel!
 
-    override func setUp() {
-        super.setUp()
-        mockDataSource = MockReviewsDataSource()
-        viewModel = ReviewsViewModel(siteID: 1, data: mockDataSource)
-    }
-
-    override func tearDown() {
-        viewModel = nil
-        mockDataSource = nil
-        super.tearDown()
-    }
+    private let sampleSiteID: Int64 = 1334
 
     func testDataSourceReturnsInjectedReviewsDataSource() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
+
+        // When
         let dataSource = viewModel.dataSource
+
+        // Then
         XCTAssertNotNil(dataSource as? MockReviewsDataSource)
     }
 
     func testDelegateReturnsInjectedReviewsDelegate() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
+
+        // When
         let delegate = viewModel.delegate
+
+        // Then
         XCTAssertNotNil(delegate as? MockReviewsDataSource)
     }
 
     func testIsEmptyReturnsTheSameAsTheDataSource() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
+
+        // Then
         XCTAssertEqual(viewModel.isEmpty, mockDataSource.isEmpty)
     }
 
     func testDisplayPlaceHolderReviewsStopsForWardingEventsInDataSource() {
+        // Given
         let table = UITableView()
-        let ds = mockDataSource as! MockReviewsDataSource
-
+        let mockDataSource = MockReviewsDataSource()
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
         viewModel.displayPlaceholderReviews(tableView: table)
 
-        XCTAssertTrue(ds.stopsForwardingEventsWasHit)
+        // Then
+        XCTAssertTrue(mockDataSource.stopsForwardingEventsWasHit)
     }
 
     func testRemovePlaceHolderReviewsStartsForWardingEventsInDataSource() {
+        // Given
         let table = UITableView()
-        let ds = mockDataSource as! MockReviewsDataSource
+        let mockDataSource = MockReviewsDataSource()
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
 
+        // When
         viewModel.removePlaceholderReviews(tableView: table)
 
-        XCTAssertTrue(ds.startForwardingEventsWasHit)
+        // Then
+        XCTAssertTrue(mockDataSource.startForwardingEventsWasHit)
     }
 
     func testConfigureResultsControllerStartsForWardingEventsAndStartsObservingReviewsInDataSource() {
+        // Given
         let table = UITableView()
-        let ds = mockDataSource as! MockReviewsDataSource
+        let mockDataSource = MockReviewsDataSource()
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
 
+        // When
         viewModel.configureResultsController(tableView: table)
 
-        XCTAssertTrue(ds.startForwardingEventsWasHit && ds.startObservingWasHit)
+        // Then
+        XCTAssertTrue(mockDataSource.startForwardingEventsWasHit && mockDataSource.startObservingWasHit)
     }
 
     func testSyncDataHitsExpectedReviewsAndProductsActions() {
+        // Given
         let storesManager = MockReviewsStoresManager()
-        ServiceLocator.setStores(storesManager)
+        let mockDataSource = MockReviewsDataSource()
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
 
-        let expec = expectation(description: "Wait for synchronizeReviews to complete")
-
+        // Then
+        let expectation = expectation(description: "Wait for synchronizeReviews to complete")
         viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25) {
             let allTargetsHit = storesManager.syncReviewsIsHit && storesManager.retrieveProductsIsHit
             XCTAssertTrue(allTargetsHit)
             if allTargetsHit {
-                expec.fulfill()
+                expectation.fulfill()
             } else {
                 XCTFail()
             }
         }
-
         waitForExpectations(timeout: 10, handler: nil)
     }
 
     func test_hasErrorLoadingData_false_after_successful_sync() {
         // Given
+        let mockDataSource = MockReviewsDataSource()
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        storesManager.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            switch action {
+            case .synchronizeProductReviews(_, _, _, _, _, let onCompletion):
+                onCompletion(nil)
+            default:
+                return
+            }
+        }
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
         viewModel.hasErrorLoadingData = true
-        let storesManager = MockReviewsStoresManager()
-        ServiceLocator.setStores(storesManager)
 
         // When
         viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25, onCompletion: nil)
@@ -94,7 +121,7 @@ final class ReviewsViewModelTests: XCTestCase {
 
     func test_hasErrorLoadingData_true_after_failed_sync() {
         // Given
-        viewModel.hasErrorLoadingData = false
+        let mockDataSource = MockReviewsDataSource()
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
         storesManager.whenReceivingAction(ofType: ProductReviewAction.self) { action in
             switch action {
@@ -104,13 +131,70 @@ final class ReviewsViewModelTests: XCTestCase {
                 return
             }
         }
-        ServiceLocator.setStores(storesManager)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
+        viewModel.hasErrorLoadingData = false
 
         // When
         viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25, onCompletion: nil)
 
         // Then
         XCTAssertTrue(viewModel.hasErrorLoadingData)
+    }
+
+    func test_synchronizeReviews_triggers_retrieveProducts_with_all_reviewsProductIDs() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let mocks = MockReviews()
+        let sampleReviews: [ProductReview] = [
+            mocks.review(injectedReviewID: sampleSiteID, injectedProductID: 55),
+            mocks.review(injectedReviewID: sampleSiteID, injectedProductID: 668),
+            mocks.review(injectedReviewID: sampleSiteID, injectedProductID: 789)
+        ]
+
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
+        mockStores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            switch action {
+            case let .synchronizeProductReviews(_, _, _, _, _, onCompletion):
+                // simulate the delay in persisting reviews locally
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    onCompletion(nil)
+                    mockDataSource.reviews = sampleReviews
+                }
+            default:
+                break
+            }
+        }
+
+        mockStores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case .synchronizeNotifications(let onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        var retrievedProductIDs: [Int64] = []
+        mockStores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .retrieveProducts(_, productIDs, _, _, onCompletion):
+                retrievedProductIDs = productIDs
+                onCompletion(.success((products: [], hasNextPage: false)))
+            default:
+                break
+            }
+        }
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: mockStores)
+
+        // When
+        let expectation = expectation(description: "Wait for synchronizeReviews to complete")
+        viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+
+        // Then
+        XCTAssertEqual(retrievedProductIDs, [55, 668, 789])
     }
 }
 
@@ -119,11 +203,7 @@ final class ReviewsViewModelTests: XCTestCase {
 
 final class MockReviewsDataSource: NSObject, ReviewsDataSource {
 
-    private lazy var reviews: [ProductReview] = {
-        let mocks = MockReviews()
-        let mockReview = mocks.review()
-        return [mockReview, mockReview]
-    }()
+    var reviews: [ProductReview] = []
 
     var isEmpty: Bool {
         return reviews.isEmpty

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
@@ -84,9 +84,7 @@ final class ProductReviewsViewModelTests: XCTestCase {
 final class MockProductReviewsDataSource: NSObject, ReviewsDataSource {
 
     private lazy var reviews: [ProductReview] = {
-        let mocks = MockReviews()
-        let mockReview = mocks.review()
-        return [mockReview, mockReview]
+        return [.fake()]
     }()
 
     var isEmpty: Bool {
@@ -95,12 +93,6 @@ final class MockProductReviewsDataSource: NSObject, ReviewsDataSource {
 
     var reviewCount: Int {
         return reviews.count
-    }
-
-    var reviewsProductsIDs: [Int64] {
-        return reviews
-            .map { return $0.productID }
-            .uniqued()
     }
 
     var notifications: [Note] {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
@@ -164,7 +164,7 @@ final class MockProductReviewsStoresManager: DefaultStoresManager {
         switch action {
         case .synchronizeProductReviews(_, _, _, _, _, let onCompletion):
             syncReviewsIsHit = true
-            onCompletion(nil)
+            onCompletion(.success([]))
         default:
             return
         }

--- a/Yosemite/Yosemite/Actions/ProductReviewAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductReviewAction.swift
@@ -12,7 +12,7 @@ public enum ProductReviewAction: Action {
         pageSize: Int,
         products: [Int64]? = nil,
         status: ProductReviewStatus? = nil,
-        onCompletion: (Error?) -> Void)
+        onCompletion: (Result<[ProductReview], Error>) -> Void)
 
     /// Retrieves the specified ProductReview.
     ///

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockProductReviewAction.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockProductReviewAction.swift
@@ -17,7 +17,7 @@ struct MockProductReviewActionHandler: MockActionHandler {
         }
     }
 
-    func synchronizeProductReviews(siteId: Int64, onCompletion: @escaping (Error?) -> ()) {
+    func synchronizeProductReviews(siteId: Int64, onCompletion: @escaping (Result<[ProductReview], Error>) -> Void) {
         let reviews = objectGraph.reviews(forSiteId: siteId)
 
         // Deletes previous product reviews before saving new ones to avoid duplicate reviews after multiple runs.
@@ -25,6 +25,12 @@ struct MockProductReviewActionHandler: MockActionHandler {
         storage.deleteAllObjects(ofType: StorageProductReview.self)
         storage.saveIfNeeded()
 
-        save(mocks: reviews, as: StorageProductReview.self, onCompletion: onCompletion)
+        save(mocks: reviews, as: StorageProductReview.self) { error in
+            if let error = error {
+                onCompletion(.failure(error))
+            } else {
+                onCompletion(.success(reviews))
+            }
+        }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -85,11 +85,10 @@ final class ProductReviewStoreTests: XCTestCase {
 
         let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID,
                                                                    pageNumber: defaultPageNumber,
-                                                                   pageSize: defaultPageSize) { error in
-                                                                    XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductReview.self), 2)
-                                                                    XCTAssertNil(error)
-
-                                                                    expectation.fulfill()
+                                                                   pageSize: defaultPageSize) { result in
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductReview.self), 2)
+            XCTAssertTrue(result.isSuccess)
+            expectation.fulfill()
         }
 
         store.onAction(action)
@@ -107,8 +106,8 @@ final class ProductReviewStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductReview.self), 0)
 
-        let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
-            XCTAssertNil(error)
+        let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { result in
+            XCTAssertTrue(result.isSuccess)
 
             let storedProductReview = self.viewStorage.loadProductReview(siteID: self.sampleSiteID, reviewID: self.sampleReviewID)
             let readOnlyStoredProductReview = storedProductReview?.toReadOnly()
@@ -142,10 +141,10 @@ final class ProductReviewStoreTests: XCTestCase {
         waitForExpectation { exp in
             let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID,
                                                                        pageNumber: defaultPageNumber,
-                                                                       pageSize: defaultPageSize) { error in
+                                                                       pageSize: defaultPageSize) { result in
 
                 // Then
-                XCTAssertNil(error)
+                XCTAssertTrue(result.isSuccess)
 
                 // The previously upserted Product Reviews should be deleted.
                 let storedProductReview1 = self.viewStorage.loadProductReview(
@@ -184,10 +183,10 @@ final class ProductReviewStoreTests: XCTestCase {
         waitForExpectation { exp in
             let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID,
                                                                        pageNumber: 3,
-                                                                       pageSize: defaultPageSize) { error in
+                                                                       pageSize: defaultPageSize) { result in
 
                 // Then
-                XCTAssertNil(error)
+                XCTAssertTrue(result.isSuccess)
 
                 // The previously upserted Product Reviews should stay in storage.
                 let storedProductReview1 = self.viewStorage.loadProductReview(
@@ -263,8 +262,13 @@ final class ProductReviewStoreTests: XCTestCase {
         let action = ProductReviewAction.synchronizeProductReviews(
             siteID: sampleSiteID,
             pageNumber: defaultPageNumber,
-            pageSize: defaultPageSize) { error in
-                resultError = error
+            pageSize: defaultPageSize) { result in
+                switch result {
+                case .failure(let error):
+                    resultError = error
+                case .success:
+                    break
+                }
                 expectation.fulfill()
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #1907 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously we were synchronizing reviews by concurrently fetching reviews, products, and notifications and waiting until all these requests succeed to complete the synching.

Fetching products requires a list of product IDs from the fetched reviews. So there's a potential issue: if the request to fetch products starts before the request to fetch reviews completes, we'll send a request to fetch products with an empty ID list. If we haven't fetched products for the store before, we'll end up with reviews without product information.

The solution is to only sync products after the review synching is done. Required product IDs are taken from the fetched reviews and sent directly to the product synching request. This leads to the need to change the return result of `synchronizeProductReviews` to the modern `Result` with a list of reviews (hence changes in Yosemite and Networking layers).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out from your account and log back in.
- Switch immediately to the Menu tab and select Reviews.
- Notice that after loading is done, all the reviews have correct product information.

Note: you may find that the first fetch will take quite a while. We'll have to look into why it takes so long and optimize it.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/156700129-872ac2a1-bbc0-43f0-9c65-4f0548ed624c.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
