### PR TITLE
Order Creation: Sort product variations list by menu order and variation ID

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -38,7 +38,15 @@ final class AddProductVariationToOrderViewModel: ObservableObject {
     /// All purchasable product variations for the product.
     ///
     private var productVariations: [ProductVariation] {
-        productVariationsResultsController.fetchedObjects.filter { $0.purchasable }
+        productVariationsResultsController.fetchedObjects
+            .filter { $0.purchasable }
+            .sorted {
+                if $0.menuOrder == $1.menuOrder {
+                    return ProductVariationFormatter().generateName(for: $0, from: productAttributes) <
+                        ProductVariationFormatter().generateName(for: $1, from: productAttributes)
+                }
+                return $0.menuOrder < $1.menuOrder
+            }
     }
 
     /// View models for each product variation row

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -38,15 +38,7 @@ final class AddProductVariationToOrderViewModel: ObservableObject {
     /// All purchasable product variations for the product.
     ///
     private var productVariations: [ProductVariation] {
-        productVariationsResultsController.fetchedObjects
-            .filter { $0.purchasable }
-            .sorted {
-                if $0.menuOrder == $1.menuOrder {
-                    return ProductVariationFormatter().generateName(for: $0, from: productAttributes) <
-                        ProductVariationFormatter().generateName(for: $1, from: productAttributes)
-                }
-                return $0.menuOrder < $1.menuOrder
-            }
+        productVariationsResultsController.fetchedObjects.filter { $0.purchasable }
     }
 
     /// View models for each product variation row
@@ -90,8 +82,11 @@ final class AddProductVariationToOrderViewModel: ObservableObject {
     ///
     private lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
         let predicate = NSPredicate(format: "siteID == %lld AND productID == %lld", siteID, productID)
-        let descriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
-        let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        let menuOrderDescriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
+        let variationIdDescriptor = NSSortDescriptor(keyPath: \StorageProductVariation.productVariationID, ascending: false)
+        let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager,
+                                                                           matching: predicate,
+                                                                           sortedBy: [menuOrderDescriptor, variationIdDescriptor])
         return resultsController
     }()
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -170,21 +170,20 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
         XCTAssertEqual(timesSynced, 1)
     }
 
-    func test_product_variations_sorted_by_menu_order_and_name() {
+    func test_product_variations_sorted_by_menu_order_and_id() {
         // Given
-        let product = Product.fake().copy(productID: sampleProductID,
-                                          attributes: [ProductAttribute.fake().copy(siteID: sampleSiteID, attributeID: 1, name: "Color", variation: true)])
-        let variation1 = sampleProductVariation.copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")], menuOrder: 1)
-        let variation2 = sampleProductVariation.copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Green")], menuOrder: 0)
-        let variation3 = sampleProductVariation.copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Red")], menuOrder: 0)
+        let product = Product.fake().copy(productID: sampleProductID)
+        let variation1 = sampleProductVariation.copy(productVariationID: 3, menuOrder: 1)
+        let variation2 = sampleProductVariation.copy(productVariationID: 2, menuOrder: 0)
+        let variation3 = sampleProductVariation.copy(productVariationID: 1, menuOrder: 0)
         insert([variation1, variation2, variation3])
 
         // When
         let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
 
         // Then
-        let sortedProductVariationNames = viewModel.productVariationRows.map { $0.name }
-        XCTAssertEqual(sortedProductVariationNames, ["Green", "Red", "Blue"])
+        let sortedProductVariationIDs = viewModel.productVariationRows.map { $0.productOrVariationID }
+        XCTAssertEqual(sortedProductVariationIDs, [2, 1, 3])
     }
 }
 


### PR DESCRIPTION
Closes: #5945

## Description

When adding a product variation to a new order, the product variations list could be ordered randomly. This happened because the list was sorted by `menu_order`, and sometimes all variations can have `menu_order` set to `0`.

We now sort first by `menu_order` and then the variation ID (descending) for more deterministic sorting.

## Changes

In `AddProductVariationToOrderViewModel`:

Because the variation's name is generated at the UI layer, and not a stored property, we do this sorting on the fetched product variations. If `menu_order` is the same, we compare the names generated with `ProductVariationFormatter().generateName`.

## Testing

Setup:

- Create at least one variable product in wp-admin, and use drag-and-drop to sort the variations. (These variations will each have a unique `menu_order`.)
- Create at least one variable product in the app. (These variations will all have the same `menu_order`.)

Testing:

1. Go to the Orders tab and create a new order.
2. Select "Add Product."
3. Select the variable product created in wp-admin. Confirm the variations are sorted in the same order as wp-admin.
4. Go back to your product list and select the variable product created in the app. Confirm the variations are sorted alphabetically by name.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-14 at 15 19 36](https://user-images.githubusercontent.com/8658164/158215719-43889f2f-32fb-40bd-8bf6-400713687fed.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-03-14 at 15 21 32](https://user-images.githubusercontent.com/8658164/158215729-0af45155-0b6a-4529-b6e6-7bafe606bc57.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
