### PR TITLE
Order Creation: Fix potential leak in sync error notice

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -437,7 +437,8 @@ private extension NewOrderViewModel {
     ///
     func configureSyncErrors() {
         orderSynchronizer.statePublisher
-            .map { state in
+            .map { [weak self] state in
+                guard let self = self else { return nil }
                 switch state {
                 case .error(let error):
                     DDLogError("⛔️ Error syncing new order remotely: \(error)")


### PR DESCRIPTION
## Description

As noted in https://github.com/woocommerce/woocommerce-ios/pull/6373#pullrequestreview-902003977 there's a potential memory leak during Order Creation in `configureSyncErrors()`. This is a quick followup to that PR to resolve that leak.

## Changes

* Updates `configureSyncErrors()` to capture a weak reference to `self`.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
