### PR TITLE
Order Creation: Add support to delete orders in the Networking layer

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -238,6 +238,22 @@ public class OrdersRemote: Remote {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Deletes the given order.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site which hosts the Order.
+    ///   - orderID: Identifier of the Order to be deleted.
+    ///   - force: If true, the Order will be permanently deleted.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func deleteOrder(for siteID: Int64, orderID: Int64, force: Bool, completion: @escaping (Result<Order, Error>) -> Void) {
+        let path = "\(Constants.ordersPath)/\(orderID)"
+        let parameters = [ParameterKeys.force: String(force)]
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .delete, siteID: siteID, path: path, parameters: parameters)
+        let mapper = OrderMapper(siteID: siteID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -266,6 +282,7 @@ public extension OrdersRemote {
         static let fields: String           = "_fields"
         static let after: String            = "after"
         static let before: String           = "before"
+        static let force: String            = "force"
     }
 
     enum ParameterValues {


### PR DESCRIPTION
Part of: #5815

## Description

If a merchant exits order creation without creating the order, we want to be able to clean up by deleting the order if it was saved remotely. This adds support in the Networking layer to delete an order according to the [REST API documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#delete-an-order).

## Changes

* Adds a `deleteOrder` method to `OrdersRemote`. This method has the `force` parameter which gives the option to delete the order permanently (skipping the trash).
* Adds unit tests for the new order deletion method.

## Testing

Confirm tests pass in CI (endpoint is not yet used in app) and method matches documented API behavior.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
