### PR TITLE
Simple Payments: Add auto draft support

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -88,9 +88,25 @@ extension SimplePaymentsAmountHostingController: UIAdaptivePresentationControlle
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
             return
         }
-        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+
+        presentCancelOrderActionSheet(viewController: self) { [weak self] _ in
             self?.dismiss(animated: true, completion: nil)
-        })
+        }
+    }
+
+    private func presentCancelOrderActionSheet(viewController: UIViewController, onDismiss: ((UIAlertAction) -> Void)? = nil) {
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+        actionSheet.addDestructiveActionWithTitle(SimplePaymentsAmount.Localization.dismissOrder, handler: onDismiss)
+        actionSheet.addCancelActionWithTitle(SimplePaymentsAmount.Localization.cancelTitle)
+
+        if let popoverController = actionSheet.popoverPresentationController {
+            popoverController.sourceView = viewController.view
+            popoverController.sourceRect = viewController.view.bounds
+            popoverController.permittedArrowDirections = []
+        }
+
+        viewController.present(actionSheet, animated: true)
     }
 }
 
@@ -194,6 +210,7 @@ private extension SimplePaymentsAmount {
         static let created = NSLocalizedString("🎉 Order created", comment: "Notice text after creating a simple payment order")
         static let completed = NSLocalizedString("🎉 Order completed", comment: "Notice text after completing a simple payment order")
         static let buttonTitle = NSLocalizedString("Next", comment: "Title for the button to confirm the amount in the simple payments screen")
+        static let dismissOrder = NSLocalizedString("Dismiss Order", comment: "Title for dismiss the action when dragging the screen down.")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -122,7 +122,10 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
             guard let self = self else { return }
 
             // Order created as taxable to delegate taxes calculation to the API.
-            let action = OrderAction.createSimplePaymentsOrder(siteID: self.siteID, amount: self.amount, taxable: true) { [weak self] result in
+            let action = OrderAction.createSimplePaymentsOrder(siteID: self.siteID,
+                                                               status: initialOrderStatus,
+                                                               amount: self.amount,
+                                                               taxable: true) { [weak self] result in
                 guard let self = self else { return }
                 self.loading = false
 
@@ -139,7 +142,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
                 }
             }
 
-            stores.dispatch(action)
+            self.stores.dispatch(action)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -224,6 +224,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         let action = OrderAction.updateSimplePaymentsOrder(siteID: siteID,
                                                            orderID: orderID,
                                                            feeID: feeID,
+                                                           status: .pending, // Force .pending status to properly generate the payment link in the next screen.
                                                            amount: providedAmount,
                                                            taxable: enableTaxes,
                                                            orderNote: noteContent,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -168,7 +168,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
                                                        stores: mockStores)
         mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
+            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(.success(Order.fake()))
             default:
                 XCTFail("Unexpected action: \(action)")
@@ -203,7 +203,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
                                                        stores: mockStores)
         mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
+            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -257,6 +257,29 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         XCTAssertTrue(receivedError)
     }
 
+    func test_order_is_updated_with_pending_status() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0", totalWithTaxes: "1.0", taxLines: [], stores: mockStores)
+
+        // When
+        let updateStatus: OrderStatusEnum = waitFor { promise in
+            mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateSimplePaymentsOrder(_, _, _, status, _, _, _, _, _):
+                    promise(status)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            viewModel.updateOrder()
+        }
+
+        // Then
+        XCTAssertEqual(updateStatus, .pending)
+    }
+
     func test_when_order_is_updated_navigation_to_payments_method_is_triggered() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
@@ -266,7 +289,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
                                                        stores: mockStores)
         mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
+            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(.success(Order.fake()))
             default:
                 XCTFail("Unexpected action: \(action)")
