### PR TITLE
Add unit tests to FeeLineDetailsViewModelTests

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -26,6 +26,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.amount, "11.30")
         XCTAssertEqual(viewModel.currencySymbol, "$")
         XCTAssertEqual(viewModel.currencyPosition, .left)
+        XCTAssertFalse(viewModel.isExistingFeeLine)
     }
 
     func test_view_model_formats_negative_amount_correctly() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -22,12 +22,9 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         viewModel.amount = "hi:11.3005.02-"
 
         // Then
-        XCTAssertFalse(viewModel.isPercentageOptionAvailable)
         XCTAssertEqual(viewModel.amount, "11.30")
         XCTAssertEqual(viewModel.currencySymbol, "$")
         XCTAssertEqual(viewModel.currencyPosition, .left)
-        XCTAssertFalse(viewModel.isExistingFeeLine)
-        XCTAssertEqual(viewModel.amountPlaceholder, "0")
     }
 
     func test_view_model_formats_negative_amount_correctly() {
@@ -303,5 +300,35 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(savedFeeLine?.taxStatus, .taxable)
+    }
+
+    func test_view_model_amount_placeholder_is_not_empty_string() {
+        // Given
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 0,
+                                                feesTotal: "",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.amountPlaceholder, "0")
+    }
+
+    func test_view_model_initializes_correctly_with_no_existing_fee_line() {
+        // Given
+        let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
+                                                baseAmountForPercentage: 0,
+                                                feesTotal: "",
+                                                locale: usLocale,
+                                                storeCurrencySettings: usStoreSettings,
+                                                didSelectSave: { _ in })
+
+        // When
+        viewModel.amount = "hi:11.3005.02-"
+
+        // Then
+        XCTAssertFalse(viewModel.isPercentageOptionAvailable)
+        XCTAssertFalse(viewModel.isExistingFeeLine)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -302,7 +302,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(savedFeeLine?.taxStatus, .taxable)
     }
 
-    func test_view_model_amount_placeholder_is_not_empty_string() {
+    func test_view_model_amount_placeholder_has_expected_value() {
         // Given
         let viewModel = FeeLineDetailsViewModel(isExistingFeeLine: false,
                                                 baseAmountForPercentage: 0,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -27,6 +27,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currencySymbol, "$")
         XCTAssertEqual(viewModel.currencyPosition, .left)
         XCTAssertFalse(viewModel.isExistingFeeLine)
+        XCTAssertEqual(viewModel.amountPlaceholder, "0")
     }
 
     func test_view_model_formats_negative_amount_correctly() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -324,9 +324,6 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
                                                 storeCurrencySettings: usStoreSettings,
                                                 didSelectSave: { _ in })
 
-        // When
-        viewModel.amount = "hi:11.3005.02-"
-
         // Then
         XCTAssertFalse(viewModel.isPercentageOptionAvailable)
         XCTAssertFalse(viewModel.isExistingFeeLine)


### PR DESCRIPTION
_Re-do of https://github.com/woocommerce/woocommerce-ios/pull/6347_
Also changed the name of the second test per @rachelmcr's [suggestion](https://github.com/woocommerce/woocommerce-ios/pull/6347#discussion_r822508573).

### Description
This PR adds two tests to test items that were not yet tested.
**First:** `.isExistingFeeLine` already has an `AssertTrue` in `test_view_model_prefills_input_data_correctly`, but an `AssertFalse` can alert us to a potential situation where initialization of `.isExistingFeeLine` is broken.
**Second:** `amountPlaceholder` was not being tested yet. It should always be `"0"`, so I used AssertEqual to ensure we do not pass an empty string instead of `"0"`.
I moved both of these asserts into new tests, along with `XCTAssertFalse(viewModel.isPercentageOptionAvailable)`

### Testing instructions
Both tests should pass if you run `test_view_model_formats_amount_correctly`.
Then, try to make them fail:
1. Try initializing with `.isExistingFeeLine` set to true. (line 116 of `FeeLineDetailsViewModel`)
2. Try passing an empty string, or any string other than "0". (line 114 of `FeeLineDetailsViewModel`)

Can you think of other ways to break these? Especially `.isExistingFeeLine`?

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


