### PR TITLE
Issue/6119 product sync error notice

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -34,9 +34,10 @@ struct NoticeModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .animation(nil, value: notice) // Only apply the animation to the notice stack, not the rest of the view content
-            .overlay(buildNoticeStack())
-            .animation(.easeInOut, value: notice)
+            .overlay(
+                buildNoticeStack()
+                    .animation(.easeInOut, value: notice)
+            )
     }
 
     /// Builds a notice view at the bottom of the screen.

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -34,6 +34,7 @@ struct NoticeModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .animation(nil, value: notice) // Only apply the animation to the notice stack, not the rest of the view content
             .overlay(buildNoticeStack())
             .animation(.easeInOut, value: notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -25,8 +25,8 @@ struct AddProductToOrder: View {
                             Divider().frame(height: Constants.dividerHeight)
                                 .padding(.leading, Constants.defaultPadding)
                         }
+                        .background(Color(.listForeground))
                     }
-                                       .background(Color(.listForeground))
                 case .empty:
                     EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
                         .frame(maxHeight: .infinity)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -57,6 +57,7 @@ struct AddProductToOrder: View {
             }
         }
         .wooNavigationBarStyle()
+        .notice($viewModel.notice)
     }
 
     /// Creates the `ProductRow` for a product, depending on whether the product is variable.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -24,6 +24,11 @@ final class AddProductToOrderViewModel: ObservableObject {
     ///
     let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
 
