### PR TITLE
[Mobile Payments] Wait for Charge to be fetched before continuing to refund confirmation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -11,7 +11,8 @@ final class IssueRefundViewController: UIViewController {
 
     @IBOutlet private var headerStackView: UIStackView!
     @IBOutlet private var itemsSelectedLabel: UILabel!
-    @IBOutlet private var nextButton: UIButton!
+    @IBOutlet private var nextButton: ButtonActivityIndicator!
+
     @IBOutlet private var selectAllButton: UIButton!
 
     private let imageService: ImageService
@@ -74,7 +75,7 @@ private extension IssueRefundViewController {
     func updateWithViewModelContent() {
         title = viewModel.title
         itemsSelectedLabel.text = viewModel.selectedItemsTitle
-        nextButton.isEnabled = viewModel.isNextButtonEnabled
+        updateButtonState(enabled: viewModel.isNextButtonEnabled, showActivityIndicator: viewModel.isNextButtonAnimating)
         selectAllButton.isHidden = !viewModel.isSelectAllButtonVisible
         tableView.reloadData()
     }
@@ -162,6 +163,16 @@ private extension IssueRefundViewController {
         headerStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
         headerStackView.alignment = headerStackView.axis == .vertical ? .center : .fill
         headerStackView.spacing = 8
+    }
+
+    func updateButtonState(enabled: Bool, showActivityIndicator: Bool) {
+        nextButton.isEnabled = enabled && !showActivityIndicator
+        switch showActivityIndicator {
+        case true:
+            nextButton.showActivityIndicator()
+        case false:
+            nextButton.hideActivityIndicator()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -12,7 +12,6 @@ final class IssueRefundViewController: UIViewController {
     @IBOutlet private var headerStackView: UIStackView!
     @IBOutlet private var itemsSelectedLabel: UILabel!
     @IBOutlet private var nextButton: ButtonActivityIndicator!
-
     @IBOutlet private var selectAllButton: UIButton!
 
     private let imageService: ImageService

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -166,10 +166,9 @@ private extension IssueRefundViewController {
 
     func updateButtonState(enabled: Bool, showActivityIndicator: Bool) {
         nextButton.isEnabled = enabled && !showActivityIndicator
-        switch showActivityIndicator {
-        case true:
+        if showActivityIndicator {
             nextButton.showActivityIndicator()
-        case false:
+        } else {
             nextButton.hideActivityIndicator()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -45,7 +45,7 @@
             <rect key="frame" x="0.0" y="0.0" width="417" height="67"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="omw-71-nel">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="omw-71-nel" customClass="ButtonActivityIndicator" customModule="WooCommerce" customModuleProvider="target">
                     <rect key="frame" x="20" y="0.0" width="377" height="67"/>
                     <state key="normal" title="Button"/>
                     <connections>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -138,6 +138,7 @@ final class IssueRefundViewModel {
         isSelectAllButtonVisible = calculateSelectAllButtonVisibility()
         selectedItemsTitle = createSelectedItemsCount()
         hasUnsavedChanges = calculatePendingChangesState()
+        observeCharge()
         fetchCharge()
     }
 
@@ -263,14 +264,18 @@ private extension IssueRefundViewModel {
         return ResultsController<StorageWCPayCharge>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
     }
 
+    func observeCharge() {
+        chargeResultsController?.onDidChangeContent = { [weak self] in
+            guard let self = self else { return }
+            self.state.charge = self.charge
+        }
+    }
+
     func fetchCharge() {
         guard let chargeID = state.order.chargeID else {
             return
         }
-        let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: state.order.siteID, chargeID: chargeID, onCompletion: { [weak self] _ in
-            guard let self = self else { return }
-            self.state.charge = self.charge
-        })
+        let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: state.order.siteID, chargeID: chargeID, onCompletion: { _ in })
         stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -263,7 +263,8 @@ private extension IssueRefundViewModel {
     }
 
     func createWcPayChargeResultsController() -> ResultsController<StorageWCPayCharge>? {
-        guard let chargeID = state.order.chargeID else {
+        guard let chargeID = state.order.chargeID,
+              chargeID.isNotEmpty else {
             return nil
         }
         let predicate = NSPredicate(format: "siteID == %ld AND chargeID == %@", state.order.siteID, chargeID)
@@ -442,7 +443,7 @@ extension IssueRefundViewModel {
     ///
     private func calculateNextButtonAnimatingState() -> Bool {
         // When we have a chargeID, we need to wait until we fetch the charge.
-        return state.order.chargeID != nil && state.charge == nil
+        state.charge == nil && !state.order.chargeID.isNilOrEmpty
     }
 
     /// Calculates whether there are pending changes to commit

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -107,7 +107,7 @@ final class IssueRefundViewModel {
     /// Charge related to the order. Used to show card details in the `Refund Via` section, and the refund confirmation screen.
     ///
     private var charge: WCPayCharge? {
-        return chargeResultsController?.fetchedObjects.first
+        chargeResultsController?.fetchedObjects.first
     }
 
     /// ResultsController for the charge relating to the order. Used to show card details in the `Refund Via` section, and the refund confirmation screen.
@@ -454,7 +454,7 @@ extension IssueRefundViewModel {
     /// Calculates whether the "select all" button should be visible or not.
     ///
     private func calculateSelectAllButtonVisibility() -> Bool {
-        return state.itemsToRefund.isNotEmpty
+        state.itemsToRefund.isNotEmpty
     }
 
     /// Returns `true` if a shipping refund is found.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonActivityIndicator.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonActivityIndicator.swift
@@ -15,6 +15,8 @@ final class ButtonActivityIndicator: UIButton {
             frm.origin.y = (frame.height - frm.height) / 2.0
             indicator.frame = frm.integral
         }
+
+        titleLabel?.isHidden = indicator.isAnimating
     }
 
     /// Display the loader indicator inside the button

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -627,6 +627,30 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isNextButtonAnimating)
     }
 
+    func test_viewModel_does_not_show_spinner_when_there_is_no_charge_to_fetch() {
+        // Given
+        // The order has a chargeID
+        let order = MockOrders().sampleOrder().copy(chargeID: nil)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
+
+        // Then
+        XCTAssertFalse(viewModel.isNextButtonAnimating)
+    }
+
+    func test_viewModel_does_not_show_spinner_when_there_is_no_charge_to_fetch_but_an_empty_chargeID() {
+        // Given
+        // The order has a chargeID
+        let order = MockOrders().sampleOrder().copy(chargeID: "")
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
+
+        // Then
+        XCTAssertFalse(viewModel.isNextButtonAnimating)
+    }
+
     func test_viewModel_hides_spinner_when_charge_found_in_storage() {
         // Given
         // The order has a chargeID

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 import Yosemite
+import protocol Storage.StorageManagerType
+import protocol Storage.StorageType
 
 @testable import WooCommerce
 
@@ -10,8 +12,17 @@ final class IssueRefundViewModelTests: XCTestCase {
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
 
+    /// Mock Storage: InMemory
+    private var storageManager: StorageManagerType!
+
+    /// View storage for tests
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
     override func setUp() {
         super.setUp()
+        storageManager = MockStorageManager()
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
@@ -602,5 +613,33 @@ final class IssueRefundViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(chargeFetched)
+    }
+
+    func test_viewModel_shows_spinner_when_charge_not_fetched_yet() {
+        // Given
+        // The order has a chargeID
+        let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
+
+        // Then
+        XCTAssertTrue(viewModel.isNextButtonAnimating)
+    }
+
+    func test_viewModel_hides_spinner_when_charge_found_in_storage() {
+        // Given
+        // The order has a chargeID
+        let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
+
+        let charge = storage.insertNewObject(ofType: StorageWCPayCharge.self)
+        charge.update(with: WCPayCharge.fake().copy(siteID: order.siteID, id: "ch_id"))
+        storage.saveIfNeeded()
+
+        // Then
+        XCTAssertFalse(viewModel.isNextButtonAnimating)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6471
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
IPP Interac payments in Canada must be refunded to the original payment card, with the customer present, using a client-side refund flow where the customer presents the original payment card again.

To determine whether we need to use the client-side refund flow, as opposed to the existing WCPay API refund flow, we fetch the `WCPayCharge` from the API when performing a refund. This is already used to display the original card details, and will be used to build the `RefundParameters` for the client side refund in future work.

The existing fetch was best-effort, and not required to continue with the refund. This change disables the `Next` button on the refund confirmation screen until the `WCPayCharge` is received.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### With a WCPay IPP order:
1. Open the order details, and tap `Issue Refund`
2. Observe that the next button is disabled, with a spinner showing, and then changes to a `Next` button.
3. Note that for a Simple Payments order, the button will remain disabled until the `Refund Fees` toggle is enabled, which is expected.

#### With any other order:
1. Repeat the steps above.
2. Observe that the `Next` button is displayed, and no spinner is used

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/159509319-bf2138d8-5fb6-4e07-89fe-412dad5ae499.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
