### PR TITLE
Order Creation: Add support to delete orders in the Yosemite layer

### DIFF
--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -86,5 +86,5 @@ public enum OrderAction: Action {
 
     /// Deletes a given order.
     ///
-    case deleteOrder(siteID: Int64, orderID: Int64, deletePermanently: Bool, onCompletion: (Result<Order, Error>) -> Void)
+    case deleteOrder(siteID: Int64, order: Order, deletePermanently: Bool, onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -83,4 +83,8 @@ public enum OrderAction: Action {
                                    orderNote: String?,
                                    email: String?,
                                    onCompletion: (Result<Order, Error>) -> Void)
+
+    /// Deletes a given order.
+    ///
+    case deleteOrder(siteID: Int64, orderID: Int64, deletePermanently: Bool, onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -76,6 +76,8 @@ public class OrderStore: Store {
                                       orderNote: orderNote,
                                       email: email,
                                       onCompletion: onCompletion)
+        case let .deleteOrder(siteID, orderID, deletePermanently, onCompletion):
+            deleteOrder(siteID: siteID, orderID: orderID, deletePermanently: deletePermanently, onCompletion: onCompletion)
         }
     }
 }
@@ -365,6 +367,20 @@ private extension OrderStore {
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
                     onCompletion(result)
                 })
+            case .failure:
+                onCompletion(result)
+            }
+        }
+    }
+
+    /// Deletes a given order.
+    ///
+    func deleteOrder(siteID: Int64, orderID: Int64, deletePermanently: Bool, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        remote.deleteOrder(for: siteID, orderID: orderID, force: deletePermanently) { [weak self] result in
+            switch result {
+            case .success:
+                self?.deleteStoredOrder(siteID: siteID, orderID: orderID)
+                onCompletion(result)
             case .failure:
                 onCompletion(result)
             }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -76,8 +76,8 @@ public class OrderStore: Store {
                                       orderNote: orderNote,
                                       email: email,
                                       onCompletion: onCompletion)
-        case let .deleteOrder(siteID, orderID, deletePermanently, onCompletion):
-            deleteOrder(siteID: siteID, orderID: orderID, deletePermanently: deletePermanently, onCompletion: onCompletion)
+        case let .deleteOrder(siteID, order, deletePermanently, onCompletion):
+            deleteOrder(siteID: siteID, order: order, deletePermanently: deletePermanently, onCompletion: onCompletion)
         }
     }
 }
@@ -375,14 +375,22 @@ private extension OrderStore {
 
     /// Deletes a given order.
     ///
-    func deleteOrder(siteID: Int64, orderID: Int64, deletePermanently: Bool, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        remote.deleteOrder(for: siteID, orderID: orderID, force: deletePermanently) { [weak self] result in
+    func deleteOrder(siteID: Int64, order: Order, deletePermanently: Bool, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        // Optimistically delete the order from storage
+        deleteStoredOrder(siteID: siteID, orderID: order.orderID)
+
+        remote.deleteOrder(for: siteID, orderID: order.orderID, force: deletePermanently) { [weak self] result in
             switch result {
             case .success:
-                self?.deleteStoredOrder(siteID: siteID, orderID: orderID)
                 onCompletion(result)
             case .failure:
-                onCompletion(result)
+                // Revert optimistic deletion unless the order is an auto-draft (shouldn't be stored)
+                guard order.status != .autoDraft else {
+                    return onCompletion(result)
+                }
+                self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
+                    onCompletion(result)
+                })
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -827,6 +827,25 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
     }
+
+    func test_delete_order_removes_order_from_storage() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        store.upsertStoredOrder(readOnlyOrder: sampleOrder(), in: viewStorage)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
+
+        // When
+        let result: Result<Yosemite.Order, Error> = waitFor { promise in
+            let action = OrderAction.deleteOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID, deletePermanently: false) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)
+    }
 }
 
 


### PR DESCRIPTION
Part of: #5815
⚠️ Depends on #6394 ⚠️ 

## Description

If a merchant exits order creation without creating the order, we want to be able to clean up by deleting the order if it was saved remotely. This adds support in the Yosemite layer to delete an order.

## Changes

* Adds a `deleteOrder` action to `OrderAction`.
* Adds `deleteOrder` to `OrderStore`. If the order is successfully deleted remotely, the order is deleted (if needed) from storage.
* Adds a unit test to confirm the order is deleted from storage.

## Testing

Confirm tests pass in CI (endpoint is not yet used in app). You can also test firing this action with an existing order ID to confirm it deletes the order remotely and from storage as expected.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
