### PR TITLE
[Mobile Payments] Ensure card has been removed before attempting a payment

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -212,6 +212,10 @@ extension StripeCardReaderService: CardReaderService {
         // This isn't enforced by the type system, but it is guaranteed as long as all the
         // steps produce a Future.
 
+        // If a card was left from a previous payment attempt, we want that removed before we initiate a new payment.
+        // However, a new payment probably means a new subscription to readerEvents, which won't rely the old `.removeCard`
+        // message. If there is a card inserted, we manually send a display message prompting to remove the card,
+        // and wait for that before continuing.
         if isChipCardInserted {
             sendReaderEvent(CardReaderEvent.make(displayMessage: .removeCard))
         }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -211,14 +211,23 @@ extension StripeCardReaderService: CardReaderService {
         // a single value or it will fail.
         // This isn't enforced by the type system, but it is guaranteed as long as all the
         // steps produce a Future.
-        return createPaymentIntent(parameters)
-            .flatMap { intent in
+
+        if isChipCardInserted {
+            sendReaderEvent(CardReaderEvent.make(displayMessage: .removeCard))
+        }
+        return waitForInsertedCardToBeRemoved()
+            .flatMap {
+                self.createPaymentIntent(parameters)
+            }.flatMap { intent in
                 self.collectPaymentMethod(intent: intent)
             }.flatMap { intent in
                 self.processPayment(intent: intent)
             }.flatMap { intent in
-                self.waitForInsertedCardToBeRemoved(intent: intent)
-            }.eraseToAnyPublisher()
+                self.waitForInsertedCardToBeRemoved()
+                    .map { intent }
+            }
+            .map(PaymentIntent.init(intent:))
+            .eraseToAnyPublisher()
     }
 
     public func cancelPaymentIntent() -> Future<Void, Error> {
@@ -406,7 +415,7 @@ private extension StripeCardReaderService {
         }
     }
 
-    func waitForInsertedCardToBeRemoved(intent: PaymentIntent) -> Future<PaymentIntent, Error> {
+    func waitForInsertedCardToBeRemoved() -> Future<Void, Error> {
         return Future() { [weak self] promise in
             guard let self = self else {
                 return
@@ -414,7 +423,7 @@ private extension StripeCardReaderService {
 
             // If there is no chip card inserted, it is ok to immediatedly return. The payment method may have been swipe or tap.
             if !self.isChipCardInserted {
-                return promise(.success(intent))
+                return promise(.success(()))
             }
 
             self.timerCancellable = Timer.publish(every: 1, tolerance: 0.1, on: .main, in: .default)
@@ -423,13 +432,13 @@ private extension StripeCardReaderService {
                 .sink(receiveValue: { _ in
                     if !self.isChipCardInserted {
                         self.timerCancellable?.cancel()
-                        return promise(.success(intent))
+                        return promise(.success(()))
                     }
                 })
         }
     }
 
-    func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<PaymentIntent, Error> {
+    func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {
         return Future() { [weak self] promise in
             Terminal.shared.processPayment(intent) { (intent, error) in
                 if let error = error {
@@ -438,7 +447,7 @@ private extension StripeCardReaderService {
                 }
 
                 if let intent = intent {
-                    promise(.success(PaymentIntent(intent: intent)))
+                    promise(.success(intent))
                     self?.activePaymentIntent = nil
                 }
             }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 - [*] Reviews: Fixed missing product information on first load [https://github.com/woocommerce/woocommerce-ios/pull/6367]
 - [internal] Removed the feature flag for My store tab UI updates. Please smoke test the store stats and top performers in the "My store" tab to make sure everything works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6334]
 - [*] In-Person Payments: Add support for accepting payments on bookable products [https://github.com/woocommerce/woocommerce-ios/pull/6364]
+- [*] In-Person Payments: Fixed issue where payment could be stuck prompting to remove the card if the payment was declined and retried before removing the card.
 
 8.6
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6392
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

If a payment fails and the customer hasn't removed the card from the reader before attempting the payment again, the app would stay stuck in the "Remove card" screen.

This PR will check if there is a card inserted and show the UI to remove the card before attempting a new payment.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. From the orders list, tap + to collect a simple payment
2. Add a test amount that would cause the payment to fail (e.g. 12.05)
3. Attempt to collect payment with card. Connect to the M2 reader if needed.
4. When prompted, insert (not tap or swipe) the card. Do not remove the card yet. The payment should be declined.
5. Tap "Try again" to attempt the payment a second time.
6. The app shows a "Remove card" modal. Removing the card resumes the payment flow.

Note that the payment will still fail because of the test amount, but it shouldn't get stuck in a modal.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
