### PR TITLE
Add Debounce to Chart interacted() Calls

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsUsageTracksEventEmitter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsUsageTracksEventEmitter.swift
@@ -1,7 +1,22 @@
 import Foundation
 
-/// Note: If we ever change the algorithm in the future, we should probably consider renaming
-/// the Tracks event to avoid incorrect comparisons with old events.
+/// Accepts interaction events from the Analytics / My Store UI and decides whether the group of interactions can be
+/// considered as a _usage_ of the UI.
+///
+/// See p91TBi-6Cl-p2 for more information about the algorithm.
+///
+/// The UI should call `interacted` when these events happen:
+///
+/// - Scrolling
+/// - Pull-to-refresh
+/// - Tapping on the bars in the chart
+/// - Changing the tab
+/// - Navigating to the My Store tab
+/// - Tapping on a product in the Top Performers list
+///
+/// If we ever change the algorithm in the future, we should probably consider renaming the Tracks event to avoid
+/// incorrect comparisons with old events. We should also make sure to change the Android code if we're changing anything
+/// in here. Both platforms should have the same algorithm so we are able to compare both.
 final class StoreStatsUsageTracksEventEmitter {
 
     private let analytics: Analytics

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -454,7 +454,7 @@ extension StoreStatsV4PeriodViewController: ChartViewDelegate {
 
     private func observeChartValueSelectedEvents() {
         chartValueSelectedEventsSubject
-            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .debounce(for: .seconds(Constants.chartValueSelectedEventsDebounce), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 print("shiki: chartValueSelected \(Date().timeIntervalSince1970)")
                 self?.usageTracksEventEmitter.interacted()
@@ -713,5 +713,12 @@ private extension StoreStatsV4PeriodViewController {
         static let headerComponentBackgroundColor: UIColor = .clear
 
         static let ghostStyle: GhostStyle = .wooDefaultGhostStyle
+
+        /// The wait time before the `StoreStatsUsageTracksEventEmitter.interacted()` is called.
+        ///
+        /// We debounce it because there are just too many events received from `chartValueSelected()` when
+        /// the user holds and drags on the chart. Having too many events might skew the
+        /// `StoreStatsUsageTracksEventEmitter` algorithm.
+        static let chartValueSelectedEventsDebounce: TimeInterval = 1.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -452,6 +452,12 @@ extension StoreStatsV4PeriodViewController: ChartViewDelegate {
         chartValueSelectedEventsSubject.send()
     }
 
+    /// Observe `chartValueSelected` events and call `StoreStatsUsageTracksEventEmitter.interacted()` when
+    /// no similar events have been received after some time.
+    ///
+    /// We debounce it because there are just too many events received from `chartValueSelected()` when
+    /// the user holds and drags on the chart. Having too many events might skew the
+    /// `StoreStatsUsageTracksEventEmitter` algorithm.
     private func observeChartValueSelectedEvents() {
         chartValueSelectedEventsSubject
             .debounce(for: .seconds(Constants.chartValueSelectedEventsDebounce), scheduler: DispatchQueue.main)
@@ -715,10 +721,6 @@ private extension StoreStatsV4PeriodViewController {
         static let ghostStyle: GhostStyle = .wooDefaultGhostStyle
 
         /// The wait time before the `StoreStatsUsageTracksEventEmitter.interacted()` is called.
-        ///
-        /// We debounce it because there are just too many events received from `chartValueSelected()` when
-        /// the user holds and drags on the chart. Having too many events might skew the
-        /// `StoreStatsUsageTracksEventEmitter` algorithm.
         static let chartValueSelectedEventsDebounce: TimeInterval = 1.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -462,7 +462,6 @@ extension StoreStatsV4PeriodViewController: ChartViewDelegate {
         chartValueSelectedEventsSubject
             .debounce(for: .seconds(Constants.chartValueSelectedEventsDebounce), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                print("shiki: chartValueSelected \(Date().timeIntervalSince1970)")
                 self?.usageTracksEventEmitter.interacted()
             }.store(in: &cancellables)
     }


### PR DESCRIPTION
Closes #6430. This is an enhancement on https://github.com/woocommerce/woocommerce-ios/pull/5503. But more importantly, it's to make sure that we're matching the behavior on Android (https://github.com/woocommerce/woocommerce-android/pull/5964#discussion_r818755008). 

## Problem

Currently, holding and dragging on the chart causes too many `interacted()` calls:


https://user-images.githubusercontent.com/198826/158273506-b4e5055f-dc3f-454c-bfd3-4a6aca7c38eb.mov

This might skew the [`StoreStatsUsageTracksEventEmitter`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsUsageTracksEventEmitter.swift) algorithm. Even though we have a [`minimumInteractionTime`](https://github.com/woocommerce/woocommerce-ios/blob/07ffeca91e400c9360e0f5393217ac36fa23e6b8/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsUsageTracksEventEmitter.swift#L11) to counteract this, the potential of more than 10+ events is still enough to make it useless. 

## Solution

In https://github.com/woocommerce/woocommerce-android/pull/5964#discussion_r818755008, we added a debounce of 1 second. I'm doing the same here. 

Here's the result:


https://user-images.githubusercontent.com/198826/158274030-2dda79d6-907a-456b-b9f6-266e9beced07.mov



## Testing

1. Add a `println()` in the [`interacted()`](https://github.com/woocommerce/woocommerce-ios/blob/07ffeca91e400c9360e0f5393217ac36fa23e6b8/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsUsageTracksEventEmitter.swift#L38) function.
1. Log in to a site with lots of chart data.
2. Hold and drag on the chart. 
3. Confirm that the `interacted()` function is only called after you've stopped interacting with the chart for 1 second.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

