### PR TITLE
[Mobile Payments] Allow mapping of interacPresent WCPayCharges

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		03DCB7822627394500C8953D /* CouponMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7812627394500C8953D /* CouponMapperTests.swift */; };
 		03DCB786262739D200C8953D /* CouponMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB785262739D200C8953D /* CouponMapper.swift */; };
 		03DCB796262741E000C8953D /* Coupon+Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB795262741E000C8953D /* Coupon+Decoder.swift */; };
+		03E6676927E0F62B00890E6F /* wcpay-charge-interac-present.json in Resources */ = {isa = PBXBuildFile; fileRef = 03E6676827E0F62B00890E6F /* wcpay-charge-interac-present.json */; };
 		03E8FEC427B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */; };
 		077F39C8269F2C7E00ABEADC /* SystemPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */; };
 		077F39D426A58DE700ABEADC /* SystemStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */; };
@@ -781,6 +782,7 @@
 		03DCB7812627394500C8953D /* CouponMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapperTests.swift; sourceTree = "<group>"; };
 		03DCB785262739D200C8953D /* CouponMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapper.swift; sourceTree = "<group>"; };
 		03DCB795262741E000C8953D /* Coupon+Decoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Coupon+Decoder.swift"; sourceTree = "<group>"; };
+		03E6676827E0F62B00890E6F /* wcpay-charge-interac-present.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-interac-present.json"; sourceTree = "<group>"; };
 		03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card-present-minimal.json"; sourceTree = "<group>"; };
 		077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPlugin.swift; sourceTree = "<group>"; };
 		077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapper.swift; sourceTree = "<group>"; };
@@ -2034,6 +2036,7 @@
 				077F39D726A58EB600ABEADC /* systemStatus.json */,
 				0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */,
 				0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */,
+				03E6676827E0F62B00890E6F /* wcpay-charge-interac-present.json */,
 				03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */,
 				0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */,
 				45CCFCE927A2E59B0012E8CB /* inbox-note-list.json */,
@@ -2528,6 +2531,7 @@
 				D865CE73278CC215002C8520 /* stripe-customer-error.json in Resources */,
 				74C8F06620EEB76400B6EDC9 /* order-notes.json in Resources */,
 				7426CA1321AF34A3004E9FFC /* site-api.json in Resources */,
+				03E6676927E0F62B00890E6F /* wcpay-charge-interac-present.json in Resources */,
 				453305ED2459E1AA00264E50 /* site-post.json in Resources */,
 				74749B99224135C4005C4CF2 /* product.json in Resources */,
 				4515281F257A89B90076B03C /* product-attribute-create.json in Resources */,

--- a/Networking/Networking/Model/WCPayCardFunding.swift
+++ b/Networking/Networking/Model/WCPayCardFunding.swift
@@ -13,5 +13,7 @@ public enum WCPayCardFunding: String, Codable, GeneratedCopiable, GeneratedFakea
     case credit
     case debit
     case prepaid
+    case checking
+    case savings
     case unknown
 }

--- a/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
+++ b/Networking/Networking/Model/WCPayPaymentMethodDetails.swift
@@ -16,6 +16,9 @@ public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFa
     /// A card present payment, with `details`. This represents an In-Person Payment.
     case cardPresent(details: WCPayCardPresentPaymentDetails)
 
+    /// An interac present payment, with `details`. This represents an In-Person Payment, and is specific to some Canadian payments.
+    case interacPresent(details: WCPayCardPresentPaymentDetails)
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -36,8 +39,10 @@ public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFa
             }
             self = .cardPresent(details: cardPresentDetails)
         case .interacPresent:
-            // Unsupported for now, coming up in https://github.com/woocommerce/woocommerce-ios/issues/5979
-            self = .unknown
+            guard let interacPresentDetails = try? container.decode(WCPayCardPresentPaymentDetails.self, forKey: .interacPresent) else {
+                throw WCPayPaymentMethodDetailsDecodingError.noDetailsPresentForPaymentType
+            }
+            self = .interacPresent(details: interacPresentDetails)
         case .unknown:
             self = .unknown
         }
