### PR TITLE
Order Creation: Enable product stepper subtract (-) button to remove product when quantity is 1

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -215,9 +215,16 @@ final class NewOrderViewModel: ObservableObject {
                                        name: product.name,
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
-                                       displayMode: .attributes(attributes))
+                                       displayMode: .attributes(attributes),
+                                       removeProduct: { [weak self] in
+                self?.selectOrderItem(item.itemID) })
         } else {
-            return ProductRowViewModel(id: item.itemID, product: product, quantity: item.quantity, canChangeQuantity: canChangeQuantity)
+            return ProductRowViewModel(id: item.itemID,
+                                       product: product,
+                                       quantity: item.quantity,
+                                       canChangeQuantity: canChangeQuantity,
+                                       removeProduct: { [weak self] in
+                self?.selectOrderItem(item.itemID) })
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -216,14 +216,14 @@ final class NewOrderViewModel: ObservableObject {
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
                                        displayMode: .attributes(attributes),
-                                       removeProduct: { [weak self] in
+                                       removeProductIntent: { [weak self] in
                 self?.selectOrderItem(item.itemID) })
         } else {
             return ProductRowViewModel(id: item.itemID,
                                        product: product,
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
-                                       removeProduct: { [weak self] in
+                                       removeProductIntent: { [weak self] in
                 self?.selectOrderItem(item.itemID) })
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRowViewModel.swift
@@ -89,10 +89,9 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         quantity < minimumQuantity
     }
 
-    /// Closure to remove the product.
-    /// Used when the quantity is decremented below the minimum quantity.
+    /// Closure to run when the quantity is decremented below the minimum quantity.
     ///
-    var removeProduct: () -> Void
+    var removeProductIntent: () -> Void
 
     /// Number of variations in a variable product
     ///
@@ -112,7 +111,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          numberOfVariations: Int = 0,
          variationDisplayMode: VariationDisplayMode? = nil,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-         removeProduct: @escaping (() -> Void) = {}) {
+         removeProductIntent: @escaping (() -> Void) = {}) {
         self.id = id ?? Int64(UUID().uuidString.hashValue)
         self.productOrVariationID = productOrVariationID
         self.name = name
@@ -127,7 +126,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.currencyFormatter = currencyFormatter
         self.numberOfVariations = numberOfVariations
         self.variationDisplayMode = variationDisplayMode
-        self.removeProduct = removeProduct
+        self.removeProductIntent = removeProductIntent
     }
 
     /// Initialize `ProductRowViewModel` with a `Product`
@@ -137,7 +136,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      quantity: Decimal = 1,
                      canChangeQuantity: Bool,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-                     removeProduct: @escaping (() -> Void) = {}) {
+                     removeProductIntent: @escaping (() -> Void) = {}) {
         // Don't show any price for variable products; price will be shown for each product variation.
         let price: String?
         if product.productType == .variable {
@@ -159,7 +158,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   imageURL: product.imageURL,
                   numberOfVariations: product.variations.count,
                   currencyFormatter: currencyFormatter,
-                  removeProduct: removeProduct)
+                  removeProductIntent: removeProductIntent)
     }
 
     /// Initialize `ProductRowViewModel` with a `ProductVariation`
@@ -171,7 +170,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      canChangeQuantity: Bool,
                      displayMode: VariationDisplayMode,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-                     removeProduct: @escaping (() -> Void) = {}) {
+                     removeProductIntent: @escaping (() -> Void) = {}) {
         let imageURL: URL?
         if let encodedImageURLString = productVariation.image?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
             imageURL = URL(string: encodedImageURLString)
@@ -192,7 +191,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   imageURL: imageURL,
                   variationDisplayMode: displayMode,
                   currencyFormatter: currencyFormatter,
-                  removeProduct: removeProduct)
+                  removeProductIntent: removeProductIntent)
     }
 
     /// Determines which product variation details to display.
@@ -269,7 +268,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     func decrementQuantity() {
         guard quantity > minimumQuantity else {
-            return removeProduct()
+            return removeProductIntent()
         }
         quantity -= 1
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -233,15 +233,39 @@ class ProductRowViewModelTests: XCTestCase {
         // Given
         let product = Product.fake()
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
-
-        // Then
         XCTAssertEqual(viewModel.quantity, 1)
-        XCTAssertTrue(viewModel.shouldDisableQuantityDecrementer, "Quantity decrementer is not disabled at minimum value")
 
         // When
         viewModel.decrementQuantity()
 
         // Then
         XCTAssertEqual(viewModel.quantity, 1)
+    }
+
+    func test_cannot_decrement_quantity_below_zero() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(product: product, quantity: 0, canChangeQuantity: true)
+        XCTAssertEqual(viewModel.quantity, 0)
+
+        // When
+        viewModel.decrementQuantity()
+
+        // Then
+        XCTAssertEqual(viewModel.quantity, 0)
+        XCTAssertTrue(viewModel.shouldDisableQuantityDecrementer, "Quantity decrementer is not disabled")
+    }
+
+    func test_decrement_quantity_at_minimum_quantity_removes_product() {
+        // Given
+        let product = Product.fake()
+        var productRemoved = false
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true, removeProduct: { productRemoved = true })
+
+        // When
+        viewModel.decrementQuantity()
+
+        // Then
+        XCTAssertTrue(productRemoved)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -260,7 +260,7 @@ class ProductRowViewModelTests: XCTestCase {
         // Given
         let product = Product.fake()
         var productRemoved = false
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true, removeProduct: { productRemoved = true })
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true, removeProductIntent: { productRemoved = true })
 
         // When
         viewModel.decrementQuantity()


### PR DESCRIPTION
Closes: #6351

## Description

When you tap on the subtract (-) button when the product quantity is 1, the product screen is shown. This PR enables that subtract in this case (instead of disabling it) but with the same behavior, to help make it clear how to remove a product from the order.

## Changes

In `ProductRowViewModel`:

* Adds a `removeProduct` closure, to use when decrementing the product quantity below the minimum (i.e. when the product quantity is 1 and you tap the subtract button in the stepper).
* `shouldDisableQuantityDecrementer` now returns true only when the product quantity is _less_ than the minimum quantity. If the product quantity is the minimum quantity, the decrementer (subtract button) will remain enabled.
* When `decrementQuantity()` is called, if the product quantity is not greater than the minimum quantity, it calls `removeProduct()` to remove the product instead.

In `NewOrderViewModel`:

* Sets `removeProduct` in the product rows to select the item (same behavior as when you tap on the product row); this opens the product detail so you can remove it from the order.

## Testing

1. Go to the Orders tab to create a new order.
2. Add a product to the order.
3. Notice that when the product quantity is 1, the subtract (-) button is still enabled.
4. Tap the subtract button and confirm the product detail screen is opened.
5. Confirm you can either close the product detail (and the product remains in the order) or remove the product from the order.

## Screenshots

https://user-images.githubusercontent.com/8658164/158187224-f4e9d2ec-b8da-4244-93fc-796505950064.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