@@ -294,7 +317,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let trimmedEmail: String? = waitFor { promise in
             mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {
-                case let .updateSimplePaymentsOrder(_, _, _, _, _, _, email, _):
+                case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, email, _):
                     promise(email)
                 default:
                     XCTFail("Unexpected action: \(action)")
@@ -321,7 +344,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let emailSent: String? = waitFor { promise in
             mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {
-                case let .updateSimplePaymentsOrder(_, _, _, _, _, _, email, _):
+                case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, email, _):
                     promise(email)
                 default:
                     XCTFail("Unexpected action: \(action)")
@@ -409,7 +432,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, onCompletion):
+            case let .updateSimplePaymentsOrder(_, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unexpected action: \(action)")

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -78,6 +78,7 @@ public enum OrderAction: Action {
     case updateSimplePaymentsOrder(siteID: Int64,
                                    orderID: Int64,
                                    feeID: Int64,
+                                   status: OrderStatusEnum,
                                    amount: String,
                                    taxable: Bool,
                                    orderNote: String?,

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -67,7 +67,7 @@ public enum OrderAction: Action {
 
     /// Creates a simple payments order with a specific amount value and  tax status.
     ///
-    case createSimplePaymentsOrder(siteID: Int64, amount: String, taxable: Bool, onCompletion: (Result<Order, Error>) -> Void)
+    case createSimplePaymentsOrder(siteID: Int64, status: OrderStatusEnum, amount: String, taxable: Bool, onCompletion: (Result<Order, Error>) -> Void)
 
     /// Creates a manual order with the provided order details.
     ///

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -7,14 +7,14 @@ public enum OrderFactory {
     /// Creates an order suitable to be used as a simple payments order.
     /// Under the hood it uses a fee line with or without taxes to create an order with the desired amount.
     ///
-    static func simplePaymentsOrder(amount: String, taxable: Bool) -> Order {
+    static func simplePaymentsOrder(status: OrderStatusEnum = .autoDraft, amount: String, taxable: Bool) -> Order {
         Order(siteID: 0,
               orderID: 0,
               parentID: 0,
               customerID: 0,
               orderKey: "",
               number: "",
-              status: .pending,
+              status: status,
               currency: "",
               customerNote: "",
               dateCreated: Date(),

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -7,7 +7,7 @@ public enum OrderFactory {
     /// Creates an order suitable to be used as a simple payments order.
     /// Under the hood it uses a fee line with or without taxes to create an order with the desired amount.
     ///
-    static func simplePaymentsOrder(status: OrderStatusEnum = .autoDraft, amount: String, taxable: Bool) -> Order {
+    static func simplePaymentsOrder(status: OrderStatusEnum, amount: String, taxable: Bool) -> Order {
         Order(siteID: 0,
               orderID: 0,
               parentID: 0,

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -67,10 +67,11 @@ public class OrderStore: Store {
         case let .createOrder(siteID, order, onCompletion):
             createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
 
-        case let .updateSimplePaymentsOrder(siteID, orderID, feeID, amount, taxable, orderNote, email, onCompletion):
+        case let .updateSimplePaymentsOrder(siteID, orderID, feeID, status, amount, taxable, orderNote, email, onCompletion):
             updateSimplePaymentsOrder(siteID: siteID,
                                       orderID: orderID,
                                       feeID: feeID,
+                                      status: status,
                                       amount: amount,
                                       taxable: taxable,
                                       orderNote: orderNote,
@@ -293,6 +294,7 @@ private extension OrderStore {
     func updateSimplePaymentsOrder(siteID: Int64,
                                    orderID: Int64,
                                    feeID: Int64,
+                                   status: OrderStatusEnum,
                                    amount: String,
                                    taxable: Bool,
                                    orderNote: String?,
@@ -300,7 +302,7 @@ private extension OrderStore {
                                    onCompletion: @escaping (Result<Order, Error>) -> Void) {
 
         // Recreate the original order
-        let originalOrder = OrderFactory.simplePaymentsOrder(amount: amount, taxable: taxable)
+        let originalOrder = OrderFactory.simplePaymentsOrder(status: status, amount: amount, taxable: taxable)
 
         // Create updated fields
         let newFee = OrderFactory.simplePaymentFee(feeID: feeID, amount: amount, taxable: taxable)
@@ -318,7 +320,7 @@ private extension OrderStore {
 
         // Set new fields
         let updatedOrder = originalOrder.copy(orderID: orderID, customerNote: orderNote, billingAddress: newBillingAddress, fees: [newFee])
-        let updateFields: [OrderUpdateField] = [.customerNote, .billingAddress, .fees]
+        let updateFields: [OrderUpdateField] = [.customerNote, .billingAddress, .fees, .status]
 
         updateOrder(siteID: siteID, order: updatedOrder, fields: updateFields, onCompletion: onCompletion)
     }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -62,8 +62,8 @@ public class OrderStore: Store {
         case let .updateOrder(siteID, order, fields, onCompletion):
             updateOrder(siteID: siteID, order: order, fields: fields, onCompletion: onCompletion)
 
-        case let .createSimplePaymentsOrder(siteID, amount, taxable, onCompletion):
-            createSimplePaymentsOrder(siteID: siteID, amount: amount, taxable: taxable, onCompletion: onCompletion)
+        case let .createSimplePaymentsOrder(siteID, status, amount, taxable, onCompletion):
+            createSimplePaymentsOrder(siteID: siteID, status: status, amount: amount, taxable: taxable, onCompletion: onCompletion)
         case let .createOrder(siteID, order, onCompletion):
             createOrder(siteID: siteID, order: order, onCompletion: onCompletion)
 
@@ -265,9 +265,13 @@ private extension OrderStore {
 
     /// Creates a simple payments order with a specific amount value and no tax.
     ///
-    func createSimplePaymentsOrder(siteID: Int64, amount: String, taxable: Bool, onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        let order = OrderFactory.simplePaymentsOrder(amount: amount, taxable: taxable)
-        remote.createOrder(siteID: siteID, order: order, fields: [.feeLines]) { [weak self] result in
+    func createSimplePaymentsOrder(siteID: Int64,
+                                   status: OrderStatusEnum,
+                                   amount: String,
+                                   taxable: Bool,
+                                   onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        let order = OrderFactory.simplePaymentsOrder(status: status, amount: amount, taxable: taxable)
+        remote.createOrder(siteID: siteID, order: order, fields: [.status, .feeLines]) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -274,6 +274,11 @@ private extension OrderStore {
         remote.createOrder(siteID: siteID, order: order, fields: [.status, .feeLines]) { [weak self] result in
             switch result {
             case .success(let order):
+                // Auto-draft orders are temporary and should not be stored
+                guard order.status != .autoDraft else {
+                    return onCompletion(result)
+                }
+
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
                     onCompletion(result)
                 })

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -645,7 +645,7 @@ final class OrderStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders", filename: "order")
 
         // When
-        let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, amount: "125.50", taxable: false) { _ in }
+        let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, status: .autoDraft, amount: "125.50", taxable: false) { _ in }
         store.onAction(action)
 
         // Then
@@ -667,7 +667,7 @@ final class OrderStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders", filename: "order")
 
         // When
-        let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, amount: "125.50", taxable: true) { _ in }
+        let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, status: .autoDraft, amount: "125.50", taxable: true) { _ in }
         store.onAction(action)
 
         // Then
@@ -683,14 +683,14 @@ final class OrderStoreTests: XCTestCase {
         assertEqual(received, expected)
     }
 
-    func test_create_simple_payments_order_stores_orders_correctly() throws {
+    func test_create_pending_simple_payments_order_stores_orders_correctly() throws {
         // Given
         let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "orders", filename: "order")
 
         // When
         let storedOrder: Yosemite.Order? = waitFor { promise in
-            let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, amount: "125.50", taxable: false) { _ in
+            let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, status: .pending, amount: "125.50", taxable: false) { _ in
                 let order = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)?.toReadOnly()
                 promise(order)
             }
@@ -699,6 +699,24 @@ final class OrderStoreTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(storedOrder)
+    }
+
+    func test_create_draft_simple_payments_order_does_not_get_stored() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "order-auto-draft-status")
+
+        // When
+        let storedOrder: Yosemite.Order? = waitFor { promise in
+            let action = OrderAction.createSimplePaymentsOrder(siteID: self.sampleSiteID, status: .autoDraft, amount: "125.50", taxable: false) { _ in
+                let order = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)?.toReadOnly()
+                promise(order)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertNil(storedOrder)
     }
 
     func test_create_order_stores_orders_correctly() throws {
@@ -734,6 +752,7 @@ final class OrderStoreTests: XCTestCase {
         let action = OrderAction.updateSimplePaymentsOrder(siteID: sampleSiteID,
                                                            orderID: sampleOrderID,
                                                            feeID: feeID,
+                                                           status: .pending,
                                                            amount: amount,
                                                            taxable: taxable,
                                                            orderNote: note,


### PR DESCRIPTION
# Why

Now that the app supports the `auto-draft` status(For stores with WC version greater than `6.3`), this PR adds the auto-draft support to the **Simple Payments** feature in order to not have trailing pending orders until the merchant finishes the simple payments flow.

# How

- Update `OrdersAction` & `OrderStore` to allow a simple payments order to be created and updated with a given status.

- Update `SimplePaymentsAmmountViewModel` to create a simple payment order with an `auto-draft` status if possible.

- Update `SimplePaymentsSummaryViewModel` tp update the other with a `.pending` status before proceeding to the payments screen.

- Updates unit tests.

# Demo

https://user-images.githubusercontent.com/562080/158504317-135a3f24-9915-4091-9e02-52885aa25c3c.mov

https://user-images.githubusercontent.com/562080/158504307-22ffc397-dee0-4c75-8a3e-d08276851112.mov

https://user-images.githubusercontent.com/562080/158504291-fa147662-73a2-493d-8c6f-8b91e4183889.mov


# Testing 

- Make sure to run the app with a store that has `WC 6.3` or greater.

## Draft Status
- Start the simple payments flow
- Enter an amount and tap next
- Cancel flow
- See that the order is not present in the order list (because it was created with an `auto-draft` status)

## Pending Status
- Start the simple payments flow
- Enter an amount and tap next
- Tap next in the Summary screen
- Cancel the flow
- See that the order is present in the order list (because it was updated to `.pending` to be able to take payments)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
