### PR TITLE
[Mobile Payments] IPP Client side refund actions

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		03B440AA2754DFC400759429 /* UnderlyingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B440A92754DFC400759429 /* UnderlyingError.swift */; };
 		03CF78D327C6710C00523706 /* interac.svg in Resources */ = {isa = PBXBuildFile; fileRef = 03CF78D227C6710B00523706 /* interac.svg */; };
 		03CF78D527C92FF900523706 /* ReaderDisplayMessage+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D427C92FF900523706 /* ReaderDisplayMessage+Localization.swift */; };
+		03CF78D727DF9BE600523706 /* RefundParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D627DF9BE500523706 /* RefundParameters.swift */; };
+		03CF78D927DF9D0500523706 /* RefundParameters+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D827DF9D0500523706 /* RefundParameters+Stripe.swift */; };
 		311889EB2653286B0080AEA2 /* PaymentIntentMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */; };
 		317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975BF274EB1F9004357B1 /* DeclineReason.swift */; };
 		317975C2274EBC1F004357B1 /* DeclineReason+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */; };
@@ -140,6 +142,8 @@
 		03B440A92754DFC400759429 /* UnderlyingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlyingError.swift; sourceTree = "<group>"; };
 		03CF78D227C6710B00523706 /* interac.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = interac.svg; sourceTree = "<group>"; };
 		03CF78D427C92FF900523706 /* ReaderDisplayMessage+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderDisplayMessage+Localization.swift"; sourceTree = "<group>"; };
+		03CF78D627DF9BE500523706 /* RefundParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundParameters.swift; sourceTree = "<group>"; };
+		03CF78D827DF9D0500523706 /* RefundParameters+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RefundParameters+Stripe.swift"; sourceTree = "<group>"; };
 		0C16E0AAFF5A7B364BD4E171 /* Pods-Hardware.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.release-alpha.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		1CC96A71F2937BCB7432766F /* Pods-HardwareTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HardwareTests.debug.xcconfig"; path = "Target Support Files/Pods-HardwareTests/Pods-HardwareTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleReceiptPrinter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -410,6 +414,7 @@
 				E1E125AD26EB66B30068A9B0 /* FallibleCancelable.swift */,
 				D89B8F0125DDC7500001C726 /* PaymentIntentStatus.swift */,
 				D88FDB2325DD21B000CB0DBD /* PaymentIntentParameters.swift */,
+				03CF78D627DF9BE500523706 /* RefundParameters.swift */,
 				D88FDB2025DD21AF00CB0DBD /* PaymentStatus.swift */,
 				D845BDBB262D980C00A3E40F /* CardPresentTransactionDetails.swift */,
 				D81AE86325E6B77F00D9CFD3 /* CardReaderServiceError.swift */,
@@ -452,6 +457,7 @@
 				E1E125AF26EB66EA0068A9B0 /* Cancelable+Stripe.swift */,
 				317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */,
 				03CF78D427C92FF900523706 /* ReaderDisplayMessage+Localization.swift */,
+				03CF78D827DF9D0500523706 /* RefundParameters+Stripe.swift */,
 			);
 			path = StripeCardReader;
 			sourceTree = "<group>";
@@ -778,6 +784,7 @@
 				D845BDDE262DAB8300A3E40F /* PaymentMethod+Stripe.swift in Sources */,
 				D89B8F0C25DDC9D30001C726 /* ChargeStatus.swift in Sources */,
 				E140F61C2668CDC900FDB5FF /* Logging.swift in Sources */,
+				03CF78D727DF9BE600523706 /* RefundParameters.swift in Sources */,
 				03B440AA2754DFC400759429 /* UnderlyingError.swift in Sources */,
 				E1E125AC26EB582B0068A9B0 /* CardReaderSoftwareUpdateState.swift in Sources */,
 				D88FDB3125DD21B000CB0DBD /* CardReader.swift in Sources */,
