### PR TITLE
Order Creation: Add/Update Analytics for Shipping & Fees

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -368,6 +368,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderFeeAdd, properties: [Keys.flow: flow.rawValue])
         }
 
+        static func orderShippingMethodAdd(flow: Flow) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderShippingMethodAdd, properties: [Keys.flow: flow.rawValue])
+        }
+
         static func orderStatusChange(flow: Flow, orderID: Int64?, from oldStatus: OrderStatusEnum, to newStatus: OrderStatusEnum) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [
                 Keys.flow: flow.rawValue,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -364,6 +364,10 @@ extension WooAnalyticsEvent {
             ])
         }
 
+        static func orderFeeAdd(flow: Flow) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderFeeAdd, properties: [Keys.flow: flow.rawValue])
+        }
+
         static func orderStatusChange(flow: Flow, orderID: Int64?, from oldStatus: OrderStatusEnum, to newStatus: OrderStatusEnum) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [
                 Keys.flow: flow.rawValue,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -342,6 +342,8 @@ extension WooAnalyticsEvent {
             static let orderStatus = "order_status"
             static let productCount = "product_count"
             static let hasCustomerDetails = "has_customer_details"
+            static let hasFees = "has_fees"
+            static let hasShippingMethod = "has_shipping_method"
             static let errorContext = "error_context"
             static let errorDescription = "error_description"
             static let to = "to"
@@ -384,11 +386,15 @@ extension WooAnalyticsEvent {
 
         static func orderCreateButtonTapped(status: OrderStatusEnum,
                                             productCount: Int,
-                                            hasCustomerDetails: Bool) -> WooAnalyticsEvent {
+                                            hasCustomerDetails: Bool,
+                                            hasFees: Bool,
+                                            hasShippingMethod: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreateButtonTapped, properties: [
                 Keys.orderStatus: status.rawValue,
                 Keys.productCount: Int64(productCount),
-                Keys.hasCustomerDetails: hasCustomerDetails
+                Keys.hasCustomerDetails: hasCustomerDetails,
+                Keys.hasFees: hasFees,
+                Keys.hasShippingMethod: hasShippingMethod
             ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -233,6 +233,7 @@ public enum WooAnalyticsStat: String {
     case orderTrackingDeleteFailed = "order_tracking_delete_failed"
     case orderTrackingDeleteSuccess = "order_tracking_delete_success"
     case orderTrackingProvidersLoaded = "order_tracking_providers_loaded"
+    case orderFeeAdd = "order_fee_add"
 
     // MARK: Order List Sorting/Filtering
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -234,6 +234,7 @@ public enum WooAnalyticsStat: String {
     case orderTrackingDeleteSuccess = "order_tracking_delete_success"
     case orderTrackingProvidersLoaded = "order_tracking_providers_loaded"
     case orderFeeAdd = "order_fee_add"
+    case orderShippingMethodAdd = "order_shipping_method_add"
 
     // MARK: Order List Sorting/Filtering
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -129,6 +129,8 @@ final class NewOrderViewModel: ObservableObject {
     /// - Parameter shippingLine: Optional shipping line object to save. `nil` will remove existing shipping line.
     func saveShippingLine(_ shippingLine: ShippingLine?) {
         orderSynchronizer.setShipping.send(shippingLine)
+
+        analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: .creation))
     }
 
     /// Saves a fee.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -557,6 +557,7 @@ private extension NewOrderViewModel {
     /// Tracks when customer details have been added
     ///
     func trackCustomerDetailsAdded() {
+        guard customerDataViewModel.isDataAvailable else { return }
         let areAddressesDifferent: Bool = {
             guard let billingAddress = orderSynchronizer.order.billingAddress, let shippingAddress = orderSynchronizer.order.shippingAddress else {
                 return false
@@ -573,7 +574,7 @@ private extension NewOrderViewModel {
     /// or figure out a better way to get the product count.
     ///
     func trackCreateButtonTapped() {
-        let hasCustomerDetails = orderSynchronizer.order.billingAddress != nil || orderSynchronizer.order.shippingAddress != nil
+        let hasCustomerDetails = customerDataViewModel.isDataAvailable
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(status: orderSynchronizer.order.status,
                                                                                 productCount: orderSynchronizer.order.items.count,
                                                                                 hasCustomerDetails: hasCustomerDetails,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -136,6 +136,8 @@ final class NewOrderViewModel: ObservableObject {
     /// - Parameter shippingLine: Optional shipping line object to save. `nil` will remove existing shipping line.
     func saveFeeLine(_ feeLine: OrderFeeLine?) {
         orderSynchronizer.setFee.send(feeLine)
+
+        analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: .creation))
     }
 
     // MARK: -

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -572,7 +572,9 @@ private extension NewOrderViewModel {
         let hasCustomerDetails = orderSynchronizer.order.billingAddress != nil || orderSynchronizer.order.shippingAddress != nil
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(status: orderSynchronizer.order.status,
                                                                                 productCount: orderSynchronizer.order.items.count,
-                                                                                hasCustomerDetails: hasCustomerDetails))
+                                                                                hasCustomerDetails: hasCustomerDetails,
+                                                                                hasFees: orderSynchronizer.order.fees.isNotEmpty,
+                                                                                hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty))
     }
 
     /// Tracks an order creation success

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -130,7 +130,9 @@ final class NewOrderViewModel: ObservableObject {
     func saveShippingLine(_ shippingLine: ShippingLine?) {
         orderSynchronizer.setShipping.send(shippingLine)
 
-        analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: .creation))
+        if shippingLine != nil {
+            analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: .creation))
+        }
     }
 
     /// Saves a fee.
@@ -139,7 +141,9 @@ final class NewOrderViewModel: ObservableObject {
     func saveFeeLine(_ feeLine: OrderFeeLine?) {
         orderSynchronizer.setFee.send(feeLine)
 
-        analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: .creation))
+        if feeLine != nil {
+            analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: .creation))
+        }
     }
 
     // MARK: -

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -532,6 +532,62 @@ class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 2.50)
 
     }