@@ -49,6 +54,7 @@ internal extension WCPayPaymentMethodDetails {
         case type
         case card
         case cardPresent = "card_present"
+        case interacPresent = "interac_present"
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
@@ -53,6 +53,39 @@ class WCPayChargeMapperTests: XCTestCase {
         XCTAssertEqual(wcpayCharge, expectedWcpayCharge)
     }
 
+    /// Verifies that the fields are all parsed correctly for an interac present payment
+    ///
+    func test_WCPayCharge_map_parses_all_fields_in_result_for_interac_present() throws {
+        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .interacPresent)
+
+        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1647257154) //2022-03-14 11:25:54 UTC
+
+        let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.interacPresent(
+            details: .init(brand: .visa,
+                           last4: "1933",
+                           funding: .debit,
+                           receipt: .init(accountType: .checking,
+                                          applicationPreferredName: "Interac",
+                                          dedicatedFileName: "A0000002771010")))
+
+        let expectedWcpayCharge = WCPayCharge(siteID: dummySiteID,
+                                              id: "ch_3KdC1s2ETjwGHy9P0Cawro7o",
+                                              amount: 200,
+                                              amountCaptured: 200,
+                                              amountRefunded: 0,
+                                              authorizationCode: "123456",
+                                              captured: true,
+                                              created: expectedCreatedDate,
+                                              currency: "cad",
+                                              paid: true,
+                                              paymentIntentID: "pi_3KdC1s2ETjwGHy9P0BM3JOST",
+                                              paymentMethodID: "pm_1KdC2A2ETjwGHy9PzX5ptD6N",
+                                              paymentMethodDetails: expectedPaymentMethodDetails,
+                                              refunded: false,
+                                              status: .succeeded)
+        assertEqual(wcpayCharge, expectedWcpayCharge)
+    }
+
     /// Verifies that the fields are all parsed correctly for a card present payment
     ///
     func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present_with_nulls() throws {
@@ -142,5 +175,6 @@ private extension WCPayChargeMapperTests {
         case cardPresent = "wcpay-charge-card-present"
         case cardPresentMinimal = "wcpay-charge-card-present-minimal"
         case card = "wcpay-charge-card"
+        case interacPresent = "wcpay-charge-interac-present"
     }
 }

