### PR TITLE
Inbox Notes: now it's possible to see entirely the last element of the pagination

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -75,7 +75,7 @@ struct Inbox: View {
                     .background(Constants.listForeground)
                 }
             }
-            .ignoresSafeArea()
+            .ignoresSafeArea(.container, edges: [.horizontal])
             .background(Constants.listBackground.ignoresSafeArea())
             .navigationTitle(Localization.title)
             .onAppear {

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -75,7 +75,7 @@ struct Inbox: View {
                     .background(Constants.listForeground)
                 }
             }
-            
+            .ignoresSafeArea(.container, edges: [.horizontal])
             .background(Constants.listBackground.ignoresSafeArea())
             .navigationTitle(Localization.title)
             .onAppear {

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -75,7 +75,7 @@ struct Inbox: View {
                     .background(Constants.listForeground)
                 }
             }
-            .ignoresSafeArea(.container, edges: [.horizontal])
+            
             .background(Constants.listBackground.ignoresSafeArea())
             .navigationTitle(Localization.title)
             .onAppear {


### PR DESCRIPTION
Fixes #6443 

### Description
When scrolling to the bottom of the Inbox screen, the bottom-most content was covered by the tab bar. This is likely cause by the ignoresSafeArea() modifier on the content view. Updating it to `.ignoresSafeArea(.container, edges: [.horizontal])` fixed the issue. At the same time, I discovered another issue. When you arrive at the end of the pagination, there is a sort of glitch with the bounce of the scrollview. I tried different solution for fixing it, but no solution worked for the moment.

### Testing instructions
1. Launch the app
2. Go to the Menu tab
3. Tap on "Inbox" 
4. After syncing, scroll to the bottom of the notes --> notice that the bottom content is no more covered by the tab bar.

### Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-17 at 12 46 33](https://user-images.githubusercontent.com/495617/158985355-4806cf82-5d63-45ef-98c1-5fb7fae4529c.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-17 at 15 18 43](https://user-images.githubusercontent.com/495617/158985383-88c8b5d4-0b51-4ff5-9256-f2bedb15d881.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
