### PR TITLE
Fix tests build error

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -678,7 +678,7 @@ final class NewOrderViewModelTests: XCTestCase {
     func test_discard_order_deletes_order_if_order_exists_remotely() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores, enableRemoteSync: true)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
         waitForExpectation { expectation in
             stores.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {


### PR DESCRIPTION
## Description
Due to merge timing, https://github.com/woocommerce/woocommerce-ios/pull/6426 added a test that used function parameter already removed from `trunk` in https://github.com/woocommerce/woocommerce-ios/pull/6429.
This PR removes extra parameter to resolve tests build issue.

## Testing
Check CI status or build tests locally.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.