--- a/Networking/NetworkingTests/Responses/wcpay-charge-interac-present.json
+++ b/Networking/NetworkingTests/Responses/wcpay-charge-interac-present.json
@@ -1,0 +1,134 @@
+{
+    "data": {
+        "id": "ch_3KdC1s2ETjwGHy9P0Cawro7o",
+        "object": "charge",
+        "amount": 200,
+        "amount_captured": 200,
+        "amount_refunded": 0,
+        "application": "ca_Ex84e31yMTLaNU5ozQvi5woLclpIDVpX",
+        "application_fee": null,
+        "application_fee_amount": null,
+        "authorization_code": "123456",
+        "balance_transaction": {
+            "id": "txn_3KdC1s2ETjwGHy9P0zKKeVTf",
+            "object": "balance_transaction",
+            "amount": 200,
+            "available_on": 1647820800,
+            "created": 1647257158,
+            "currency": "cad",
+            "description": "In-Person Payment for Order #86 for My WordPress Site",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": 200,
+            "reporting_category": "charge",
+            "source": "ch_3KdC1s2ETjwGHy9P0Cawro7o",
+            "status": "pending",
+            "type": "charge"
+        },
+        "billing_details": {
+            "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "formatted_address": ""
+        },
+        "calculated_statement_descriptor": "JHMOOSE.MYSTAGINGWEBSI",
+        "captured": true,
+        "created": 1647257154,
+        "currency": "cad",
+        "customer": "cus_LJph2ywrktFOKY",
+        "description": "In-Person Payment for Order #86 for My WordPress Site",
+        "destination": null,
+        "dispute": null,
+        "disputed": false,
+        "failure_code": null,
+        "failure_message": null,
+        "fraud_details": [],
+        "invoice": null,
+        "livemode": false,
+        "metadata": {
+            "order_id": "86",
+            "payment_type": "single",
+            "paymentintent.storename": "My WordPress Site",
+            "reader_ID": "WPC323026000396",
+            "reader_model": "WISEPAD_3",
+            "site_url": "https://moose.example.com"
+        },
+        "on_behalf_of": null,
+        "order": {
+            "number": "86",
+            "url": "https://moose.example.com/wp-admin/post.php?post=86&action=edit",
+            "customer_url": "admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=27",
+            "subscriptions": []
+        },
+        "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "not_assessed",
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+        },
+        "paid": true,
+        "payment_intent": "pi_3KdC1s2ETjwGHy9P0BM3JOST",
+        "payment_method": "pm_1KdC2A2ETjwGHy9PzX5ptD6N",
+        "payment_method_details": {
+            "interac_present": {
+                "brand": "visa",
+                "cardholder_name": "USA INTERAC/Test Card 01",
+                "country": "CA",
+                "emv_auth_data": "8A023030",
+                "exp_month": 12,
+                "exp_year": 2022,
+                "fingerprint": "rRszUUzMmNu5Onxg",
+                "funding": "debit",
+                "generated_card": null,
+                "last4": "1933",
+                "network": "interac",
+                "preferred_locales": [
+                    "en"
+                ],
+                "read_method": "contact_emv",
+                "receipt": {
+                    "account_type": "checking",
+                    "application_cryptogram": "36F7094AF11F1801",
+                    "application_preferred_name": "Interac",
+                    "authorization_code": null,
+                    "authorization_response_code": "3030",
+                    "cardholder_verification_method": "offline_pin",
+                    "dedicated_file_name": "A0000002771010",
+                    "terminal_verification_results": "8000008000",
+                    "transaction_status_information": "6800"
+                }
+            },
+            "type": "interac_present"
+        },
+        "receipt_email": null,
+        "receipt_number": null,
+        "receipt_url": "https://pay.stripe.com/receipts/acct_1KWgPj2ETjwGHy9P/ch_3KdC1s2ETjwGHy9P0Cawro7o/rcpt_LJph4uuWUNwUSmaH7J4cjRCNpP0EyYR",
+        "refunded": false,
+        "refunds": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3KdC1s2ETjwGHy9P0Cawro7o/refunds"
+        },
+        "review": null,
+        "shipping": null,
+        "source": null,
+        "source_transfer": null,
+        "statement_descriptor": "JHMOOSE.MYSTAGINGWEBSI",
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": null
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -155,14 +155,16 @@ private extension RefundConfirmationViewModel {
     ///
     func makeRefundViaRow() -> RefundConfirmationViewModelRow {
         if gatewaySupportsAutomaticRefunds() {
-            guard case .cardPresent(let cardDetails) = details.charge?.paymentMethodDetails else {
+            switch details.charge?.paymentMethodDetails {
+            case .some(.cardPresent(let cardDetails)), .some(.interacPresent(let cardDetails)):
+                return PaymentDetailsRow(cardIcon: cardDetails.brand.icon,
+                                         cardIconAspectHorizontal: cardDetails.brand.iconAspectHorizontal,
+                                         paymentGateway: details.order.paymentMethodTitle,
+                                         paymentMethodDescription: cardDetails.brand.cardDescription(last4: cardDetails.last4),
+                                         accessibilityDescription: cardDetails.brand.cardAccessibilityDescription(last4: cardDetails.last4))
+            default:
                 return SimpleTextRow(text: details.order.paymentMethodTitle)
             }
-            return PaymentDetailsRow(cardIcon: cardDetails.brand.icon,
-                                     cardIconAspectHorizontal: cardDetails.brand.iconAspectHorizontal,
-                                     paymentGateway: details.order.paymentMethodTitle,
-                                     paymentMethodDescription: cardDetails.brand.cardDescription(last4: cardDetails.last4),
-                                     accessibilityDescription: cardDetails.brand.cardAccessibilityDescription(last4: cardDetails.last4))
         } else {
             return TitleAndBodyRow(title: Localization.manualRefund(via: details.order.paymentMethodTitle),
                                    body: Localization.refundWillNotBeIssued(paymentMethod: details.order.paymentMethodTitle))

--- a/Yosemite/Yosemite/Model/Storage/WCPayCharge+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WCPayCharge+ReadOnlyConvertible.swift
@@ -60,6 +60,8 @@ private extension WCPayPaymentMethodDetails {
             return "card"
         case .cardPresent(_):
             return "cardPresent"
+        case .interacPresent(_):
+            return "interacPresent"
         }
     }
 
@@ -71,6 +73,8 @@ private extension WCPayPaymentMethodDetails {
             self = .card(details: cardDetails)
         case ("cardPresent", _, .some(let cardPresentDetails)):
             self = .cardPresent(details: cardPresentDetails)
+        case ("interacPresent", _, .some(let interacPresentDetails)):
+            self = .interacPresent(details: interacPresentDetails)
         default:
             self = .unknown
         }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -559,6 +559,10 @@ private extension CardPresentPaymentStore {
             upsertCardPresentDetails(details, for: storageWCPayCharge, in: storage)
         case .card(let details):
             upsertCardDetails(details, for: storageWCPayCharge, in: storage)
+        case .interacPresent(let details):
+            storageWCPayCharge.cardDetails = nil
+            storageWCPayCharge.cardPresentDetails = nil
+            #warning("actually do this")
         case .unknown:
             storageWCPayCharge.cardDetails = nil
             storageWCPayCharge.cardPresentDetails = nil

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -555,14 +555,10 @@ private extension CardPresentPaymentStore {
         let storageWCPayCharge = existingOrNewWCPayCharge(siteID: readonlyCharge.siteID, chargeID: readonlyCharge.id, in: storage)
 
         switch readonlyCharge.paymentMethodDetails {
-        case .cardPresent(let details):
+        case .cardPresent(let details), .interacPresent(let details):
             upsertCardPresentDetails(details, for: storageWCPayCharge, in: storage)
         case .card(let details):
             upsertCardDetails(details, for: storageWCPayCharge, in: storage)
-        case .interacPresent(let details):
-            storageWCPayCharge.cardDetails = nil
-            storageWCPayCharge.cardPresentDetails = nil
-            #warning("actually do this")
         case .unknown:
             storageWCPayCharge.cardDetails = nil
             storageWCPayCharge.cardPresentDetails = nil

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -43,6 +43,10 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     ///
     private let sampleChargeID = "ch_3KMVap2EdyGr1FMV1uKJEWtg"
 
+    /// Testing Charge ID for interac transaction
+    ///
+    private let sampleInteracChargeID = "ch_3KdC1s2ETjwGHy9P0Cawro7o"
+
     /// Testing Charge ID for card transaction
     ///
     private let sampleCardChargeID = "ch_3KMuym2EdyGr1FMV0uQZeFqm"
@@ -505,6 +509,37 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         let storedDetails = storageCharge?.cardDetails
         XCTAssertEqual(storedDetails?.last4, "1111")
         XCTAssertNil(storageCharge?.cardPresentDetails)
+    }
+
+    func test_fetchWCPayCharge_inserts_interac_present_charge_details_in_storage() throws {
+        let store = CardPresentPaymentStore(dispatcher: dispatcher,
+                                            storageManager: storageManager,
+                                            network: network,
+                                            cardReaderService: mockCardReaderService)
+
+        network.simulateResponse(requestUrlSuffix: "payments/charges/\(sampleInteracChargeID)",
+                                 filename: "wcpay-charge-interac-present")
+
+        let result: Result<Yosemite.WCPayCharge, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: self.sampleSiteID, chargeID: self.sampleInteracChargeID, onCompletion: { result in
+                promise(result)
+            })
+            store.onAction(action)
+        }
+        XCTAssertTrue(result.isSuccess)
+
+        XCTAssert(viewStorage.countObjects(ofType: Storage.WCPayCharge.self, matching: nil) == 1)
+
+        let storageCharge = viewStorage.loadWCPayCharge(siteID: sampleSiteID, chargeID: sampleInteracChargeID)
+
+        XCTAssert(viewStorage.countObjects(ofType: Storage.WCPayCardPaymentDetails.self, matching: nil) == 0)
+        XCTAssert(viewStorage.countObjects(ofType: Storage.WCPayCardPresentPaymentDetails.self, matching: nil) == 1)
+        XCTAssert(viewStorage.countObjects(ofType: Storage.WCPayCardPresentReceiptDetails.self, matching: nil) == 1)
+
+        let storedDetails = storageCharge?.cardPresentDetails
+        XCTAssertEqual(storedDetails?.receipt?.applicationPreferredName, "Interac")
+        XCTAssertEqual(storedDetails?.last4, "1933")
+        XCTAssertNil(storageCharge?.cardDetails)
     }
 
     /// Verifies that the store hits the network when fetching a charge, and propagates errors.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6437 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This will allow us to get the details of IPP interac payments, e.g. last4, card brand, which we use on the refund confirmation view to show the card details. We also need this to process interac refunds, not just for the UI, since the charge ID and currency are also required to initiate the client-side refund.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Using a Canada-based store set up for In-Person Payments
2. On the Orders tab, tap `+` to make a new simple payment order, or submit a COD order on the web.
3. Open the order, and navigate to collect payment
4. Take payment with an Interac card
5. Open the Order details screen, and tap `Issue Refund`
6. Observe that the card details (brand image, last 4 digits) are shown.

N.B. Most interac cards, including our test cards, are co-branded with a more widely known card brand, and that should be shown. That is the reason for the Visa logo in the screen below.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![interac-refund-confirmation](https://user-images.githubusercontent.com/2472348/158603838-cc3c7a22-9669-43cf-82a6-12336702138f.jpg)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
