### PR TITLE
Add displaying error notices in bulk price update failures

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonActivityIndicator.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonActivityIndicator.swift
@@ -25,11 +25,13 @@ final class ButtonActivityIndicator: UIButton {
         }
         indicator.isUserInteractionEnabled = false
         indicator.center = CGPoint(x: self.bounds.size.width/2, y: self.bounds.size.height/2)
+        indicator.hidesWhenStopped = true
+        // If `hideActivityIndicator()` is called immediately after this method, it will find the indicator and remove it
+        addSubview(indicator)
         UIView.transition(with: self, duration: Constants.animationDuration, options: .curveEaseOut, animations: { [weak self] in
             self?.titleLabel?.alpha = 0.0
         }) { [weak self] (_) in
             guard let self = self else { return }
-            self.addSubview(self.indicator)
             self.indicator.startAnimating()
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
 		03FBDAFD263EE4E800ACE257 /* CouponListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */; };
+		093B265927DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093B265827DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift */; };
 		09468D9027D5014E0054A751 /* BulkUpdatePriceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09468D8F27D5014E0054A751 /* BulkUpdatePriceViewController.swift */; };
 		09468D9227D501990054A751 /* BulkUpdatePriceViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09468D9127D501980054A751 /* BulkUpdatePriceViewController.xib */; };
 		094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */; };
@@ -2096,6 +2097,7 @@
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
 		03FBDAFC263EE4E700ACE257 /* CouponListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModelTests.swift; sourceTree = "<group>"; };
+		093B265827DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BulkUpdatePriceViewControllerTests.swift; sourceTree = "<group>"; };
 		09468D8F27D5014E0054A751 /* BulkUpdatePriceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdatePriceViewController.swift; sourceTree = "<group>"; };
 		09468D9127D501980054A751 /* BulkUpdatePriceViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BulkUpdatePriceViewController.xib; sourceTree = "<group>"; };
 		094C161127B0604700B25F51 /* ProductVariationFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -4389,6 +4391,7 @@
 		09BE3A8F27C921980070B69D /* Bulk Edit Price */ = {
 			isa = PBXGroup;
 			children = (
+				093B265827DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift */,
 				09BE3A9027C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift */,
 			);
 			path = "Bulk Edit Price";
@@ -9671,6 +9674,7 @@
 				D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */,
 				A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */,
 				D83A6A7A23792B2400419D48 /* UIColor+Muriel-Tests.swift in Sources */,
+				093B265927DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift in Sources */,
 				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewControllerTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+/// Tests for `BulkUpdatePriceViewController`.
+///
+final class BulkUpdatePriceViewControllerTests: XCTestCase {
+
+    func test_view_controller_displays_notice_on_update_error() throws {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        let noticePresenter = MockNoticePresenter()
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         bulkUpdateOptionsModel: BulkUpdateOptionsModel(productVariations: []),
+                                                         editingPriceType: .regular,
+                                                         priceUpdateDidFinish: {},
+                                                         storesManager: storesManager)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .updateProductVariations(_, _, _, onCompletion):
+                onCompletion(.failure(.unexpected))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+        let viewController = BulkUpdatePriceViewController(viewModel: viewModel, noticePresenter: noticePresenter)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewModel.handlePriceChange("42")
+        viewModel.saveButtonTapped()
+
+        waitUntil {
+            noticePresenter.queuedNotices.count == 1
+        }
+
+        // Then
+        let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
+        XCTAssertEqual(notice.feedbackType, .error)
+    }
+
+    func test_view_controller_displays_notice_on_no_regular_price_validation_error() throws {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        let noticePresenter = MockNoticePresenter()
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), salePrice: "42")]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         bulkUpdateOptionsModel: BulkUpdateOptionsModel(productVariations: variations),
+                                                         editingPriceType: .regular,
+                                                         priceUpdateDidFinish: {},
+                                                         storesManager: storesManager)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .updateProductVariations(_, _, _, onCompletion):
+                onCompletion(.failure(.unexpected))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+        let viewController = BulkUpdatePriceViewController(viewModel: viewModel, noticePresenter: noticePresenter)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewModel.handlePriceChange("")
+        viewModel.saveButtonTapped()
+
+        waitUntil {
+            noticePresenter.queuedNotices.count == 1
+        }
+
+        // Then
+        let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
+        XCTAssertEqual(notice.feedbackType, .error)
+    }
+
+    func test_view_controller_displays_notice_on_selected_regular_price_is_less_than_sale_price_validation_error() throws {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        let noticePresenter = MockNoticePresenter()
+        let variations = [MockProductVariation().productVariation().copy(dateOnSaleStart: Date(), dateOnSaleEnd: Date(), salePrice: "42")]
+        let viewModel = BulkUpdatePriceSettingsViewModel(siteID: 0,
+                                                         productID: 0,
+                                                         bulkUpdateOptionsModel: BulkUpdateOptionsModel(productVariations: variations),
+                                                         editingPriceType: .regular,
+                                                         priceUpdateDidFinish: {},
+                                                         storesManager: storesManager)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .updateProductVariations(_, _, _, onCompletion):
+                onCompletion(.failure(.unexpected))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+        let viewController = BulkUpdatePriceViewController(viewModel: viewModel, noticePresenter: noticePresenter)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewModel.handlePriceChange("9")
+        viewModel.saveButtonTapped()
+
+        waitUntil {
+            noticePresenter.queuedNotices.count == 1
+        }
+
+        // Then
+        let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
+        XCTAssertEqual(notice.feedbackType, .error)
+    }
+}


### PR DESCRIPTION
Part of: #6562 

### Description
This PR adds displaying failure notices when bulk price update for regular prices fails. This can be due to network errors or due to input validation errors. In the `BulkUpdatePriceViewController` we added listening for changes in the `$bulkUpdatePriceError` of the `BulkUpdatePriceSettingsViewModel`, in case of an error we create and display and error `Notice` with the appropriate title. There is not redo action in the `Notice` since it will be redundant because the user stays in the same screen and can tap again the save button.

### Testing instructions

Testing network error:

1. Go to the products tab
2. Select a product with variations
3. Go to the list of variations
4. Tap on the "more" button in the navigation bar
5. Select the "Bulk update"
6. After the view loads, select the regular price option
7. After the price setting screen loads, select a valid regular price and diplay the network (airplane mode, close wifi etc.)
8. Tap save an error message "Unable to update price" should be displayed

Testing validation error:

repeat the 1 to 6 steps from above and then:
1. Select an empty (zero) regular price or a regular price that is lower that than sale price
2 Tap save
3. A validation error message should be displayed. 

###  Screenshots

Network error:
![Simulator Screen Shot - iPod touch (7th generation) - 2022-03-14 at 08 29 36](https://user-images.githubusercontent.com/96764631/158119475-e1724af4-c1bb-4c55-99ea-f6f4ade5657c.png)

Validation error:
![Simulator Screen Shot - iPod touch (7th generation) - 2022-03-14 at 08 29 23](https://user-images.githubusercontent.com/96764631/158119485-c48e8612-7331-40fb-9cc5-86f0382e341b.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

