### PR TITLE
Handle survey type in Inbox

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -5,8 +5,6 @@ import Yosemite
 struct InboxNoteRow: View {
     let viewModel: InboxNoteRowViewModel
 
-    // Tracks the scale of the view due to accessibility changes.
-    @ScaledMetric private var scale: CGFloat = 1
     @State private var tappedAction: InboxNoteRowActionViewModel?
     @State private var isDismissButtonLoading: Bool = false
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -7,6 +7,7 @@ struct InboxNoteRow: View {
 
     @State private var tappedAction: InboxNoteRowActionViewModel?
     @State private var isDismissButtonLoading: Bool = false
+    @State private var surveyCompleted: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,11 +41,15 @@ struct InboxNoteRow: View {
                         ForEach(viewModel.actions) { action in
                             if viewModel.isSurvey {
                                 Button(action.title) {
+                                    withAnimation(.easeInOut) {
+                                        surveyCompleted = true
+                                    }
                                     viewModel.markInboxNoteAsActioned(actionID: action.id)
                                 }
                                 .buttonStyle(SecondaryButtonStyle())
                                 .frame(minWidth: Constants.minWidthSurveyButton)
                                 .fixedSize(horizontal: true, vertical: true)
+                                .renderedIf(!surveyCompleted)
                             }
                             else if action.url != nil {
                                 Button(action.title) {
@@ -58,6 +63,11 @@ struct InboxNoteRow: View {
                                 Text(action.title)
                             }
                         }
+
+                        Text("Thank you for your feedback!")
+                            .secondaryBodyStyle()
+                            .renderedIf(surveyCompleted)
+
                         if isDismissButtonLoading {
                             ActivityIndicator(isAnimating: .constant(true), style: .medium)
                         }
@@ -68,9 +78,10 @@ struct InboxNoteRow: View {
                                     isDismissButtonLoading = false
                                 }
                             }
-                        .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
-                        .font(.body)
-                        .buttonStyle(PlainButtonStyle())
+                            .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
+                            .font(.body)
+                            .buttonStyle(PlainButtonStyle())
+                            .renderedIf(!surveyCompleted)
                         }
                         Spacer()
                     }
@@ -181,7 +192,8 @@ struct InboxNoteRow_Previews: PreviewProvider {
                                                          siteID: 1,
                                                          isPlaceholder: true,
                                                          isRead: true,
-                                                         isSurvey: false)
+                                                         isSurvey: false,
+                                                         isActioned: false)
         Group {
             VStack {
                 InboxNoteRow(viewModel: .init(note: note.copy(type: "marketing", dateCreated: today), today: today))

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -64,7 +64,7 @@ struct InboxNoteRow: View {
                             }
                         }
 
-                        Text("Thank you for your feedback!")
+                        Text(Localization.surveyCompleted)
                             .secondaryBodyStyle()
                             .renderedIf(surveyCompleted)
 
@@ -137,6 +137,8 @@ private extension InboxNoteRow {
         )
         static let doneButtonWebview = NSLocalizedString("Done",
                                                          comment: "Done navigation button in Inbox Notes webview")
+        static let surveyCompleted = NSLocalizedString("Thank you for your feedback!",
+                                                       comment: "Confirmation message in Inbox Notes after responding to a survey.")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -49,7 +49,7 @@ struct InboxNoteRow: View {
                                 .buttonStyle(SecondaryButtonStyle())
                                 .frame(minWidth: Constants.minWidthSurveyButton)
                                 .fixedSize(horizontal: true, vertical: true)
-                                .renderedIf(!surveyCompleted)
+                                .renderedIf(!surveyCompleted &&  !viewModel.isActioned)
                             }
                             else if action.url != nil {
                                 Button(action.title) {
@@ -66,7 +66,7 @@ struct InboxNoteRow: View {
 
                         Text(Localization.surveyCompleted)
                             .secondaryBodyStyle()
-                            .renderedIf(surveyCompleted)
+                            .renderedIf(surveyCompleted || (viewModel.isSurvey && viewModel.isActioned))
 
                         if isDismissButtonLoading {
                             ActivityIndicator(isAnimating: .constant(true), style: .medium)
@@ -81,7 +81,7 @@ struct InboxNoteRow: View {
                             .foregroundColor(Color(.withColorStudio(.gray, shade: .shade30)))
                             .font(.body)
                             .buttonStyle(PlainButtonStyle())
-                            .renderedIf(!surveyCompleted)
+                            .renderedIf(!surveyCompleted || (viewModel.isSurvey && !viewModel.isActioned))
                         }
                         Spacer()
                     }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -40,7 +40,14 @@ struct InboxNoteRow: View {
                     // HStack with actions and dismiss action.
                     HStack(spacing: Constants.spacingBetweenActions) {
                         ForEach(viewModel.actions) { action in
-                            if action.url != nil {
+                            if viewModel.isSurvey {
+                                Button(action.title) {
+                                    viewModel.markInboxNoteAsActioned(actionID: action.id)
+                                }
+                                .buttonStyle(SecondaryButtonStyle())
+                                .fixedSize(horizontal: true, vertical: true)
+                            }
+                            else if action.url != nil {
                                 Button(action.title) {
                                     tappedAction = action
                                     viewModel.markInboxNoteAsActioned(actionID: action.id)
@@ -173,7 +180,8 @@ struct InboxNoteRow_Previews: PreviewProvider {
                                                          actions: [],
                                                          siteID: 1,
                                                          isPlaceholder: true,
-                                                         isRead: true)
+                                                         isRead: true,
+                                                         isSurvey: false)
         Group {
             VStack {
                 InboxNoteRow(viewModel: .init(note: note.copy(type: "marketing", dateCreated: today), today: today))
@@ -181,11 +189,14 @@ struct InboxNoteRow_Previews: PreviewProvider {
                 InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "warning").copy(dateCreated: today.addingTimeInterval(-6*3600)), today: today))
                 InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "update").copy(dateCreated: today.addingTimeInterval(-6*86400)), today: today))
                 InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "info").copy(dateCreated: today.addingTimeInterval(-14*86400)), today: today))
-                InboxNoteRow(viewModel: .init(note: shortNote.copy(type: "survey").copy(dateCreated: today.addingTimeInterval(-1.5*86400)), today: today))
+                InboxNoteRow(viewModel: .init(note: shortNote
+                                                .copy(type: "survey")
+                                                .copy(dateCreated: today .addingTimeInterval(-1.5*86400))
+                                                .copy(title: "This is a Survey"), today: today))
             }
                 .preferredColorScheme(.dark)
                 .environment(\.sizeCategory, .extraSmall)
-                .previewLayout(.sizeThatFits)
+                .previewLayout(.fixed(width: 375, height: 1100))
             InboxNoteRow(viewModel: .init(note: note.copy(dateCreated: today.addingTimeInterval(-86400*2)), today: today))
                 .preferredColorScheme(.light)
             InboxNoteRow(viewModel: .init(note: note.copy(dateCreated: today.addingTimeInterval(-6*60)), today: today))

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -45,6 +45,7 @@ struct InboxNoteRow: View {
                                     viewModel.markInboxNoteAsActioned(actionID: action.id)
                                 }
                                 .buttonStyle(SecondaryButtonStyle())
+                                .frame(minWidth: Constants.minWidthSurveyButton)
                                 .fixedSize(horizontal: true, vertical: true)
                             }
                             else if action.url != nil {
@@ -136,6 +137,7 @@ private extension InboxNoteRow {
         static let defaultPadding: CGFloat = 16
         static let dividerHeight: CGFloat = 1
         static let dateTextColor: UIColor = .withColorStudio(.gray, shade: .shade30)
+        static let minWidthSurveyButton: CGFloat = 40
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -32,6 +32,9 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Indicate if the note is a survey or not.
     let isSurvey: Bool
 
+    /// Indicate if the note is actioned or not.
+    let isActioned: Bool
+
     init(note: InboxNote,
          today: Date = .init(),
          locale: Locale = .current,
@@ -60,7 +63,9 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
                   stores: stores,
                   isPlaceholder: false,
                   isRead: note.isRead,
-                  isSurvey: note.type == "survey")
+                  isSurvey: note.type == "survey",
+                  isActioned: note.status == "actioned"
+        )
     }
 
     init(id: Int64,
@@ -72,7 +77,8 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
          stores: StoresManager = ServiceLocator.stores,
          isPlaceholder: Bool,
          isRead: Bool,
-         isSurvey: Bool) {
+         isSurvey: Bool,
+         isActioned: Bool) {
         self.id = id
         self.date = date
         self.title = title
@@ -83,6 +89,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
         self.isPlaceholder = isPlaceholder
         self.isRead = isRead
         self.isSurvey = isSurvey
+        self.isActioned = isActioned
     }
 
     static func == (lhs: InboxNoteRowViewModel, rhs: InboxNoteRowViewModel) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -29,6 +29,9 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Indicate if the note was actioned or not (the user did an action, so the note will be considered as read).
     let isRead: Bool
 
+    /// Indicate if the note is a survey or not.
+    let isSurvey: Bool
+
     init(note: InboxNote,
          today: Date = .init(),
          locale: Locale = .current,
@@ -56,7 +59,8 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
                   siteID: note.siteID,
                   stores: stores,
                   isPlaceholder: false,
-                  isRead: note.isRead)
+                  isRead: note.isRead,
+                  isSurvey: note.type == "survey")
     }
 
     init(id: Int64,
@@ -67,7 +71,8 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
          siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          isPlaceholder: Bool,
-         isRead: Bool) {
+         isRead: Bool,
+         isSurvey: Bool) {
         self.id = id
         self.date = date
         self.title = title
@@ -77,6 +82,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
         self.stores = stores
         self.isPlaceholder = isPlaceholder
         self.isRead = isRead
+        self.isSurvey = isSurvey
     }
 
     static func == (lhs: InboxNoteRowViewModel, rhs: InboxNoteRowViewModel) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -23,7 +23,8 @@ final class InboxViewModel: ObservableObject {
                               siteID: 123,
                               isPlaceholder: true,
                               isRead: true,
-                              isSurvey: false)
+                              isSurvey: false,
+                              isActioned: false)
     }
 
     // MARK: Sync

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -22,7 +22,8 @@ final class InboxViewModel: ObservableObject {
                               actions: [.init(id: 0, title: "Placeholder", url: nil)],
                               siteID: 123,
                               isPlaceholder: true,
-                              isRead: true)
+                              isRead: true,
+                              isSurvey: false)
     }
 
     // MARK: Sync


