### PR TITLE
Order Creation: Fixes issue that prevented products to be added on a new order.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -56,7 +56,7 @@ final class LocalOrderSynchronizer: OrderSynchronizer {
     /// Creates the order remotely.
     ///
     func commitAllChanges(onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        let action = OrderAction.createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
+        let action = OrderAction.createOrder(siteID: siteID, order: order.removingItemIDs(), onCompletion: onCompletion)
         stores.dispatch(action)
     }
 }
@@ -110,5 +110,16 @@ private extension LocalOrderSynchronizer {
             return input
         }
         return input.updating(id: Int64(UUID().uuidString.hashValue))
+    }
+}
+
+// MARK: Order Helpers
+private extension Order {
+    /// Removes the `itemID` values from items.
+    /// This is needed to create the item without the random generated ID, the remote API would fail otherwise.
+    func removingItemIDs() -> Order {
+        copy (
+            items: items.map { $0.copy(itemID: .zero) }
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/LocalOrderSynchronizer.swift
@@ -119,7 +119,7 @@ private extension Order {
     /// This is needed to create the item without the random generated ID, the remote API would fail otherwise.
     func removingItemIDs() -> Order {
         copy (
-            items: items.map { $0.copy(itemID: .zero) }
+            items: items.map { $0.copy(itemID: .zero, subtotal: "", total: "") }
         )
     }
 }


### PR DESCRIPTION
Closes: #6388

# Why

- 7 days ago we merged code that [standardized how we encode items](https://github.com/woocommerce/woocommerce-ios/commit/634a6cd7eb9b419c374a80033edc8cac90e141c9) when creating an order. 

- The shared encoder encodes the `item id`  if one is provided. 

- `LocalOrderSynchronizer` uses randomly generated `item ids` to identify items before they are created.

- I failed to properly remove those randomly generated ids before sending items for creation, which causes the API to fail.

# How 

This PR fixes the issue by setting the order items ids to `.zero` before making the network request.

# Demo

https://user-images.githubusercontent.com/562080/157266112-ce924cdc-f3e1-4b53-bf8a-1a62f4caea84.mov

# Testing

- Make sure you have Order Creation toggled in experimental features
- Head into Orders -> `+` -> Create order
- Add a Product
- Tap Create.
- See that the order is created.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
