### PR TITLE
Adding bulk price settings view controller

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
@@ -117,7 +117,7 @@ final class BulkUpdatePriceSettingsViewModel {
     /// Update the button state to enable/disable based on price value
     ///
     private func updateButtonStateBasedOnCurrentPrice() {
-        // While the keyboard is in loading state do not change the state
+        // While the action button is a loading state do not change the state
         guard saveButtonState != .loading else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
@@ -44,6 +44,9 @@ final class BulkUpdatePriceViewController: UIViewController {
     ///
     func configureSaveButton() {
         saveButton.applyPrimaryButtonStyle()
+        // The transparency of the disable state makes content of the tableview appear to overlap with the button
+        // So we give it a solid background color to match the tableView
+        saveButton.backgroundColor = .listBackground
         saveButton.setTitle(Localization.saveButtonTitle, for: .normal)
         saveButton.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
     }
@@ -155,6 +158,8 @@ extension BulkUpdatePriceViewController {
         let bottomInset = keyboardHeight > 0 ? keyboardHeight - view.safeAreaInsets.bottom : keyboardHeight
 
         saveButtonToBottom?.constant = bottomInset + Constants.saveButtonToBottomInset
+        tableView.contentInset.bottom = bottomInset
+        tableView.verticalScrollIndicatorInsets.bottom = bottomInset
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
@@ -40,7 +40,7 @@ final class BulkUpdatePriceViewController: UIViewController {
         keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
     }
 
-    /// Configures the  title and appearance of the save button
+    /// Configures the title and appearance of the save button
     ///
     func configureSaveButton() {
         saveButton.applyPrimaryButtonStyle()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
@@ -63,8 +63,6 @@ final class BulkUpdatePriceViewController: UIViewController {
 
             if state == .loading {
                 self?.saveButton.showActivityIndicator()
-                // Dismiss the keyboard while we are in loading state
-                self?.view.endEditing(true)
             } else {
                 self?.saveButton.hideActivityIndicator()
             }
@@ -91,6 +89,8 @@ final class BulkUpdatePriceViewController: UIViewController {
     /// Called when the save button is tapped to update the price for all variations
     ///
     @objc private func saveButtonTapped() {
+        // Dismiss the keyboard before triggering the update
+        view.endEditing(true)
         viewModel.saveButtonTapped()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
@@ -1,0 +1,193 @@
+import Foundation
+import UIKit
+import Yosemite
+import Combine
+import WordPressKit
+
+// MARK: - BulkUpdatePriceViewController
+//
+final class BulkUpdatePriceViewController: UIViewController {
+
+    @IBOutlet weak private var tableView: UITableView!
+    @IBOutlet weak var saveButtonToBottom: NSLayoutConstraint!
+    @IBOutlet weak var saveButton: ButtonActivityIndicator!
+
+    private var viewModel: BulkUpdatePriceSettingsViewModel
+    private var subscriptions = Set<AnyCancellable>()
+
+    /// Tracking when the keyboard appears to keep the save button visible.
+    ///
+    private lazy var keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: { [weak self] frame in
+        self?.handleKeyboardFrameUpdate(keyboardFrame: frame)
+    })
+
+    init(viewModel: BulkUpdatePriceSettingsViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTitleAndBackground()
+        configureTableView()
+        configureSaveButton()
+        configureViewModel()
+        keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
+    }
+
+    /// Configures the  title and appearance of the save button
+    ///
+    func configureSaveButton() {
+        saveButton.applyPrimaryButtonStyle()
+        saveButton.setTitle(Localization.saveButtonTitle, for: .normal)
+        saveButton.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
+    }
+
+    /// Configures the screen title and background
+    ///
+    private func configureTitleAndBackground() {
+        title = viewModel.screenTitle()
+        view.backgroundColor = .listBackground
+    }
+
+    /// Setup receiving updates for data changes from the view model
+    ///
+    private func configureViewModel() {
+        viewModel.$saveButtonState.sink { [weak self] state in
+            self?.saveButton.isEnabled = state == .enabled
+
+            if state == .loading {
+                self?.saveButton.showActivityIndicator()
+                // Dismiss the keyboard while we are in loading state
+                self?.view.endEditing(true)
+            } else {
+                self?.saveButton.hideActivityIndicator()
+            }
+        }.store(in: &subscriptions)
+    }
+
+    /// Configures the table view: registers Nibs & setup dataSource
+    ///
+    private func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        registerTableViewCells()
+
+        tableView.dataSource = self
+    }
+
+    private func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+    }
+
+    /// Called when the save button is tapped to update the price for all variations
+    ///
+    @objc private func saveButtonTapped() {
+        viewModel.saveButtonTapped()
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension BulkUpdatePriceViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = viewModel.sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, at: indexPath)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return viewModel.sections[section].footer
+    }
+}
+
+// MARK: - Cell configuration
+//
+private extension BulkUpdatePriceViewController {
+    /// Configures a cell
+    ///
+    func configure(_ cell: UITableViewCell, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as UnitInputTableViewCell:
+            let cellViewModel = Product.createRegularPriceViewModel(regularPrice: viewModel.currentPrice,
+                                                                    using: ServiceLocator.currencySettings) { [weak self] value in
+                self?.viewModel.handlePriceChange(value)
+            }
+            cell.selectionStyle = .none
+            cell.configure(viewModel: cellViewModel)
+        default:
+            fatalError("Unidentified bulk update row type")
+            break
+        }
+    }
+}
+
+// MARK: - Methods for handling the [dis]appearance of the keyboard
+//
+extension BulkUpdatePriceViewController {
+    private func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
+        let keyboardHeight = keyboardFrame.height
+        // Home Indicator safe area height is included in the keyboardHeight
+        // and since our constant is with the bottom safe are we do not want to add it two times
+        let bottomInset = keyboardHeight > 0 ? keyboardHeight - view.safeAreaInsets.bottom : keyboardHeight
+
+        saveButtonToBottom?.constant = bottomInset + Constants.saveButtonToBottomInset
+    }
+}
+
+extension BulkUpdatePriceViewController {
+
+    struct Section: Equatable {
+        let footer: String?
+        let rows: [Row]
+    }
+
+    enum Row: CaseIterable {
+        case price
+
+        fileprivate var type: UITableViewCell.Type {
+            switch self {
+            case .price:
+                return UnitInputTableViewCell.self
+            }
+        }
+
+        fileprivate var reuseIdentifier: String {
+            return type.reuseIdentifier
+        }
+    }
+}
+
+private extension BulkUpdatePriceViewController {
+    enum Localization {
+        static let saveButtonTitle = NSLocalizedString("Save", comment: "Button title that save the price selection for bulk variation update")
+    }
+}
+
+private struct Constants {
+    /// THe distance of the save button from the bottom
+    static let saveButtonToBottomInset = 16.0
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
@@ -151,7 +151,7 @@ extension BulkUpdatePriceViewController {
     private func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
         let keyboardHeight = keyboardFrame.height
         // Home Indicator safe area height is included in the keyboardHeight
-        // and since our constant is with the bottom safe are we do not want to add it two times
+        // and since our save button constraint is with the bottom safe are we do not want to add it two times
         let bottomInset = keyboardHeight > 0 ? keyboardHeight - view.safeAreaInsets.bottom : keyboardHeight
 
         saveButtonToBottom?.constant = bottomInset + Constants.saveButtonToBottomInset

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.xib
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BulkUpdatePriceViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="saveButton" destination="X1b-gF-s7m" id="n02-Ea-zBg"/>
+                <outlet property="saveButtonToBottom" destination="Gf8-46-2fD" id="J6g-lE-j5E"/>
+                <outlet property="tableView" destination="B7D-HL-T2u" id="hXx-fu-ZKw"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="B7D-HL-T2u">
+                    <rect key="frame" x="0.0" y="44" width="390" height="700"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X1b-gF-s7m" customClass="ButtonActivityIndicator" customModule="WooCommerce" customModuleProvider="target">
+                    <rect key="frame" x="16" y="760" width="358" height="34"/>
+                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                    <state key="normal" title="Button"/>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="X1b-gF-s7m" secondAttribute="bottom" constant="16" id="Gf8-46-2fD"/>
+                <constraint firstItem="B7D-HL-T2u" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="HpD-hD-bmb"/>
+                <constraint firstItem="B7D-HL-T2u" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="L7I-pg-JWg"/>
+                <constraint firstItem="B7D-HL-T2u" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" constant="-66" id="kET-6V-oIh"/>
+                <constraint firstItem="X1b-gF-s7m" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="pc2-rD-UrA"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="X1b-gF-s7m" secondAttribute="trailing" constant="16" id="wAU-2T-K2x"/>
+                <constraint firstItem="B7D-HL-T2u" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="zba-Si-zxe"/>
+            </constraints>
+            <point key="canvasLocation" x="-383" y="-78"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -166,7 +166,7 @@ final class BulkUpdateViewController: UIViewController {
             self.navigationController?.popToViewController(self, animated: true)
         })
         let viewController = BulkUpdatePriceViewController(viewModel: bulkUpdatePriceSettingsViewModel)
-        navigationController?.pushViewController(viewController, animated: true)
+        show(viewController, sender: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -162,7 +162,8 @@ final class BulkUpdateViewController: UIViewController {
     ///
     private func navigateToEditPriceSettings() {
         let bulkUpdatePriceSettingsViewModel = viewModel.viewModelForBulkUpdatePriceOfType(.regular, priceUpdateDidFinish: { [weak self] in
-            self?.navigationController?.popToRootViewController(animated: true)
+            guard let self = self else { return }
+            self.navigationController?.popToViewController(self, animated: true)
         })
         let viewController = BulkUpdatePriceViewController(viewModel: bulkUpdatePriceSettingsViewModel)
         navigationController?.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -157,6 +157,16 @@ final class BulkUpdateViewController: UIViewController {
 
         noticePresenter.enqueue(notice: notice)
     }
+
+    /// Called when the price option is selected
+    ///
+    private func navigateToEditPriceSettings() {
+        let bulkUpdatePriceSettingsViewModel = viewModel.viewModelForBulkUpdatePriceOfType(.regular, priceUpdateDidFinish: { [weak self] in
+            self?.navigationController?.popToRootViewController(animated: true)
+        })
+        let viewController = BulkUpdatePriceViewController(viewModel: bulkUpdatePriceSettingsViewModel)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
 }
 
 // MARK: - UITableViewDataSource Conformance
@@ -206,6 +216,15 @@ private extension BulkUpdateViewController {
 // MARK: - UITableViewDelegate Conformance
 //
 extension BulkUpdateViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let row = rowAtIndexPath(indexPath)
+
+        switch row {
+        case .regularPrice:
+            navigateToEditPriceSettings()
+        }
+    }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -105,6 +105,18 @@ final class BulkUpdateViewModel {
         onCancelButtonTapped()
     }
 
+    /// Creates a view model for the bulk price setting.
+    ///
+    func viewModelForBulkUpdatePriceOfType(_ editingPriceType: BulkUpdatePriceSettingsViewModel.EditingPriceType,
+                                           priceUpdateDidFinish: @escaping () -> Void) -> BulkUpdatePriceSettingsViewModel {
+        return BulkUpdatePriceSettingsViewModel(siteID: siteID,
+                                                productID: productID,
+                                                bulkUpdateOptionsModel: bulkUpdateFormModel,
+                                                editingPriceType: editingPriceType,
+                                                priceUpdateDidFinish: priceUpdateDidFinish)
+
+    }
+
     /// Provides the view model with all user facing data of the option for updating the regular price
     ///
     func viewModelForDisplayingRegularPrice() -> ValueOneTableViewCell.ViewModel {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -416,6 +416,8 @@
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
 		03FBDAFD263EE4E800ACE257 /* CouponListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */; };
+		09468D9027D5014E0054A751 /* BulkUpdatePriceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09468D8F27D5014E0054A751 /* BulkUpdatePriceViewController.swift */; };
+		09468D9227D501990054A751 /* BulkUpdatePriceViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09468D9127D501980054A751 /* BulkUpdatePriceViewController.xib */; };
 		094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */; };
 		095A077E27CF486C007A61D2 /* ValueOneTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095A077D27CF486C007A61D2 /* ValueOneTableViewCellTests.swift */; };
 		0968B80C27CFB2EF0021210A /* BulkUpdateOptionsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0968B80B27CFB2EF0021210A /* BulkUpdateOptionsModelTests.swift */; };
@@ -2094,6 +2096,8 @@
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
 		03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModelTests.swift; sourceTree = "<group>"; };
