### PR TITLE
Order Creation: Properly reflect disabled states

### DIFF
--- a/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
+++ b/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
@@ -94,18 +94,26 @@ struct WooNavigationBarStyle: ViewModifier {
 }
 
 struct LinkStyle: ViewModifier {
+    /// Environment `enabled` state.
+    ///
+    @Environment(\.isEnabled) var isEnabled
+
     func body(content: Content) -> some View {
         content
             .font(.body)
-            .foregroundColor(Color(.accent))
+            .foregroundColor(isEnabled ? Color(.accent) : Color(.textTertiary))
     }
 }
 
 struct HeadlineLinkStyle: ViewModifier {
+    /// Environment `enabled` state.
+    ///
+    @Environment(\.isEnabled) var isEnabled
+
     func body(content: Content) -> some View {
         content
             .font(.headline)
-            .foregroundColor(Color(.accent))
+            .foregroundColor(isEnabled ? Color(.accent) : Color(.textTertiary))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -198,6 +198,8 @@ private struct LinkButton: View {
 }
 
 private struct PlusButton: View {
+    @Environment(\.isEnabled) var isEnabled
+
     let configuration: ButtonStyleConfiguration
 
     var body: some View {
@@ -215,7 +217,11 @@ private struct PlusButton: View {
     }
 
     var foregroundColor: UIColor {
-        configuration.isPressed ? .accentDark : .accent
+        if isEnabled {
+            return configuration.isPressed ? .accentDark : .accent
+        } else {
+            return .buttonDisabledTitle
+        }
     }
 }
 
@@ -247,6 +253,10 @@ struct PrimaryButton_Previews: PreviewProvider {
 
             Button("Plus button") {}
                 .buttonStyle(PlusButtonStyle())
+
+            Button("Plus button (disabled)") {}
+            .buttonStyle(PlusButtonStyle())
+            .disabled(true)
         }
         .padding()
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -184,6 +184,8 @@ private struct SecondaryButton: View {
 }
 
 private struct LinkButton: View {
+    @Environment(\.isEnabled) var isEnabled
+
     let configuration: ButtonStyleConfiguration
 
     var body: some View {
@@ -193,7 +195,11 @@ private struct LinkButton: View {
     }
 
     var foregroundColor: UIColor {
-        configuration.isPressed ? .accentDark : .accent
+        if isEnabled {
+            return configuration.isPressed ? .accentDark : .accent
+        } else {
+            return .buttonDisabledTitle
+        }
     }
 }
 
@@ -250,6 +256,10 @@ struct PrimaryButton_Previews: PreviewProvider {
 
             Button("Link button") {}
                 .buttonStyle(LinkButtonStyle())
+
+            Button("Link button (Disabled)") {}
+            .buttonStyle(LinkButtonStyle())
+            .disabled(true)
 
             Button("Plus button") {}
                 .buttonStyle(PlusButtonStyle())


### PR DESCRIPTION
Closes: #6328  

# Why

When synching or creating an order we set the `NewOrder` view components as disabled to prevent the merchant to make any change while we submit additive changes.

Prior to this PR, some view components did not reflect properly the disabled state. 

# How

- Update the necessary view components & modifiers to render its foreground color depending on the `isEnabled` environment value.

# Demo

https://user-images.githubusercontent.com/562080/157473487-1da40f4b-cf0c-4de3-bf31-f76b2fd8def4.mov

# Testing Steps

- Navigate to the new order screen
- Start performing additive changes. (Add product | add fees | add shipping)
- See the actionable view components reflect a proper disabled style.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
