### PR TITLE
Order Creation: Add retry button and fix tap-to-dismiss on product error notices

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -76,17 +76,24 @@ struct NoticeModifier: ViewModifier {
     private func dispatchClearNoticeTask() {
         guard autoDismiss else { return }
         clearNoticeTask.cancel()
-        clearNoticeTask = .init {
-            $notice.wrappedValue = nil
-        }
+        setClearNoticeTask()
         DispatchQueue.main.asyncAfter(deadline: .now() + onScreenNoticeTime, execute: clearNoticeTask)
     }
 
     /// Synchronously performs the clear notice task and cancels it to prevent any future execution.
     ///
     private func performClearNoticeTask() {
+        setClearNoticeTask()
         clearNoticeTask.perform()
         clearNoticeTask.cancel()
+    }
+
+    /// Sets the clear notice task.
+    ///
+    private func setClearNoticeTask() {
+        clearNoticeTask = .init {
+            $notice.wrappedValue = nil
+        }
     }
 
     /// Sends haptic feedback if required.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -55,9 +55,9 @@ struct AddProductToOrder: View {
             .onAppear {
                 viewModel.onLoadTrigger.send()
             }
+            .notice($viewModel.notice)
         }
         .wooNavigationBarStyle()
-        .notice($viewModel.notice)
     }
 
     /// Creates the `ProductRow` for a product, depending on whether the product is variable.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -55,7 +55,7 @@ struct AddProductToOrder: View {
             .onAppear {
                 viewModel.onLoadTrigger.send()
             }
