### PR TITLE
Coupons: Update error state for when loading discounted amount fails

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -216,7 +216,7 @@ struct CouponDetails: View {
 
     private func showAmountLoadingErrorDetails() {
         if viewModel.hasWCAnalyticsDisabled {
-            // TODO: show modal for disabled analytics
+            // TODO-6360: show modal for disabled analytics
         } else {
             showingAmountLoadingErrorPrompt = true
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -102,7 +102,10 @@ struct CouponDetails: View {
                                     .padding(.horizontal, Constants.margin)
                                 Spacer()
                                 Group {
-                                    if let amount = viewModel.discountedAmount {
+                                    if viewModel.shouldShowErrorLoadingAmount {
+                                        Text(Localization.errorLoadingData)
+                                            .secondaryBodyStyle()
+                                    } else if let amount = viewModel.discountedAmount {
                                         Text(amount)
                                             .font(.title)
                                     } else {
@@ -254,6 +257,10 @@ private extension CouponDetails {
         static let discountedOrders = NSLocalizedString("Discounted Orders", comment: "Title of the Discounted Orders label on Coupon Details screen")
         static let amount = NSLocalizedString("Amount", comment: "Title of the Amount label on Coupon Details screen")
         static let usageDetails = NSLocalizedString("Usage details", comment: "Title of the Usage details row in Coupon Details screen")
+        static let errorLoadingData = NSLocalizedString(
+            "Error loading data",
+            comment: "Message displayed on Coupon Details screen when loading total discounted amount fails"
+        )
         static let errorLoadingAnalytics = NSLocalizedString(
             "We encountered a problem loading analytics",
             comment: "Message displayed in the error prompt when loading total discounted amount in Coupon Details screen fails"

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -26,6 +26,9 @@ struct CouponDetails: View {
     @State private var showingShareSheet: Bool = false
     @State private var showingUsageDetails: Bool = false
 
+    // Tracks the scale of the view due to accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
     /// The presenter to display notice when the coupon code is copied.
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
     let noticePresenter: DefaultNoticePresenter
@@ -89,10 +92,30 @@ struct CouponDetails: View {
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .padding(.horizontal, Constants.margin)
                                 Spacer()
-                                Text(Localization.amount)
-                                    .secondaryBodyStyle()
+                                Button {
+                                    // TODO
+                                } label: {
+                                    HStack(spacing: Constants.errorIconHorizontalPadding) {
+                                        Text(Localization.amount)
+                                            .secondaryBodyStyle()
+
+                                        Image(uiImage: .infoImage)
+                                            .renderingMode(.template)
+                                            .resizable()
+                                            .foregroundColor(Color(viewModel.hasWCAnalyticsDisabled ?
+                                                                   UIColor.withColorStudio(.orange, shade: .shade30) :
+                                                                    UIColor.error))
+                                            .frame(width: Constants.errorIconSize * scale,
+                                                   height: Constants.errorIconSize * scale)
+                                            .renderedIf(viewModel.shouldShowErrorLoadingAmount)
+                                        Spacer()
+                                    }
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.horizontal, Constants.margin)
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(!viewModel.shouldShowErrorLoadingAmount)
+                                .padding(.horizontal, Constants.margin)
                             }
                             HStack(alignment: .firstTextBaseline) {
                                 Text(viewModel.discountedOrdersCount)
@@ -187,6 +210,8 @@ private extension CouponDetails {
     enum Constants {
         static let margin: CGFloat = 16
         static let verticalSpacing: CGFloat = 8
+        static let errorIconSize: CGFloat = 20
+        static let errorIconHorizontalPadding: CGFloat = 4
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -179,6 +179,12 @@ struct CouponDetails: View {
 
     @ViewBuilder
     private var amountTitleView: some View {
+        Text(Localization.amount)
+            .secondaryBodyStyle()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Constants.margin)
+            .renderedIf(!viewModel.shouldShowErrorLoadingAmount)
+
         Button(action: showAmountLoadingErrorDetails) {
             HStack(spacing: Constants.errorIconHorizontalPadding) {
                 Text(Localization.amount)
@@ -187,12 +193,11 @@ struct CouponDetails: View {
                 Image(uiImage: .infoImage)
                     .renderingMode(.template)
                     .resizable()
-                    .foregroundColor(Color(viewModel.hasWCAnalyticsDisabled ?
-                                           UIColor.withColorStudio(.orange, shade: .shade30) :
-                                            UIColor.error))
+                    .foregroundColor(viewModel.hasWCAnalyticsDisabled ?
+                                     Color(UIColor.withColorStudio(.orange, shade: .shade30)) :
+                                     Color(UIColor.error))
                     .frame(width: Constants.errorIconSize * scale,
                            height: Constants.errorIconSize * scale)
-                    .renderedIf(viewModel.shouldShowErrorLoadingAmount)
                     .actionSheet(isPresented: $showingAmountLoadingErrorPrompt) {
                         ActionSheet(
                             title: Text(Localization.errorLoadingAnalytics),
@@ -210,8 +215,8 @@ struct CouponDetails: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!viewModel.shouldShowErrorLoadingAmount)
         .padding(.horizontal, Constants.margin)
+        .renderedIf(viewModel.shouldShowErrorLoadingAmount)
     }
 
     private func showAmountLoadingErrorDetails() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6360 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates how the error state for loading the discounted amount on the coupon details screen is displayed.

Previously, I was simply displaying an error text when the loading fails, but this doesn't give users the option to address the issue.

In this PR, I added the functionality to retrieve the analytics setting for the store when loading coupon analytics fails. If analytics is found to be disabled, the coupon details view is notified to displayed a special state (the orange (i) icon). Otherwise, the view displays the red (i) icon next to "Amount".

I also added an action sheet to be displayed when a general error is found. This gives users the option to retry loading coupon analytics. The handling for the case of disabled analytics will be handled in a separate PR to not bloat this PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that your test store has coupons enabled (in WP Admin > WC Settings > General > Coupons) and analytics enabled (in WP Admin > WC Settings > Advanced > Features > Analytics). The store should have at least one coupon set up (in WP Admin > Marketing > Coupons) that has been applied to at least one order.
- Navigate to More tab > Coupons. Turn off internet connection and select the coupon that has been applied to at least one order. Notice that after loading for a while, a red (i) icon is displayed next to "Amount". The skeleton animation is not removed.
- Tapping on the Amount text, notice that an action sheet (or popover on iPad) is displayed. Tapping on Retry, the (i) icon should disappear and appear back if the connection is still off.
- Try again with a coupon that hasn't been applied to any order. Since the discounted amount is zero, no error state is displayed.
- Turn off WC Analytics in WP Admin, repeat the steps above with the internet connection on. Notice the orange (i) icon next to "Amount"; tapping on this doesn't display anything yet for now.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Internet connection off:

https://user-images.githubusercontent.com/5533851/158790738-5a75c8e7-6a95-4852-b56f-9a6f426b67f2.MP4


WC Analytics off:

https://user-images.githubusercontent.com/5533851/158790827-eabd04cb-8376-48b5-a056-7b4716e256e4.MP4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
