### PR TITLE
Coupons: Show error message when loading discounted amount fails

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Coupons: Replace the toggles on Usage Details screen with text for uneditable contents. [https://github.com/woocommerce/woocommerce-ios/pull/6287]
 - [*] Improve image loading for thumbnails especially on the Product list. [https://github.com/woocommerce/woocommerce-ios/pull/6299]
 - [*] Coupons: Added feedback banner on the top of the coupon list. [https://github.com/woocommerce/woocommerce-ios/pull/6316]
+- [*] Coupons: Handled error when loading total discounted amount fails. [https://github.com/woocommerce/woocommerce-ios/pull/6368]
 - [internal] Removed all feature flags for Shipping Labels. Please smoke test all parts of Shipping Labels to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6270]
 - [*] In-Person Payments: Localized messages and UI [https://github.com/woocommerce/woocommerce-ios/pull/6317]
 - [*] My Store: Fixed incorrect currency symbol of revenue text for stores with non-USD currency. [https://github.com/woocommerce/woocommerce-ios/pull/6335]

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -82,40 +82,45 @@ struct CouponDetails: View {
                             .bold()
                             .padding(Constants.margin)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
-                        HStack(spacing: 0) {
-                            VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                        VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                            HStack(alignment: .firstTextBaseline) {
                                 Text(Localization.discountedOrders)
                                     .secondaryBodyStyle()
-                                Text(viewModel.discountedOrdersCount)
-                                    .font(.title)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, Constants.margin)
                                 Spacer()
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-
-                            VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
                                 Text(Localization.amount)
                                     .secondaryBodyStyle()
-                                if viewModel.hasErrorLoadingAmount && viewModel.discountedAmount == nil {
-                                    Text(Localization.errorLoadingAnalytics)
-                                        .errorStyle()
-                                } else if let amount = viewModel.discountedAmount {
-                                    Text(amount)
-                                        .font(.title)
-                                } else {
-                                    // Shimmering effect on mock data
-                                    Text("$0.00")
-                                        .font(.title)
-                                        .redacted(reason: .placeholder)
-                                        .shimmering()
-                                }
-                                Spacer()
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, Constants.margin)
                             }
-                            .padding(.leading, Constants.margin)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            HStack(alignment: .firstTextBaseline) {
+                                Text(viewModel.discountedOrdersCount)
+                                    .font(.title)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, Constants.margin)
+                                Spacer()
+                                Group {
+                                    if viewModel.hasErrorLoadingAmount && viewModel.discountedAmount == nil {
+                                        Text(Localization.errorLoadingAnalytics)
+                                            .errorStyle()
+                                    } else if let amount = viewModel.discountedAmount {
+                                        Text(amount)
+                                            .font(.title)
+                                    } else {
+                                        // Shimmering effect on mock data
+                                        Text("$0.00")
+                                            .font(.title)
+                                            .redacted(reason: .placeholder)
+                                            .shimmering()
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, Constants.margin)
+                            }
                         }
-                        .padding([.horizontal, .bottom], Constants.margin)
-                        .padding(.horizontal, insets: geometry.safeAreaInsets)
                     }
+                    .padding(.bottom, Constants.margin)
                     .background(Color(.listForeground))
 
                     Divider()

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -95,11 +95,18 @@ struct CouponDetails: View {
                             VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
                                 Text(Localization.amount)
                                     .secondaryBodyStyle()
-                                if let amount = viewModel.discountedAmount {
+                                if viewModel.hasErrorLoadingAmount && viewModel.discountedAmount == nil {
+                                    Text(Localization.errorLoadingAnalytics)
+                                        .errorStyle()
+                                } else if let amount = viewModel.discountedAmount {
                                     Text(amount)
                                         .font(.title)
                                 } else {
-                                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                                    // Shimmering effect on mock data
+                                    Text("$0.00")
+                                        .font(.title)
+                                        .redacted(reason: .placeholder)
+                                        .shimmering()
                                 }
                                 Spacer()
                             }
@@ -193,6 +200,10 @@ private extension CouponDetails {
         static let discountedOrders = NSLocalizedString("Discounted Orders", comment: "Title of the Discounted Orders label on Coupon Details screen")
         static let amount = NSLocalizedString("Amount", comment: "Title of the Amount label on Coupon Details screen")
         static let usageDetails = NSLocalizedString("Usage details", comment: "Title of the Usage details row in Coupon Details screen")
+        static let errorLoadingAnalytics = NSLocalizedString(
+            "Error loading data",
+            comment: "Message displayed when fail to loading total discounted amount in Coupon Details screen"
+        )
     }
 
     struct DetailRow: Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -24,6 +24,10 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var expiryDate: String = ""
 
+    /// Indicates if loading total discounted amount fails
+    ///
+    @Published private(set) var hasErrorLoadingAmount: Bool = false
+
     /// The message to be shared about the coupon
     ///
     var shareMessage: String {
@@ -86,7 +90,9 @@ final class CouponDetailsViewModel: ObservableObject {
             case .success(let report):
                 self.discountedOrdersCount = "\(report.ordersCount)"
                 self.discountedAmount = self.formatStringAmount("\(report.amount)")
+                self.hasErrorLoadingAmount = false
             case .failure(let error):
+                self.hasErrorLoadingAmount = true
                 DDLogError("⛔️ Error loading coupon report: \(error)")
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -238,6 +238,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
                 break
             }
         }
+        viewModel.loadCouponReport()
 
         // Then
         XCTAssertFalse(viewModel.hasErrorLoadingAmount)
@@ -259,6 +260,7 @@ final class CouponDetailsViewModelTests: XCTestCase {
                 break
             }
         }
+        viewModel.loadCouponReport()
 
         // Then
         XCTAssertTrue(viewModel.hasErrorLoadingAmount)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -213,4 +213,54 @@ final class CouponDetailsViewModelTests: XCTestCase {
         let shareMessage = String(format: NSLocalizedString("Apply %@ off to some products with the promo code “%@”.", comment: ""), "10%", "TEST")
         XCTAssertEqual(viewModel.shareMessage, shareMessage)
     }
+
+    func test_hasErrorLoadingAmount_returns_false_initially() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(code: "TEST", amount: "10.00", discountType: .percent, productIds: [12, 23])
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertFalse(viewModel.hasErrorLoadingAmount)
+    }
+
+    func test_hasErrorLoadingAmount_returns_false_if_loading_amount_succeeds() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(code: "TEST", amount: "10.00", discountType: .percent, productIds: [12, 23])
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon, stores: stores)
+
+        // When
+        stores.whenReceivingAction(ofType: CouponAction.self) { action in
+            switch action {
+            case .loadCouponReport(_, _, _, let onCompletion):
+                onCompletion(.success(CouponReport(couponID: 234, amount: 20, ordersCount: 1)))
+            default:
+                break
+            }
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.hasErrorLoadingAmount)
+    }
+
+    func test_hasErrorLoadingAmount_returns_true_if_loading_amount_fails() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(code: "TEST", amount: "10.00", discountType: .percent, productIds: [12, 23])
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon, stores: stores)
+
+        // When
+        stores.whenReceivingAction(ofType: CouponAction.self) { action in
+            switch action {
+            case .loadCouponReport(_, _, _, let onCompletion):
+                let error = NSError(domain: "Test", code: 0, userInfo: [:])
+                onCompletion(.failure(error))
+            default:
+                break
+            }
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.hasErrorLoadingAmount)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6360 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We're currently loading the discounted amount for a coupon using endpoint `wc-analytics/reports/coupons/`. If WC Analytics is disabled in a store, this endpoint will return 404.

This PR handles this error by displaying an error message if the request fails. Additionally, the loading indicator for the Amount field on the coupon detail screen is also replaced with a shimmering view to make it looks nicer.

### Design reviews
Please let me know if the error message here makes sense and if the wording needs to be updated.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure your test store enables Coupons and has set up at least one coupon and applied it to at least one order.
- Turn off WC Analytics (WC Settings > Advanced > Features > Enables WooCommerce Analytics).
- On the app, navigate to Menu > Coupons > Select the aforementioned coupon to see its details. Notice that the amount field shows an error message after loading amount fails.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/156713536-b04f475c-3a34-47d8-9b88-91e482fab8e9.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
