### PR TITLE
Fix: injection of our custom user agent in the `AuthenticatedWebView` component

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Fixed issue presenting Edit Customer Note screen as a modal on large screens. [https://github.com/woocommerce/woocommerce-ios/pull/6406]
 - [*] Products displayed in Order Detail now follow the same order of the web. [https://github.com/woocommerce/woocommerce-ios/pull/6401]
 - [*] Simple Payments now shows a detailed tax break up before taking the payment. [https://github.com/woocommerce/woocommerce-ios/pull/6412]
+- [internal] Shipping Labels: the navigation bar in the web view for adding payments is now correctly hidden. [https://github.com/woocommerce/woocommerce-ios/pull/6435]
 
 8.7
 -----

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import WebKit
 import Alamofire
-import Networking
+import class Networking.UserAgent
 
 // Bridge UIKit `WKWebView` component to SwiftUI for URLs that need authentication on WPCom
 struct AuthenticatedWebView: UIViewRepresentable {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import WebKit
 import Alamofire
+import Networking
 
 // Bridge UIKit `WKWebView` component to SwiftUI for URLs that need authentication on WPCom
 struct AuthenticatedWebView: UIViewRepresentable {
@@ -31,6 +32,7 @@ struct AuthenticatedWebView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> WKWebView {
         let webview = WKWebView()
+        webview.customUserAgent = UserAgent.defaultUserAgent
         webview.navigationDelegate = context.coordinator
 
         configureForSandboxEnvironment(webview)


### PR DESCRIPTION
### Description
@astralbodies reported that the Calypso tweak we put in to hide navigation isn't working in the web view for adding a new payment method in the Shipping Label creation process.
The reason was that we weren't injecting the user agent in the `AuthenticatedWebView` component.

### Testing instructions
1. Disable AutoProxxy (if you are curious why you can find the answer here: pMz3w-bAI#comment-80199).
2. Open an order eligible for Shipping Labels.
3. Start the flow for creating a Shipping Label, and try to add a new payment method (you should be the store owner).
4. The navigation bar in the web view should be hidden.


### Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-15 at 16 11 43](https://user-images.githubusercontent.com/495617/158411906-9c52938e-eb20-4abc-8dd1-193b1136bbd0.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-15 at 16 17 02](https://user-images.githubusercontent.com/495617/158411925-59e95b3e-4651-442f-b4ed-076ac4150368.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