### PR DESCRIPTION
Closes: #6173 

### Description
In this PR; I handled the survey type in Inbox Notes, which should be managed in a different way because the design is different from other notifications.
The buttons have a different design, and after pressing one of the survey options (aka actions), you should see a message "Thank you for your feedback".


### Testing instructions
Unfortunately, I wasn't able to do a lot of tests around this functionality because the number of surveys in our test stores are few (I found in total just 3 surveys across 10 testing stores), and I wasn't able to add a new survey in my testing store. Right now the plugin that allows us to add new entries in our testing store doesn't allow us to add survey type notifications (😢).

1. Try to find a store with survey types in inbox notes (good luck!).
2. Open the store in the app, and navigate to Inbox Notes.3. 
3. Find in the list the Survey note.
4. Respond to the survey. You should see the animation and a thank you message.

**Note**: as I said, I have not been able to test this feature thoroughly, but during one of the tests I noticed a strange behavior that unfortunately I cannot try to replicate. After responding to a survey from the app, when you reopen the inbox notes the survey is still there. But if you open the inbox notes from the web, the survey will disappear in the web and in the app. 🤷 If you are able to find a survey type and to test this case (maybe with the browser console opened) it would be great.

### Screenshots
| Survey type             |  Survey notification after responding to it |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-03 at 12 23 14](https://user-images.githubusercontent.com/495617/156741117-d1ac5947-b388-49cf-a3f3-255998e1a191.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-03 at 12 22 57](https://user-images.githubusercontent.com/495617/156741155-fa9229f7-ceb7-41f3-8c61-a5c35cbaec1c.png)

### Video
https://user-images.githubusercontent.com/495617/156741205-a3bd491d-1bf9-46e3-b1d7-4a5b8679e174.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