+		09468D8F27D5014E0054A751 /* BulkUpdatePriceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdatePriceViewController.swift; sourceTree = "<group>"; };
+		09468D9127D501980054A751 /* BulkUpdatePriceViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BulkUpdatePriceViewController.xib; sourceTree = "<group>"; };
 		094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModelTests.swift; sourceTree = "<group>"; };
 		095A077D27CF486C007A61D2 /* ValueOneTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueOneTableViewCellTests.swift; sourceTree = "<group>"; };
 		0968B80B27CFB2EF0021210A /* BulkUpdateOptionsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateOptionsModelTests.swift; sourceTree = "<group>"; };
@@ -4376,6 +4380,8 @@
 			isa = PBXGroup;
 			children = (
 				09BE3A8D27C91E730070B69D /* BulkUpdatePriceSettingsViewModel.swift */,
+				09468D9127D501980054A751 /* BulkUpdatePriceViewController.xib */,
+				09468D8F27D5014E0054A751 /* BulkUpdatePriceViewController.swift */,
 			);
 			path = "Bulk Edit Price";
 			sourceTree = "<group>";
@@ -8093,6 +8099,7 @@
 				31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */,
 				02F4F510237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.xib in Resources */,
 				45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */,
+				09468D9227D501990054A751 /* BulkUpdatePriceViewController.xib in Resources */,
 				45A0E4CC2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib in Resources */,
 				45FBDF39238D3F8800127F77 /* ExtendedAddProductImageCollectionViewCell.xib in Resources */,
 				77E53EB9250E6A4E003D385F /* ProductDownloadListViewController.xib in Resources */,
