### PR TITLE
Xcode 13.3: fix incremental build error from cycle dependencies in frameworks

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -2343,9 +2343,9 @@
 			buildConfigurationList = B557D9F7209753AA005962F4 /* Build configuration list for PBXNativeTarget "Networking" */;
 			buildPhases = (
 				6BC2909022759950DF06CC9F /* [CP] Check Pods Manifest.lock */,
+				B557D9E0209753AA005962F4 /* Headers */,
 				B557D9DE209753AA005962F4 /* Sources */,
 				B557D9DF209753AA005962F4 /* Frameworks */,
-				B557D9E0209753AA005962F4 /* Headers */,
 				B557D9E1209753AA005962F4 /* Resources */,
 				263E37D32641ACEA00260D3B /* Embed Frameworks */,
 			);

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -1004,9 +1004,9 @@
 			buildConfigurationList = B54CA5AD20A4BBA600F38CD1 /* Build configuration list for PBXNativeTarget "Storage" */;
 			buildPhases = (
 				3A8FEF735A87B89A39A6FF95 /* [CP] Check Pods Manifest.lock */,
+				B54CA59620A4BBA500F38CD1 /* Headers */,
 				B54CA59420A4BBA500F38CD1 /* Sources */,
 				B54CA59520A4BBA500F38CD1 /* Frameworks */,
-				B54CA59620A4BBA500F38CD1 /* Headers */,
 				B54CA59720A4BBA500F38CD1 /* Resources */,
 				263E37D82641AD5100260D3B /* Embed Frameworks */,
 			);

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -1643,9 +1643,9 @@
 			buildConfigurationList = B5C9DE092087FEC0006B910A /* Build configuration list for PBXNativeTarget "Yosemite" */;
 			buildPhases = (
 				D05CE52EBA8EDA14B248EF77 /* [CP] Check Pods Manifest.lock */,
+				B5C9DDF22087FEC0006B910A /* Headers */,
 				B5C9DDF02087FEC0006B910A /* Sources */,
 				B5C9DDF12087FEC0006B910A /* Frameworks */,
-				B5C9DDF22087FEC0006B910A /* Headers */,
 				B5C9DDF32087FEC0006B910A /* Resources */,
 				263E37DD2641AD6B00260D3B /* Embed Frameworks */,
 			);


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes build error in Xcode 13.3
Ref p1647427882721219-slack-CGPNUU63E
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In Xcode 13.3, the first build works fine but there is a build error in incremental builds on cycle dependencies:

```
Cycle in dependencies between targets 'WooCommerce' and 'Storage'; building could produce unreliable results. This usually can be resolved by moving the target's Headers build phase before Compile Sources.
Cycle path: WooCommerce → Storage → WooCommerce
```

<details>
 <summary>Example full error</summary>

Showing Recent Messages
Cycle in dependencies between targets 'WooCommerce' and 'Storage'; building could produce unreliable results. This usually can be resolved by moving the target's Headers build phase before Compile Sources.
Cycle path: WooCommerce → Storage → WooCommerce
Cycle details:
→ Target 'WooCommerce' has target dependency on Target 'Storage'
→ Target 'Storage' has copy command from '/Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Intermediates.noindex/Storage.build/Debug-iphonesimulator/Storage.build/Objects-normal/arm64/Storage-Swift.h' to '/Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/Headers/Storage-Swift.h'
○ Target 'Storage' has compile command for Swift source files
○ Target 'Storage' has copy command from '/Users/jaclynchen/Developer/woocommerce-ios/Storage/Storage/Storage.h' to '/Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/Headers/Storage.h'


Raw dependency cycle trace:

target:  ->

node: <all> ->

command: <all> ->

node: /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/WooCommerce.app/Frameworks/Codegen.framework ->

command: target-WooCommerce-d7432f1470c1e5b259409f3e8de6736fceaf35a615d31722bbb7dd87a7449cea-:Debug:Copy /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/WooCommerce.app/Frameworks/Codegen.framework /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/PackageFrameworks/Codegen.framework ->

node: <target-WooCommerce-d7432f1470c1e5b259409f3e8de6736fceaf35a615d31722bbb7dd87a7449cea--entry> ->

command: Gate target-WooCommerce-d7432f1470c1e5b259409f3e8de6736fceaf35a615d31722bbb7dd87a7449cea--entry ->

node: <target-Storage-2730a5d3b006dbf60144ce32026b01407902eddf38d9981896c638b99e1de4d5--end> ->

command: Gate target-Storage-2730a5d3b006dbf60144ce32026b01407902eddf38d9981896c638b99e1de4d5--end ->

CYCLE POINT ->

node: /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/Headers/Storage-Swift.h ->

command: target-Storage-2730a5d3b006dbf60144ce32026b01407902eddf38d9981896c638b99e1de4d5-:Debug:Copy /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/Headers/Storage-Swift.h /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Intermediates.noindex/Storage.build/Debug-iphonesimulator/Storage.build/Objects-normal/arm64/Storage-Swift.h ->

node: /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Intermediates.noindex/Storage.build/Debug-iphonesimulator/Storage.build/Objects-normal/arm64/Storage-Swift.h/ ->

directoryTreeSignature: � ->

directoryContents: /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Intermediates.noindex/Storage.build/Debug-iphonesimulator/Storage.build/Objects-normal/arm64/Storage-Swift.h ->

node: /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Intermediates.noindex/Storage.build/Debug-iphonesimulator/Storage.build/Objects-normal/arm64/Storage-Swift.h ->

command: target-Storage-2730a5d3b006dbf60144ce32026b01407902eddf38d9981896c638b99e1de4d5-:Debug:CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler ->

node: /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/Headers/Storage.h ->

command: target-Storage-2730a5d3b006dbf60144ce32026b01407902eddf38d9981896c638b99e1de4d5-:Debug:CpHeader /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/Headers/Storage.h /Users/jaclynchen/Developer/woocommerce-ios/Storage/Storage/Storage.h ->

node: <target-Storage-2730a5d3b006dbf60144ce32026b01407902eddf38d9981896c638b99e1de4d5--phase1-compile-sources> ->

command: Gate target-Storage-2730a5d3b006dbf60144ce32026b01407902eddf38d9981896c638b99e1de4d5--phase1-compile-sources ->

node: /Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/Headers/Storage-Swift.h
</details>

I checked the Storage framework, and it has no reference of the WooCommerce app - the only dependent frameworks are CoreData and Codegen (no dependencies on other frameworks). Thus, I followed the suggested fix in the error message `This usually can be resolved by moving the target's Headers build phase before Compile Sources.` and was able to build the app incrementally after moving the `Headers` step to before the `Compile Sources` step. After fixing the cycle dependencies error from `Storage` framework, then I got a similar error from `Networking` framework and then similarly from `Yosemite` framework. It's probably because these 3 frameworks were created a long time ago, the more recent Xcode frameworks like `Hardware` and `Experiments` frameworks both have the `Headers` step before the `Compile Sources` step (example in [`Hardware` porject file](https://github.com/woocommerce/woocommerce-ios/blob/df4d399eddb86f31d622c15ebf8f81b0d3bd1ebc/Hardware/Hardware.xcodeproj/project.pbxproj#L529-L535)).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Pre Xcode 13.3

- Build the app from Xcode 13.2.* or below that is compatible with the app --> the app should build like before on the first run and incrementally

#### Xcode 13.3

- Build the app from Xcode 13.3, clean the build folder if needed --> the first build should succeed
- Build the app again --> the build should still succeed

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->