### PR TITLE
Orders: Hide update of split view under feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,6 @@
 
 8.8
 -----
-- [**] Show split view for Orders tab on large screens. [https://github.com/woocommerce/woocommerce-ios/pull/6387]
-
 - [*] Products displayed in Order Detail now follow the same order of the web. [https://github.com/woocommerce/woocommerce-ios/pull/6401]
 
 8.7

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -21,7 +21,9 @@ class WooNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
         super.delegate = navigationDelegate
-        extendedLayoutIncludesOpaqueBars = true
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            extendedLayoutIncludesOpaqueBars = true
+        }
     }
 
     /// Sets the status bar of the pushed view to white.
@@ -57,7 +59,9 @@ private class WooNavigationControllerDelegate: NSObject, UINavigationControllerD
     /// Configures the back button for the managed `ViewController` and forwards the event to the children delegate.
     ///
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        viewController.extendedLayoutIncludesOpaqueBars = true
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            viewController.extendedLayoutIncludesOpaqueBars = true
+        }
         currentController = viewController
         configureOfflineBanner(for: viewController)
         configureBackButton(for: viewController)
@@ -137,6 +141,7 @@ private extension WooNavigationControllerDelegate {
         offlineBannerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(offlineBannerView)
 
+        // TODO-6381: fix issue with zero extra bottom space for split view
         let extraBottomSpace = viewController.hidesBottomBarWhenPushed ? navigationController.view.safeAreaInsets.bottom : 0
         NSLayoutConstraint.activate([
             offlineBannerView.heightAnchor.constraint(equalToConstant: OfflineBannerView.height),

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -110,6 +110,9 @@ final class MainTabBarController: UITabBarController {
 
     private let isHubMenuFeatureFlagOn = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.hubMenu)
 
+    // This needs to be static to be accessed from static methods too
+    private static let isOrdersSplitViewFeatureFlagOn = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
+
     deinit {
         cancellableSiteID?.cancel()
     }
@@ -338,11 +341,11 @@ extension MainTabBarController {
         switch note.kind {
         case .storeOrder:
             switchToOrdersTab {
-                guard let ordersVC: OrdersSplitViewWrapperController = childViewController() else {
-                    return
+                if isOrdersSplitViewFeatureFlagOn {
+                    (childViewController() as? OrdersSplitViewWrapperController)?.presentDetails(for: note)
+                } else {
+                    (childViewController() as? OrdersRootViewController)?.presentDetails(for: note)
                 }
-
-                ordersVC.presentDetails(for: note)
             }
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -451,7 +451,11 @@ private extension MainTabBarController {
     }
 
     func createOrdersViewController(siteID: Int64) -> UIViewController {
-        OrdersSplitViewWrapperController(siteID: siteID)
+        if Self.isOrdersSplitViewFeatureFlagOn {
+            return OrdersSplitViewWrapperController(siteID: siteID)
+        } else {
+            return OrdersRootViewController(siteID: siteID)
+        }
     }
 
     func createProductsViewController(siteID: Int64) -> UIViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -93,6 +93,13 @@ final class OrderDetailsViewController: UIViewController {
         super.viewDidLayoutSubviews()
         tableView.updateHeaderHeight()
     }
+
+    override var shouldShowOfflineBanner: Bool {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            return false
+        }
+        return true
+    }
 }
 
 // MARK: - TableView Configuration

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -116,6 +116,8 @@ final class OrderListViewController: UIViewController {
     ///
     private var selectedIndexPath: IndexPath?
 
+    private lazy var isSplitViewInOrdersTabEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
+
     // MARK: - View Lifecycle
 
     /// Designated initializer.
@@ -572,7 +574,7 @@ private extension OrderListViewController {
 extension OrderListViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if splitViewController?.isCollapsed == true {
+        if splitViewController?.isCollapsed == true || !isSplitViewInOrdersTabEnabled {
             tableView.deselectRow(at: indexPath, animated: true)
         }
 
@@ -590,7 +592,9 @@ extension OrderListViewController: UITableViewDelegate {
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
                                                                     "status": order.status.rawValue])
 
-        switchDetailsHandler(orderDetailsViewModel)
+        if isSplitViewInOrdersTabEnabled {
+            switchDetailsHandler(orderDetailsViewModel)
+        }
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -599,7 +603,7 @@ extension OrderListViewController: UITableViewDelegate {
         }
 
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: itemIndex)
-        if indexPath == selectedIndexPath {
+        if isSplitViewInOrdersTabEnabled, indexPath == selectedIndexPath {
             highlightSelectedRowIfNeeded()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -575,6 +575,9 @@ extension OrderListViewController: UITableViewDelegate {
 
         if isSplitViewInOrdersTabEnabled {
             switchDetailsHandler(orderDetailsViewModel)
+        } else {
+            let viewController = OrderDetailsViewController(viewModel: orderDetailsViewModel)
+            navigationController?.pushViewController(viewController, animated: true)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -183,6 +183,14 @@ final class OrderListViewController: UIViewController {
         tableView.updateHeaderHeight()
     }
 
+    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransition(to: newCollection, with: coordinator)
+        if isSplitViewInOrdersTabEnabled, selectedIndexPath != nil {
+            // Reload table view to update selected state on the list when changing rotation
+            tableView.reloadData()
+        }
+    }
+
     /// Returns a function that creates cells for `dataSource`.
     private func makeCellProvider() -> UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>.CellProvider {
         return { [weak self] tableView, indexPath, objectID in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Yosemite
 import Combine
+import Experiments
 
 /// The root tab controller for Orders, which contains the `OrderListViewController` .
 ///
@@ -56,14 +57,20 @@ final class OrdersRootViewController: UIViewController {
     ///
     private var isOrderCreationEnabled: Bool = false
 
+    private let featureFlagService: FeatureFlagService
+
     // MARK: View Lifecycle
 
     init(siteID: Int64) {
         self.siteID = siteID
+        self.featureFlagService = ServiceLocator.featureFlagService
         super.init(nibName: Self.nibName, bundle: nil)
 
         configureTitle()
-        configureTabBarItem()
+
+        if !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            configureTabBarItem()
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -90,6 +97,13 @@ final class OrdersRootViewController: UIViewController {
         fetchExperimentalTogglesAndConfigureNavigationButtons()
 
         ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
+    }
+
+    override var shouldShowOfflineBanner: Bool {
+        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            return false
+        }
+        return true
     }
 
     /// Shows `SearchViewController`.
@@ -180,7 +194,7 @@ private extension OrdersRootViewController {
     func configureFiltersBar() {
         // Display the filtered orders bar
         // if the feature flag is enabled
-        let isOrderListFiltersEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderListFilters)
+        let isOrderListFiltersEnabled = featureFlagService.isFeatureFlagEnabled(.orderListFilters)
         if isOrderListFiltersEnabled {
             stackView.addArrangedSubview(filtersBar)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -63,6 +63,7 @@ final class OrdersRootViewController: UIViewController {
         super.init(nibName: Self.nibName, bundle: nil)
 
         configureTitle()
+        configureTabBarItem()
     }
 
     required init?(coder: NSCoder) {
@@ -109,6 +110,17 @@ final class OrdersRootViewController: UIViewController {
         present(navigationController, animated: true, completion: nil)
     }
 
+    /// Presents the Details for the Notification with the specified Identifier.
+    ///
+    func presentDetails(for note: Note) {
+        guard let orderID = note.meta.identifier(forKey: .order), let siteID = note.meta.identifier(forKey: .site) else {
+            DDLogError("## Notification with [\(note.noteID)] lacks its OrderID!")
+            return
+        }
+        let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
+        navigationController?.pushViewController(loaderViewController, animated: true)
+    }
+
     /// Present `FilterListViewController`
     ///
     private func filterButtonTapped() {
@@ -127,6 +139,8 @@ final class OrdersRootViewController: UIViewController {
         present(filterOrderListViewController, animated: true, completion: nil)
     }
 
+    /// This is to update the order detail in split view
+    ///
     private func handleSwitchingDetails(viewModel: OrderDetailsViewModel) {
         let orderDetailsViewController = OrderDetailsViewController(viewModel: viewModel)
         let orderDetailsNavigationController = WooNavigationController(rootViewController: orderDetailsViewController)
@@ -145,6 +159,14 @@ private extension OrdersRootViewController {
 
     func configureTitle() {
         title = Localization.defaultOrderListTitle
+    }
+
+    /// Set up properties for `self` as a root tab bar controller.
+    ///
+    func configureTabBarItem() {
+        tabBarItem.title = title
+        tabBarItem.image = .pagesImage
+        tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
     }
 
     /// Sets navigation buttons.

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -6,15 +6,18 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isHubMenuOn: Bool
     private let isTaxLinesInSimplePaymentsOn: Bool
     private let isInboxOn: Bool
+    private let isSplitViewInOrdersTabOn: Bool
 
     init(isJetpackConnectionPackageSupportOn: Bool = false,
          isHubMenuOn: Bool = false,
          isTaxLinesInSimplePaymentsOn: Bool = false,
-         isInboxOn: Bool = false) {
+         isInboxOn: Bool = false,
+         isSplitViewInOrdersTabOn: Bool = false) {
         self.isJetpackConnectionPackageSupportOn = isJetpackConnectionPackageSupportOn
         self.isHubMenuOn = isHubMenuOn
         self.isTaxLinesInSimplePaymentsOn = isTaxLinesInSimplePaymentsOn
         self.isInboxOn = isInboxOn
+        self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -27,6 +30,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isTaxLinesInSimplePaymentsOn
         case .inbox:
             return isInboxOn
+        case .splitViewInOrdersTab:
+            return isSplitViewInOrdersTabOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -25,8 +25,10 @@ final class MainTabBarControllerTests: XCTestCase {
         // Arrange
         // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
         let isHubMenuFeatureFlagOn = false
-        ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn))
-        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
+        let featureFlagService = MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn)
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
+            return MainTabBarController(coder: coder, featureFlagService: featureFlagService)
+        }) else {
             return
         }
 
@@ -53,9 +55,10 @@ final class MainTabBarControllerTests: XCTestCase {
         // Arrange
         // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
         let isHubMenuFeatureFlagOn = true
-        ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn))
-
-        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
+        let featureFlagService = MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn)
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
+            return MainTabBarController(coder: coder, featureFlagService: featureFlagService)
+        }) else {
             return
         }
 
@@ -83,9 +86,11 @@ final class MainTabBarControllerTests: XCTestCase {
         // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
         let isSplitViewInOrdersTabOn = true
         let isHubMenuFeatureFlagOn = true
-        ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn, isSplitViewInOrdersTabOn: isSplitViewInOrdersTabOn))
+        let featureFlagService = MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn, isSplitViewInOrdersTabOn: isSplitViewInOrdersTabOn)
 
-        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
+            return MainTabBarController(coder: coder, featureFlagService: featureFlagService)
+        }) else {
             return
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -42,7 +42,7 @@ final class MainTabBarControllerTests: XCTestCase {
         assertThat(tabBarController.tabNavigationController(tab: .myStore, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
                    isAnInstanceOf: DashboardViewController.self)
         assertThat(tabBarController.tabNavigationController(tab: .orders, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
-                   isAnInstanceOf: OrdersSplitViewWrapperController.self)
+                   isAnInstanceOf: OrdersRootViewController.self)
         assertThat(tabBarController.tabNavigationController(tab: .products, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
                    isAnInstanceOf: ProductsViewController.self)
         assertThat(tabBarController.tabNavigationController(tab: .reviews, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
@@ -54,6 +54,36 @@ final class MainTabBarControllerTests: XCTestCase {
         // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
         let isHubMenuFeatureFlagOn = true
         ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn))
+
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
+            return
+        }
+
+        // Trigger `viewDidLoad`
+        XCTAssertNotNil(tabBarController.view)
+
+        // Action
+        let siteID: Int64 = 134
+        stores.updateDefaultStore(storeID: siteID)
+
+        // Assert
+        XCTAssertEqual(tabBarController.viewControllers?.count, 4)
+        assertThat(tabBarController.tabNavigationController(tab: .myStore, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
+                   isAnInstanceOf: DashboardViewController.self)
+        assertThat(tabBarController.tabNavigationController(tab: .orders, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
+                   isAnInstanceOf: OrdersRootViewController.self)
+        assertThat(tabBarController.tabNavigationController(tab: .products, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
+                   isAnInstanceOf: ProductsViewController.self)
+        assertThat(tabBarController.tabNavigationController(tab: .hubMenu, isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
+                   isAnInstanceOf: HubMenuViewController.self)
+    }
+
+    func test_tab_view_controllers_returns_expected_values_with_hub_menu_and_split_view_in_orders_tab_enabled() {
+        // Arrange
+        // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
+        let isSplitViewInOrdersTabOn = true
+        let isHubMenuFeatureFlagOn = true
+        ServiceLocator.setFeatureFlagService(MockFeatureFlagService(isHubMenuOn: isHubMenuFeatureFlagOn, isSplitViewInOrdersTabOn: isSplitViewInOrdersTabOn))
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController else {
             return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6381 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR hides all changes that affect the app under the feature flag so that we can safely marge the WIP of split view in the Orders tab. These changes include:
- We had to add `extendedLayoutIncludesOpaqueBars = true` as a workaround to get rid of the extra bottom space in view controllers when embedded in split views. The universal update in `WooNavigationController` helps with not having to add this update to every view controller, but it messes with the bottom safe area, so the offline banner cannot be displayed properly. So, we need to hide this update under the feature flag.
- MainTabBarController: only adds split view and forwards notifications to split view if the feature is enabled
- Order details: still shows the offline banner by itself if the split view is disabled.
- Order list: the update of the selected row is only enabled with split view.
- Orders root: restore the configuration for tab bar item, notification handling, and offline banner visibility for the non-split view case.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- With the feature flag off, notice that everything still works as before: UI layout, selection of items, handling of notifications, offline banner.
- With the feature flag on, notice that the orders tab is displayed in a split view on large screens. UI layout, selection of items, and handling of notifications should still work - but the offline banner will need to be handled in a separate PR (when I figure out how to fix it 😅)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Feature flag off:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-11 at 17 13 50](https://user-images.githubusercontent.com/5533851/157847602-c2acd0c3-327c-4d39-be38-28e843fa75e2.png)
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-11 at 17 13 55](https://user-images.githubusercontent.com/5533851/157847614-ec8d908d-d75c-4783-9491-af9b6c3b3352.png)


Feature flag on:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-11 at 13 14 03](https://user-images.githubusercontent.com/5533851/157812800-78a150a2-5cdf-4136-85dd-ab35663dc980.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
