### PR TITLE
Inbox design enhancements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -89,6 +89,7 @@ struct Inbox: View {
                     .renderedIf(viewModel.syncState == .results)
             }
         }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -4,6 +4,9 @@ import Yosemite
 
 /// Shows a list of inbox notes as shown in WooCommerce Admin in core.
 struct Inbox: View {
+    /// Environment safe areas
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     /// View model that drives the view.
     @ObservedObject private(set) var viewModel: InboxViewModel
     @State private var showingActionSheet: Bool = false
@@ -47,11 +50,14 @@ struct Inbox: View {
                     }
                     .background(Constants.listForeground)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
+                .background(Constants.listForeground)
             case .empty:
                 EmptyState(title: Localization.emptyStateTitle,
                            description: Localization.emptyStateMessage,
                            image: .emptyInboxNotesImage)
                     .frame(maxHeight: .infinity)
+                    .padding(insets: safeAreaInsets)
             case .syncingFirstPage:
                 ScrollView {
                     LazyVStack(spacing: 0) {
@@ -60,11 +66,13 @@ struct Inbox: View {
                                 .redacted(reason: .placeholder)
                                 .shimmering()
                         }
-                        .background(Constants.listForeground)
                     }
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
+                .background(Constants.listForeground)
             }
         }
+        .ignoresSafeArea()
         .background(Constants.listBackground.ignoresSafeArea())
         .navigationTitle(Localization.title)
         .onAppear {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #6303 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updated the inbox view based on some PR suggestions:

- Extend the inbox view to be fullwidth while respecting safe areas for the content https://github.com/woocommerce/woocommerce-ios/commit/2135164a6e5f50f7e700d7b64ee7dde355806a06
- The ellipsis button in the navigation bar should have pink as the tint color by applying `wooNavigationBarStyle` to the toolbar https://github.com/woocommerce/woocommerce-ios/commit/1a7b0f66f60f11ad53b2b64290287ec0e6b3b314

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* Launch the app
* Go to the Menu tab
* Tap on "Inbox" --> the view should always extend to fullscreen while the content stays within the safe areas

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Note: I noticed the inbox view has a short spacing at the top, but I'm not sure where that comes from since it didn't appear in previous PRs ([example](https://github.com/woocommerce/woocommerce-ios/pull/6272)) 🤔 I created a separate issue to track this https://github.com/woocommerce/woocommerce-ios/issues/6369

placeholder | results | empty state
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2022-03-04 at 13 57 51](https://user-images.githubusercontent.com/1945542/156727957-3b363482-5252-4b70-b575-ea48693bebd1.png) | ![Simulator Screen Shot - iPhone 11 - 2022-03-04 at 13 57 59](https://user-images.githubusercontent.com/1945542/156727969-b879f3b5-ea6b-41e1-ac08-6aead3de8752.png) | ![Simulator Screen Shot - iPhone 11 - 2022-03-04 at 13 59 56](https://user-images.githubusercontent.com/1945542/156727974-d4edf686-c224-4763-ae72-c8dee258d4b4.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
