### PR TITLE
Order Creation - Order Sync: Adds Shipping support

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -114,7 +114,7 @@ private extension RemoteOrderSynchronizer {
         setShipping.withLatestFrom(orderPublisher)
             .map { [weak self] shippingLineInput, order in
                 guard let self = self else { return order }
-                let updatedOrder = order.copy(shippingTotal: shippingLineInput?.total ?? "0", shippingLines: shippingLineInput.flatMap { [$0] } ?? [])
+                let updatedOrder = ShippingInputTransformer.update(input: shippingLineInput, on: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }
@@ -191,7 +191,7 @@ private extension RemoteOrderSynchronizer {
             }
             .map { [weak self] order -> AnyPublisher<Order, Never> in // Allow multiple requests, once per update request.
                 guard let self = self else { return Empty().eraseToAnyPublisher() }
-                self.state = .syncing(blocking: order.containsLocalItems()) // Set a `blocking` state if the order contains new items
+                self.state = .syncing(blocking: order.containsLocalLines()) // Set a `blocking` state if the order contains new lines
                 return self.updateOrderRemotely(order)
                     .catch { [weak self] error -> AnyPublisher<Order, Never> in // When an error occurs, update state & finish.
                         self?.state = .error(error)
@@ -292,10 +292,10 @@ private extension RemoteOrderSynchronizer {
         ///
         private var currentID: Int64 = 0
 
-        /// Returns true if a given ID is deemed to be local(negative).
+        /// Returns true if a given ID is deemed to be local(zero or negative).
         ///
         static func isIDLocal(_ id: Int64) -> Bool {
-            id < 0
+            id <= 0
         }
 
         /// Creates a new and unique local ID for this session.
@@ -309,10 +309,13 @@ private extension RemoteOrderSynchronizer {
 
 // MARK: Order Helpers
 private extension Order {
-    /// Returns true if the order contains local items.
+    /// Returns true if the order contains any local line (items, shipping, or fees).
     ///
-    func containsLocalItems() -> Bool {
-        items.contains { RemoteOrderSynchronizer.LocalIDStore.isIDLocal($0.itemID) }
+    func containsLocalLines() -> Bool {
+        let containsLocalLineItems = items.contains { RemoteOrderSynchronizer.LocalIDStore.isIDLocal($0.itemID) }
+        let containsLocalShippingLines = shippingLines.contains { RemoteOrderSynchronizer.LocalIDStore.isIDLocal($0.shippingID) }
+        let containsLocalFeeLines = fees.contains { RemoteOrderSynchronizer.LocalIDStore.isIDLocal($0.feeID) }
+        return containsLocalLineItems || containsLocalShippingLines || containsLocalFeeLines
     }
 
     /// Removes the `itemID`, `total` & `subtotal` values from local items.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -13,7 +13,6 @@ struct ShippingInputTransformer {
         guard let input = input else {
             let linesToRemove = order.shippingLines.map { $0.copy(methodID: .some(nil), total: "0") }
             return order.copy(shippingTotal: "0", shippingLines: linesToRemove)
-
         }
 
         // If there is no existing shipping lines, we insert the input one.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Yosemite
+
+/// Helper to updates an `order` given an `ShippingLine` input type.
+///
+struct ShippingInputTransformer {
+
+    /// Adds, deletes, or updates a shipping line input into an existing order.
+    ///
+    static func update(input: ShippingLine?, on order: Order) -> Order {
+        // If input is `nil`, then we remove any existing shipping line.
+        // We remove a shipping like by setting its `methodID` to nil.
+        guard let input = input else {
+            let linesToRemove = order.shippingLines.map { $0.copy(methodID: .some(nil)) }
+            return order.copy(shippingTotal: "0", shippingLines: linesToRemove)
+
+        }
+
+        // If there is no existing shipping lines, we insert the input one.
+        guard let existingShippingLine = order.shippingLines.first else {
+            return order.copy(shippingTotal: input.total, shippingLines: [input])
+        }
+
+        // Since we only support one shipping line, if we find one, we update our input with the existing `shippingID`.
+        let updatedShippingLine = input.copy(shippingID: existingShippingLine.shippingID)
+        return order.copy(shippingTotal: updatedShippingLine.total, shippingLines: [updatedShippingLine])
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -11,7 +11,7 @@ struct ShippingInputTransformer {
         // If input is `nil`, then we remove any existing shipping line.
         // We remove a shipping like by setting its `methodID` to nil.
         guard let input = input else {
-            let linesToRemove = order.shippingLines.map { $0.copy(methodID: .some(nil)) }
+            let linesToRemove = order.shippingLines.map { $0.copy(methodID: .some(nil), total: "0") }
             return order.copy(shippingTotal: "0", shippingLines: linesToRemove)
 
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -504,6 +504,7 @@
 		268EC46426D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */; };
 		268FD44727580A81008FDF9B /* CollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268FD44627580A81008FDF9B /* CollectOrderPaymentUseCase.swift */; };
 		269098B427D2BBFC001FEB07 /* ShippingInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B327D2BBFC001FEB07 /* ShippingInputTransformer.swift */; };
+		269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B527D2C09D001FEB07 /* ShippingInputTransformerTests.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -2171,6 +2172,7 @@
 		268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelTests.swift; sourceTree = "<group>"; };
 		268FD44627580A81008FDF9B /* CollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
 		269098B327D2BBFC001FEB07 /* ShippingInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputTransformer.swift; sourceTree = "<group>"; };
+		269098B527D2C09D001FEB07 /* ShippingInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputTransformerTests.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -4382,6 +4384,7 @@
 			children = (
 				2602A64127BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift */,
 				2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */,
+				269098B527D2C09D001FEB07 /* ShippingInputTransformerTests.swift */,
 				2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */,
 				CC4B252C27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift */,
 			);
@@ -9320,6 +9323,7 @@
 				023EC2E624DAB1270021DA91 /* EditableProductVariationModelTests.swift in Sources */,
 				095A077E27CF486C007A61D2 /* ValueOneTableViewCellTests.swift in Sources */,
 				E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */,
+				269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				FEEB2F6E268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift in Sources */,
 				31E906A326CC91A70099A985 /* CardReaderConnectionControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -503,6 +503,7 @@
 		268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */; };
 		268EC46426D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */; };
 		268FD44727580A81008FDF9B /* CollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268FD44627580A81008FDF9B /* CollectOrderPaymentUseCase.swift */; };
+		269098B427D2BBFC001FEB07 /* ShippingInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B327D2BBFC001FEB07 /* ShippingInputTransformer.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -2169,6 +2170,7 @@
 		268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModel.swift; sourceTree = "<group>"; };
 		268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelTests.swift; sourceTree = "<group>"; };
 		268FD44627580A81008FDF9B /* CollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
+		269098B327D2BBFC001FEB07 /* ShippingInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputTransformer.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -4626,6 +4628,7 @@
 				2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */,
 				2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */,
 				2602A64527BDBEBA00B347F1 /* ProductInputTransformer.swift */,
+				269098B327D2BBFC001FEB07 /* ShippingInputTransformer.swift */,
 				CC4B252A27CFCEE2008D2E6E /* OrderTotalsCalculator.swift */,
 			);
 			path = Synchronizer;
@@ -8574,6 +8577,7 @@
 				455DC3A327393C7E00D4644C /* OrderDatesFilterViewController.swift in Sources */,
 				45B6F4EF27592A4000C18782 /* ReviewsView.swift in Sources */,
 				268FD44727580A81008FDF9B /* CollectOrderPaymentUseCase.swift in Sources */,
+				269098B427D2BBFC001FEB07 /* ShippingInputTransformer.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				45F627B6253603AE00894B86 /* Product+DownloadSettingsViewModels.swift in Sources */,
 				B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -142,7 +142,8 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         synchronizer.setShipping.send(nil)
 
         // Then
-        XCTAssertEqual(synchronizer.order.shippingLines, [])
+        let firstLine = try XCTUnwrap(synchronizer.order.shippingLines.first)
+        XCTAssertNil(firstLine.methodID)
     }
 
     func test_sending_product_input_triggers_order_creation() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import TestKit
+import Fakes
+
+@testable import WooCommerce
+@testable import Yosemite
+
+class ShippingInputTransformerTests: XCTestCase {
+
+    private let sampleShippingID: Int64 = 123
+    private let sampleMethodID = "other"
+
+    func test_new_input_adds_shipping_line_to_order() throws {
+        // Given
+        let order = Order.fake()
+        let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "10.00")
+
+        // When
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        XCTAssertEqual(shippingLine, input)
+        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
+    }
+
+    func test_new_input_updates_shipping_line_from_order() throws {
+        // Given
+        let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
+        let order = Order.fake().copy(shippingLines: [shipping])
+
+        // When
+        let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "12.00")
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        XCTAssertEqual(shippingLine.shippingID, shipping.shippingID)
+        XCTAssertEqual(shippingLine.methodID, input.methodID)
+        XCTAssertEqual(shippingLine.total, input.total)
+        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
+    }
+
+    func test_new_input_deletes_shipping_line_from_order() throws {
+        // Given
+        let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
+        let order = Order.fake().copy(shippingLines: [shipping])
+
+        // When
+        let updatedOrder = ShippingInputTransformer.update(input: nil, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        XCTAssertNil(shippingLine.methodID)
+        XCTAssertEqual(shippingLine.shippingID, shipping.shippingID)
+        XCTAssertEqual(shippingLine.total, "0")
+        XCTAssertEqual(updatedOrder.shippingTotal, "0")
+    }
+}


### PR DESCRIPTION
Closes: #6140 

# Why

This PR adds proper sync support to adding, updating, and removing shipping lines.

# How

- Adds a new type `ShippingInputTransformer` to take care of updating an order given the shipping input.

- Make sure that we set the shipping `methodID` to `nil` when trying to delete a shipping line.

- Update the `containsLocalItems` method to take into account shipping lines & fee lines

- Update the `isIDLocal` method to consider `.zero` a local ID.

# Demo

https://user-images.githubusercontent.com/562080/156852414-20651e67-5d13-4967-bc40-67d0c3c634a9.mov

# Testing Steps

- Set `orderCreationRemoteSynchronizer` feature flag to `true`
- Go to the new order screen.
- Adds a shipping fee & see the totals updated.
- Updates the shipping fee & see the totals updated.
- Remove the shipping fee & see the fee being removed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
