### PR TITLE
Coupons: Update SiteSettingsRemote to add endpoints to load and update coupon setting

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -626,6 +626,7 @@
 		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
 		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
 		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
+		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1310,6 +1311,7 @@
 		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
 		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
 		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
+		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -1950,6 +1952,7 @@
 				57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */,
 				D88D5A42230BC668007B6E01 /* reviews-single.json */,
 				267066082774BF3B008E1F68 /* settings-advanced.json */,
+				DE74F29B27E0A1D00002FE59 /* setting-coupon.json */,
 				74046E20217A73D0007DD7BF /* settings-general.json */,
 				7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */,
 				74159622224D2C86003C21CF /* settings-product.json */,
@@ -2494,6 +2497,7 @@
 				D865CE63278CA1DA002C8520 /* stripe-payment-intent-requires-capture.json in Resources */,
 				02A26F1B2744F5FC008E4EDB /* wc-site-settings-partial.json in Resources */,
 				028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */,
+				DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */,
 				02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */,
 				CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */,
 				45150AA2268373F8006922EA /* countries.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 		DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BE279583A100171F1C /* CouponReportListMapper.swift */; };
 		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
 		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
+		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1308,6 +1309,7 @@
 		DE2095BE279583A100171F1C /* CouponReportListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapper.swift; sourceTree = "<group>"; };
 		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
 		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
+		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -2098,6 +2100,7 @@
 				31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */,
 				DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */,
 				74046E1E217A6B70007DD7BF /* SiteSettingsMapper.swift */,
+				DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */,
 				B53EF53B21814900003E146F /* SuccessResultMapper.swift */,
 				74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */,
 				CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */,
@@ -2794,6 +2797,7 @@
 				31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */,
 				02BE0A7B274B695F001176D2 /* WordPressMediaMapper.swift in Sources */,
 				45150A9A268340D2006922EA /* Country.swift in Sources */,
+				DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
 				CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */,
 				456930AB264EB85A009ED69D /* ShippingLabelCarriersAndRatesMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
 		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
 		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
+		DE74F29E27E0A6800002FE59 /* SiteSettingMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29D27E0A6800002FE59 /* SiteSettingMapperTests.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1312,6 +1313,7 @@
 		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
 		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
 		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
+		DE74F29D27E0A6800002FE59 /* SiteSettingMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapperTests.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -2238,6 +2240,7 @@
 				311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */,
 				DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */,
 				74A7B4BB217A807400E85A8B /* SiteSettingsMapperTests.swift */,
+				DE74F29D27E0A6800002FE59 /* SiteSettingMapperTests.swift */,
 				74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */,
 				45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */,
 				74ABA1D4213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift */,
@@ -3078,6 +3081,7 @@
 				DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */,
 				CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */,
 				FE28F6EC268436C9004465C7 /* UserRemoteTests.swift in Sources */,
