### PR TITLE
Coupons: Update Yosemite to retrieve and update coupon setting

### DIFF
--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -25,4 +25,12 @@ public enum SettingAction: Action {
     /// Retrieves the store payments page path.
     ///
     case getPaymentsPagePath(siteID: Int64, onCompletion: (Result<String, SettingStore.SettingError>) -> Void)
+
+    /// Retrieves the setting for whether coupons are enabled for the specified store
+    ///
+    case retrieveCouponSetting(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Enables coupons for the specified store
+    ///
+    case enableCouponSetting(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -140,7 +140,17 @@ private extension SettingStore {
     /// Enables coupons for the specified store
     ///
     func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        // TODO
+        siteSettingsRemote.updateSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons, value: SettingValue.yes) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    onCompletion(.success(Void()))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -44,6 +44,10 @@ public class SettingStore: Store {
             retrieveSiteAPI(siteID: siteID, onCompletion: onCompletion)
         case let .getPaymentsPagePath(siteID, onCompletion):
             getPaymentsPagePath(siteID: siteID, onCompletion: onCompletion)
+        case let .retrieveCouponSetting(siteID, onCompletion):
+            retrieveCouponSetting(siteID: siteID, onCompletion: onCompletion)
+        case let .enableCouponSetting(siteID, onCompletion):
+            enableCouponSetting(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -114,6 +118,18 @@ private extension SettingStore {
               }
 
         onCompletion(.success(paymentPagePath))
+    }
+
+    /// Retrieves the setting for whether coupons are enabled for the specified store
+    ///
+    func retrieveCouponSetting(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void) {
+        // TODO
+    }
+
+    /// Enables coupons for the specified store
+    ///
+    func enableCouponSetting(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void) {
+        // TODO
     }
 }
 

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -122,13 +122,24 @@ private extension SettingStore {
 
     /// Retrieves the setting for whether coupons are enabled for the specified store
     ///
-    func retrieveCouponSetting(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void) {
-        // TODO
+    func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    let isEnabled = setting.value == SettingValue.yes
+                    onCompletion(.success(isEnabled))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
     }
 
     /// Enables coupons for the specified store
     ///
-    func enableCouponSetting(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void) {
+    func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         // TODO
     }
 }
@@ -234,5 +245,10 @@ extension SettingStore {
     ///
     private enum SettingKeys {
         static let paymentsPage = "woocommerce_checkout_pay_endpoint"
+        static let coupons = "woocommerce_enable_coupons"
+    }
+
+    private enum SettingValue {
+        static let yes = "yes"
     }
 }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -132,7 +132,13 @@ private extension SettingStore {
                     onCompletion(.success(isEnabled))
                 }
             case .failure(let error):
-                onCompletion(.failure(error))
+                // fall back to retrieve from storage
+                if let setting = self.sharedDerivedStorage.loadSiteSetting(siteID: siteID, settingID: SettingKeys.coupons) {
+                    let isEnabled = setting.value == SettingValue.yes
+                    onCompletion(.success(isEnabled))
+                } else {
+                    onCompletion(.failure(error))
+                }
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 /// SettingStoreTests Unit Tests
 ///
-class SettingStoreTests: XCTestCase {
+final class SettingStoreTests: XCTestCase {
 
     /// Mock Dispatcher!
     ///
@@ -629,6 +629,81 @@ class SettingStoreTests: XCTestCase {
         // Then
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error, .paymentsPageNotFound)
+    }
+
+    func test_retrieveCouponSetting_returns_correct_setting() throws {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", filename: "setting-coupon")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = SettingAction.retrieveCouponSetting(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try XCTUnwrap(result.get())
+        XCTAssertTrue(isEnabled)
+    }
+
+    func test_retrieveCouponSetting_updates_stored_settings() {
+        // Given
+        let oldSetting = SiteSetting.fake().copy(siteID: sampleSiteID, settingID: "woocommerce_enable_coupons", value: "no", settingGroupKey: "general")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: oldSetting)
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", filename: "setting-coupon")
+
+        // When
+        let action = SettingAction.retrieveCouponSetting(siteID: self.sampleSiteID) { _ in }
+        store.onAction(action)
+
+        // Then
+        let expected = SiteSetting.fake().copy(siteID: sampleSiteID, settingID: "woocommerce_enable_coupons", value: "no", settingGroupKey: "general")
+        let updated = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: expected.settingID)?.toReadOnly()
+        XCTAssertEqual(expected, updated)
+    }
+
+    func test_retrieveCouponSetting_returns_error_when_loading_fails_and_setting_is_not_found_in_storage() {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", error: expectedError)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = SettingAction.retrieveCouponSetting(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    func test_retrieveCouponSetting_returns_stored_setting_when_loading_fails_and_setting_is_found_in_storage() throws {
+        // Given
+        let oldSetting = SiteSetting.fake().copy(siteID: sampleSiteID, settingID: "woocommerce_enable_coupons", value: "no", settingGroupKey: "general")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: oldSetting)
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", error: expectedError)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = SettingAction.retrieveCouponSetting(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertFalse(result.isFailure)
+        let isEnabled = try XCTUnwrap(result.get())
+        XCTAssertFalse(isEnabled)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6250 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For #6250 we want to be able to retrieve current setting for coupons for a specific store. Updates include:
- Add a new action to retrieve coupon setting. To make sure to get the latest setting, I'm loading the setting from remote and persisting it to the local storage. If the API request fails, attempt to fetch the setting from local storage or return error otherwise.
- Add a new action to enable coupons for a specific store. After the setting is updated successfully remotely, the updated setting is also persisted to the local storage.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These new actions haven't been integrated yet so just CI passing is sufficient.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
