### PR TITLE
[Mobile Payments] Update LearnMore link in IPP flows

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -122,7 +122,6 @@ extension WooConstants {
         /// URL for adding a payment method in WCShip extension
         ///
         case addPaymentMethodWCShip = "https://wordpress.com/me/purchases/add-payment-method"
-    
 
 #if DEBUG
         case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-testing"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -122,14 +122,7 @@ extension WooConstants {
         /// URL for adding a payment method in WCShip extension
         ///
         case addPaymentMethodWCShip = "https://wordpress.com/me/purchases/add-payment-method"
-        
-        /// URL for IPP with WCPay documentation
-        ///
-        case inPersonPaymentsLearnMoreWCPay = "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
-        
-        /// URL for IPP with Stripe Extension documentation
-        ///
-        case inPersonPaymentsLearnMoreStripe = "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"
+    
 
 #if DEBUG
         case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-testing"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -126,7 +126,7 @@ extension WooConstants {
         /// URL for WCPay IPP documentation
         ///
         case inPersonPaymentsLearnMoreWCPay = "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
-        
+
         /// URL for Stripe IPP documentation
         ///
         case inPersonPaymentsLearnMoreStripe = "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -123,6 +123,14 @@ extension WooConstants {
         ///
         case addPaymentMethodWCShip = "https://wordpress.com/me/purchases/add-payment-method"
 
+        /// URL for WCPay IPP documentation
+        ///
+        case inPersonPaymentsLearnMoreWCPay = "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
+        
+        /// URL for Stripe IPP documentation
+        ///
+        case inPersonPaymentsLearnMoreStripe = "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"
+
 #if DEBUG
         case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-testing"
 #else

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -122,6 +122,14 @@ extension WooConstants {
         /// URL for adding a payment method in WCShip extension
         ///
         case addPaymentMethodWCShip = "https://wordpress.com/me/purchases/add-payment-method"
+        
+        /// URL for IPP with WCPay documentation
+        ///
+        case inPersonPaymentsLearnMoreWCPay = "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
+        
+        /// URL for IPP with Stripe Extension documentation
+        ///
+        case inPersonPaymentsLearnMoreStripe = "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"
 
 #if DEBUG
         case simplePaymentsPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-testing"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -49,11 +49,8 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
         }
 
         self.viewModel?.didUpdate = onViewModelDidUpdate
-        Task {
-            if let url = await self.viewModel?.learnMoreURL {
-                rootView.learnMoreUrl = url
-            }
-        }
+
+        rootView.learnMoreUrl = self.viewModel?.learnMoreURL
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -144,10 +144,10 @@ struct CardReaderSettingsSearchingView: View {
             InPersonPaymentsLearnMore()
                 .customOpenURL(action: { url in
                     switch url {
-                        case InPersonPaymentsLearnMore.learnMoreURL:
-                            showURL?(....)
-                        default:
-                            showURL?(url)
+                    // case InPersonPaymentsLearnMore.learnMoreURL:
+                        // if let url = viewModel.learnMoreURL { showURL?(url) }
+                    default:
+                        showURL?(url)
                     }
                 })
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -142,7 +142,14 @@ struct CardReaderSettingsSearchingView: View {
                 .padding(.bottom, 8)
 
             InPersonPaymentsLearnMore()
-                .customOpenURL(action: {url in showURL?(url)})
+                .customOpenURL(action: { url in
+                    switch url {
+                        case InPersonPaymentsLearnMore.learnMoreURL:
+                            showURL?(....)
+                        default:
+                            showURL?(url)
+                    }
+                })
         }
             .frame(
                 maxWidth: .infinity,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -49,6 +49,11 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
         }
 
         self.viewModel?.didUpdate = onViewModelDidUpdate
+        Task {
+            if let url = await self.viewModel?.learnMoreURL {
+                rootView.learnMoreUrl = url
+            }
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -109,6 +114,7 @@ private extension CardReaderSettingsSearchingViewController {
 struct CardReaderSettingsSearchingView: View {
     var connectClickAction: (() -> Void)? = nil
     var showURL: ((URL) -> Void)? = nil
+    var learnMoreUrl: URL? = nil
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
@@ -144,8 +150,10 @@ struct CardReaderSettingsSearchingView: View {
             InPersonPaymentsLearnMore()
                 .customOpenURL(action: { url in
                     switch url {
-                    // case InPersonPaymentsLearnMore.learnMoreURL:
-                        // if let url = viewModel.learnMoreURL { showURL?(url) }
+                    case InPersonPaymentsLearnMore.learnMoreURL:
+                        if let url = learnMoreUrl {
+                            showURL?(url)
+                        }
                     default:
                         showURL?(url)
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
@@ -97,7 +97,7 @@ final class CardReaderSettingsSearchingViewModel: CardReaderSettingsPresentedVie
             didChangeShouldShow?(shouldShow)
         }
     }
-    
+
     private func updateLearnMoreURL() {
         let loadLearnMoreUrlAction = CardPresentPaymentAction
             .loadLearnMoreURL(preferredPaymentGateway: nil) { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
@@ -6,24 +6,7 @@ final class CardReaderSettingsSearchingViewModel: CardReaderSettingsPresentedVie
     private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
     var didUpdate: (() -> Void)?
-    var learnMoreURL: URL {
-        get async {
-                return await withCheckedContinuation({
-                    (continuation: CheckedContinuation<URL, Never>) in
-                    let loadLearnMoreUrlAction = CardPresentPaymentAction
-                        .loadActivePaymentGatewayExtension() { result in
-                                switch result {
-                                case .wcpay:
-                                    continuation.resume(returning: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
-                                case .stripe:
-                                    continuation.resume(returning: WooConstants.URLs.inPersonPaymentsLearnMoreStripe.asURL())
-                                }
-                        }
-                    stores.dispatch(loadLearnMoreUrlAction)
-                })
-        }
-    }
-    let stores: StoresManager
+    var learnMoreURL: URL? = nil
 
     private(set) var noConnectedReader: CardReaderSettingsTriState = .isUnknown {
         didSet {
@@ -50,13 +33,13 @@ final class CardReaderSettingsSearchingViewModel: CardReaderSettingsPresentedVie
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?, knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil,
          stores: StoresManager = ServiceLocator.stores
     ) {
-        self.stores = stores
         self.didChangeShouldShow = didChangeShouldShow
         self.siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
         self.knownReaderProvider = knownReaderProvider
 
         beginKnownReaderObservation()
         beginConnectedReaderObservation()
+        updateLearnMoreUrl(stores: stores)
     }
 
     deinit {
@@ -111,5 +94,20 @@ final class CardReaderSettingsSearchingViewModel: CardReaderSettingsPresentedVie
         if didChange {
             didChangeShouldShow?(shouldShow)
         }
+    }
+
+    /// Load active payment gateway plugin from the payment store and update learn more url
+    ///
+    private func updateLearnMoreUrl(stores: StoresManager) {
+        let loadLearnMoreUrlAction = CardPresentPaymentAction
+            .loadActivePaymentGatewayExtension() { [weak self] result in
+                switch result {
+                case .wcpay:
+                    self?.learnMoreURL = WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL()
+                case .stripe:
+                    self?.learnMoreURL = WooConstants.URLs.inPersonPaymentsLearnMoreStripe.asURL()
+                }
+            }
+        stores.dispatch(loadLearnMoreUrlAction)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -159,7 +159,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             // have Stripe. In that case, we can tell them that IPP is not supported for Stripe in
             // their country yet.
             if stripeInstalledAndActive(stripe: stripe) {
-                return .countryNotSupportedStripe(countryCode: countryCode)
+                return .countryNotSupportedStripe(plugin: .stripe, countryCode: countryCode)
             } else {
                 return wcPayOnlyOnboardingState(plugin: wcPay)
             }
@@ -219,16 +219,16 @@ private extension CardPresentPaymentsOnboardingUseCase {
             return .pluginInTestModeWithLiveStripeAccount(plugin: plugin)
         }
         guard !isStripeAccountUnderReview(account: account) else {
-            return .stripeAccountUnderReview
+            return .stripeAccountUnderReview(plugin: plugin)
         }
         guard !isStripeAccountOverdueRequirements(account: account) else {
-            return .stripeAccountOverdueRequirement
+            return .stripeAccountOverdueRequirement(plugin: plugin)
         }
         guard !isStripeAccountPendingRequirements(account: account) else {
-            return .stripeAccountPendingRequirement(deadline: account.currentDeadline)
+            return .stripeAccountPendingRequirement(plugin: plugin, deadline: account.currentDeadline)
         }
         guard !isStripeAccountRejected(account: account) else {
-            return .stripeAccountRejected
+            return .stripeAccountRejected(plugin: plugin)
         }
         guard !isInUndefinedState(account: account) else {
             return .genericError

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsLearnMore: View {
+    static let learnMoreURL = URL(string: "woocommerce://in-person-payments/learn-more")!
     @Environment(\.customOpenURL) var customOpenURL
 
     var body: some View {
@@ -15,7 +16,7 @@ struct InPersonPaymentsLearnMore: View {
             .padding(.vertical, Constants.verticalPadding)
             .onTapGesture {
                 ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
-                customOpenURL?(Constants.learnMoreURL!)
+                customOpenURL?(InPersonPaymentsLearnMore.learnMoreURL)
             }
     }
 
@@ -40,7 +41,6 @@ struct InPersonPaymentsLearnMore: View {
 
 private enum Constants {
     static let verticalPadding: CGFloat = 8
-    static let learnMoreURL = URL(string: "https://woocommerce.com/payments")
 }
 
 private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -71,7 +71,7 @@ struct InPersonPaymentsView: View {
             case InPersonPaymentsSupportLink.supportURL:
                 showSupport?()
             case InPersonPaymentsLearnMore.learnMoreURL:
-                showURL?(viewModel.learnMoreURL)
+                if let url = viewModel.learnMoreURL { showURL?(url) }
             default:
                 showURL?(url)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -70,6 +70,8 @@ struct InPersonPaymentsView: View {
             switch url {
             case InPersonPaymentsSupportLink.supportURL:
                 showSupport?()
+            case InPersonPaymentsLearnMore.learnMoreURL:
+                showURL?(viewModel.learnMoreURL)
             default:
                 showURL?(url)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -37,7 +37,7 @@ struct InPersonPaymentsView: View {
                 }
             case .countryNotSupported(let countryCode):
                 InPersonPaymentsCountryNotSupported(countryCode: countryCode)
-            case .countryNotSupportedStripe(let countryCode):
+            case .countryNotSupportedStripe(_, let countryCode):
                 InPersonPaymentsCountryNotSupportedStripe(countryCode: countryCode)
             case .pluginNotInstalled:
                 InPersonPaymentsPluginNotInstalled(onRefresh: viewModel.refresh)
@@ -52,7 +52,7 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsPluginNotSetup(plugin: plugin, onRefresh: viewModel.refresh)
             case .stripeAccountOverdueRequirement:
                 InPersonPaymentsStripeAccountOverdue()
-            case .stripeAccountPendingRequirement(let deadline):
+            case .stripeAccountPendingRequirement(_, let deadline):
                 InPersonPaymentsStripeAccountPending(deadline: deadline)
             case .stripeAccountUnderReview:
                 InPersonPaymentsStripeAcountReview()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -71,7 +71,9 @@ struct InPersonPaymentsView: View {
             case InPersonPaymentsSupportLink.supportURL:
                 showSupport?()
             case InPersonPaymentsLearnMore.learnMoreURL:
-                if let url = viewModel.learnMoreURL { showURL?(url) }
+                if let url = viewModel.learnMoreURL {
+                    showURL?(url)
+                }
             default:
                 showURL?(url)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -44,7 +44,12 @@ final class InPersonPaymentsViewModel: ObservableObject {
         case .pluginUnsupportedVersion(let plugin),
                 .pluginNotActivated(let plugin),
                 .pluginInTestModeWithLiveStripeAccount(let plugin),
-                .pluginSetupNotCompleted(let plugin):
+                .pluginSetupNotCompleted(let plugin),
+                .countryNotSupportedStripe(let plugin, _),
+                .stripeAccountUnderReview(let plugin),
+                .stripeAccountPendingRequirement(let plugin, _),
+                .stripeAccountOverdueRequirement(let plugin),
+                .stripeAccountRejected(let plugin):
             return getLearnMoreUrl(plugin: plugin)
         default:
             return getLearnMoreUrl(plugin: nil)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -47,7 +47,7 @@ final class InPersonPaymentsViewModel: ObservableObject {
     }
 
     private func updateLearnMoreURL(state: CardPresentPaymentOnboardingState) {
-        let preferredPlugin: CardPresentPaymentsPlugins?
+        let preferredPlugin: CardPresentPaymentsPlugins
         switch state {
         case .pluginUnsupportedVersion(let plugin),
                 .pluginNotActivated(let plugin),
@@ -60,14 +60,17 @@ final class InPersonPaymentsViewModel: ObservableObject {
                 .stripeAccountRejected(let plugin):
             preferredPlugin = plugin
         default:
-            preferredPlugin = nil
+            preferredPlugin = .wcPay
         }
 
-        let loadLearnMoreUrlAction = CardPresentPaymentAction
-            .loadLearnMoreURL(preferredPaymentGateway: preferredPlugin) { [weak self] result in
-                self?.learnMoreURL = result
+        learnMoreURL = { () -> URL in
+            switch preferredPlugin {
+            case .wcPay:
+                return WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL()
+            case .stripe:
+                return WooConstants.URLs.inPersonPaymentsLearnMoreStripe.asURL()
             }
-        stores.dispatch(loadLearnMoreUrlAction)
+        }()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -4,6 +4,9 @@ import Yosemite
 final class InPersonPaymentsViewModel: ObservableObject {
     @Published var state: CardPresentPaymentOnboardingState
     var userIsAdministrator: Bool
+    var learnMoreURL: URL {
+        get { return getLearnMoreUrl(state: state) }
+    }
     private let useCase = CardPresentPaymentsOnboardingUseCase()
 
 
@@ -34,6 +37,27 @@ final class InPersonPaymentsViewModel: ObservableObject {
     ///
     func refresh() {
         useCase.refresh()
+    }
+
+    private func getLearnMoreUrl(state: CardPresentPaymentOnboardingState) -> URL {
+        switch state {
+        case .pluginUnsupportedVersion(let plugin),
+                .pluginNotActivated(let plugin),
+                .pluginInTestModeWithLiveStripeAccount(let plugin),
+                .pluginSetupNotCompleted(let plugin):
+            return getLearnMoreUrl(plugin: plugin)
+        default:
+            return getLearnMoreUrl(plugin: nil)
+        }
+    }
+
+    private func getLearnMoreUrl(plugin: CardPresentPaymentsPlugins?) -> URL {
+        switch plugin {
+            case .stripe:
+                return WooConstants.URLs.inPersonPaymentsLearnMoreStripe.asURL()
+            case .wcPay, nil:
+                return WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -62,7 +62,7 @@ final class InPersonPaymentsViewModel: ObservableObject {
         default:
             preferredPlugin = nil
         }
-        
+
         let loadLearnMoreUrlAction = CardPresentPaymentAction
             .loadLearnMoreURL(preferredPaymentGateway: preferredPlugin) { [weak self] result in
                 self?.learnMoreURL = result

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -17,6 +17,7 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
     private var failUpdate: Bool
     private var failConnection: Bool
     private var softwareUpdateSubject: CurrentValueSubject<CardReaderSoftwareUpdateState, Never> = .init(.none)
+    private var paymentExtension: CardPresentPaymentGatewayExtension
 
     init(connectedReaders: [CardReader],
          discoveredReaders: [CardReader],
@@ -24,7 +25,8 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
          storageManager: StorageManagerType = MockStorageManager(),
          failDiscovery: Bool = false,
          failUpdate: Bool = false,
-         failConnection: Bool = false
+         failConnection: Bool = false,
+         paymentExtension: CardPresentPaymentGatewayExtension = .wcpay
     ) {
         self.connectedReaders = connectedReaders
         self.discoveredReaders = discoveredReaders
@@ -32,6 +34,7 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
         self.failUpdate = failUpdate
         self.failConnection = failConnection
         self.storageManager = storageManager
+        self.paymentExtension = paymentExtension
         super.init(sessionManager: sessionManager)
     }
 
@@ -83,6 +86,8 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
         case .loadAccounts(let siteID, let onCompletion):
             insertSamplePaymentGateway(forSiteID: siteID)
             onCompletion(Result.success(()))
+        case .loadActivePaymentGatewayExtension(let onCompletion):
+            onCompletion(paymentExtension)
         default:
             fatalError("Not available")
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -87,7 +87,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .countryNotSupportedStripe(countryCode: "CA"))
+        XCTAssertEqual(state, .countryNotSupportedStripe(plugin: .stripe, countryCode: "CA"))
     }
 
     func test_onboarding_does_not_return_country_unsupported_with_canada_for_wcpay() {
@@ -398,7 +398,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
     // MARK: - Payment Account checks
 
-    func test_onboarding_returns_plugin_setup_not_completed_with_nil_account_for_wcplay_plugin() {
+    func test_onboarding_returns_plugin_setup_not_completed_with_nil_account_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -412,7 +412,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .wcPay))
     }
 
-    func test_onboarding_returns_plugin_setup_not_completed_with_no_account_for_wcplay_plugin() {
+    func test_onboarding_returns_plugin_setup_not_completed_with_no_account_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -456,7 +456,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .stripe))
     }
 
-    func test_onboarding_returns_pending_requirements_when_account_is_restricted_with_pending_requirements_for_wcplay_plugin() {
+    func test_onboarding_returns_pending_requirements_when_account_is_restricted_with_pending_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -467,10 +467,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountPendingRequirement(deadline: nil))
+        XCTAssertEqual(state, .stripeAccountPendingRequirement(plugin: .wcPay, deadline: nil))
     }
 
-    func test_onboarding_returns_pending_requirements_when_account_is_restricted_soon_with_pending_requirements_for_wcplay_plugin() {
+    func test_onboarding_returns_pending_requirements_when_account_is_restricted_soon_with_pending_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -479,12 +479,11 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
         let state = useCase.state
-
         // Then
-        XCTAssertEqual(state, .stripeAccountPendingRequirement(deadline: nil))
+        XCTAssertEqual(state, .stripeAccountPendingRequirement(plugin: .wcPay, deadline: nil))
     }
 
-    func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_requirements_for_wcplay_plugin() {
+    func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -495,10 +494,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountOverdueRequirement)
+        XCTAssertEqual(state, .stripeAccountOverdueRequirement(plugin: .wcPay))
     }
 
-    func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_and_pending_requirements_for_wcplay_plugin() {
+    func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_and_pending_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -509,10 +508,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountOverdueRequirement)
+        XCTAssertEqual(state, .stripeAccountOverdueRequirement(plugin: .wcPay))
     }
 
-    func test_onboarding_returns_review_when_account_is_restricted_with_no_requirements_for_wcplay_plugin() {
+    func test_onboarding_returns_review_when_account_is_restricted_with_no_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -523,11 +522,11 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountUnderReview)
+        XCTAssertEqual(state, .stripeAccountUnderReview(plugin: .wcPay))
     }
 
 
-    func test_onboarding_returns_rejected_when_account_is_rejected_for_fraud_for_wcplay_plugin() {
+    func test_onboarding_returns_rejected_when_account_is_rejected_for_fraud_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -538,10 +537,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountRejected)
+        XCTAssertEqual(state, .stripeAccountRejected(plugin: .wcPay))
     }
 
-    func test_onboarding_returns_rejected_when_account_is_rejected_for_tos_for_wcplay_plugin() {
+    func test_onboarding_returns_rejected_when_account_is_rejected_for_tos_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -552,10 +551,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountRejected)
+        XCTAssertEqual(state, .stripeAccountRejected(plugin: .wcPay))
     }
 
-    func test_onboarding_returns_rejected_when_account_is_listed_for_wcplay_plugin() {
+    func test_onboarding_returns_rejected_when_account_is_listed_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -566,10 +565,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountRejected)
+        XCTAssertEqual(state, .stripeAccountRejected(plugin: .wcPay))
     }
 
-    func test_onboarding_returns_rejected_when_account_is_rejected_for_other_reasons_for_wcplay_plugin() {
+    func test_onboarding_returns_rejected_when_account_is_rejected_for_other_reasons_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -580,10 +579,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .stripeAccountRejected)
+        XCTAssertEqual(state, .stripeAccountRejected(plugin: .wcPay))
     }
 
-    func test_onboarding_returns_generic_error_when_account_status_unknown_for_wcplay_plugin() {
+    func test_onboarding_returns_generic_error_when_account_status_unknown_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
@@ -597,7 +596,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .genericError)
     }
 
-    func test_onboarding_returns_complete_when_account_is_setup_successfully_for_wcplay_plugin() {
+    func test_onboarding_returns_complete_when_account_is_setup_successfully_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		03FBDA2A263296C400ACE257 /* CouponStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA29263296C400ACE257 /* CouponStoreTests.swift */; };
 		03FBDA2E2632A9B400ACE257 /* MockCouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */; };
 		03FBDA3E2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */; };
+		073AF84427DB10270074EDF0 /* CardPresentPaymentGatewayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073AF84327DB10270074EDF0 /* CardPresentPaymentGatewayExtension.swift */; };
 		077F39DE26A5A1CB00ABEADC /* SystemStatusAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */; };
 		077F39E026A5A6F500ABEADC /* SystemStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */; };
 		077F39E226A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */; };
@@ -504,6 +505,7 @@
 		03FBDA29263296C400ACE257 /* CouponStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreTests.swift; sourceTree = "<group>"; };
 		03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponsRemote.swift; sourceTree = "<group>"; };
 		03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		073AF84327DB10270074EDF0 /* CardPresentPaymentGatewayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentGatewayExtension.swift; sourceTree = "<group>"; };
 		077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusAction.swift; sourceTree = "<group>"; };
 		077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStore.swift; sourceTree = "<group>"; };
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -814,6 +816,7 @@
 			isa = PBXGroup;
 			children = (
 				0212AC5D242C67FA00C51F6C /* ProductsSortOrder.swift */,
+				073AF84327DB10270074EDF0 /* CardPresentPaymentGatewayExtension.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1934,6 +1937,7 @@
 				D831E2E6230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift in Sources */,
 				CE4FD4502350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift in Sources */,
 				02FF055123D983F30058E6E7 /* MediaAssetExporter.swift in Sources */,
+				073AF84427DB10270074EDF0 /* CardPresentPaymentGatewayExtension.swift in Sources */,
 				45AB8B1724AA4B3D00B5B36E /* ProductTagStore.swift in Sources */,
 				02137903270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift in Sources */,
 				247CE8342582F20100F9D9D1 /* MockAppSettingsActionHandler.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -7,7 +7,7 @@ public enum CardPresentPaymentAction: Action {
     /// Sets the store to use a given payment gateway
     ///
     case use(paymentGatewayAccount: PaymentGatewayAccount)
-    
+
     /// Retrieves url of the documentation for the provided payment gateway.
     /// If no payment gateway is provided, returns url of the active payment gateway if not empty,
     /// otherwise url of wcpay documentation.

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -8,10 +8,9 @@ public enum CardPresentPaymentAction: Action {
     ///
     case use(paymentGatewayAccount: PaymentGatewayAccount)
 
-    /// Retrieves url of the documentation for the provided payment gateway.
-    /// If no payment gateway is provided, returns url of the active payment gateway if not empty,
-    /// otherwise url of wcpay documentation.
-    case loadLearnMoreURL(preferredPaymentGateway: CardPresentPaymentsPlugins?, onCompletion: (URL) -> Void)
+    /// Retrieves the current configuration for IPP.
+    ///
+    case loadActivePaymentGatewayExtension(onCompletion: (CardPresentPaymentGatewayExtension) -> Void)
 
     /// Retrieves and stores payment gateway account(s) for the provided `siteID`
     /// We support payment gateway accounts for both the WooCommerce Payments extension AND

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -7,6 +7,11 @@ public enum CardPresentPaymentAction: Action {
     /// Sets the store to use a given payment gateway
     ///
     case use(paymentGatewayAccount: PaymentGatewayAccount)
+    
+    /// Retrieves url of the documentation for the provided payment gateway.
+    /// If no payment gateway is provided, returns url of the active payment gateway if not empty,
+    /// otherwise url of wcpay documentation.
+    case loadLearnMoreURL(preferredPaymentGateway: CardPresentPaymentsPlugins?, onCompletion: (URL) -> Void)
 
     /// Retrieves and stores payment gateway account(s) for the provided `siteID`
     /// We support payment gateway accounts for both the WooCommerce Payments extension AND

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -18,7 +18,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// Store is not located in one of the supported countries for Stripe (but it is for WCPay).
     ///
-    case countryNotSupportedStripe(countryCode: String)
+    case countryNotSupportedStripe(plugin: CardPresentPaymentsPlugins, countryCode: String)
 
     /// No CPP plugin is installed on the store.
     ///
@@ -43,21 +43,21 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// The connected Stripe account has not been reviewed by Stripe yet. This is a temporary state and the user needs to wait.
     ///
-    case stripeAccountUnderReview
+    case stripeAccountUnderReview(plugin: CardPresentPaymentsPlugins)
 
     /// There are some pending requirements on the connected Stripe account. The merchant still has some time before the deadline to fix them expires.
     /// In-person payments should work without issues.
     ///
-    case stripeAccountPendingRequirement(deadline: Date?)
+    case stripeAccountPendingRequirement(plugin: CardPresentPaymentsPlugins, deadline: Date?)
 
     /// There are some overdue requirements on the connected Stripe account. Connecting to a reader or accepting payments is not supported in this state.
     ///
-    case stripeAccountOverdueRequirement
+    case stripeAccountOverdueRequirement(plugin: CardPresentPaymentsPlugins)
 
     /// The Stripe account was rejected by Stripe.
     /// This can happen for example when the account is flagged as fraudulent or the merchant violates the terms of service.
     ///
-    case stripeAccountRejected
+    case stripeAccountRejected(plugin: CardPresentPaymentsPlugins)
 
     /// Generic error - for example, one of the requests failed.
     ///

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -377,8 +377,10 @@ private extension CardPresentPaymentStore {
         }
 
         switch backend {
-            case CardPresentPaymentStoreBackend.wcpay: onCompletion(URL(string: "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/")!)
-            case CardPresentPaymentStoreBackend.stripe: onCompletion(URL(string: "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/")!)
+            case CardPresentPaymentStoreBackend.wcpay:
+                onCompletion(URL(string: "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/")!)
+            case CardPresentPaymentStoreBackend.stripe:
+                onCompletion(URL(string: "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/")!)
         }
     }
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -58,6 +58,9 @@ public final class CardPresentPaymentStore: Store {
         switch action {
         case .use(let account):
             use(paymentGatewayAccount: account)
+        case .loadLearnMoreURL(let preferredPaymentGateway,
+                               let completion):
+            loadLearnMoreUrl(preferredPaymentGateway: preferredPaymentGateway, onCompletion: completion)
         case .loadAccounts(let siteID, let onCompletion):
             loadAccounts(siteID: siteID,
                          onCompletion: onCompletion)
@@ -362,6 +365,21 @@ private extension CardPresentPaymentStore {
         }
 
         usingBackend = .wcpay
+    }
+
+    func loadLearnMoreUrl(preferredPaymentGateway: CardPresentPaymentsPlugins?, onCompletion: (URL) -> Void) {
+        let backend: CardPresentPaymentStoreBackend
+
+        switch preferredPaymentGateway {
+            case .wcPay: backend = CardPresentPaymentStoreBackend.wcpay
+            case .stripe: backend = CardPresentPaymentStoreBackend.stripe
+            case nil: backend = usingBackend
+        }
+
+        switch backend {
+            case CardPresentPaymentStoreBackend.wcpay: onCompletion(URL(string: "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/")!)
+            case CardPresentPaymentStoreBackend.stripe: onCompletion(URL(string: "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/")!)
+        }
     }
 
     /// Loads the account corresponding to the currently selected backend. Deletes the other (if it exists).

--- a/Yosemite/Yosemite/Stores/Enums/CardPresentPaymentGatewayExtension.swift
+++ b/Yosemite/Yosemite/Stores/Enums/CardPresentPaymentGatewayExtension.swift
@@ -1,0 +1,11 @@
+/// Payment Gateway used with In Person Payments
+///
+public enum CardPresentPaymentGatewayExtension {
+    /// WooCommerce Payments Extension
+    ///
+    case wcpay
+
+    /// Stripe Payment Gateway by WooCommerce Extension
+    ///
+    case stripe
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6045 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Implements navigation to IPP documentation based on the active payment gateway plugin - wcpay/stripe. If the active plugin is `Stripe` the app navigates to `https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/`, if it's `wcpay` or unknown it navigates to `https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/`.

The app supports navigation to IPP documentation from - onboarding error screens (`InPersonPaymentsViewController`) and connect to reader screen (`CardReaderSettingsSearchingViewController`).

I've tried different approaches and opted for introducing an action in Payments Store which returns the currently active plugin. The `CardReaderSettingsSearchingViewModel` can invoke this action and choose the URL based on the active plugin.

SideNotes:
- I also tried using `async/await` property and it worked nicely, however, the CI was complaining that async properties are not supported on ios 14 and lower.
- I also tried passing the active plugin into viewmodel's/controller's constructors and adding "docsUrl(..)" method in `CardPresentPaymentsConfiguration` but it turned out to be tricky, since we are using some kind of parent VM/Controller (CardReaderSettingsViewModelsOrderedList) and I couldn't figure out how to pass the active plugin from `CardReaderSettingsPresentingView` and it felt more hacky than the current solution anyway.
- I also considered returning a configuration instead of the active plugin directly from the newly introduced action, but since we already have `CardPresentPaymentsConfiguration` which doesn't know about the active plugin, introducing yet another configuration felt weird.

I think it might be worth to consider storing the active plugin into a persistent key-value store, but that's above the scope of this PR. Wdyt?

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Select a store with stripe extension installed but which fails the onboarding checks - eg. outdated plugin version
2. Select "In Person Payments" in the app settings
3. Tap on "learn more" button and notice you are navigated to "IPP with Stripe" documentation
4. Repeat the same steps with wcpay extension and verify "IPP with wcpay" documentation is shown
-------------------
1. Select a store with stripe extension installed and onboarding completed
2. Select "In Person Payments" in the app settings
3. Tap on "Manage card reader"
4. Tap on "Learn more" and notice you are navigated to "IPP with Stripe" documentation
5. Repeat the same steps with wcpay extension and verify "IPP with wcpay" documentation is shown

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2261188/157836452-51e9df3e-0fff-4c00-b7f7-06d2ab543392.mov


https://user-images.githubusercontent.com/2261188/157837207-51eb6672-41d5-4a76-93fe-0d3d3c9511ab.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
