### PR TITLE
Revert: Allow order items price to be decoded as a strings

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -77,14 +77,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         }
 
         let quantity = try container.decode(Decimal.self, forKey: .quantity)
-
-        /// WC versions lower than `6.3` send the item price as a `number`.
-        /// WC Versions equal or greater than `6.3` send the item price as a `string`.
-        ///
-        let decimalPrice = container.failsafeDecodeIfPresent(targetType: String.self,
-                                                             forKey: .price,
-                                                             alternativeTypes: [.decimal { String(describing: $0) }])
-        let price = NSDecimalNumber(string: decimalPrice)
+        let decimalPrice = try container.decodeIfPresent(Decimal.self, forKey: .price) ?? Decimal(0)
+        let price = NSDecimalNumber(decimal: decimalPrice)
 
         let sku = try container.decodeIfPresent(String.self, forKey: .sku)
         let subtotal = try container.decode(String.self, forKey: .subtotal)


### PR DESCRIPTION
# Why

In [this commit](https://github.com/woocommerce/woocommerce-ios/commit/3b9e56f392ad5205d26d337692b76a4dbf496e7f) we added type-safe parsing for the order items price because `WC 6.3` was supposed to change the return type of the order item price from a `number` to a `string`.

Luckily, that change was reverted and  `WC 6.3` maintained the number price in its final release.

# Testing Steps

- Make sure your store is on `WC 6.3`
- Open the app and load an order with items
- See items properly displayed.