### PR TITLE
Order Creation: Fix dynamic type issues

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -107,16 +107,17 @@ struct FeeLineDetails: View {
                 .bodyStyle()
                 .fixedSize()
 
-            Spacer()
-
-            BindableTextfield(viewModel.amountPlaceholder,
-                              text: $viewModel.amount,
-                              focus: $focusFixedAmountInput)
-                .keyboardType(.numbersAndPunctuation)
-                .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
-                .onTapGesture {
-                    focusFixedAmountInput = true
-                }
+            HStack {
+                Spacer()
+                BindableTextfield(viewModel.amountPlaceholder,
+                                  text: $viewModel.amount,
+                                  focus: $focusFixedAmountInput)
+                    .keyboardType(.numbersAndPunctuation)
+                    .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
+                    .onTapGesture {
+                        focusFixedAmountInput = true
+                    }
+            }
         }
         .frame(minHeight: Layout.rowHeight)
         .padding([.leading, .trailing], Layout.rowPadding)
@@ -128,15 +129,16 @@ struct FeeLineDetails: View {
                 .bodyStyle()
                 .fixedSize()
 
-            Spacer()
-
-            BindableTextfield("0",
-                              text: $viewModel.percentage,
-                              focus: $focusPercentageAmountInput)
-                .keyboardType(.numbersAndPunctuation)
-                .onTapGesture {
-                    focusPercentageAmountInput = true
-                }
+            HStack {
+                Spacer()
+                BindableTextfield("0",
+                                  text: $viewModel.percentage,
+                                  focus: $focusPercentageAmountInput)
+                    .keyboardType(.numbersAndPunctuation)
+                    .onTapGesture {
+                        focusPercentageAmountInput = true
+                    }
+            }
         }
         .frame(minHeight: Layout.rowHeight)
         .padding([.leading, .trailing], Layout.rowPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -30,15 +30,15 @@ struct ShippingLineDetails: View {
                                 Text(Localization.amountField)
                                     .bodyStyle()
                                     .fixedSize()
-
-                                Spacer()
-
-                                BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount, focus: $focusAmountInput)
-                                    .keyboardType(.numbersAndPunctuation)
-                                    .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
-                                    .onTapGesture {
-                                        focusAmountInput = true
-                                    }
+                                HStack {
+                                    Spacer()
+                                    BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount, focus: $focusAmountInput)
+                                        .keyboardType(.numbersAndPunctuation)
+                                        .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
+                                        .onTapGesture {
+                                            focusAmountInput = true
+                                        }
+                                }
                             }
                             .frame(minHeight: Layout.amountRowHeight)
                             .padding([.leading, .trailing], Layout.amountRowPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -11,11 +11,11 @@ struct OrderStatusSection: View {
     var body: some View {
         Divider()
 
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: .zero) {
             Text(viewModel.dateString)
                 .footnoteStyle()
 
-            HStack {
+            HStack(alignment: .lastTextBaseline) {
                 Text(viewModel.statusBadgeViewModel.title)
                     .foregroundColor(.black)
                     .footnoteStyle()
@@ -23,7 +23,8 @@ struct OrderStatusSection: View {
                     .padding(.vertical, Layout.StatusBadge.verticalPadding)
                     .background(Color(viewModel.statusBadgeViewModel.color))
                     .cornerRadius(Layout.StatusBadge.cornerRadius)
-                    .padding(.vertical, Layout.StatusBadge.outsideVerticalPadding)
+                    .padding(.top, Layout.StatusBadge.topPadding)
+                    .padding(.bottom, Layout.StatusBadge.bottomPadding)
 
                 Spacer()
 
@@ -55,7 +56,8 @@ private extension OrderStatusSection {
         enum StatusBadge {
             static let horizontalPadding: CGFloat = 12.0
             static let verticalPadding: CGFloat = 4.0
-            static let outsideVerticalPadding: CGFloat = 10.0
+            static let topPadding: CGFloat = 8.0
+            static let bottomPadding: CGFloat = 16.0
             static let cornerRadius: CGFloat = 4.0
         }
         static let linkButtonTrailingPadding: CGFloat = 22.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -23,6 +23,7 @@ struct OrderStatusSection: View {
                     .padding(.vertical, Layout.StatusBadge.verticalPadding)
                     .background(Color(viewModel.statusBadgeViewModel.color))
                     .cornerRadius(Layout.StatusBadge.cornerRadius)
+                    .padding(.vertical, Layout.StatusBadge.outsideVerticalPadding)
 
                 Spacer()
 
@@ -54,6 +55,7 @@ private extension OrderStatusSection {
         enum StatusBadge {
             static let horizontalPadding: CGFloat = 12.0
             static let verticalPadding: CGFloat = 4.0
+            static let outsideVerticalPadding: CGFloat = 10.0
             static let cornerRadius: CGFloat = 4.0
         }
         static let linkButtonTrailingPadding: CGFloat = 22.0


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6464.
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6465.
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6466.

## Description

This PR fixes alignment issues for shipping and fees input fields and adds padding on order status badge.

## Changes

- Updates `ShippingLineDetails` with field alignment fix.
- Updates `FeeLineDetails`  with fields alignment fix.
- Updates `OrderStatusSection` with additional vertical padding on order status badge.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Make sure Order Creation is enabled under Settings > Experimental Features.
3. Go to the Orders tab and tap the + button. Tap "Create order" in the bottom sheet.
4. Add a product (to enable percentage fees).
5. Switch to biggest accessibility size in settings.
6. Check order status badge layou and padding.
7. Open shipping line details screen and check input layout.
9. Open fee details screen and  check input layout for both fixed amount and percentage.

## Screenshots

-|before|after
--|--|--
status badge|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/159345807-dc176591-27da-4844-9907-f44391ef2e89.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/159345861-016b0969-8fe2-444c-b22d-6480b6478cfa.png)
shipping details|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/159346177-06ad0839-2d80-4e2b-889c-d67193148116.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/159346242-2fb2a4ce-cb22-4324-80fd-d01fb660e6f9.png)
fee details|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/159346660-a84778d0-f2ed-4882-8962-799a5f403e64.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/159346748-c4a29fcc-61ae-4747-a1a2-5d33ea386da4.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
