### PR TITLE
Order Creation: Accessibility improvements for product row

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -158,7 +158,7 @@ private struct ProductsSection: View {
                     .headlineStyle()
 
                 ForEach(viewModel.productRows) { productRow in
-                    ProductRow(viewModel: productRow)
+                    ProductRow(viewModel: productRow, accessibilityHint: NewOrder.Localization.productRowAccessibilityHint)
                         .onTapGesture {
                             viewModel.selectOrderItem(productRow.id)
                         }
@@ -206,6 +206,8 @@ private extension NewOrder {
         static let createButton = NSLocalizedString("Create", comment: "Button to create an order on the New Order screen")
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating a new order")
         static let addProduct = NSLocalizedString("Add Product", comment: "Title text of the button that adds a product when creating a new order")
+        static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
+                                                                   comment: "Accessibility hint for selecting a product in a new order")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -73,8 +73,10 @@ struct AddProductToOrder: View {
                     DisclosureIndicator()
                 }
             }
+            .accessibilityHint(Localization.variableProductRowAccessibilityHint)
         } else {
             ProductRow(viewModel: rowViewModel)
+                .accessibilityHint(Localization.productRowAccessibilityHint)
                 .onTapGesture {
                     viewModel.selectProduct(rowViewModel.productOrVariationID)
                     isPresented.toggle()
@@ -95,6 +97,12 @@ private extension AddProductToOrder {
         static let emptyStateMessage = NSLocalizedString("No products found",
                                                          comment: "Message displayed if there are no products to display in the Add Product screen")
         static let searchPlaceholder = NSLocalizedString("Search Products", comment: "Placeholder on the search field to search for a specific product")
+        static let productRowAccessibilityHint = NSLocalizedString("Adds product to order.",
+                                                                   comment: "Accessibility hint for selecting a product in the Add Product screen")
+        static let variableProductRowAccessibilityHint = NSLocalizedString(
+            "Opens list of product variations.",
+            comment: "Accessibility hint for selecting a variable product in the Add Product screen"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -21,6 +21,7 @@ struct AddProductVariationToOrder: View {
                                    loadAction: viewModel.syncNextPage) {
                     ForEach(viewModel.productVariationRows) { rowViewModel in
                         ProductRow(viewModel: rowViewModel)
+                            .accessibilityHint(Localization.productRowAccessibilityHint)
                             .padding(Constants.defaultPadding)
                             .onTapGesture {
                                 viewModel.selectVariation(rowViewModel.productOrVariationID)
@@ -79,6 +80,8 @@ private extension AddProductVariationToOrder {
                                                          comment: "Message displayed if there are no product variations for a product.")
 
         static let backButtonAccessibilityLabel = NSLocalizedString("Back", comment: "Accessibility label for Back button in the navigation bar")
+        static let productRowAccessibilityHint = NSLocalizedString("Adds variation to order.",
+                                                                   comment: "Accessibility hint for selecting a variation in a list of product variations")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -11,6 +11,16 @@ struct ProductRow: View {
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1
 
+    /// Accessibility hint describing the product row tap gesture.
+    /// Avoids overwriting the product stepper accessibility hint, when the stepper is rendered.
+    ///
+    let accessibilityHint: String
+
+    init(viewModel: ProductRowViewModel, accessibilityHint: String = "") {
+        self.viewModel = viewModel
+        self.accessibilityHint = accessibilityHint
+    }
+
     var body: some View {
         VStack {
             AdaptiveStack(horizontalAlignment: .leading) {
@@ -39,8 +49,10 @@ struct ProductRow: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
-                .accessibilityElement()
+                .accessibilityElement(children: .ignore)
+                .accessibilityAddTraits(.isButton)
                 .accessibilityLabel(viewModel.productAccessibilityLabel)
+                .accessibilityHint(accessibilityHint)
 
                 ProductStepper(viewModel: viewModel)
                     .renderedIf(viewModel.canChangeQuantity)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -36,10 +36,11 @@ struct ProductRow: View {
                         Text(viewModel.skuLabel)
                             .subheadlineStyle()
                     }
-                    .accessibilityElement(children: .combine)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
+                .accessibilityElement()
+                .accessibilityLabel(viewModel.productAccessibilityLabel)
 
                 ProductStepper(viewModel: viewModel)
                     .renderedIf(viewModel.canChangeQuantity)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductRow.swift
@@ -95,8 +95,8 @@ private struct ProductStepper: View {
                 .stroke(Color(UIColor.separator), lineWidth: Layout.stepperBorderWidth)
         )
         .accessibilityElement(children: .ignore)
-        .accessibility(label: Text(Localization.quantityLabel))
-        .accessibility(value: Text(viewModel.quantity.description))
+        .accessibilityLabel("\(viewModel.name): \(Localization.quantityLabel)")
+        .accessibilityValue(viewModel.quantity.description)
         .accessibilityAdjustableAction { direction in
             switch direction {
             case .decrement:


### PR DESCRIPTION
Closes: #6069, #6125

## Description

This improves the accessibility for product rows in order creation:

* Product details now have a custom accessibility label. This removes the "•" separator and uses a period between each detail (e.g. "Cap. In stock. $16.99.")
* Product rows are marked as a button and have a hint that describes what selecting the product will do.
* The product quantity stepper now includes the product name in the accessibility label for clarity (e.g. "Cap: Quantity" instead of just "Quantity").

## Changes

* `ProductRowViewModel` now has separate properties for each product detail (stock or attributes, price, variations). They are combined as before to create the visible label, but they are also used to create a custom accessibility label that includes all product details with a period separator.
* Updates `ProductRow` to take an optional accessibility hint. This is applied to the product details, which are also now marked as a button and use the custom accessibility label from the view model. The accessibility hint is optional because it's only needed to differentiate between the hint for selecting the product details and the hint for the product stepper, when the stepper is rendered.
* Updates `ProductStepper` to add the product name to the accessibility label.
* Updates `AddProductToOrder` and `AddProductVariationToOrder` to set accessibility hints for the product rows there.

## Testing

1. If testing on a real device, enable VoiceOver. If testing in a simulator, open the Accessibility Inspector to check the accessibility for each element.
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and create a new order.
4. Select "Add Product" to open the product list.
5. Confirm the row for a non-variable product contains the expected label, button trait, and hint.
6. Confirm the row for a variable product contains the expected label, button trait, and hint.
7. Select a variable product and confirm the row for the product variations contain the expected label, button trait, and hint.
8. Add a product or variation to the order.
9. On the New Order screen, select the product in the order and confirm it contains the expected label, button trait, and hint.
10. Select the quantity stepper and confirm it contains the expected label.

## Screenshots

Before|After
-|-
![Product-Before](https://user-images.githubusercontent.com/8658164/159060206-0f5e234b-91e6-43d4-be99-39c9fd58494d.PNG)|![Product-After](https://user-images.githubusercontent.com/8658164/159060349-083d4d3a-2e2c-4bff-bc9e-314551a30b19.PNG)
![VariableProduct-Before](https://user-images.githubusercontent.com/8658164/159060200-48e5a014-5398-4877-a194-5cde44b74ee8.PNG)|![VariableProduct-After](https://user-images.githubusercontent.com/8658164/159060335-f4112920-2d3a-413d-866b-f750a1d1be63.PNG)
![Variation-Before](https://user-images.githubusercontent.com/8658164/159060194-c119ec83-ee52-470a-af1a-09ef966e95f8.PNG)|![Variation-After](https://user-images.githubusercontent.com/8658164/159060316-98dbedc9-049d-42fb-98df-711c9409b565.PNG)
![NewOrder-ProductDetail-Before](https://user-images.githubusercontent.com/8658164/159060186-8d94895c-ba5d-4ca7-a748-0095671693e6.PNG)|![NewOrder-Product-After](https://user-images.githubusercontent.com/8658164/159060256-5cb9e63b-38b0-4f6d-9993-216b3a2b6c0b.PNG)
![ProductStepper-Before](https://user-images.githubusercontent.com/8658164/159060210-1ec098be-de35-47fa-9436-e387171a331e.PNG)|![ProductStepper-After](https://user-images.githubusercontent.com/8658164/159060282-7ff95fa6-d2a0-4a6e-8174-40c55c34f358.PNG)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
