### PR TITLE
Order Creation: Makes fees taxable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import struct Yosemite.OrderFeeLine
+import Yosemite
 
 class FeeLineDetailsViewModel: ObservableObject {
 
@@ -135,14 +135,7 @@ class FeeLineDetailsViewModel: ObservableObject {
             return
         }
 
-        let feeLine = OrderFeeLine(feeID: 0,
-                                   name: "Fee",
-                                   taxClass: "",
-                                   taxStatus: .none,
-                                   total: priceFieldFormatter.formatAmount(finalAmountString),
-                                   totalTax: "",
-                                   taxes: [],
-                                   attributes: [])
+        let feeLine = OrderFactory.newOrderFee(total: priceFieldFormatter.formatAmount(finalAmountString))
         didSelectSave(feeLine)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -207,4 +207,23 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         viewModel.saveData()
         XCTAssertEqual(savedFeeLine?.total, "20.00")
     }
+
+    func test_view_model_creates_fee_line_with_taxes_enabled() {
+        // Given
+        var savedFeeLine: OrderFeeLine?
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 200,
+                                                feesTotal: "100",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { newFeeLine in
+            savedFeeLine = newFeeLine
+        })
+
+        // When
+        viewModel.saveData()
+
+        // Then
+        XCTAssertEqual(savedFeeLine?.taxStatus, .taxable)
+    }
 }

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -52,6 +52,19 @@ public enum OrderFactory {
               attributes: [])
     }
 
+    /// Creates a fee line suitable to be used within a new order.
+    ///
+    public static func newOrderFee(total: String) -> OrderFeeLine {
+        OrderFeeLine(feeID: 0,
+                     name: "Fee",
+                     taxClass: "",
+                     taxStatus: .taxable,
+                     total: total,
+                     totalTax: "",
+                     taxes: [],
+                     attributes: [])
+    }
+
     /// Creates a fee line suitable to delete a fee line already saved remotely in an order.
     ///
     public static func deletedFeeLine(_ feeLine: OrderFeeLine) -> OrderFeeLine {


### PR DESCRIPTION
# Why 

During the development of #6141 I noticed that, unlike core, the app's fees for a new order are not taxable.

This PR makes the fees taxable by setting the fee `tasStatus` to `.taxable`.

# Demo

https://user-images.githubusercontent.com/562080/157112607-ca55e5e2-8242-43bf-be85-da3c2dc699b2.mov

# Testing Steps

- Set `orderCreationRemoteSynchronizer` feature flag to true.
- Go to the new order screen.
- Add a product.
- Add a fee & see the tax updated.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