+    /// Defines the current notice that should be shown.
+    /// Defaults to `nil`.
+    ///
+    @Published var notice: Notice?
+
     /// All products that can be added to an order.
     ///
     private var products: [Product] {
@@ -159,6 +164,7 @@ extension AddProductToOrderViewModel: SyncingCoordinatorDelegate {
             case .success:
                 self.updateProductsResultsController()
             case .failure(let error):
+                self.notice = NoticeFactory.productSyncNotice()
                 DDLogError("⛔️ Error synchronizing products during order creation: \(error)")
             }
 
@@ -184,6 +190,7 @@ extension AddProductToOrderViewModel: SyncingCoordinatorDelegate {
             case .success:
                 self.updateProductsResultsController()
             case .failure(let error):
+                self.notice = NoticeFactory.productSyncNotice()
                 DDLogError("⛔️ Error searching products during order creation: \(error)")
             }
 
@@ -311,5 +318,21 @@ extension AddProductToOrderViewModel {
                             manageStock: false,
                             canChangeQuantity: false,
                             imageURL: nil)
+    }
+
+    /// Add Product to Order notices
+    ///
+    enum NoticeFactory {
+        /// Returns a default product sync error notice.
+        ///
+        static func productSyncNotice() -> Notice {
+            Notice(title: Localization.errorMessage, feedbackType: .error)
+        }
+    }
+}
+
+private extension AddProductToOrderViewModel {
+    enum Localization {
+        static let errorMessage = NSLocalizedString("Unable to sync products", comment: "Notice displayed when syncing the list of products fails")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -190,7 +190,7 @@ extension AddProductToOrderViewModel: SyncingCoordinatorDelegate {
             case .success:
                 self.updateProductsResultsController()
             case .failure(let error):
-                self.notice = NoticeFactory.productSyncNotice()
+                self.notice = NoticeFactory.productSearchNotice()
                 DDLogError("⛔️ Error searching products during order creation: \(error)")
             }
 
@@ -326,13 +326,20 @@ extension AddProductToOrderViewModel {
         /// Returns a default product sync error notice.
         ///
         static func productSyncNotice() -> Notice {
-            Notice(title: Localization.errorMessage, feedbackType: .error)
+            Notice(title: Localization.syncErrorMessage, feedbackType: .error)
+        }
+
+        /// Returns a product search error notice.
+        ///
+        static func productSearchNotice() -> Notice {
+            Notice(title: Localization.searchErrorMessage, feedbackType: .error)
         }
     }
 }
 
 private extension AddProductToOrderViewModel {
     enum Localization {
-        static let errorMessage = NSLocalizedString("Unable to sync products", comment: "Notice displayed when syncing the list of products fails")
+        static let syncErrorMessage = NSLocalizedString("Unable to sync products", comment: "Notice displayed when syncing the list of products fails")
+        static let searchErrorMessage = NSLocalizedString("Unable to search products", comment: "Notice displayed when searching the list of products fails")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -64,6 +64,7 @@ struct AddProductVariationToOrder: View {
         .onAppear {
             viewModel.onLoadTrigger.send()
         }
+        .notice($viewModel.notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -23,6 +23,11 @@ final class AddProductVariationToOrderViewModel: ObservableObject {
     ///
     let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
 
+    /// Defines the current notice that should be shown.
+    /// Defaults to `nil`.
+    ///
+    @Published var notice: Notice?
+
     /// The ID of the parent variable product
     ///
     private let productID: Int64
@@ -147,6 +152,7 @@ extension AddProductVariationToOrderViewModel: SyncingCoordinatorDelegate {
             guard let self = self else { return }
 
             if let error = error {
+                self.notice = NoticeFactory.productVariationSyncNotice()
                 DDLogError("⛔️ Error synchronizing product variations during order creation: \(error)")
             } else {
                 self.updateProductVariationsResultsController()
@@ -251,5 +257,22 @@ extension AddProductVariationToOrderViewModel {
                             manageStock: false,
                             canChangeQuantity: false,
                             imageURL: nil)
+    }
+
+    /// Add Product Variation to Order notices
+    ///
+    enum NoticeFactory {
+        /// Returns a default product variation sync error notice.
+        ///
+        static func productVariationSyncNotice() -> Notice {
+            Notice(title: Localization.errorMessage, feedbackType: .error)
+        }
+    }
+}
+
+private extension AddProductVariationToOrderViewModel {
+    enum Localization {
+        static let errorMessage = NSLocalizedString("Unable to sync product variations",
+                                                    comment: "Notice displayed when syncing the list of product variations fails")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -257,6 +257,28 @@ class AddProductToOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.notice, AddProductToOrderViewModel.NoticeFactory.productSyncNotice())
     }
+
+    func test_view_model_fires_error_notice_when_product_search_fails() {
+        // Given
+        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        let notice: Notice? = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: ProductAction.self) { action in
+                switch action {
+                case let .searchProducts(_, _, _, _, _, onCompletion):
+                    onCompletion(.failure(NSError(domain: "Error", code: 0)))
+                    promise(viewModel.notice)
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+            viewModel.searchTerm = "shirt"
+        }
+
+        // Then
+        XCTAssertEqual(notice, AddProductToOrderViewModel.NoticeFactory.productSearchNotice())
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -238,6 +238,25 @@ class AddProductToOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.productRows.count, 2)
     }
+
+    func test_view_model_fires_error_notice_when_product_sync_fails() {
+        // Given
+        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID, stores: stores)
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .synchronizeProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertEqual(viewModel.notice, AddProductToOrderViewModel.NoticeFactory.productSyncNotice())
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -185,6 +185,25 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
         let sortedProductVariationIDs = viewModel.productVariationRows.map { $0.productOrVariationID }
         XCTAssertEqual(sortedProductVariationIDs, [2, 1, 3])
     }
+
+    func test_view_model_fires_error_notice_when_product_variation_sync_fails() {
+        // Given
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID, product: Product.fake(), stores: stores)
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+                onCompletion(NSError(domain: "Error", code: 0))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertEqual(viewModel.notice, AddProductVariationToOrderViewModel.NoticeFactory.productVariationSyncNotice())
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Part of: #6119

## Description

This adds error notices for failures when syncing products or product variations or searching products during order creation.

## Changes

* Adds the `notice` view modifier to the `AddProductToOrder` and `AddProductVariationToOrder` views, to display a notice when the view model provides one.
* Adds a `NoticeFactory` to generate sync and search error notices when sync or search fails in `AddProductToOrderViewModel`.
* Adds a `NoticeFactory` to generate a notice when sync fails in `AddProductVariationToOrderViewModel` (no search in this view).
* Adds unit tests to confirm the notices fire when expected.

* Also updates `NoticeModifier` to limit the notice animation to the notice stack. (This prevents the rest of the view from animating when the notice changes, which can cause weird glitchy animations in the list.)

## Testing

1. Make sure Order Creation is enabled under Settings > Experimental Features.
2. Go to the Orders tab and tap the + button to create a new order.
3. Disable your internet connection (to force network errors).
4. Tap "Add Product" and confirm a notice appears with a product sync error.
5. Try searching for a product and confirm a notice appears with a product search error.
6. Select a product variation. (If you don't have any in local storage, you'll need to reconnect to wifi and sync/search for one, and then disconnect again.)
7. Confirm a notice appears on the variation list screen with a product variation sync error.

## Screenshots

Empty product list|Some products loaded|Product search|Empty product variation list
-|-|-|-
![SyncError-ProductsEmpty](https://user-images.githubusercontent.com/8658164/158842772-a21f73ca-cbf1-4c0d-9696-b65dedde47c9.png)|![SyncError-Products](https://user-images.githubusercontent.com/8658164/158842768-2dea3c3d-3afe-47f7-b6dd-d4f1b997b05e.png)|![SearchError](https://user-images.githubusercontent.com/8658164/158842761-c089783a-0bfb-4bec-8c0d-273c429e4be8.png)|![SyncError-ProductVariations](https://user-images.githubusercontent.com/8658164/158842775-b2fde61d-07cd-4f15-a1e4-f6152b511e03.png)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
