### PR TITLE
Add feature flag for the split view on Orders tab

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -29,6 +29,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .bulkEditProductVariations:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .splitViewInOrdersTab:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -57,4 +57,8 @@ public enum FeatureFlag: Int {
     /// Displays the bulk update option in product variations
     ///
     case bulkEditProductVariations
+
+    /// Displays the Orders tab in a split view
+    ///
+    case splitViewInOrdersTab
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6381 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new feature flag for the split view on the Orders tab. I miscalculated the size of this task and hopefully, it's not too late to hide the changes under this flag to avoid releasing issues.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This flag hasn't been used yet so just CI passing is sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
