### PR TITLE
Update WordPress Authenticator to remove Lottie dependency

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -40,9 +40,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.43.1'
+  # pod 'WordPressAuthenticator', '~> 2.0.0-beta.1'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'remove-lottie'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.15'

--- a/Podfile
+++ b/Podfile
@@ -40,9 +40,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 2.0.0-beta.1'
+  pod 'WordPressAuthenticator', '~> 2.0.0-beta.1'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'remove-lottie'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.15'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,6 @@ PODS:
   - GTMSessionFetcher/Core (1.7.0)
   - KeychainAccess (3.2.1)
   - Kingfisher (6.0.1)
-  - lottie-ios (3.1.9)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
   - Reachability (3.2)
@@ -48,12 +47,11 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.43.1):
+  - WordPressAuthenticator (2.0.0-beta.1):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
-    - lottie-ios (~> 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
     - WordPressKit (~> 4.18-beta)
@@ -100,7 +98,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.6)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.43.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `remove-lottie`)
   - WordPressKit (~> 4.46.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.4)
@@ -110,8 +108,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -125,7 +121,6 @@ SPEC REPOS:
     - GTMSessionFetcher
     - KeychainAccess
     - Kingfisher
-    - lottie-ios
     - NSObject-SafeExpectations
     - "NSURL+IDN"
     - Reachability
@@ -152,6 +147,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: remove-lottie
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 113290f66464fdeba9b5862b6155cd45d323bc10
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -165,7 +170,6 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
   Kingfisher: adde87a4f74f6a3845395769354efff593581740
-  lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
@@ -177,7 +181,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: d0fee204f467dacf8808b7ac14ce43affeb271a5
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: aa53a5339e241852252e16199e23bd9c3364b983
+  WordPressAuthenticator: 18acfe95bc0748e8e5c7cc2194ac1d3591f7163b
   WordPressKit: 67cc1b0bda0d114c806a631ad726027d535d28a8
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 9e470758bc3a4a25e94478c2babe106f4ae7315a
@@ -193,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 6a578f9f9306d5a23c420153e878231942400068
+PODFILE CHECKSUM: 3761c1b297126f75aabb132a5606c21a9a99b817
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -154,7 +154,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 113290f66464fdeba9b5862b6155cd45d323bc10
+    :commit: 5277dbead4ffd0f3050c64c07045891d51edcbaf
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -98,7 +98,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.6)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `remove-lottie`)
+  - WordPressAuthenticator (~> 2.0.0-beta.1)
   - WordPressKit (~> 4.46.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.4)
@@ -108,6 +108,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -147,16 +149,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :branch: remove-lottie
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 5277dbead4ffd0f3050c64c07045891d51edcbaf
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -181,7 +173,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: d0fee204f467dacf8808b7ac14ce43affeb271a5
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 18acfe95bc0748e8e5c7cc2194ac1d3591f7163b
+  WordPressAuthenticator: abf8310fc4ebab25a81cb96211df80b5ec1db479
   WordPressKit: 67cc1b0bda0d114c806a631ad726027d535d28a8
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 9e470758bc3a4a25e94478c2babe106f4ae7315a
@@ -197,6 +189,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 3761c1b297126f75aabb132a5606c21a9a99b817
+PODFILE CHECKSUM: 9dacb1e36bc2fc9bb4f57a645f38a3819cae7af4
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description

See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/640.

### Testing instructions

As you can see, the UI tests are green and we do test the login flow extensively. On top of that, I used the Installable Build to test:

- Direct login via the iOS password manager prompt.
- Login via login button and 1Password autofill.
- Google login.
- That the signup flow works, i.e. results in me receiving a signup-link mail at the given address. 
- That the prologue carousel still works (unnecessary, given it's a [different class](https://github.com/woocommerce/woocommerce-ios/blob/595b3521748894649f63167cfd30ba8ba6d92fe7/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift) than the library's, but felt like it wouldn't hurt 😅).


<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
