### PR TITLE
Order Creation: Removes orderCreationRemoteSynchronizer feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -13,8 +13,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .orderCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .orderCreationRemoteSynchronizer:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .hubMenu:
             return true
         case .systemStatusReport:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -26,10 +26,6 @@ public enum FeatureFlag: Int {
     ///
     case orderCreation
 
-    /// Allows new orders to be created and synced as drafts
-    ///
-    case orderCreationRemoteSynchronizer
-
     /// Display the new tab "Menu" in the tab bar.
     ///
     case hubMenu

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -159,7 +159,7 @@ final class NewOrderViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          analytics: Analytics = ServiceLocator.analytics,
-         enableRemoteSync: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreationRemoteSynchronizer)) {
+         enableRemoteSync: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation)) {
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -53,7 +53,7 @@ struct OrderPaymentSection: View {
 
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}
 
-            if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreationRemoteSynchronizer) {
+            if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) {
                 Text(Localization.taxesInfo)
                     .footnoteStyle()
                     .padding([.horizontal, .bottom])


### PR DESCRIPTION
# Why

Since the `RemoteOrderSynchronizer` is now complete, we don't need its feature flag and continue development behind the main `.orderCreation` feature flag.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
