### PR TITLE
Orders: Enhancements to split view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -93,10 +93,6 @@ final class OrderDetailsViewController: UIViewController {
         super.viewDidLayoutSubviews()
         tableView.updateHeaderHeight()
     }
-
-    override var shouldShowOfflineBanner: Bool {
-        return true
-    }
 }
 
 // MARK: - TableView Configuration

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -426,25 +426,6 @@ extension OrderListViewController {
 // MARK: - Split view helpers
 //
 private extension OrderListViewController {
-    /// Attempt showing details for first item if:
-    /// - the order detail screen is not already displayed
-    /// - the split view is not collapsed
-    /// - there's available data
-    ///
-    func attemptShowingDetailsForFirstItem() {
-        let secondaryColumnNavigationController = splitViewController?.viewController(for: .secondary) as? UINavigationController
-        let displayedOrderDetail = secondaryColumnNavigationController?.viewControllers.first as? OrderDetailsViewController
-
-        guard displayedOrderDetail == nil,
-              !dataSource.isEmpty,
-              splitViewController?.isCollapsed == false else {
-            return
-        }
-        let firstIndexPath = IndexPath(row: 0, section: 0)
-        tableView(tableView, didSelectRowAt: firstIndexPath)
-        tableView.selectRow(at: firstIndexPath, animated: false, scrollPosition: .none)
-    }
-
     /// Highlights the selected row if any row has been selected and the split view is not collapsed.
     /// Removes the selected state otherwise.
     ///
@@ -644,7 +625,7 @@ private extension OrderListViewController {
         case .syncing:
             ensureFooterSpinnerIsStarted()
         case .results:
-            attemptShowingDetailsForFirstItem()
+            break
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -93,10 +93,6 @@ final class OrdersRootViewController: UIViewController {
         ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
     }
 
-    override var shouldShowOfflineBanner: Bool {
-        return true
-    }
-
     /// Shows `SearchViewController`.
     ///
     @objc private func displaySearchOrders() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -25,6 +25,10 @@ final class OrdersSplitViewWrapperController: UIViewController {
         configureChildViewController()
     }
 
+    override var shouldShowOfflineBanner: Bool {
+        return true
+    }
+
     /// Presents the Details for the Notification with the specified Identifier.
     ///
     func presentDetails(for note: Note) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -51,16 +51,20 @@ private extension OrdersSplitViewWrapperController {
         ordersNavigationController.viewControllers = [ordersViewController]
 
         // workaround to remove extra space at the bottom when embedded in spit view
-        let ghostTableViewController = GhostTableViewController()
-        let ghostTableViewNavigationController = WooNavigationController(rootViewController: ghostTableViewController)
+        let emptyStateViewController = EmptyStateViewController(style: .basic)
+        let config = EmptyStateViewController.Config.simple(
+            message: .init(string: Localization.emptyOrderDetails),
+            image: .emptySearchResultsImage
+        )
+        emptyStateViewController.configure(config)
 
-        ordersSplitViewController.viewControllers = [ordersNavigationController, ghostTableViewNavigationController]
+        ordersSplitViewController.viewControllers = [ordersNavigationController, emptyStateViewController]
     }
 
     /// Set up properties for `self` as a root tab bar controller.
     ///
     func configureTabBarItem() {
-        tabBarItem.title = NSLocalizedString("Orders", comment: "The title of the Orders tab.")
+        tabBarItem.title = Localization.ordersTabTitle
         tabBarItem.image = .pagesImage
         tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
     }
@@ -70,5 +74,13 @@ private extension OrdersSplitViewWrapperController {
         addChild(ordersSplitViewController)
         view.addSubview(contentView)
         ordersSplitViewController.didMove(toParent: self)
+    }
+}
+
+extension OrdersSplitViewWrapperController {
+    private enum Localization {
+        static let ordersTabTitle = NSLocalizedString("Orders", comment: "The title of the Orders tab.")
+        static let emptyOrderDetails = NSLocalizedString("No order selected",
+                                                         comment: "Message on the detail view of the Orders tab before any order is selected")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -177,6 +177,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     /// Configure the elements to be displayed.
     ///
     func configure(_ config: Config) {
+        _ = view // trigger loading view before configuring contents
         configuration = config
         messageLabel.attributedText = config.message
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6381
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a few enhancements to the work in progress of split view in the Orders tab. Since the PR #6387 is already in review, I figure I should add these new updates in a separate PR:
- Update the offline banner to only display it on the split view wrapper controller instead of displaying it separately on the list and the details screens.
- In the previous PR, I was showing a loading view in place of the detail column initially. There's an edge case when merchants don't have any order yet - we don't want the placeholder there forever. So I decided to replace it with an empty view with the message "No order selected". That way - it makes sense even for an empty order list.

### Design reviews
Design team - please take a look at the screenshots and let me know if the message and the image used in the empty view of the details column look alright.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Testing offline banner:
- Build the app to a device because the simulator doesn't detect network availability correctly.
- Switch to the Orders tab and select any order, notice that the banner still looks great on both phones and tablets.

Testing initial state of the detail column:
- Build the app and switch to the Orders tab. Notice that an empty state is displayed in the second column initially. We are no longer select the first row automatically.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| List with data | Empty list |
| ----- | ----- | 
| <img src="https://user-images.githubusercontent.com/5533851/157430499-8bbe256f-7465-486e-8ca5-2050fda8fa6c.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/157430579-5f2547bc-34a4-4c4c-97f9-f8b3f1b492e5.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
