### PR TITLE
Order Creation: Fix minimal back button direction in RTL layout

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -57,7 +57,7 @@ struct AddProductVariationToOrder: View {
                 Button {
                     presentation.wrappedValue.dismiss()
                 } label: {
-                    Image(uiImage: .chevronLeftImage.imageFlippedForRightToLeftLayoutDirection())
+                    Image(uiImage: .chevronLeftImage).flipsForRightToLeftLayoutDirection(true)
                 }
                 .accessibilityLabel(Text(Localization.backButtonAccessibilityLabel))
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -59,7 +59,7 @@ struct AddProductVariationToOrder: View {
                 } label: {
                     Image(uiImage: .chevronLeftImage).flipsForRightToLeftLayoutDirection(true)
                 }
-                .accessibilityLabel(Text(Localization.backButtonAccessibilityLabel))
+                .accessibilityLabel(Localization.backButtonAccessibilityLabel)
             }
         }
         .onAppear {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -39,6 +39,7 @@ struct ShippingLabelAddNewPackage: View {
                     } label: {
                         Image(uiImage: .chevronLeftImage).flipsForRightToLeftLayoutDirection(true)
                     }
+                    .accessibilityLabel(Localization.backButtonAccessibilityLabel)
                 }
                 // Done button
                 ToolbarItem(placement: .confirmationAction, content: {
@@ -96,6 +97,7 @@ private extension ShippingLabelAddNewPackage {
         static let errorAlertTitle = NSLocalizedString("Cannot add package", comment: "The title of the alert when there is a generic error adding the package")
         static let errorAlertMessage = NSLocalizedString("Unexpected error",
                                                          comment: "The message of the alert when there is an unexpected error adding the package")
+        static let backButtonAccessibilityLabel = NSLocalizedString("Back", comment: "Accessibility label for Back button in the navigation bar")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -37,7 +37,7 @@ struct ShippingLabelAddNewPackage: View {
                     Button {
                         presentation.wrappedValue.dismiss()
                     } label: {
-                        Image(uiImage: .chevronLeftImage.imageFlippedForRightToLeftLayoutDirection())
+                        Image(uiImage: .chevronLeftImage).flipsForRightToLeftLayoutDirection(true)
                     }
                 }
                 // Done button


### PR DESCRIPTION
Closes: #6470

## Description

The minimal (chevron-only) back button was not getting flipped in SwiftUI views using a right-to-left layout. This fixes that back button in the two views that use it, and adds an accessibility label to the view that didn't have one.

## Changes

* For some reason, the UIKit `.imageFlippedForRightToLeftLayoutDirection()` no longer works to flip the chevron back button image in SwiftUI views. The views with that image now use the SwiftUI `.flipsForRightToLeftLayoutDirection(true)` modifier to ensure the image is flipped.
* The view `ShippingLabelAddNewPackage` now has an accessibility label for the back button.

## Testing

Set your device to an RTL language (e.g. Arabic or Hebrew) or build the app with a pseudo-language in Xcode: Go to Product > Scheme > Edit Scheme, select the Run scheme action, and for App Language select “Right-to-Left Pseudolanguage.”
Go to the orders tab and create a new order.
Select "Add Product."
Select a variable product from the list.
Confirm the list of product variations appears with the chevron pointing back (to the right).
Go back to the orders tab and select an order that is eligible to create a shipping label.
Select "Create Shipping Label."
Go through the shipping label form until you reach "Package Details."
In the Package Details screen, select "Package Selected."
Select "Create new package."
Confirm the "Add New Package" screen appears with the chevron pointing back (to the right).

## Screenshots

Before|After
-|-
![image](https://user-images.githubusercontent.com/8658164/159301465-2614c658-08e0-468b-a74d-7b873e683faa.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-03-21 at 13 31 51](https://user-images.githubusercontent.com/8658164/159301480-81b55577-e80f-4bb8-95ac-d6b9d00ff762.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-21 at 13 27 17](https://user-images.githubusercontent.com/8658164/159301513-d118bba6-7025-4b2c-90d1-cd7d44169b04.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-03-21 at 13 32 35](https://user-images.githubusercontent.com/8658164/159301532-377548db-b7c6-4974-9460-491f7f1bb2c2.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
