### PR TITLE
Order Creation: Add remote sync error notice

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -12,11 +12,15 @@ struct NoticeModifier: ViewModifier {
     ///
     @Binding var notice: Notice?
 
+    /// Whether the notice should be auto-dismissed.
+    ///
+    var autoDismiss: Bool
+
     /// Cancelable task that clears a notice.
     ///
     @State private var clearNoticeTask = DispatchWorkItem(block: {})
 
-    /// Time the notice will remain on screen.
+    /// Time the notice will remain on screen, if it is auto-dismissed.
     ///
     private let onScreenNoticeTime = 5.0
 
@@ -65,9 +69,10 @@ struct NoticeModifier: ViewModifier {
         }
     }
 
-    /// Cancels any ongoing clear notice task and dispatches it again.
+    /// Cancels any ongoing clear notice task and dispatches it again, if the notice should be auto-dismissed.
     ///
     private func dispatchClearNoticeTask() {
+        guard autoDismiss else { return }
         clearNoticeTask.cancel()
         clearNoticeTask = .init {
             $notice.wrappedValue = nil
@@ -217,8 +222,11 @@ private extension NoticeAlert {
 extension View {
     /// Shows the provided notice in front of the view.
     ///
-    func notice(_ notice: Binding<Notice?>) -> some View {
-        modifier(NoticeModifier(notice: notice))
+    /// - Parameters:
+    ///   - notice: Notice to be displayed.
+    ///   - autoDismiss: Whether the notice should be auto-dismissed.
+    func notice(_ notice: Binding<Notice?>, autoDismiss: Bool = true) -> some View {
+        modifier(NoticeModifier(notice: notice, autoDismiss: autoDismiss))
     }
 }
 

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -14,7 +14,7 @@ struct NoticeModifier: ViewModifier {
 
     /// Whether the notice should be auto-dismissed.
     ///
-    var autoDismiss: Bool
+    let autoDismiss: Bool
 
     /// Cancelable task that clears a notice.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -69,7 +69,7 @@ struct NewOrder: View {
             }
         }
         .wooNavigationBarStyle()
-        .notice($viewModel.notice)
+        .notice($viewModel.notice, autoDismiss: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -705,7 +705,7 @@ extension NewOrderViewModel {
 private extension NewOrderViewModel {
     enum Localization {
         static let errorMessageOrderCreation = NSLocalizedString("Unable to create new order", comment: "Notice displayed when order creation fails")
-        static let errorMessageOrderSync = NSLocalizedString("Unable to sync draft order", comment: "Notice displayed when draft order fails to sync")
+        static let errorMessageOrderSync = NSLocalizedString("Unable to load taxes for order", comment: "Notice displayed when taxes cannot be synced for new order")
         static let retryOrderSync = NSLocalizedString("Retry", comment: "Action button to retry syncing the draft order")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -437,17 +437,16 @@ private extension NewOrderViewModel {
     ///
     func configureSyncErrors() {
         orderSynchronizer.statePublisher
-            .sink { [weak self] state in
-                guard let self = self else { return }
+            .map { state in
                 switch state {
                 case .error(let error):
-                    self.notice = NoticeFactory.syncOrderErrorNotice(with: self.orderSynchronizer)
                     DDLogError("⛔️ Error syncing new order remotely: \(error)")
+                    return NoticeFactory.syncOrderErrorNotice(with: self.orderSynchronizer)
                 default:
-                    self.notice = nil
+                    return nil
                 }
             }
-            .store(in: &self.cancellables)
+            .assign(to: &$notice)
     }
 
     /// Updates status badge viewmodel based on status order property.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -247,7 +247,7 @@ final class NewOrderViewModel: ObservableObject {
                 self.onOrderCreated(newOrder)
                 self.trackCreateOrderSuccess()
             case .failure(let error):
-                self.notice = NoticeFactory.createOrderCreationErrorNotice()
+                self.notice = NoticeFactory.createOrderErrorNotice()
                 self.trackCreateOrderFailure(error: error)
                 DDLogError("⛔️ Error creating new order: \(error)")
             }
@@ -440,7 +440,7 @@ private extension NewOrderViewModel {
             .sink { [weak self] state in
                 guard let self = self else { return }
                 if case let .error(error) = state {
-                    self.notice = NoticeFactory.createOrderSyncErrorNotice(with: self.orderSynchronizer)
+                    self.notice = NoticeFactory.syncOrderErrorNotice(with: self.orderSynchronizer)
                     DDLogError("⛔️ Error syncing new order remotely: \(error)")
                 }
             }
@@ -688,13 +688,13 @@ extension NewOrderViewModel {
     enum NoticeFactory {
         /// Returns a default order creation error notice.
         ///
-        static func createOrderCreationErrorNotice() -> Notice {
+        static func createOrderErrorNotice() -> Notice {
             Notice(title: Localization.errorMessageOrderCreation, feedbackType: .error)
         }
 
         /// Returns an order sync error notice.
         ///
-        static func createOrderSyncErrorNotice(with orderSynchronizer: OrderSynchronizer) -> Notice {
+        static func syncOrderErrorNotice(with orderSynchronizer: OrderSynchronizer) -> Notice {
             Notice(title: Localization.errorMessageOrderSync, feedbackType: .error, actionTitle: Localization.retryOrderSync) {
                 orderSynchronizer.retryTrigger.send()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -705,7 +705,8 @@ extension NewOrderViewModel {
 private extension NewOrderViewModel {
     enum Localization {
         static let errorMessageOrderCreation = NSLocalizedString("Unable to create new order", comment: "Notice displayed when order creation fails")
-        static let errorMessageOrderSync = NSLocalizedString("Unable to load taxes for order", comment: "Notice displayed when taxes cannot be synced for new order")
+        static let errorMessageOrderSync = NSLocalizedString("Unable to load taxes for order",
+                                                             comment: "Notice displayed when taxes cannot be synced for new order")
         static let retryOrderSync = NSLocalizedString("Retry", comment: "Action button to retry syncing the draft order")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -440,7 +440,7 @@ private extension NewOrderViewModel {
             .sink { [weak self] state in
                 guard let self = self else { return }
                 if case let .error(error) = state {
-                    self.notice = NoticeFactory.createOrderSyncErrorNotice()
+                    self.notice = NoticeFactory.createOrderSyncErrorNotice(with: self.orderSynchronizer)
                     DDLogError("⛔️ Error syncing new order remotely: \(error)")
                 }
             }
@@ -694,8 +694,10 @@ extension NewOrderViewModel {
 
         /// Returns an order sync error notice.
         ///
-        static func createOrderSyncErrorNotice() -> Notice {
-            Notice(title: Localization.errorMessageOrderSync, feedbackType: .error)
+        static func createOrderSyncErrorNotice(with orderSynchronizer: OrderSynchronizer) -> Notice {
+            Notice(title: Localization.errorMessageOrderSync, feedbackType: .error, actionTitle: Localization.retryOrderSync) {
+                orderSynchronizer.retryTrigger.send()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -433,15 +433,18 @@ private extension NewOrderViewModel {
             .assign(to: &$navigationTrailingItem)
     }
 
-    /// Fires an error notice when `statePublisher` is `.error`
+    /// Updates the notice based on the `orderSynchronizer` sync state.
     ///
     func configureSyncErrors() {
         orderSynchronizer.statePublisher
             .sink { [weak self] state in
                 guard let self = self else { return }
-                if case let .error(error) = state {
+                switch state {
+                case .error(let error):
                     self.notice = NoticeFactory.syncOrderErrorNotice(with: self.orderSynchronizer)
                     DDLogError("⛔️ Error syncing new order remotely: \(error)")
+                default:
+                    self.notice = nil
                 }
             }
             .store(in: &self.cancellables)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -32,6 +32,8 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
 
     var setFee = PassthroughSubject<OrderFeeLine?, Never>()
 
+    var retryTrigger = PassthroughSubject<Void, Never>()
+
     // MARK: Private properties
 
     private let siteID: Int64
@@ -50,9 +52,6 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
     }
 
     // MARK: Methods
-    func retrySync() {
-        // No op
-    }
 
     /// Creates the order remotely.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -81,9 +81,9 @@ protocol OrderSynchronizer {
     ///
     var setFee: PassthroughSubject<OrderFeeLine?, Never> { get }
 
-    /// Retires the order sync. State needs to be in `.error` to initiate work.
+    /// Trigger to retry a remote sync.
     ///
-    func retrySync()
+    var retryTrigger: PassthroughSubject<Void, Never> { get }
 
     /// Commits all order changes to the remote source. State needs to be in `.synced` to initiate work.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -32,6 +32,8 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
 
     var setFee = PassthroughSubject<OrderFeeLine?, Never>()
 
+    var retryTrigger = PassthroughSubject<Void, Never>()
+
     // MARK: Private properties
 
     private let siteID: Int64
@@ -65,9 +67,6 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
     }
 
     // MARK: Methods
-    func retrySync() {
-        // TODO: Implement
-    }
 
     /// Creates the order remotely.
     ///
@@ -138,6 +137,7 @@ private extension RemoteOrderSynchronizer {
             .merge(with: setAddresses.map { _ in () })
             .merge(with: setShipping.map { _ in () })
             .merge(with: setFee.map { _ in () })
+            .merge(with: retryTrigger.map { _ in () })
             .debounce(for: 0.5, scheduler: DispatchQueue.main) // Group & wait for 0.5 since the last signal was emitted.
             .compactMap { [weak self] in
                 guard let self = self else { return nil }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -108,6 +108,7 @@ class NewOrderViewModelTests: XCTestCase {
     func test_view_model_fires_error_notice_when_order_sync_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores, enableRemoteSync: true)
         let expectation = expectation(description: "Order sync failed")
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
@@ -125,7 +126,7 @@ class NewOrderViewModelTests: XCTestCase {
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
 
         // Then
-        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.createOrderSyncErrorNotice())
+        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.createOrderSyncErrorNotice(with: synchronizer))
     }
 
     func test_view_model_loads_synced_pending_order_status() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -102,7 +102,7 @@ class NewOrderViewModelTests: XCTestCase {
         viewModel.createOrder()
 
         // Then
-        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.createOrderCreationErrorNotice())
+        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.createOrderErrorNotice())
     }
 
     func test_view_model_fires_error_notice_when_order_sync_fails() {
@@ -126,7 +126,7 @@ class NewOrderViewModelTests: XCTestCase {
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
 
         // Then
-        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.createOrderSyncErrorNotice(with: synchronizer))
+        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.syncOrderErrorNotice(with: synchronizer))
     }
 
     func test_view_model_loads_synced_pending_order_status() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -684,6 +684,99 @@ class RemoteOrderSynchronizerTests: XCTestCase {
                                       .shippingLines,
                                       .items])
     }
+
+    func test_sending_retry_trigger_after_failed_order_creation_retries_expected_order_creation() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let error = NSError(domain: "", code: 0, userInfo: nil)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let orderCreationFailed: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder(_, _, let completion):
+                    completion(.failure(error))
+                    promise(true)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1)
+            synchronizer.setProduct.send(input)
+        }
+        XCTAssertTrue(orderCreationFailed)
+
+        let createdOrderItems: [OrderItem] = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder(_, let order, _):
+                    promise(order.items)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            synchronizer.retryTrigger.send()
+        }
+
+        // Then
+        XCTAssertEqual(createdOrderItems.count, 1)
+        XCTAssertEqual(createdOrderItems.first?.productID, product.productID)
+        XCTAssertEqual(createdOrderItems.first?.quantity, 1)
+    }
+
+    func test_sending_retry_trigger_with_remote_order_triggers_order_update() {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let error = NSError(domain: "", code: 0, userInfo: nil)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let orderUpdateFailed: Bool = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createOrder(_, _, let completion):
+                    completion(.success(.fake().copy(orderID: self.sampleOrderID)))
+                case .updateOrder(_, _, _, let completion):
+                    completion(.failure(error))
+                    promise(true)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            // Wait for order creation
+            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1)
+            self.createOrder(on: synchronizer, input: input)
+
+            // Trigger order update
+            let input2 = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2)
+            synchronizer.setProduct.send(input2)
+        }
+        XCTAssertTrue(orderUpdateFailed)
+
+        let updatedOrderItems: [OrderItem] = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .updateOrder(_, let order, _, _):
+                    promise(order.items)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            synchronizer.retryTrigger.send()
+        }
+
+        // Then
+        XCTAssertEqual(updatedOrderItems.count, 1)
+        XCTAssertEqual(updatedOrderItems.first?.productID, product.productID)
+        XCTAssertEqual(updatedOrderItems.first?.quantity, 2)
+    }
 }
 
 private extension RemoteOrderSynchronizerTests {


### PR DESCRIPTION
Closes: #6134

## Description

This adds an error notice that appears when order creation or sync fails with `RemoteOrderSynchronizer`. The notice includes a "Retry" action that retries the order creation/update.

Note that we do this sync primarily to get the taxes for the order, so the error message focuses on communicating that to the merchant ("Unable to load taxes for order").

## Changes

* Updated the `OrderSynchronizer` protocol to remove the `retrySync()` method and instead add a `retryTrigger` subject.
* Updated `RemoteOrderSynchronizer` to include the `retryTrigger` subject as one of the possible triggers in `bindOrderSync`, so that when that trigger is sent it will sync the existing order again (using the existing logic to create or update the order as needed).
* Updated `NewOrderViewModel` to create a sync error notice in `NoticeFactory` with an action that sends the `retryTrigger` to the synchronizer. That notice is triggered when the `orderSynchronizer.statePublisher` sends an `error` state, and reset for any other state.
* Updated the SwiftUI `.notice` view modifier to accept an `autoDismiss` parameter. When set to false, the notice will not be auto-dismissed. (This is now used on the `NewOrder` view to make the notice persistent.)
* Adds unit tests for the notice and the retry trigger.

## Testing

1. Enable the `orderCreationRemoteSynchronizer` feature flag.
2. Open the app and load the product list.
3. Turn off your wifi.
4. Go to the order creation screen & add a product.
5. See that the order failed to get updated (no taxes available).
6. Confirm a notice appears with the message "Unable to load taxes for order" and a "Retry" button.
7. Turn on your wifi and tap "Retry."
8. Confirm the order is synced and taxes appear.

(You can also try again to disable your wifi, make another change to the order, and confirm the notice and retry button continue to work as expected when updating the previously synced order.)

## Screenshots

https://user-images.githubusercontent.com/8658164/157054204-b626e683-11f9-47f0-9670-bc385f848fc2.mp4

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