+
+    func test_shipping_method_tracked_when_added() throws {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        let shippingLine = ShippingLine.fake()
+
+        // When
+        viewModel.saveShippingLine(shippingLine)
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodAdd.rawValue])
+
+        let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
+        XCTAssertEqual(properties, "creation")
+    }
+
+    func test_shipping_method_not_tracked_when_removed() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.saveShippingLine(nil)
+
+        // Then
+        XCTAssertTrue(analytics.receivedEvents.isEmpty)
+    }
+
+    func test_fee_line_tracked_when_added() throws {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        let feeLine = OrderFeeLine.fake()
+
+        // When
+        viewModel.saveFeeLine(feeLine)
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderFeeAdd.rawValue])
+
+        let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
+        XCTAssertEqual(properties, "creation")
+    }
+
+    func test_fee_line_not_tracked_when_removed() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.saveFeeLine(nil)
+
+        // Then
+        XCTAssertTrue(analytics.receivedEvents.isEmpty)
+    }
 }
 
 private extension MockStorageManager {


### PR DESCRIPTION
Closes: #6007

## Description

Adds and updates analytics events for Order Creation Milestone 2 (Shipping & Fees):

- `woocommerceios_order_shipping_method_add` (747-gh-Automattic/tracks-events-registration)
- `woocommerceios_order_fee_add` (748-gh-Automattic/tracks-events-registration)
- `woocommerceios_order_create_button_tapped` (adds `has_fees` and `has_shipping_method` properties)

Also fixes the tracking for customer details on an order, to handle when customer details are empty but non-nil. (To prevent the `order_customer_add` event from firing when customer details are removed, and ensure the `has_customer_details` property is accurate when the create button is tapped.)

## Testing

1. Build the app and enable the order creation experimental toggle.
2. Create a new order.
3. Add shipping to the order and confirm the related event is fired.
4. Remove shipping from the order and confirm no event is fired.
5. Add a fee to the order and confirm the related event is fired.
6. Remove the fee from the order and confirm no event is fired.
7. Add customer details to the order and confirm the related event is fired.
8. Remove all customer details from the order and confirm no event is fired.
9. Tap the "create" button and confirm the related event is fired with expected properties.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.