### PR TITLE
Orders: Select the correct column when collapsing split view

### DIFF
--- a/WooCommerce/Classes/System/WooSplitViewController.swift
+++ b/WooCommerce/Classes/System/WooSplitViewController.swift
@@ -5,7 +5,16 @@ import UIKit
 ///
 final class WooSplitViewController: UISplitViewController {
 
-    init() {
+    /// Convenient type for the closure to handle collapsing a split view
+    ///
+    typealias ColumnForCollapsingHandler = (UISplitViewController) -> UISplitViewController.Column
+
+    private let columnForCollapsingHandler: ColumnForCollapsingHandler
+
+    /// Init a split view with an optional handler to decide which column to collapse the split view into.
+    /// By default, always display the primary column when collapsed.
+    init(columnForCollapsingHandler: @escaping ColumnForCollapsingHandler = { _ in .primary }) {
+        self.columnForCollapsingHandler = columnForCollapsingHandler
         super.init(style: .doubleColumn)
         configureCommonStyle()
     }
@@ -24,8 +33,7 @@ final class WooSplitViewController: UISplitViewController {
 extension WooSplitViewController: UISplitViewControllerDelegate {
     func splitViewController(_ splitViewController: UISplitViewController,
                              topColumnForCollapsingToProposedTopColumn proposedTopColumn: UISplitViewController.Column) -> UISplitViewController.Column {
-        // Always fall back to display the primary column when collapsed.
-        return .primary
+        return columnForCollapsingHandler(splitViewController)
     }
 
     func splitViewController(_ splitViewController: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {

--- a/WooCommerce/Classes/System/WooSplitViewController.swift
+++ b/WooCommerce/Classes/System/WooSplitViewController.swift
@@ -9,11 +9,11 @@ final class WooSplitViewController: UISplitViewController {
     ///
     typealias ColumnForCollapsingHandler = (UISplitViewController) -> UISplitViewController.Column
 
-    private let columnForCollapsingHandler: ColumnForCollapsingHandler
+    private let columnForCollapsingHandler: ColumnForCollapsingHandler?
 
     /// Init a split view with an optional handler to decide which column to collapse the split view into.
     /// By default, always display the primary column when collapsed.
-    init(columnForCollapsingHandler: @escaping ColumnForCollapsingHandler = { _ in .primary }) {
+    init(columnForCollapsingHandler: ColumnForCollapsingHandler? = nil) {
         self.columnForCollapsingHandler = columnForCollapsingHandler
         super.init(style: .doubleColumn)
         configureCommonStyle()
@@ -33,7 +33,7 @@ final class WooSplitViewController: UISplitViewController {
 extension WooSplitViewController: UISplitViewControllerDelegate {
     func splitViewController(_ splitViewController: UISplitViewController,
                              topColumnForCollapsingToProposedTopColumn proposedTopColumn: UISplitViewController.Column) -> UISplitViewController.Column {
-        return columnForCollapsingHandler(splitViewController)
+        return columnForCollapsingHandler?(splitViewController) ?? proposedTopColumn
     }
 
     func splitViewController(_ splitViewController: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -6,7 +6,7 @@ import Yosemite
 final class OrdersSplitViewWrapperController: UIViewController {
     private let siteID: Int64
 
-    private let ordersSplitViewController = WooSplitViewController()
+    private lazy var ordersSplitViewController = WooSplitViewController(columnForCollapsingHandler: handleCollapsingSplitView)
 
     init(siteID: Int64) {
         self.siteID = siteID
@@ -59,6 +59,17 @@ private extension OrdersSplitViewWrapperController {
         emptyStateViewController.configure(config)
 
         ordersSplitViewController.viewControllers = [ordersNavigationController, emptyStateViewController]
+    }
+
+    func handleCollapsingSplitView(splitViewController: UISplitViewController) -> UISplitViewController.Column {
+        let secondaryColumnNavigationController = splitViewController.viewController(for: .secondary) as? UINavigationController
+        if let navigationController = secondaryColumnNavigationController,
+           navigationController.viewControllers.contains(where: { $0 is OrderDetailsViewController }),
+           ((navigationController.topViewController is OrderDetailsViewController) == false ||
+            navigationController.topViewController?.presentedViewController != nil) {
+            return .secondary
+        }
+        return .primary
     }
 
     /// Set up properties for `self` as a root tab bar controller.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -64,9 +64,7 @@ private extension OrdersSplitViewWrapperController {
     func handleCollapsingSplitView(splitViewController: UISplitViewController) -> UISplitViewController.Column {
         let secondaryColumnNavigationController = splitViewController.viewController(for: .secondary) as? UINavigationController
         if let navigationController = secondaryColumnNavigationController,
-           navigationController.viewControllers.contains(where: { $0 is OrderDetailsViewController }),
-           ((navigationController.topViewController is OrderDetailsViewController) == false ||
-            navigationController.topViewController?.presentedViewController != nil) {
+           navigationController.viewControllers.contains(where: { $0 is OrderDetailsViewController }) {
             return .secondary
         }
         return .primary

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -62,8 +62,7 @@ private extension OrdersSplitViewWrapperController {
     }
 
     func handleCollapsingSplitView(splitViewController: UISplitViewController) -> UISplitViewController.Column {
-        let secondaryColumnNavigationController = splitViewController.viewController(for: .secondary) as? UINavigationController
-        if let navigationController = secondaryColumnNavigationController,
+        if let navigationController = splitViewController.viewController(for: .secondary) as? UINavigationController,
            navigationController.viewControllers.contains(where: { $0 is OrderDetailsViewController }) {
             return .secondary
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6381 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When reviewing #6399, @jaclync found that the orders split view always displays the order list when rotating to portrait mode.

This PR fixes that by adding an optional closure to the initializer of `WooSplitViewController` to enable deciding which column to collapse the split view into.

The Orders split view then handles this by asking the split view to display the secondary column if the navigation stack in this column contains an order details view controller. Otherwise, the order list should be displayed.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build the changes to a large phone, e.g iPhone Pro Max. Make sure that the feature flag for `.splitViewInOrdersTab` is enabled.
- Launch the app in portrait mode and navigate to Orders tab. Notice that the tab displays the order list initially.
- Select an item in the order list and switch to landscape mode. Notice that the tab is displayed in 2 columns.
- Switch back to portrait mode. Notice that the Orders tab now shows the order details screen like before.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/158151464-1bb0f6b7-94cc-4c89-97de-4620ae1b596e.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
