### PR TITLE
Fixed table style to grouped for the bulk update screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.xib
@@ -20,7 +20,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fCF-yK-YZD">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="fCF-yK-YZD">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>


### PR DESCRIPTION
Part of #6239

### Description
This PR changes the style of the table view for the bulk update screen to group to remove the sticky headers.

### Testing instructions
1. Go to the products tab
2. Select a product with variations
3. Go to the list of variations
4. Tap on the more button and select the "bulk update" option
5. You will see that the "jump" between the loading state and loaded state is reduced

### Screenshots

Before:

https://user-images.githubusercontent.com/96764631/156823024-2cb45d78-b508-4682-9f29-be892aa774ce.mp4

After:

https://user-images.githubusercontent.com/96764631/156823042-460c798d-475d-46df-b3f5-2052a2715ce9.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


