### PR TITLE
IPP Analytics: add `country` property to typed IPP events

### DIFF
--- a/Hardware/Hardware/CardReader/CardReader.swift
+++ b/Hardware/Hardware/CardReader/CardReader.swift
@@ -15,7 +15,7 @@ public struct CardReader {
     /// The Hardware status.
     public let status: CardReaderStatus
 
-    /// The reader's sofware version, if available
+    /// The reader's software version, if available
     public let softwareVersion: String?
 
     /// The reader's battery level, if available.

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -270,7 +270,7 @@ extension StripeCardReaderService: CardReaderService {
     }
 
     public func connect(_ reader: CardReader) -> AnyPublisher<CardReader, Error> {
-        guard let stripeReader = self.discoveredStripeReadersCache.reader(matching: reader) as? Reader else {
+        guard let stripeReader = discoveredStripeReadersCache.reader(matching: reader) as? Reader else {
             return Future() { promise in
                 promise(.failure(CardReaderServiceError.connection()))
             }.eraseToAnyPublisher()

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -596,8 +596,9 @@ extension WooAnalyticsEvent {
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `batteryLevel` is the battery level (if available) to be included in the event properties in Tracks, e.g. 0.75 = 75%.
         ///
-        static func cardReaderConnectionSuccess(forGatewayID: String?, batteryLevel: Float?) -> WooAnalyticsEvent {
+        static func cardReaderConnectionSuccess(forGatewayID: String?, batteryLevel: Float?, countryCode: String) -> WooAnalyticsEvent {
             var properties = [
+                Keys.countryCode: countryCode,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
             ]
 
@@ -612,9 +613,10 @@ extension WooAnalyticsEvent {
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `error` is the error to be included in the event properties.
         ///
-        static func cardReaderConnectionFailed(forGatewayID: String?, error: Error) -> WooAnalyticsEvent {
+        static func cardReaderConnectionFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderConnectionFailed,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription
                               ]
@@ -625,9 +627,10 @@ extension WooAnalyticsEvent {
         /// Tracked when disconnecting from a card reader
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardReaderDisconnectTapped(forGatewayID: String?) -> WooAnalyticsEvent {
+        static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDisconnectTapped,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )
@@ -676,7 +679,7 @@ extension WooAnalyticsEvent {
             )
         }
 
-        /// Tracksed when a software update completes successfully
+        /// Tracked when a software update completes successfully
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `updateType` is `.required` or `.optional`
         ///
@@ -729,9 +732,10 @@ extension WooAnalyticsEvent {
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `error` is the error to be included in the event properties.
         ///
-        static func collectPaymentFailed(forGatewayID: String?, error: Error) -> WooAnalyticsEvent {
+        static func collectPaymentFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentFailed,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription
                               ]
@@ -741,9 +745,10 @@ extension WooAnalyticsEvent {
         /// Tracked when the payment collection is cancelled
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func collectPaymentCanceled(forGatewayID: String?) -> WooAnalyticsEvent {
+        static func collectPaymentCanceled(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentCanceled,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )
@@ -752,9 +757,10 @@ extension WooAnalyticsEvent {
         /// Tracked when payment collection succeeds
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func collectPaymentSuccess(forGatewayID: String?) -> WooAnalyticsEvent {
+        static func collectPaymentSuccess(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -640,9 +640,10 @@ extension WooAnalyticsEvent {
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `updateType` is `.required` or `.optional`
         ///
-        static func cardReaderSoftwareUpdateTapped(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateTapped(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateTapped,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -653,9 +654,10 @@ extension WooAnalyticsEvent {
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `updateType` is `.required` or `.optional`
         ///
-        static func cardReaderSoftwareUpdateStarted(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateStarted(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateStarted,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -668,10 +670,11 @@ extension WooAnalyticsEvent {
         /// `error` is the error to be included in the event properties.
         ///
         static func cardReaderSoftwareUpdateFailed(
-            forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, error: Error
+            forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, error: Error, countryCode: String
         ) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateFailed,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue,
                                 Keys.errorDescription: error.localizedDescription
@@ -683,9 +686,10 @@ extension WooAnalyticsEvent {
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `updateType` is `.required` or `.optional`
         ///
-        static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateSuccess,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -695,9 +699,12 @@ extension WooAnalyticsEvent {
         /// Tracked when an update cancel button is tapped
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardReaderSoftwareUpdateCancelTapped(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateCancelTapped(forGatewayID: String?,
+                                                         updateType: SoftwareUpdateTypeProperty,
+                                                         countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCancelTapped,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -707,9 +714,10 @@ extension WooAnalyticsEvent {
         /// Tracked when an update is cancelled
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCanceled,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -579,8 +579,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when card reader discovery fails
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `error` is the error to be included in the event properties.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - error: the error to be included in the event properties.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderDiscoveryFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDiscoveryFailed,
@@ -593,8 +596,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when connecting to a card reader
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `batteryLevel` is the battery level (if available) to be included in the event properties in Tracks, e.g. 0.75 = 75%.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - batteryLevel: the battery level (if available) to be included in the event properties in Tracks, e.g. 0.75 = 75%.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderConnectionSuccess(forGatewayID: String?, batteryLevel: Float?, countryCode: String) -> WooAnalyticsEvent {
             var properties = [
@@ -610,8 +616,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when connecting to a card reader fails
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `error` is the error to be included in the event properties.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - error: the error to be included in the event properties.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderConnectionFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderConnectionFailed,
@@ -625,7 +634,10 @@ extension WooAnalyticsEvent {
 
 
         /// Tracked when disconnecting from a card reader
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDisconnectTapped,
@@ -637,8 +649,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when a software update is initiated manually
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `updateType` is `.required` or `.optional`
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - updateType: `.required` or `.optional`.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderSoftwareUpdateTapped(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateTapped,
@@ -651,8 +666,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when a card reader update starts
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `updateType` is `.required` or `.optional`
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - updateType: `.required` or `.optional`.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderSoftwareUpdateStarted(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateStarted,
@@ -665,9 +683,12 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when a card reader update fails
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `updateType` is `.required` or `.optional`
-        /// `error` is the error to be included in the event properties.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - updateType: `.required` or `.optional`.
+        ///   - error: the error to be included in the event properties.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderSoftwareUpdateFailed(
             forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, error: Error, countryCode: String
@@ -683,8 +704,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when a software update completes successfully
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `updateType` is `.required` or `.optional`
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - updateType: `.required` or `.optional`.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateSuccess,
@@ -697,7 +721,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when an update cancel button is tapped
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - updateType: `.required` or `.optional`.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderSoftwareUpdateCancelTapped(forGatewayID: String?,
                                                          updateType: SoftwareUpdateTypeProperty,
@@ -712,7 +740,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when an update is cancelled
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - updateType: `.required` or `.optional`.
+        ///   - countryCode: the country code of the store.
         ///
         static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCanceled,
@@ -725,7 +757,10 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when the user taps to collect a payment
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
         ///
         static func collectPaymentTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentTapped,
@@ -737,8 +772,11 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when the payment collection fails
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
-        /// `error` is the error to be included in the event properties.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - error: the error to be included in the event properties.
+        ///   - countryCode: the country code of the store.
         ///
         static func collectPaymentFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentFailed,
@@ -751,7 +789,10 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when the payment collection is cancelled
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
         ///
         static func collectPaymentCanceled(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentCanceled,
@@ -763,7 +804,10 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when payment collection succeeds
-        /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
         ///
         static func collectPaymentSuccess(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -566,6 +566,7 @@ extension WooAnalyticsEvent {
 
         enum Keys {
             static let batteryLevel = "battery_level"
+            static let countryCode = "country"
             static let gatewayID = "plugin_slug"
             static let errorDescription = "error_description"
             static let softwareUpdateType = "software_update_type"
@@ -581,9 +582,10 @@ extension WooAnalyticsEvent {
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `error` is the error to be included in the event properties.
         ///
-        static func cardReaderDiscoveryFailed(forGatewayID: String?, error: Error) -> WooAnalyticsEvent {
+        static func cardReaderDiscoveryFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDiscoveryFailed,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription
                               ]
@@ -630,7 +632,8 @@ extension WooAnalyticsEvent {
                               ]
             )
         }
-        /// Tracksed when a software update is initiated manually
+
+        /// Tracked when a software update is initiated manually
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         /// `updateType` is `.required` or `.optional`
         ///
@@ -713,9 +716,10 @@ extension WooAnalyticsEvent {
         /// Tracked when the user taps to collect a payment
         /// `forGatewayID` is the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func collectPaymentTapped(forGatewayID: String?) -> WooAnalyticsEvent {
+        static func collectPaymentTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentTapped,
                               properties: [
+                                Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -78,6 +78,6 @@ enum PaymentsModalActionsMode {
     /// Two action buttons
     case twoAction
 
-    /// Two action buttons and an auxiiary button
+    /// Two action buttons and an auxiliary button
     case twoActionAndAuxiliary
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -3,7 +3,7 @@ import WordPressAuthenticator
 import SafariServices
 
 
-/// UI containing modals preented in the Card Present Payments flows.
+/// UI containing modals presented in the Card Present Payments flows.
 final class CardPresentPaymentsModalViewController: UIViewController {
     /// The view model providing configuration for this view controller
     /// and support for user actions

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -81,6 +81,7 @@ final class CardReaderConnectionController {
     private var siteID: Int64
     private var knownCardReaderProvider: CardReaderSettingsKnownReaderProvider
     private var alerts: CardReaderSettingsAlertsProvider
+    private let configuration: CardPresentPaymentsConfiguration
 
     /// Reader(s) discovered by the card reader service
     ///
@@ -127,7 +128,8 @@ final class CardReaderConnectionController {
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
         knownReaderProvider: CardReaderSettingsKnownReaderProvider,
-        alertsProvider: CardReaderSettingsAlertsProvider
+        alertsProvider: CardReaderSettingsAlertsProvider,
+        configuration: CardPresentPaymentsConfiguration
     ) {
         siteID = forSiteID
         self.storageManager = storageManager
@@ -138,6 +140,7 @@ final class CardReaderConnectionController {
         foundReaders = []
         knownReaderID = nil
         skippedReaderIDs = []
+        self.configuration = configuration
 
         configureResultsControllers()
         loadPaymentGatewayAccounts()
@@ -367,7 +370,9 @@ private extension CardReaderConnectionController {
                 guard let self = self else { return }
 
                 ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID, error: error)
+                    event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
+                                                                                        error: error,
+                                                                                        countryCode: self.configuration.countryCode)
                 )
                 self.state = .discoveryFailed(error)
             })

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -572,7 +572,10 @@ private extension CardReaderConnectionController {
                 guard let self = self else { return }
                 self.knownCardReaderProvider.rememberCardReader(cardReaderID: reader.id)
                 ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionSuccess(forGatewayID: self.gatewayID, batteryLevel: reader.batteryLevel)
+                    event: WooAnalyticsEvent.InPersonPayments
+                        .cardReaderConnectionSuccess(forGatewayID: self.gatewayID,
+                                                     batteryLevel: reader.batteryLevel,
+                                                     countryCode: self.configuration.countryCode)
                 )
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete
@@ -586,7 +589,9 @@ private extension CardReaderConnectionController {
             case .failure(let error):
                 guard let self = self else { return }
                 ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID, error: error)
+                    event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
+                                                                                         error: error,
+                                                                                         countryCode: self.configuration.countryCode)
                 )
                 self.state = .connectingFailed(error)
             }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -487,7 +487,8 @@ private extension CardReaderConnectionController {
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateCancelTapped(
                         forGatewayID: self.gatewayID,
-                        updateType: .required
+                        updateType: .required,
+                        countryCode: self.configuration.countryCode
                     )
                 )
                 cancelable.cancel { result in
@@ -497,7 +498,8 @@ private extension CardReaderConnectionController {
                         ServiceLocator.analytics.track(
                             event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateCanceled(
                                 forGatewayID: self.gatewayID,
-                                updateType: .required
+                                updateType: .required,
+                                countryCode: self.configuration.countryCode
                             )
                         )
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -10,6 +10,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     private var didGetConnectedReaders: Bool = false
     private var connectedReaders = [CardReader]()
     private let knownReaderProvider: CardReaderSettingsKnownReaderProvider?
+    private let configuration: CardPresentPaymentsConfiguration
     private(set) var siteID: Int64
 
     private(set) var optionalReaderUpdateAvailable: Bool = false
@@ -45,10 +46,12 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
          knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil,
+         configuration: CardPresentPaymentsConfiguration,
          delayToShowUpdateSuccessMessage: DispatchTimeInterval = .seconds(1)) {
         self.didChangeShouldShow = didChangeShouldShow
         self.knownReaderProvider = knownReaderProvider
         self.siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
+        self.configuration = configuration
         self.delayToShowUpdateSuccessMessage = delayToShowUpdateSuccessMessage
 
         configureResultsControllers()
@@ -239,7 +242,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     func disconnectReader() {
         ServiceLocator.analytics.track(
             event: WooAnalyticsEvent.InPersonPayments.cardReaderDisconnectTapped(
-                forGatewayID: self.connectedGatewayID
+                forGatewayID: connectedGatewayID, countryCode: configuration.countryCode
             )
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -110,7 +110,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                         self.readerUpdateProgress = 0
                         ServiceLocator.analytics.track(
                             event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateStarted(
-                                forGatewayID: self.connectedGatewayID, updateType: self.updateType
+                                forGatewayID: self.connectedGatewayID, updateType: self.updateType, countryCode: self.configuration.countryCode
                             )
                         )
                     case .installing(progress: let progress):
@@ -124,7 +124,10 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                         self.readerUpdateError = error
                         ServiceLocator.analytics.track(
                             event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateFailed(
-                                forGatewayID: self.connectedGatewayID, updateType: self.updateType, error: error
+                                forGatewayID: self.connectedGatewayID,
+                                updateType: self.updateType,
+                                error: error,
+                                countryCode: self.configuration.countryCode
                             )
                         )
                         self.completeCardReaderUpdate(success: false)
@@ -133,7 +136,9 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                         self.softwareUpdateCancelable = nil
                         ServiceLocator.analytics.track(
                             event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateSuccess(
-                                forGatewayID: self.connectedGatewayID, updateType: self.updateType
+                                forGatewayID: self.connectedGatewayID,
+                                updateType: self.updateType,
+                                countryCode: self.configuration.countryCode
                             )
                         )
                         // If we were installing a software update, introduce a small delay so the user can
@@ -189,7 +194,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     func startCardReaderUpdate() {
         ServiceLocator.analytics.track(
             event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateTapped(
-                forGatewayID: self.connectedGatewayID, updateType: self.updateType
+                forGatewayID: connectedGatewayID, updateType: updateType, countryCode: configuration.countryCode
             )
         )
         let action = CardPresentPaymentAction.startCardReaderUpdate
@@ -205,7 +210,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
             guard let self = self else { return }
             ServiceLocator.analytics.track(
                 event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateCancelTapped(
-                    forGatewayID: self.connectedGatewayID, updateType: self.updateType
+                    forGatewayID: self.connectedGatewayID, updateType: self.updateType, countryCode: self.configuration.countryCode
                 )
             )
             self.softwareUpdateCancelable?.cancel(completion: { [weak self] result in
@@ -216,7 +221,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                 } else {
                     ServiceLocator.analytics.track(
                         event: WooAnalyticsEvent.InPersonPayments.cardReaderSoftwareUpdateCanceled(
-                            forGatewayID: self.connectedGatewayID, updateType: self.updateType
+                            forGatewayID: self.connectedGatewayID, updateType: self.updateType, countryCode: self.configuration.countryCode
                         )
                     )
                     self.completeCardReaderUpdate(success: false)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import SwiftUI
 
 final class CardReaderSettingsPresentingViewController: UIViewController {
 
@@ -41,7 +40,7 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
             return
         }
 
-        childViewController = self.storyboard!.instantiateViewController(withIdentifier: viewModelAndView.viewIdentifier)
+        childViewController = storyboard!.instantiateViewController(withIdentifier: viewModelAndView.viewIdentifier)
 
         guard let childViewController = childViewController else {
             return
@@ -76,23 +75,6 @@ private extension CardReaderSettingsPresentingViewController {
 
 // MARK: - SwiftUI compatibility
 //
-
-/// SwiftUI wrapper for CardReaderSettingsPresentingViewController
-///
-struct CardReaderSettingsPresentingView: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> some UIViewController {
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
-            fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
-        }
-
-        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
-        viewController.configure(viewModelsAndViews: viewModelsAndViews)
-        return viewController
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
-    }
-}
 
 // MARK: - Localization
 //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -13,18 +13,19 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
     /// Connection Controller (helps connect readers)
     ///
     private lazy var connectionController: CardReaderConnectionController? = {
-        guard let siteID = viewModel?.siteID else {
+        guard let viewModel = viewModel else {
             return nil
         }
 
-        guard let knownReaderProvider = viewModel?.knownReaderProvider else {
+        guard let knownReaderProvider = viewModel.knownReaderProvider else {
             return nil
         }
 
         return CardReaderConnectionController(
-            forSiteID: siteID,
+            forSiteID: viewModel.siteID,
             knownReaderProvider: knownReaderProvider,
-            alertsProvider: CardReaderSettingsAlerts()
+            alertsProvider: CardReaderSettingsAlerts(),
+            configuration: viewModel.configuration
         )
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -13,11 +13,7 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
     /// Connection Controller (helps connect readers)
     ///
     private lazy var connectionController: CardReaderConnectionController? = {
-        guard let viewModel = viewModel else {
-            return nil
-        }
-
-        guard let knownReaderProvider = viewModel.knownReaderProvider else {
+        guard let viewModel = viewModel, let knownReaderProvider = viewModel.knownReaderProvider else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
@@ -30,12 +30,16 @@ final class CardReaderSettingsSearchingViewModel: CardReaderSettingsPresentedVie
         foundReader?.id
     }
 
-    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?, knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil,
-         stores: StoresManager = ServiceLocator.stores
-    ) {
+    let configuration: CardPresentPaymentsConfiguration
+
+    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
+         knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil,
+         stores: StoresManager = ServiceLocator.stores,
+         configuration: CardPresentPaymentsConfiguration) {
         self.didChangeShouldShow = didChangeShouldShow
         self.siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
         self.knownReaderProvider = knownReaderProvider
+        self.configuration = configuration
 
         beginKnownReaderObservation()
         beginConnectedReaderObservation()
@@ -82,7 +86,7 @@ final class CardReaderSettingsSearchingViewModel: CardReaderSettingsPresentedVie
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not
-    /// Notifes the viewModel owner if a change occurs via didChangeShouldShow
+    /// Notifies the viewModel owner if a change occurs via didChangeShouldShow
     ///
     private func reevaluateShouldShow() {
         let newShouldShow: CardReaderSettingsTriState = noConnectedReader

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -1,4 +1,5 @@
 import Foundation
+import struct Yosemite.CardPresentPaymentsConfiguration
 
 /// Aggregates an ordered list of viewmodels, conforming to the viewmodel provider protocol. Priority is given to
 /// the first viewmodel in the list to return true for shouldShow
@@ -17,7 +18,7 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
 
     private var knownReaderProvider: CardReaderSettingsKnownReaderProvider?
 
-    init() {
+    init(configuration: CardPresentPaymentsConfiguration) {
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
         knownReaderProvider = CardReaderSettingsKnownReaderStorage()
@@ -34,7 +35,8 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
                     didChangeShouldShow: { [weak self] state in
                         self?.onDidChangeShouldShow(state)
                     },
-                    knownReaderProvider: knownReaderProvider
+                    knownReaderProvider: knownReaderProvider,
+                    configuration: configuration
                 ),
                 viewIdentifier: "CardReaderSettingsSearchingViewController"
             )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -48,7 +48,8 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
                     didChangeShouldShow: { [weak self] state in
                         self?.onDidChangeShouldShow(state)
                     },
-                    knownReaderProvider: knownReaderProvider
+                    knownReaderProvider: knownReaderProvider,
+                    configuration: configuration
                 ),
                 viewIdentifier: "CardReaderSettingsConnectedViewController"
             )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -141,7 +141,7 @@ extension InPersonPaymentsMenuViewController {
             fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
         }
 
-        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
+        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList(configuration: configurationLoader.configuration)
         viewController.configure(viewModelsAndViews: viewModelsAndViews)
         show(viewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -31,9 +31,9 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsLoading()
             case .selectPlugin:
                 if viewModel.userIsAdministrator {
-                    InPersonPaymentsPluginConfictAdmin(onRefresh: viewModel.refresh)
+                    InPersonPaymentsPluginConflictAdmin(onRefresh: viewModel.refresh)
                 } else {
-                    InPersonPaymentsPluginConfictShopManager(onRefresh: viewModel.refresh)
+                    InPersonPaymentsPluginConflictShopManager(onRefresh: viewModel.refresh)
                 }
             case .countryNotSupported(let countryCode):
                 InPersonPaymentsCountryNotSupported(countryCode: countryCode)
@@ -55,7 +55,7 @@ struct InPersonPaymentsView: View {
             case .stripeAccountPendingRequirement(_, let deadline):
                 InPersonPaymentsStripeAccountPending(deadline: deadline)
             case .stripeAccountUnderReview:
-                InPersonPaymentsStripeAcountReview()
+                InPersonPaymentsStripeAccountReview()
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected()
             case .completed(let plugin):

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct InPersonPaymentsPluginConfictAdmin: View {
+struct InPersonPaymentsPluginConflictAdmin: View {
     let onRefresh: () -> Void
     @State var presentedSetupURL: URL? = nil
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -80,6 +80,6 @@ private enum Constants {
 
 struct InPersonPaymentsPluginConfictAdmin_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginConfictAdmin(onRefresh: {})
+        InPersonPaymentsPluginConflictAdmin(onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Yosemite
 
-struct InPersonPaymentsPluginConfictShopManager: View {
+struct InPersonPaymentsPluginConflictShopManager: View {
     let onRefresh: () -> Void
     @State var presentedSetupURL: URL? = nil
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -66,6 +66,6 @@ private enum Constants {
 
 struct InPersonPaymentsPluginConfictShopManager_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginConfictShopManager(onRefresh: {})
+        InPersonPaymentsPluginConflictShopManager(onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct InPersonPaymentsStripeAcountReview: View {
+struct InPersonPaymentsStripeAccountReview: View {
     var body: some View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
@@ -27,8 +27,8 @@ private enum Localization {
     )
 }
 
-struct InPersonPaymentsStripeAcountReview_Previews: PreviewProvider {
+struct InPersonPaymentsStripeAccountReview_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAcountReview()
+        InPersonPaymentsStripeAccountReview()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -11,7 +11,7 @@ protocol CollectOrderPaymentProtocol {
     /// Starts the collect payment flow.
     ///
     ///
-    /// - Parameter backButtonTitle: Title for the back button after a payment is sucessfull.
+    /// - Parameter backButtonTitle: Title for the back button after a payment is sucessful.
     /// - Parameter onCollect: Closure Invoked after the collect process has finished.
     /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed.
     func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ())

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -209,7 +209,8 @@ private extension CollectOrderPaymentUseCase {
     ///
     func handleSuccessfulPayment(receipt: CardPresentReceiptParameters, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> ()) {
         // Record success
-        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID))
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,
+                                                                                        countryCode: configurationLoader.configuration.countryCode))
 
         // Success Callback
         onCompletion(.success(receipt))
@@ -219,7 +220,9 @@ private extension CollectOrderPaymentUseCase {
     ///
     func handlePaymentFailureAndRetryPayment(_ error: Error, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> ()) {
         // Record error
-        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentFailed(forGatewayID: paymentGatewayAccount.gatewayID, error: error))
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentFailed(forGatewayID: paymentGatewayAccount.gatewayID,
+                                                                                       error: error,
+                                                                                       countryCode: configurationLoader.configuration.countryCode))
         DDLogError("Failed to collect payment: \(error.localizedDescription)")
 
         // Inform about the error
@@ -248,7 +251,8 @@ private extension CollectOrderPaymentUseCase {
     func cancelPayment() {
         paymentOrchestrator.cancelPayment { [weak self, analytics] _ in
             guard let self = self else { return }
-            analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentCanceled(forGatewayID: self.paymentGatewayAccount.gatewayID))
+            analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentCanceled(forGatewayID: self.paymentGatewayAccount.gatewayID,
+                                                                                             countryCode: self.configurationLoader.configuration.countryCode))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -11,7 +11,7 @@ protocol CollectOrderPaymentProtocol {
     /// Starts the collect payment flow.
     ///
     ///
-    /// - Parameter backButtonTitle: Title for the back button after a payment is sucessful.
+    /// - Parameter backButtonTitle: Title for the back button after a payment is successful.
     /// - Parameter onCollect: Closure Invoked after the collect process has finished.
     /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed.
     func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ())
@@ -103,7 +103,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     /// 4. If failure: Allows retry
     ///
     ///
-    /// - Parameter backButtonTitle: Title for the back button after a payment is sucessfull.
+    /// - Parameter backButtonTitle: Title for the back button after a payment is successful.
     /// - Parameter onCollect: Closure Invoked after the collect process has finished.
     /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed, Currently after merchant has handled the receipt.
     func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -71,7 +71,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     private lazy var connectionController = {
         CardReaderConnectionController(forSiteID: siteID,
                                        knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
-                                       alertsProvider: CardReaderSettingsAlerts())
+                                       alertsProvider: CardReaderSettingsAlerts(),
+                                       configuration: configurationLoader.configuration)
     }()
 
     /// IPP Configuration loader
@@ -168,7 +169,8 @@ private extension CollectOrderPaymentUseCase {
     ///
     func attemptPayment(onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> ()) {
         // Track tapped event
-        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentTapped(forGatewayID: paymentGatewayAccount.gatewayID))
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentTapped(forGatewayID: paymentGatewayAccount.gatewayID,
+                                                                                       countryCode: configurationLoader.configuration.countryCode))
 
         // Show reader ready alert
         alerts.readerIsReady(title: Localization.collectPaymentTitle(username: order.billingAddress?.firstName), amount: formattedAmount)

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -48,7 +48,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -82,7 +83,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -124,7 +126,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -159,7 +162,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -195,7 +199,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -233,7 +238,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -275,7 +281,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -310,7 +317,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -348,7 +356,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -386,7 +395,8 @@ class CardReaderConnectionControllerTests: XCTestCase {
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
-            alertsProvider: mockAlerts
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration
         )
 
         // When
@@ -400,5 +410,11 @@ class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}
+
+private extension CardReaderConnectionControllerTests {
+    enum Mocks {
+        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -20,6 +20,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         configuration: Mocks.configuration,
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
     }
 
@@ -36,6 +37,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
             XCTAssertTrue(shouldShow == .isFalse)
             expectation.fulfill()
         },
+                                                     configuration: Mocks.configuration,
                                                      delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
@@ -48,13 +50,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
             XCTAssertTrue(shouldShow == .isTrue)
             expectation.fulfill()
         },
+                                                         configuration: Mocks.configuration,
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
     func test_view_model_correctly_formats_connected_card_reader_battery_level() {
-        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil, configuration: Mocks.configuration)
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "50% Battery")
     }
 
@@ -67,12 +70,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         ServiceLocator.setStores(mockStoresManager)
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         configuration: Mocks.configuration,
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "Unknown Battery Level")
     }
 
     func test_view_model_correctly_formats_connected_card_reader_software_version() {
         let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                             configuration: Mocks.configuration,
                                                              delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Version: 1.00.03.34-SZZZ_Generic_v45-300001")
     }
@@ -86,6 +91,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         ServiceLocator.setStores(mockStoresManager)
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         configuration: Mocks.configuration,
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Unknown Software Version")
     }
@@ -131,6 +137,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         ServiceLocator.setStores(mockStoresManager)
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         configuration: Mocks.configuration,
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         var updateDidBegin = false
@@ -402,5 +409,11 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.optionalReaderUpdateAvailable)
+    }
+}
+
+private extension CardReaderSettingsConnectedViewModelTests {
+    enum Mocks {
+        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
@@ -4,6 +4,7 @@ import XCTest
 
 private struct TestConstants {
     static let mockReaderID = "CHB204909005931"
+    static let mockConfiguration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
 }
 
 final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
@@ -22,7 +23,8 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
         let _ = CardReaderSettingsSearchingViewModel(didChangeShouldShow: { shouldShow in
             XCTAssertTrue(shouldShow == .isTrue)
             expectation.fulfill()
-        }, knownReaderProvider: mockKnownReaderProvider)
+        }, knownReaderProvider: mockKnownReaderProvider,
+                                                     configuration: TestConstants.mockConfiguration)
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
@@ -42,7 +44,8 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
         let _ = CardReaderSettingsSearchingViewModel(didChangeShouldShow: { shouldShow in
             XCTAssertTrue(shouldShow == .isFalse)
             expectation.fulfill()
-        }, knownReaderProvider: mockKnownReaderProvider)
+        }, knownReaderProvider: mockKnownReaderProvider,
+                                                     configuration: TestConstants.mockConfiguration)
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public struct CardPresentPaymentsConfiguration {
-    private let countryCode: String
     private let stripeTerminalforCanadaEnabled: Bool
 
+    public let countryCode: String
     public let paymentMethods: [WCPayPaymentMethodType]
     public let currencies: [String]
     public let paymentGateways: [String]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5984 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of the tracking plan for Canada IPP support in pdfdoF-vx-p2, we're adding `country` property among others to all relevant IPP events including the pre-existing events not specific to Canada support. Since there are many affected events, I started with events defined in the `WooAnalyticsEvent.InPersonPayments` enum that are already typed. There are still other events like `*_card_present_onboarding_*` and `*_receipt_*` events that I will add the `country` property in a separate PR by also adding these events to the `WooAnalyticsEvent.InPersonPayments` enum.

There are 14 events updated in this PR:
- `card_reader_discovery_failed`
- `card_reader_connection_success`
- `card_reader_connection_failed`
- `card_reader_disconnect_tapped`
- `card_reader_software_update_tapped`
- `card_reader_software_update_started`
- `card_reader_software_update_failed`
- `card_reader_software_update_success`
- `card_reader_software_update_cancel_tapped`
- `card_reader_software_update_canceled`
- `card_present_collect_payment_tapped`
- `card_present_collect_payment_failed`
- `card_present_collect_payment_canceled`
- `card_present_collect_payment_success`

This PR also contains the removal of some unused code or unnecessary `self` usage and typo fixes from browsing the relevant code.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to test as many events as possible, I tested all events in two stores in the US and Canada in simulator with simulated card reader enabled and also on a device with an M2 reader.

For each event, there should be a new `country` property that shows the country code of the store.

- `card_reader_discovery_failed`: you can turn off Bluetooth on a device to trigger this event
- `card_reader_connection_success`
- `card_reader_connection_failed`
- `card_reader_disconnect_tapped`
- `card_reader_software_update_tapped`: this is easier to test in a simulator with simulated card reader enabled
- `card_reader_software_update_started`
- `card_reader_software_update_failed`: you can turn off Wifi in the middle of the software update to trigger this event
- `card_reader_software_update_success`
- `card_reader_software_update_cancel_tapped`
- `card_reader_software_update_canceled`
- `card_present_collect_payment_tapped`
- `card_present_collect_payment_failed`
- `card_present_collect_payment_canceled`
- `card_present_collect_payment_success`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->