### PR TITLE
Orders split view: set translucent tab bar and fix issue displaying offline banners

### DIFF
--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -10,8 +10,13 @@ extension UITabBar {
         let appearance = Self.appearance()
         appearance.barTintColor = .appTabBar
         appearance.tintColor = .text
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            // tab bar needs to be translucent to get rid of the extra space at the bottom of
+            // the view controllers embedded in split view.
+            appearance.isTranslucent = true
+        }
 
-        /// iOS 13.0 and 13.1 doesn't render the tabbar shadow color correcly while in dark mode.
+        /// iOS 13.0 and 13.1 doesn't render the tabbar shadow color correctly while in dark mode.
         /// To fix it, we have to specifically set it in the `standardAppearance` object.
         ///
         appearance.standardAppearance = createWooTabBarAppearance()

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -56,15 +56,15 @@ private class WooNavigationControllerDelegate: NSObject, UINavigationControllerD
     /// Configures the back button for the managed `ViewController` and forwards the event to the children delegate.
     ///
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        currentController = viewController
-        configureOfflineBanner(for: viewController)
         configureBackButton(for: viewController)
         forwardDelegate?.navigationController?(navigationController, willShow: viewController, animated: animated)
     }
 
-    /// Forwards the event to the children delegate.
+    /// Configures the offline banner and forwards the event to the children delegate.
     ///
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        currentController = viewController
+        configureOfflineBanner(for: viewController)
         forwardDelegate?.navigationController?(navigationController, didShow: viewController, animated: animated)
     }
 

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -21,9 +21,6 @@ class WooNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
         super.delegate = navigationDelegate
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            extendedLayoutIncludesOpaqueBars = true
-        }
     }
 
     /// Sets the status bar of the pushed view to white.
@@ -59,9 +56,6 @@ private class WooNavigationControllerDelegate: NSObject, UINavigationControllerD
     /// Configures the back button for the managed `ViewController` and forwards the event to the children delegate.
     ///
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            viewController.extendedLayoutIncludesOpaqueBars = true
-        }
         currentController = viewController
         configureOfflineBanner(for: viewController)
         configureBackButton(for: viewController)
@@ -141,8 +135,16 @@ private extension WooNavigationControllerDelegate {
         offlineBannerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(offlineBannerView)
 
-        // TODO-6381: fix issue with zero extra bottom space for split view
-        let extraBottomSpace = viewController.hidesBottomBarWhenPushed ? navigationController.view.safeAreaInsets.bottom : 0
+        let extraBottomSpace: CGFloat
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            // When split view is enabled, we're using a translucent tab bar.
+            // So when tab bar is visible, the bottom safe area is non-zero and we need to display content based on that.
+            extraBottomSpace = navigationController.view.safeAreaInsets.bottom
+        } else {
+            // With an opaque tab bar, all contents are displayed above it,
+            // so we don't need to care about the bottom safe area, only when the tab bar is hidden.
+            extraBottomSpace = viewController.hidesBottomBarWhenPushed ? navigationController.view.safeAreaInsets.bottom : 0
+        }
         NSLayoutConstraint.activate([
             offlineBannerView.heightAnchor.constraint(equalToConstant: OfflineBannerView.height),
             offlineBannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -66,6 +66,9 @@ final class ReviewOrderViewController: UIViewController {
     }
 
     override var shouldShowOfflineBanner: Bool {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            return false
+        }
         return true
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -46,6 +46,9 @@ final class ShippingLabelFormViewController: UIViewController {
     }
 
     override var shouldShowOfflineBanner: Bool {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            return false
+        }
         return true
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6381 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR attempts to do a few things:
- Remove the hacks with `extendedLayoutIncludesOpaqueBars` and set the tab bar to translucent instead
- Fix issue displaying offline banners in the correct positions:
  - Previously the tab bar is opaque, so the child view controllers are always positioned on top of it by default. Hence we're only considering the bottom safe area to position the offline banner when the `hidesBottomBarWhenPushed` property is `true`.
  - Now that the tab bar is translucent, the view controllers' bottom safe areas always include the whole tab bar so we need to always consider it for positioning the offline banner.
  - Also: the offline banner configuration has been moved to when a view controller did get added to the navigation controller, since the bottom safe area is only updated correctly at this stage. This is to fix the cases when `hidesBottomBarWhenPushed` is set to `true`. This leads to the not-so-nice transition of the offline banner when it shows up. I haven't found a good solution yet - please feel free to suggest one if possible.
- Update the display of offline banner in child flows of the Orders tab: shipping label creation and review order to be correct based on the feature flag.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
In both cases when the feature flag for `splitViewInOrdersTab` off and on: please do a smoke test to make sure that the app's layout is not broken and the offline banners are displayed properly.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/158735021-f5d217b9-b33d-4a0e-979a-3c6ffb4896f0.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