@@ -8905,6 +8912,7 @@
 				268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */,
 				CE35F11B2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift in Sources */,
 				D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */,
+				09468D9027D5014E0054A751 /* BulkUpdatePriceViewController.swift in Sources */,
 				0279F0DA252DB4BE0098D7DE /* ProductVariationDetailsFactory.swift in Sources */,
 				DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,


### PR DESCRIPTION
Part of: #6242 & #6239

### Description
Adds the view controller that allows the user to enter a new regular price and bulk update all the product variations.
This view controller is pushed when the regular price cell is tapped in the bulk update screen #6239.
The view controller has a tableview with a single cell `UnitInputTableViewCell` that contains the textfield where the user enters the price. The tableView does not extent to cover the whole view, an area at the bottom of the view is the place of the save button(of type `ButtonActivityIndicator`). The keyboard is monitored using the `KeyboardFrameObserver` and the constraint of the save button to the bottom is adjusted in order to always be 16 points above the keyboard.

The `UnitInputTableViewCell` currently has the same style as in the single variation price update, I will provide the style to match the mockups in a followup pull request(that has only the price input on the left, we have a sub-task for this).
Price change events are send to the view model, and it updates the state of the button accordingly. The view controller receives events for the state of the button and is enabled if we have a non empty price.

