### PR TITLE
Coupons: Update Yosemite to retrieve and update analytics setting

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -629,6 +629,7 @@
 		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
 		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
 		DE74F29E27E0A6800002FE59 /* SiteSettingMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29D27E0A6800002FE59 /* SiteSettingMapperTests.swift */; };
+		DE74F2A027E3137F0002FE59 /* setting-analytics.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29F27E3137F0002FE59 /* setting-analytics.json */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
@@ -1316,6 +1317,7 @@
 		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
 		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
 		DE74F29D27E0A6800002FE59 /* SiteSettingMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapperTests.swift; sourceTree = "<group>"; };
+		DE74F29F27E3137F0002FE59 /* setting-analytics.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-analytics.json"; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
@@ -1957,6 +1959,7 @@
 				D88D5A42230BC668007B6E01 /* reviews-single.json */,
 				267066082774BF3B008E1F68 /* settings-advanced.json */,
 				DE74F29B27E0A1D00002FE59 /* setting-coupon.json */,
+				DE74F29F27E3137F0002FE59 /* setting-analytics.json */,
 				74046E20217A73D0007DD7BF /* settings-general.json */,
 				7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */,
 				74159622224D2C86003C21CF /* settings-product.json */,
@@ -2518,6 +2521,7 @@
 				CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */,
 				2683D70E24456DB8002A1589 /* categories-empty.json in Resources */,
 				D865CE67278CA225002C8520 /* stripe-payment-intent-succeeded.json in Resources */,
+				DE74F2A027E3137F0002FE59 /* setting-analytics.json in Resources */,
 				0272E3F5254AA48F00436277 /* order-with-line-item-attributes.json in Resources */,
 				3105471C262E2F8000C5C02B /* wcpay-payment-intent-requires-action.json in Resources */,
 				3158FE6826129CE200E566B9 /* wcpay-account-rejected-fraud.json in Resources */,

--- a/Networking/NetworkingTests/Responses/setting-analytics.json
+++ b/Networking/NetworkingTests/Responses/setting-analytics.json
@@ -1,0 +1,23 @@
+{
+    "data": {
+        "id": "woocommerce_analytics_enabled",
+        "label": "Analytics",
+        "description": "Enables WooCommerce Analytics",
+        "type": "checkbox",
+        "default": "yes",
+        "value": "yes",
+        "group_id": "advanced",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v3/settings/advanced/woocommerce_analytics_enabled"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v3/settings/advanced"
+                }
+            ]
+        }
+    }
+}

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -33,4 +33,12 @@ public enum SettingAction: Action {
     /// Enables coupons for the specified store
     ///
     case enableCouponSetting(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Retrieves the setting for whether WC Analytics are enabled for the specified store
+    ///
+    case retrieveAnalyticsSetting(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Enables WC Analytics for the specified store
+    ///
+    case enableAnalyticsSetting(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -175,13 +175,7 @@ private extension SettingStore {
                     onCompletion(.success(isEnabled))
                 }
             case .failure(let error):
-                // fall back to retrieve from storage
-                if let setting = self.sharedDerivedStorage.loadSiteSetting(siteID: siteID, settingID: SettingKeys.analytics) {
-                    let isEnabled = setting.value == SettingValue.yes
-                    onCompletion(.success(isEnabled))
-                } else {
-                    onCompletion(.failure(error))
-                }
+                onCompletion(.failure(error))
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -48,6 +48,10 @@ public class SettingStore: Store {
             retrieveCouponSetting(siteID: siteID, onCompletion: onCompletion)
         case let .enableCouponSetting(siteID, onCompletion):
             enableCouponSetting(siteID: siteID, onCompletion: onCompletion)
+        case let .retrieveAnalyticsSetting(siteID, onCompletion):
+            retrieveAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
+        case let .enableAnalyticsSetting(siteID, onCompletion):
+            enableAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -157,6 +161,18 @@ private extension SettingStore {
                 onCompletion(.failure(error))
             }
         }
+    }
+
+    /// Retrieves the setting for whether WC Analytics are enabled for the specified store
+    ///
+    func retrieveAnalyticsSetting(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void) {
+        // TODO
+    }
+
+    /// Enables WC Analytics for the specified store
+    ///
+    func enableAnalyticsSetting(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void) {
+        // TODO
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -788,25 +788,7 @@ final class SettingStoreTests: XCTestCase {
         XCTAssertEqual(updated?.value, "yes")
     }
 
-    func test_retrieveAnalyticsSetting_returns_error_when_loading_fails_and_setting_is_not_found_in_storage() {
-        // Given
-        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
-        network.simulateError(requestUrlSuffix: "settings/advanced/woocommerce_analytics_enabled", error: expectedError)
-
-        // When
-        let result: Result<Bool, Error> = waitFor { promise in
-            let action = SettingAction.retrieveAnalyticsSetting(siteID: self.sampleSiteID) { result in
-                promise(result)
-            }
-            store.onAction(action)
-        }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-    }
-
-    func test_retrieveAnalyticsSetting_returns_stored_setting_when_loading_fails_and_setting_is_found_in_storage() throws {
+    func test_retrieveAnalyticsSetting_returns_error_when_loading_fails_and_setting_is_found_in_storage() throws {
         // Given
         let oldSetting = SiteSetting.fake().copy(siteID: sampleSiteID, settingID: "woocommerce_analytics_enabled", value: "no", settingGroupKey: "general")
         storageManager.insertSampleSiteSetting(readOnlySiteSetting: oldSetting)
@@ -823,9 +805,7 @@ final class SettingStoreTests: XCTestCase {
         }
 
         // Then
-        XCTAssertFalse(result.isFailure)
-        let isEnabled = try XCTUnwrap(result.get())
-        XCTAssertFalse(isEnabled)
+        XCTAssertTrue(result.isFailure)
     }
 
     func test_enableAnalyticsSetting_updates_stored_settings() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6360 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates error handling for loading the discounted amount in the Coupon Details screen. We need to check if WC Analytics is disabled for the store to guide merchants to enable it again if necessary.

This PR is very similar to #6441: 2 new actions are added into `SettingAction` to retrieve and enable the setting for WC Analytics:
- Add a new action to retrieve analytics setting. The setting is fetched from remote and persisted it to the local storage. I don't fall back to use the persisted setting because there's an edge case when the remote request fails due to the lost internet connection and persisted setting might be outdated (will update the same logic for the coupon setting too).
- Add a new action to enable analytics for a specific store. After the setting is updated successfully remotely, the updated setting is also persisted to the local storage 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These new actions haven't been integrated yet so just CI passing is sufficient.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