-            .notice($viewModel.notice)
+            .notice($viewModel.notice, autoDismiss: false)
         }
         .wooNavigationBarStyle()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -348,8 +348,10 @@ extension AddProductToOrderViewModel {
 
 private extension AddProductToOrderViewModel {
     enum Localization {
-        static let syncErrorMessage = NSLocalizedString("Unable to sync products", comment: "Notice displayed when syncing the list of products fails")
-        static let searchErrorMessage = NSLocalizedString("Unable to search products", comment: "Notice displayed when searching the list of products fails")
+        static let syncErrorMessage = NSLocalizedString("There was an error syncing products",
+                                                        comment: "Notice displayed when syncing the list of products fails")
+        static let searchErrorMessage = NSLocalizedString("There was an error searching products",
+                                                          comment: "Notice displayed when searching the list of products fails")
         static let errorActionTitle = NSLocalizedString("Retry", comment: "Retry action for an error notice")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -225,6 +225,7 @@ private extension AddProductToOrderViewModel {
     ///
     func transitionToSyncingState() {
         shouldShowScrollIndicator = true
+        notice = nil
         if products.isEmpty {
             syncStatus = .firstPageSync
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -192,7 +192,9 @@ extension AddProductToOrderViewModel: SyncingCoordinatorDelegate {
             case .success:
                 self.updateProductsResultsController()
             case .failure(let error):
-                self.notice = NoticeFactory.productSearchNotice()
+                self.notice = NoticeFactory.productSearchNotice() { [weak self] in
+                    self?.searchProducts(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
+                }
                 DDLogError("⛔️ Error searching products during order creation: \(error)")
             }
 
@@ -333,10 +335,12 @@ extension AddProductToOrderViewModel {
             }
         }
 
-        /// Returns a product search error notice.
+        /// Returns a product search error notice with a retry button.
         ///
-        static func productSearchNotice() -> Notice {
-            Notice(title: Localization.searchErrorMessage, feedbackType: .error)
+        static func productSearchNotice(retryAction: @escaping () -> Void) -> Notice {
+            Notice(title: Localization.searchErrorMessage, feedbackType: .error, actionTitle: Localization.errorActionTitle) {
+                retryAction()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -164,7 +164,9 @@ extension AddProductToOrderViewModel: SyncingCoordinatorDelegate {
             case .success:
                 self.updateProductsResultsController()
             case .failure(let error):
-                self.notice = NoticeFactory.productSyncNotice()
+                self.notice = NoticeFactory.productSyncNotice() { [weak self] in
+                    self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
+                }
                 DDLogError("⛔️ Error synchronizing products during order creation: \(error)")
             }
 
@@ -323,10 +325,12 @@ extension AddProductToOrderViewModel {
     /// Add Product to Order notices
     ///
     enum NoticeFactory {
-        /// Returns a default product sync error notice.
+        /// Returns a product sync error notice with a retry button.
         ///
-        static func productSyncNotice() -> Notice {
-            Notice(title: Localization.syncErrorMessage, feedbackType: .error)
+        static func productSyncNotice(retryAction: @escaping () -> Void) -> Notice {
+            Notice(title: Localization.syncErrorMessage, feedbackType: .error, actionTitle: Localization.errorActionTitle) {
+                retryAction()
+            }
         }
 
         /// Returns a product search error notice.
@@ -341,5 +345,6 @@ private extension AddProductToOrderViewModel {
     enum Localization {
         static let syncErrorMessage = NSLocalizedString("Unable to sync products", comment: "Notice displayed when syncing the list of products fails")
         static let searchErrorMessage = NSLocalizedString("Unable to search products", comment: "Notice displayed when searching the list of products fails")
+        static let errorActionTitle = NSLocalizedString("Retry", comment: "Retry action for an error notice")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -64,7 +64,7 @@ struct AddProductVariationToOrder: View {
         .onAppear {
             viewModel.onLoadTrigger.send()
         }
-        .notice($viewModel.notice)
+        .notice($viewModel.notice, autoDismiss: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -152,7 +152,9 @@ extension AddProductVariationToOrderViewModel: SyncingCoordinatorDelegate {
             guard let self = self else { return }
 
             if let error = error {
-                self.notice = NoticeFactory.productVariationSyncNotice()
+                self.notice = NoticeFactory.productVariationSyncNotice() { [weak self] in
+                    self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
+                }
                 DDLogError("⛔️ Error synchronizing product variations during order creation: \(error)")
             } else {
                 self.updateProductVariationsResultsController()
@@ -262,10 +264,12 @@ extension AddProductVariationToOrderViewModel {
     /// Add Product Variation to Order notices
     ///
     enum NoticeFactory {
-        /// Returns a default product variation sync error notice.
+        /// Returns a product variation sync error notice with a retry button.
         ///
-        static func productVariationSyncNotice() -> Notice {
-            Notice(title: Localization.errorMessage, feedbackType: .error)
+        static func productVariationSyncNotice(retryAction: @escaping () -> Void) -> Notice {
+            Notice(title: Localization.errorMessage, feedbackType: .error, actionTitle: Localization.errorActionTitle) {
+                retryAction()
+            }
         }
     }
 }
@@ -274,5 +278,6 @@ private extension AddProductVariationToOrderViewModel {
     enum Localization {
         static let errorMessage = NSLocalizedString("Unable to sync product variations",
                                                     comment: "Notice displayed when syncing the list of product variations fails")
+        static let errorActionTitle = NSLocalizedString("Retry", comment: "Retry action for an error notice")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrderViewModel.swift
@@ -276,7 +276,7 @@ extension AddProductVariationToOrderViewModel {
 
 private extension AddProductVariationToOrderViewModel {
     enum Localization {
-        static let errorMessage = NSLocalizedString("Unable to sync product variations",
+        static let errorMessage = NSLocalizedString("There was an error syncing product variations",
                                                     comment: "Notice displayed when syncing the list of product variations fails")
         static let errorActionTitle = NSLocalizedString("Retry", comment: "Retry action for an error notice")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -255,7 +255,7 @@ class AddProductToOrderViewModelTests: XCTestCase {
         viewModel.onLoadTrigger.send()
 
         // Then
-        XCTAssertEqual(viewModel.notice, AddProductToOrderViewModel.NoticeFactory.productSyncNotice())
+        XCTAssertEqual(viewModel.notice, AddProductToOrderViewModel.NoticeFactory.productSyncNotice(retryAction: {}))
     }
 
     func test_view_model_fires_error_notice_when_product_search_fails() {
@@ -277,7 +277,7 @@ class AddProductToOrderViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(notice, AddProductToOrderViewModel.NoticeFactory.productSearchNotice())
+        XCTAssertEqual(notice, AddProductToOrderViewModel.NoticeFactory.productSearchNotice(retryAction: {}))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -202,7 +202,7 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
         viewModel.onLoadTrigger.send()
 
         // Then
-        XCTAssertEqual(viewModel.notice, AddProductVariationToOrderViewModel.NoticeFactory.productVariationSyncNotice())
+        XCTAssertEqual(viewModel.notice, AddProductVariationToOrderViewModel.NoticeFactory.productVariationSyncNotice(retryAction: {}))
     }
 }
 


### PR DESCRIPTION
Closes: #6119

## Description

This is a followup to https://github.com/woocommerce/woocommerce-ios/pull/6453 and makes a few enhancements to the notices added there:

* Makes the notices permanent, instead of auto-dismissing.
* Adds a retry button to retry sync or search.
* Updates the error message to be more descriptive and consistent with other notices ("There was an error ..." instead of "Unable to ...").

It also fixes the tap-to-dismiss action, so that tapping a permanent notice dismisses it.

## Changes

* Fixes the notice tap-to-dismiss action by making sure `clearNoticeTask` is set in `View+NoticesModifier` for both sync and async actions.
* Updates notice in `AddProductToOrder` to make it permanent and sets it on the stack within the navigation view (so it doesn't persist when navigating to a variation list).
* Updates notice in `AddProductVariationToOrder` to make it permanent.
* Updates notices in both view models to add a retry action that repeats the sync or search action that failed, and updates their error messages.
* Updates `transitionToSyncingState()` in `AddProductToOrderViewModel` to set the notice to `nil`. This dismisses any existing error notice when transitioning between sync and search, so a sync error doesn't persist if search succeeds or vice versa.

## Testing

1. Make sure Order Creation is enabled under Settings > Experimental Features.
2. Go to the Orders tab and tap the + button to create a new order.
3. Disable your internet connection (to force network errors).
4. Tap "Add Product" and when the notice appears, confirm it has a retry button and isn't auto-dismissed.
5. Confirm that tapping the retry button dismisses the notice performs the sync/search action again.
6. Enable your internet connection and try searching for a product. Confirm the sync error notice is dismissed and the search works.
7. Disable your internet connection again.
8. Try searching for a product and when the notice appears, confirm it has a retry button and isn't auto-dismissed.
9. Confirm that tapping the retry button dismisses the notice performs the sync/search action again.
10. Select a product variation. (If you don't have any in local storage, you'll need to reconnect to wifi and sync/search for one, and then disconnect again.)
11. When a notice appears on the variation list screen, confirm it has a retry button and isn't auto-dismissed.
12. Confirm that tapping the retry button dismisses the notice performs the sync/search action again.

## Screenshots

Product sync error|Product search error|Product variation sync error
-|-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-18 at 13 58 24](https://user-images.githubusercontent.com/8658164/159021403-4bbe1cea-cfff-4710-9174-27c69fbe02a2.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-03-18 at 13 59 01](https://user-images.githubusercontent.com/8658164/159021397-e8784572-ef20-49ef-bddc-13e219aa8280.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-03-18 at 13 59 17](https://user-images.githubusercontent.com/8658164/159021392-44575201-c1ed-47d2-857f-530e50cdde17.png)



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