+				DE74F29E27E0A6800002FE59 /* SiteSettingMapperTests.swift in Sources */,
 				020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */,
 				DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */,
 				4599FC5A24A626B70056157A /* ProductTagListMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/SiteSettingMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingMapper.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Mapper: SiteSetting
+/// Mapper for a single SiteSetting
 ///
 struct SiteSettingMapper: Mapper {
 

--- a/Networking/Networking/Mapper/SiteSettingMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingMapper.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Mapper: SiteSetting
+///
+struct SiteSettingMapper: Mapper {
+
+    /// Site Identifier associated to the settings that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't really return the SiteID in any of the
+    /// settings endpoints.
+    ///
+    let siteID: Int64
+
+    /// Group name associated to the settings that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the group in any of the setting endpoints.
+    ///
+    let settingsGroup: SiteSettingGroup
+
+    /// (Attempts) to convert a dictionary into SiteSetting.
+    ///
+    func map(response: Data) throws -> SiteSetting {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID,
+            .settingGroupKey: settingsGroup.rawValue
+        ]
+
+        return try decoder.decode(SiteSettingEnvelope.self, from: response).setting
+    }
+}
+
+
+/// SiteSettingEnvelope Disposable Entity:
+/// The plugins endpoint returns the document within a `data` key. This entity
+/// allows us to do parse the returned plugin model with JSONDecoder.
+///
+private struct SiteSettingEnvelope: Decodable {
+    let setting: SiteSetting
+
+    private enum CodingKeys: String, CodingKey {
+        case setting = "data"
+    }
+}

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -47,30 +47,38 @@ public class SiteSettingsRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Retrieve setting for whether coupons are enabled for a given site
+    /// Retrieve detail for a single setting for a given site
     ///
     /// - Parameters:
-    ///   - siteID: Site for which we'll fetch the coupon setting.
+    ///   - siteID: Site for which we'll fetch the setting.
+    ///   - settingGroup: The group the setting belong to.
+    ///   - settingID: ID of the setting.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadCouponSetting(for siteID: Int64, completion: @escaping (Result<SiteSetting, Error>) -> Void) {
-        let path = Constants.siteSettingsPath + Constants.generalSettingsGroup + "/" + Constants.couponEnabledSettingID
+    public func loadSetting(for siteID: Int64, settingGroup: SiteSettingGroup, settingID: String, completion: @escaping (Result<SiteSetting, Error>) -> Void) {
+        let path = Constants.siteSettingsPath + settingGroup.rawValue + "/" + settingID
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Update setting for coupon for a given site
+    /// Update value for a single setting for a given site
     ///
     /// - Parameters:
-    ///   - siteID: Site for which we'll update the coupon setting.
+    ///   - siteID: Site for which we'll update setting.
+    ///   - settingGroup: The group the setting belong to.
+    ///   - settingID: ID of the setting.
     ///   - value: New value for the setting.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func updateCouponSetting(for siteID: Int64, value: String, completion: @escaping (Result<SiteSetting, Error>) -> Void) {
+    public func updateSetting(for siteID: Int64,
+                              settingGroup: SiteSettingGroup,
+                              settingID: String,
+                              value: String,
+                              completion: @escaping (Result<SiteSetting, Error>) -> Void) {
         let parameters: [String: Any] = [Constants.valueParameter: value]
-        let path = Constants.siteSettingsPath + Constants.generalSettingsGroup + "/" + Constants.couponEnabledSettingID
+        let path = Constants.siteSettingsPath + settingGroup.rawValue + "/" + settingID
         let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
         let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
 
@@ -87,7 +95,6 @@ private extension SiteSettingsRemote {
         static let generalSettingsGroup: String   = "general"
         static let productSettingsGroup: String   = "products"
         static let advancedSettingsGroup: String   = "advanced"
-        static let couponEnabledSettingID: String = "woocommerce_enable_coupons"
         static let valueParameter: String = "value"
     }
 }

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -46,6 +46,36 @@ public class SiteSettingsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Retrieve setting for whether coupons are enabled for a given site
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the coupon setting.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadCouponSetting(for siteID: Int64, completion: @escaping (Result<SiteSetting, Error>) -> Void) {
+        let path = Constants.siteSettingsPath + Constants.generalSettingsGroup + "/" + Constants.couponEnabledSettingID
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Update setting for coupon for a given site
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll update the coupon setting.
+    ///   - value: New value for the setting.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func updateCouponSetting(for siteID: Int64, value: String, completion: @escaping (Result<SiteSetting, Error>) -> Void) {
+        let parameters: [String: Any] = [Constants.valueParameter: value]
+        let path = Constants.siteSettingsPath + Constants.generalSettingsGroup + "/" + Constants.couponEnabledSettingID
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -57,5 +87,7 @@ private extension SiteSettingsRemote {
         static let generalSettingsGroup: String   = "general"
         static let productSettingsGroup: String   = "products"
         static let advancedSettingsGroup: String   = "advanced"
+        static let couponEnabledSettingID: String = "woocommerce_enable_coupons"
+        static let valueParameter: String = "value"
     }
 }

--- a/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Networking
+
+final class SiteSettingMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 242424
+
+    /// Verifies the SiteSetting fields are parsed correctly.
+    ///
+    func test_SiteSetting_fields_are_properly_parsed() throws {
+        let setting = try XCTUnwrap(mapLoadCouponSettingResponse())
+        
+        XCTAssertEqual(setting.siteID, dummySiteID)
+        XCTAssertEqual(setting.settingID, "woocommerce_enable_coupons")
+        XCTAssertEqual(setting.settingDescription, "Enable the use of coupon codes")
+        XCTAssertEqual(setting.label, "Enable coupons")
+        XCTAssertEqual(setting.value, "yes")
+    }
+
+}
+
+private extension SiteSettingMapperTests {
+
+    /// Returns the SiteSettingMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapSetting(from filename: String) -> SiteSetting? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? SiteSettingMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general).map(response: response)
+    }
+
+    /// Returns the SiteSettingMapper output upon receiving `setting-coupon`
+    ///
+    func mapLoadCouponSettingResponse() -> SiteSetting? {
+        return mapSetting(from: "setting-coupon")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
@@ -11,7 +11,6 @@ final class SiteSettingMapperTests: XCTestCase {
     ///
     func test_SiteSetting_fields_are_properly_parsed() throws {
         let setting = try XCTUnwrap(mapLoadCouponSettingResponse())
-        
         XCTAssertEqual(setting.siteID, dummySiteID)
         XCTAssertEqual(setting.settingID, "woocommerce_enable_coupons")
         XCTAssertEqual(setting.settingDescription, "Enable the use of coupon codes")

--- a/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -106,15 +106,16 @@ final class SiteSettingsRemoteTests: XCTestCase {
         XCTAssertEqual(settings.count, 2)
     }
 
-    // MARK: - Load coupon setting tests
-    func test_loadCouponSetting_properly_returns_parsed_settings() throws {
+    // MARK: - Load single setting tests
+    func test_loadSetting_properly_returns_parsed_settings() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", filename: "setting-coupon")
+        let couponSettingID = "woocommerce_enable_coupons"
+        network.simulateResponse(requestUrlSuffix: "settings/general/\(couponSettingID)", filename: "setting-coupon")
         let remote = SiteSettingsRemote(network: network)
 
         // When
         let result: Result<Networking.SiteSetting, Error> = waitFor { promise in
-            remote.loadCouponSetting(for: self.sampleSiteID) { result in
+            remote.loadSetting(for: self.sampleSiteID, settingGroup: .general, settingID: couponSettingID) { result in
                 promise(result)
             }
         }
@@ -128,13 +129,14 @@ final class SiteSettingsRemoteTests: XCTestCase {
 
     func test_loadCouponSetting_properly_relays_netwoking_errors() throws {
         // Given
+        let couponSettingID = "woocommerce_enable_coupons"
         let remote = SiteSettingsRemote(network: network)
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)
-        network.simulateError(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", error: error)
+        network.simulateError(requestUrlSuffix: "settings/general/\(couponSettingID)", error: error)
 
         // When
         let result: Result<Networking.SiteSetting, Error> = waitFor { promise in
-            remote.loadCouponSetting(for: self.sampleSiteID) { result in
+            remote.loadSetting(for: self.sampleSiteID, settingGroup: .general, settingID: couponSettingID) { result in
                 promise(result)
             }
         }
@@ -148,12 +150,13 @@ final class SiteSettingsRemoteTests: XCTestCase {
     // MARK: - Update coupon setting tests
     func test_updateCouponSetting_properly_returns_parsed_settings() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", filename: "setting-coupon")
+        let couponSettingID = "woocommerce_enable_coupons"
+        network.simulateResponse(requestUrlSuffix: "settings/general/\(couponSettingID)", filename: "setting-coupon")
         let remote = SiteSettingsRemote(network: network)
 
         // When
         let result: Result<Networking.SiteSetting, Error> = waitFor { promise in
-            remote.updateCouponSetting(for: self.sampleSiteID, value: "yes") { result in
+            remote.updateSetting(for: self.sampleSiteID, settingGroup: .general, settingID: couponSettingID, value: "yes") { result in
                 promise(result)
             }
         }
@@ -167,13 +170,14 @@ final class SiteSettingsRemoteTests: XCTestCase {
 
     func test_updateCouponSetting_properly_relays_netwoking_errors() throws {
         // Given
+        let couponSettingID = "woocommerce_enable_coupons"
         let remote = SiteSettingsRemote(network: network)
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)
-        network.simulateError(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", error: error)
+        network.simulateError(requestUrlSuffix: "settings/general/\(couponSettingID)", error: error)
 
         // When
         let result: Result<Networking.SiteSetting, Error> = waitFor { promise in
-            remote.updateCouponSetting(for: self.sampleSiteID, value: "yes") { result in
+            remote.updateSetting(for: self.sampleSiteID, settingGroup: .general, settingID: couponSettingID, value: "yes") { result in
                 promise(result)
             }
         }

--- a/Networking/NetworkingTests/Responses/setting-coupon.json
+++ b/Networking/NetworkingTests/Responses/setting-coupon.json
@@ -1,0 +1,23 @@
+{
+	"data": {
+        "id": "woocommerce_enable_coupons",
+        "label": "Enable coupons",
+        "description": "Enable the use of coupon codes",
+        "type": "checkbox",
+        "default": "yes",
+        "tip": "Coupons can be applied from the cart and checkout pages.",
+        "value": "yes",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_enable_coupons"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6250 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For #6250 we want to be able to check if coupons are enabled for a store and add the feature to enable it if necessary. This PR updates the Networking layer to add endpoints to load and update a single setting given site ID, setting group, and setting ID. This generic setup will come in handy in the future since we will also want to check and update the setting for WC Analytics too.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These endpoints haven't been integrated yet so just CI passing is sufficient.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