@@ -810,6 +817,7 @@
 				D845BDBC262D980C00A3E40F /* CardPresentTransactionDetails.swift in Sources */,
 				D88ECCE3262095A10094398A /* UpdateTimeEstimate.swift in Sources */,
 				D88ECCE7262096BD0094398A /* UpdateTimeEstimate+Stripe.swift in Sources */,
+				03CF78D927DF9D0500523706 /* RefundParameters+Stripe.swift in Sources */,
 				D88FDB2925DD21B000CB0DBD /* CardReaderServiceDiscoveryStatus.swift in Sources */,
 				D88FDB3925DD21D300CB0DBD /* StripeCardReaderService.swift in Sources */,
 				D845BE60262EDCFD00A3E40F /* ReceiptRenderer.swift in Sources */,

--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -46,6 +46,9 @@ public protocol CardReaderService {
     /// Refunds a payment
     func refundPayment(parameters: RefundParameters) -> AnyPublisher<String, Error>
 
+    /// Cancels an in-flight refund
+    func cancelRefund() -> AnyPublisher<Void, Error>
+
     /// Triggers a software update.
     ///
     /// To check the progress of the update, observe the softwareUpdateEvents publisher.

--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -43,6 +43,9 @@ public protocol CardReaderService {
     /// Cancels a PaymentIntent
     func cancelPaymentIntent() -> Future<Void, Error>
 
+    /// Refunds a payment
+    func refundPayment(parameters: RefundParameters) -> AnyPublisher<String, Error>
+
     /// Triggers a software update.
     ///
     /// To check the progress of the update, observe the softwareUpdateEvents publisher.

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -27,6 +27,15 @@ public enum CardReaderServiceError: Error {
     /// Error thrown while cancelling a payment
     case paymentCancellation(underlyingError: UnderlyingError = .internalServiceError)
 
+    /// Error thrown while setting up a refund
+    case refundCreation(underlyingError: UnderlyingError = .internalServiceError)
+
+    /// Error thrown while refunding a payment
+    case refundPayment(underlyingError: UnderlyingError = .internalServiceError)
+
+    /// Error thrown while cancelling a refund
+    case refundCancellation(underlyingError: UnderlyingError = .internalServiceError)
+
     /// Error thrown while updating the reader firmware
     case softwareUpdate(underlyingError: UnderlyingError = .internalServiceError, batteryLevel: Double?)
 
@@ -37,21 +46,17 @@ public enum CardReaderServiceError: Error {
 extension CardReaderServiceError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .connection(let underlyingError):
-            return underlyingError.errorDescription
-        case .discovery(let underlyingError):
-            return underlyingError.errorDescription
-        case .disconnection(let underlyingError):
-            return underlyingError.errorDescription
-        case .intentCreation(let underlyingError):
-            return underlyingError.errorDescription
-        case .paymentMethodCollection(let underlyingError):
-            return underlyingError.errorDescription
-        case .paymentCapture(let underlyingError):
-            return underlyingError.errorDescription
-        case .paymentCancellation(let underlyingError):
-            return underlyingError.errorDescription
-        case .softwareUpdate(let underlyingError, _):
+        case .connection(let underlyingError),
+                .discovery(let underlyingError),
+                .disconnection(let underlyingError),
+                .intentCreation(let underlyingError),
+                .paymentMethodCollection(let underlyingError),
+                .paymentCapture(let underlyingError),
+                .paymentCancellation(let underlyingError),
+                .refundCreation(let underlyingError),
+                .refundPayment(let underlyingError),
+                .refundCancellation(let underlyingError),
+                .softwareUpdate(let underlyingError, _):
             return underlyingError.errorDescription
         case .bluetoothDenied:
             return NSLocalizedString(

--- a/Hardware/Hardware/CardReader/RefundParameters.swift
+++ b/Hardware/Hardware/CardReader/RefundParameters.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct RefundParameters {
+    /// The chargeId for the charge which is being refunded
+    public let chargeId: String
+
+    /// The amount of the refund.
+    public let amount: Decimal
+
+    /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+    @CurrencyCode
+    public private(set) var currency: String
+
+    public init(chargeId: String, amount: Decimal, currency: String) {
+        self.chargeId = chargeId
+        self.amount = amount
+        self.currency = currency
+    }
+}

--- a/Hardware/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
@@ -67,6 +67,12 @@ public struct NoOpCardReaderService: CardReaderService {
         }
     }
 
+    public func refundPayment(parameters: RefundParameters) -> AnyPublisher<String, Error> {
+        return Future() { promise in
+            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+        }.eraseToAnyPublisher()
+    }
+
     /// Triggers a software update.
     ///
     /// To check the progress of the update, observe the softwareUpdateEvents publisher.

--- a/Hardware/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
@@ -73,6 +73,12 @@ public struct NoOpCardReaderService: CardReaderService {
         }.eraseToAnyPublisher()
     }
 
+    public func cancelRefund() -> AnyPublisher<Void, Error> {
+        return Future() { promise in
+            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+        }.eraseToAnyPublisher()
+    }
+
     /// Triggers a software update.
     ///
     /// To check the progress of the update, observe the softwareUpdateEvents publisher.

--- a/Hardware/Hardware/CardReader/StripeCardReader/RefundParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/RefundParameters+Stripe.swift
@@ -2,8 +2,8 @@
 import StripeTerminal
 
 extension Hardware.RefundParameters {
-    /// Initializes a StripeTerminal.PaymentIntentParameters from a
-    /// Hardware.PaymentIntentParameters
+    /// Initializes a StripeTerminal.RefundParameters from a
+    /// Hardware.RefundParameters
     func toStripe() -> StripeTerminal.RefundParameters? {
         // Shortcircuit if we do not have a valid currency code
         guard !currency.isEmpty else {

--- a/Hardware/Hardware/CardReader/StripeCardReader/RefundParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/RefundParameters+Stripe.swift
@@ -1,0 +1,24 @@
+#if !targetEnvironment(macCatalyst)
+import StripeTerminal
+
+extension Hardware.RefundParameters {
+    /// Initializes a StripeTerminal.PaymentIntentParameters from a
+    /// Hardware.PaymentIntentParameters
+    func toStripe() -> StripeTerminal.RefundParameters? {
+        // Shortcircuit if we do not have a valid currency code
+        guard !currency.isEmpty else {
+            return nil
+        }
+
+        /// The amount of the refund needs to be provided in the currency’s smallest unit.
+        /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPRefundParameters.html#/c:objc(cs)SCPRefundParameters(py)amount
+        let amountInSmallestUnit = amount * 100
+
+        let amountForStripe = NSDecimalNumber(decimal: amountInSmallestUnit).uintValue
+
+        let returnValue = StripeTerminal.RefundParameters(chargeId: chargeId, amount: amountForStripe, currency: currency)
+
+        return returnValue
+    }
+}
+#endif

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -268,10 +268,8 @@ extension UnderlyingError: LocalizedError {
             return NSLocalizedString("The card reader is busy executing another command - please try again",
                                      comment: "Error message when the card reader is busy executing another command.")
         case .readerIncompatible:
-            return NSLocalizedString("""
-The card reader is not compatible with this application - please try \
-updating the application or using a different reader
-""",
+            return NSLocalizedString("The card reader is not compatible with this application - please try updating the " +
+                                     "application or using a different reader",
                                      comment: "Error message when the card reader is incompatible with the application.")
         case .readerCommunicationError:
             return NSLocalizedString("Unable to communicate with reader - please try again",

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -137,6 +137,9 @@ public enum UnderlyingError: Error, Equatable {
 
     /// The store setup is incomplete, and the action can't be performed until the user provides a valid postal code in the site admin.
     case invalidPostalCode
+
+    /// There was no refund in progress to cancel
+    case noRefundInProgress
 }
 
 extension UnderlyingError {
@@ -321,6 +324,10 @@ extension UnderlyingError: LocalizedError {
             return NSLocalizedString("The store postal code is invalid or missing, please update it before continuing.",
                                      comment: "Error message when there is an issue with the store postal code preventing " +
                                      "an action (e.g. reader connection.)")
+        case .noRefundInProgress:
+            return NSLocalizedString("Sorry, this refund could not be canceled",
+                                     comment: "Error message shown when a refund could not be canceled (likely because " +
+                                     "it had already completed)")
         }
     }
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -62,6 +62,9 @@ public enum CardPresentPaymentAction: Action {
     ///
     case refundPayment(parameters: RefundParameters)
 
+    /// Cancels a refund, if one is in progress
+    case cancelRefund
+
     /// Check the state of available software updates.
     case observeCardReaderUpdateState(onCompletion: (AnyPublisher<CardReaderSoftwareUpdateState, Never>) -> Void)
 

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -58,6 +58,10 @@ public enum CardPresentPaymentAction: Action {
     /// Cancels an active attempt to collect a payment.
     case cancelPayment(onCompletion: ((Result<Void, Error>) -> Void)?)
 
+    /// Refund payment of an order, client side. Only for use on Interac payments
+    ///
+    case refundPayment(parameters: RefundParameters)
+
     /// Check the state of available software updates.
     case observeCardReaderUpdateState(onCompletion: (AnyPublisher<CardReaderSoftwareUpdateState, Never>) -> Void)
 

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -136,6 +136,7 @@ public typealias CardReaderServiceError = Hardware.CardReaderServiceError
 public typealias CardReaderType = Hardware.CardReaderType
 public typealias CardReaderConfigError = Hardware.CardReaderConfigError
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
+public typealias RefundParameters = Hardware.RefundParameters
 public typealias PaymentIntent = Hardware.PaymentIntent
 public typealias PrintingResult = Hardware.PrintingResult
 public typealias CardPresentReceiptParameters = Hardware.CardPresentReceiptParameters

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -265,6 +265,7 @@ private extension CardPresentPaymentStore {
             } receiveValue: { status in
                 DDLogInfo("🍁 Refund Success! \(status)")
             }
+            .store(in: &cancellables)
     }
 
     func cancelRefund() {
@@ -279,6 +280,7 @@ private extension CardPresentPaymentStore {
             } receiveValue: {
                 DDLogInfo("🍁 Refund cancelled successfully!")
             }
+            .store(in: &cancellables)
     }
 
     func observeCardReaderUpdateState(onCompletion: (AnyPublisher<CardReaderSoftwareUpdateState, Never>) -> Void) {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -258,12 +258,12 @@ private extension CardPresentPaymentStore {
             .sink { error in
                 switch error {
                 case .failure(let error):
-                    DDLogInfo("🍁 Refund error! \(error.localizedDescription)")
+                    DDLogError("⛔️ Error during client-side refund: \(error.localizedDescription)")
                 case .finished:
                     break
                 }
             } receiveValue: { status in
-                DDLogInfo("🍁 Refund Success! \(status)")
+                DDLogInfo("💳 Refund Success: \(status)")
             }
             .store(in: &cancellables)
     }
@@ -273,7 +273,7 @@ private extension CardPresentPaymentStore {
             .sink { error in
                 switch error {
                 case .failure(let error):
-                    DDLogInfo("🍁 Refund cancellation error! \(error.localizedDescription)")
+                    DDLogError("⛔️ Error cancelling client-side refund: \(error.localizedDescription)")
                 case .finished:
                     break
                 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -91,6 +91,8 @@ public final class CardPresentPaymentStore: Store {
             cancelPayment(onCompletion: completion)
         case .refundPayment(let parameters):
             refundPayment(parameters: parameters)
+        case .cancelRefund:
+            cancelRefund()
         case .observeCardReaderUpdateState(onCompletion: let completion):
             observeCardReaderUpdateState(onCompletion: completion)
         case .startCardReaderUpdate:
@@ -256,14 +258,27 @@ private extension CardPresentPaymentStore {
             .sink { error in
                 switch error {
                 case .failure(let error):
-                    print("Refund error! \(error.localizedDescription)")
+                    DDLogInfo("🍁 Refund error! \(error.localizedDescription)")
                 case .finished:
                     break
                 }
             } receiveValue: { status in
-                print("Refund Success! \(status)")
+                DDLogInfo("🍁 Refund Success! \(status)")
             }
+    }
 
+    func cancelRefund() {
+        cardReaderService.cancelRefund()
+            .sink { error in
+                switch error {
+                case .failure(let error):
+                    DDLogInfo("🍁 Refund cancellation error! \(error.localizedDescription)")
+                case .finished:
+                    break
+                }
+            } receiveValue: {
+                DDLogInfo("🍁 Refund cancelled successfully!")
+            }
     }
 
     func observeCardReaderUpdateState(onCompletion: (AnyPublisher<CardReaderSoftwareUpdateState, Never>) -> Void) {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -89,6 +89,8 @@ public final class CardPresentPaymentStore: Store {
                            onCompletion: completion)
         case .cancelPayment(let completion):
             cancelPayment(onCompletion: completion)
+        case .refundPayment(let parameters):
+            refundPayment(parameters: parameters)
         case .observeCardReaderUpdateState(onCompletion: let completion):
             observeCardReaderUpdateState(onCompletion: completion)
         case .startCardReaderUpdate:
@@ -247,6 +249,21 @@ private extension CardPresentPaymentStore {
         }, receiveValue: {
             onCompletion?(.success(()))
         }))
+    }
+
+    func refundPayment(parameters: RefundParameters) {
+        cardReaderService.refundPayment(parameters: parameters)
+            .sink { error in
+                switch error {
+                case .failure(let error):
+                    print("Refund error! \(error.localizedDescription)")
+                case .finished:
+                    break
+                }
+            } receiveValue: { status in
+                print("Refund Success! \(status)")
+            }
+
     }
 
     func observeCardReaderUpdateState(onCompletion: (AnyPublisher<CardReaderSoftwareUpdateState, Never>) -> Void) {

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -113,6 +113,12 @@ final class MockCardReaderService: CardReaderService {
             .eraseToAnyPublisher()
     }
 
+    func cancelRefund() -> AnyPublisher<Void, Error> {
+        Just(())
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
     func installUpdate() -> Void {
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -107,6 +107,12 @@ final class MockCardReaderService: CardReaderService {
         }
     }
 
+    func refundPayment(parameters: RefundParameters) -> AnyPublisher<String, Error> {
+        Just("success")
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
     func installUpdate() -> Void {
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6445
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the actions required to implement a client-side refund flow, which is required for use for Interac refunds in Canada. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Err... this isn't super testable on its own, because the new actions aren't used yet. I've tested by hacking it into the refund flow which you can do using [4dea92f](https://github.com/woocommerce/woocommerce-ios/commit/4dea92fbb35fc9cfe94b88c9fbecefb30a1b361f).

1. On the orders tab, take a new payment for a new Simple Payments order (don't use an existing paid order, as the UI hacks don't deal with the reader connection flow yet.)
2. Open the order again
3. Tap `Issue Refund` and confirm
4. Follow the reader refund instructions (the app UI doesn't wait for this... but that's not the change under test!)
5. Note that the success is recorded in the logs, including the Refund details. 50% of attempts will cancel automatically, which is also recorded in the logs.

After refunding, since we set the `automaticallyRefundsPayment` to false for interac on the refund API request, the refund is listed as `via manual refund`, which isn't ideal. This will be resolved by the API changes which are pending for this work.
{pdfdoF-yL-p2}

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![IMG_77E186394376-1](https://user-images.githubusercontent.com/2472348/158844738-fe716d64-19fe-4c59-b0ee-fb0997132dd1.jpg)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
