### PR TITLE
Order Creation - Order Sync: Commit all changes support

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -14,7 +14,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .orderCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderCreationRemoteSynchronizer:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .hubMenu:
             return true
         case .systemStatusReport:

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -287,7 +287,7 @@ public extension OrdersRemote {
 
     /// Order fields supported for update
     ///
-    enum UpdateOrderField {
+    enum UpdateOrderField: CaseIterable {
         case customerNote
         case shippingAddress
         case billingAddress

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -278,6 +278,34 @@ private extension RemoteOrderSynchronizer {
         }
         return input.updating(id: localIDStore.dispatchLocalID())
     }
+
+    /// Defines the order status that should be sent to the remote API for a given operation type.
+    ///
+    func orderStatus(for type: OperationType) -> OrderStatusEnum {
+        switch type {
+        case .sync:
+            return baseSyncStatus // When syncing always use the available draft status.
+        case .commit:
+            return order.status  // When committing changes always use the current order status.
+        }
+    }
+
+    /// Defines the order update fields that should be sent to the remote API for a given operation type.
+    ///
+    func orderUpdateFields(for type: OperationType) -> [OrderUpdateField] {
+        switch type {
+        case .sync:  // We only sync addresses, items, feels, and shipping lines.
+            return [
+                .shippingAddress,
+                .billingAddress,
+                .fees,
+                .shippingLines,
+                .items
+            ]
+        case .commit:
+            return OrderUpdateField.allCases // When committing changes, we update everything.
+        }
+    }
 }
 
 // MARK: Definitions
@@ -304,6 +332,18 @@ private extension RemoteOrderSynchronizer {
             currentID -= 1
             return currentID
         }
+    }
+
+    /// Defines the types of operations the synchronizer performs.
+    ///
+    enum OperationType {
+        /// Synching order operation type.
+        ///
+        case sync
+
+        /// Committing order changes operation type.
+        ///
+        case commit
     }
 }
 


### PR DESCRIPTION
Closes: #6143 

# Why 

Since all the necessary order properties can be synced, now it is time to commit the un-synced changes(order status as of today) when the user taps the create button.

# How

- Enable `orderCreationRemoteSynchronizer ` for all local devs & alpha builds.

- Implement `commitAllChanges` method from `RemoteOrderSynchronizer` to create or update the order.

- Added two helper methods `orderUpdateFields(for type: OperationType)` and `orderStatus(for type: OperationType) ` to be able to reuse the `createOrderRemotely` and `updateOrderRemotely` functions.

# Demo

https://user-images.githubusercontent.com/562080/157330914-0fe54b9f-05d8-4318-809a-a9f254c064fa.mov

# Testing Steps

- Navigate to the new order screen
- Add products, fees, shipping lines, customer details, status
- Tap on the create button
- See the order being created and visible on the order list.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