When the save button is tapped the API call is triggered, the keyboard is dismissed and for the duration of the call the button displays an activity indicator(and can not be tapped).
If the bulk update is successful the view controller is popped from the navigation stack. In case of error the user will remain in the current screen. In both cases an `Notice` will be displayed that will be added in a follow up pull request(, we have a sub-task for this).  
The view controller also has a footer text that displays a text informing the user about the current price of the variations and the number of variations to be updated. Plural variations have been taken in to account. To create this text we are passing in the initializer of the `BulkUpdatePriceSettingsViewModel` a  BulkUpdateOptionsModel instead of an array of product variations.

### Testing instructions
1. Goto the products tab
2. Select a product with variations
3. Go to the list of variations
4. Tap on the "more" button in the navigation bar
5. Select the "Bulk update"
6. The bulk update screen should appear, select the regular price option
7. The price setting screen should appear
8. Enter a valid price, the save button should be enabled only if the price is non empty
9. Bellow the price field a text should be displayed that depending if the variations have the same price or not the footer text have the following values:
Current price is <formated price>. The price will be updated for <number of variations> variation[s].
Current prices are mixed.. The price will be updated for <number of variations> variation[s].
Current price is not set. The price will be updated for <number of variations> variation[s].
10. Tap save button, the keyboard should be dismissed and a loading indicator should be displayed in the save button
11. The price should be updated and the user returned to the previous bulk update screen




https://user-images.githubusercontent.com/96764631/157611395-15e18cf0-defc-4108-8e0c-b7724a86af07.mp4



https://user-images.githubusercontent.com/96764631/157609296-a1ccfea3-cd5f-4820-9d39-c53adf6650bb.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
