### PR TITLE
Inbox Notes tracking events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -573,6 +573,11 @@ public enum WooAnalyticsStat: String {
     case couponsLoadedFailed = "coupons_loaded_failed"
     case couponsListSearchTapped = "coupons_list_search_tapped"
     case couponDetails = "coupon_details"
+
+    // MARK: Inbox Notes
+    case inboxNotesLoaded = "inbox_notes_loaded"
+    case inboxNotesLoadedFailed = "inbox_notes_load_failed"
+    case inboxNoteAction = "inbox_note_action"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -45,7 +45,7 @@ struct HubMenu: View {
                                 ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "view_store"])
                                 showingViewStore = true
                             case .inbox:
-                                // TODO: Inbox analytics
+                                ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "inbox"])
                                 showingInbox = true
                             case .reviews:
                                 ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "reviews"])

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -101,6 +101,8 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
 
 extension InboxNoteRowViewModel {
     func markInboxNoteAsActioned(actionID: Int64) {
+        ServiceLocator.analytics.track(.inboxNoteAction,
+                                       withProperties: ["action": "open"])
         let action = InboxNotesAction.markInboxNoteAsActioned(siteID: siteID,
                                                               noteID: id,
                                                               actionID: actionID) { result in
@@ -115,6 +117,8 @@ extension InboxNoteRowViewModel {
     }
 
     func dismissInboxNote(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        ServiceLocator.analytics.track(.inboxNoteAction,
+                                       withProperties: ["action": "dismiss"])
         let action = InboxNotesAction.dismissInboxNote(siteID: siteID, noteID: id) { result in
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -118,6 +118,8 @@ extension InboxViewModel: PaginationTrackerDelegate {
             guard let self = self else { return }
             switch result {
             case .success(let notes):
+                ServiceLocator.analytics.track(.inboxNotesLoaded,
+                                               withProperties: ["is_loading_more": pageNumber != self.pageFirstIndex])
                 let hasNextPage = notes.count == pageSize
                 onCompletion?(.success(hasNextPage))
 
@@ -130,6 +132,7 @@ extension InboxViewModel: PaginationTrackerDelegate {
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error synchronizing inbox notes: \(error)")
+                ServiceLocator.analytics.track(.inboxNotesLoadedFailed, withError: error)
                 onCompletion?(.failure(error))
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -140,6 +140,9 @@ extension InboxViewModel: PaginationTrackerDelegate {
     }
 
     func dismissAllInboxNotes() {
+        ServiceLocator.analytics.track(.inboxNoteAction,
+                                       withProperties: ["action": "dismiss_all"])
+
         // Since the dismiss all API endpoint only deletes notes that match the given parameters, we want to match the parameters with the load request
         // and specify the page size to include all the synced notes based on the last sync request.
         let pageSizeForAllSyncedNotes = highestSyncedPageNumber * pageSize


### PR DESCRIPTION
Closes #6191 

### Description
Implemented the tracking events for the Inbox Notes following the table declared here p91TBi-7aB

### Testing instructions
1. Tap the inbox notes menu under the hub menu. You should see in console the event `*_hub_menu_option_tapped` with the property `option` set to `inbox`. 
2. Open the inbox notes: you should see the event `*_inbox_notes_loaded` in console, with the property `is_loading_more` set to `false`.
3. Load more inbox notes (pagination): you should see the event `*_inbox_notes_loaded` in console, with the property `is_loading_more` set to `true`.
4. If there is an error loading the inbox notes, you should see the event `*_inbox_notes_load_failed` in console with the related error if any.
5. Try to tap on the action button of a note. You should see the event `*_inbox_note_action` in console with the property `open`.
6. Try to tap on dismiss button of a note. You should see the event `*_inbox_note_action` in console with the property `dismiss`.
6. Try to dismiss all the notifications in the view (using the navbar button). You should see the event `*_inbox_note_action` in console with the property `dismiss_all`.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
