### PR TITLE
Order Creation: Add safe area margins to product and variation lists

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -90,7 +90,7 @@ struct NewOrder: View {
 
                         Spacer(minLength: Layout.sectionSpacing)
 
-                        ProductsSection(geometry: geometry, scroll: scroll, viewModel: viewModel, navigationButtonID: $navigationButtonID)
+                        ProductsSection(scroll: scroll, viewModel: viewModel, navigationButtonID: $navigationButtonID)
 
                         Spacer(minLength: Layout.sectionSpacing)
 
@@ -136,7 +136,6 @@ struct NewOrder: View {
 /// Represents the Products section
 ///
 private struct ProductsSection: View {
-    let geometry: GeometryProxy
     let scroll: ScrollViewProxy
 
     /// View model to drive the view content
@@ -152,6 +151,10 @@ private struct ProductsSection: View {
     /// ID for Add Product button
     ///
     @Namespace var addProductButton
+
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
 
     var body: some View {
         Group {
@@ -188,7 +191,7 @@ private struct ProductsSection: View {
                         }
                 })
             }
-            .padding(.horizontal, insets: geometry.safeAreaInsets)
+            .padding(.horizontal, insets: safeAreaInsets)
             .padding()
             .background(Color(.listForeground))
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -11,10 +11,15 @@ struct AddProductToOrder: View {
     ///
     @ObservedObject var viewModel: AddProductToOrderViewModel
 
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
     var body: some View {
         NavigationView {
             VStack {
                 SearchHeader(filterText: $viewModel.searchTerm, filterPlaceholder: Localization.searchPlaceholder)
+                    .padding(.horizontal, insets: safeAreaInsets)
                 switch viewModel.syncStatus {
                 case .results:
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
@@ -25,7 +30,8 @@ struct AddProductToOrder: View {
                             Divider().frame(height: Constants.dividerHeight)
                                 .padding(.leading, Constants.defaultPadding)
                         }
-                        .background(Color(.listForeground))
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(.listForeground).ignoresSafeArea())
                     }
                 case .empty:
                     EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
@@ -36,6 +42,7 @@ struct AddProductToOrder: View {
                             .redacted(reason: .placeholder)
                             .shimmering()
                     }
+                    .padding(.horizontal, insets: safeAreaInsets)
                     .listStyle(PlainListStyle())
                 default:
                     EmptyView()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -13,6 +13,10 @@ struct AddProductVariationToOrder: View {
     ///
     @ObservedObject var viewModel: AddProductVariationToOrderViewModel
 
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
     var body: some View {
         Group {
             switch viewModel.syncStatus {
@@ -30,7 +34,8 @@ struct AddProductVariationToOrder: View {
                         Divider().frame(height: Constants.dividerHeight)
                             .padding(.leading, Constants.defaultPadding)
                     }
-                    .background(Color(.listForeground))
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .background(Color(.listForeground).ignoresSafeArea())
                 }
             case .empty:
                 EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
@@ -41,6 +46,7 @@ struct AddProductVariationToOrder: View {
                         .redacted(reason: .placeholder)
                         .shimmering()
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .listStyle(PlainListStyle())
             default:
                 EmptyView()


### PR DESCRIPTION
Closes: #6467

## Description

When adding items to a new order in landscape mode, the Product and Product Variation lists now respect the device safe area margins.

This also simplifies the margins for the Products section on the New Order screen (no visual change).

## Changes

* In `New Order`, replaces the `ProductsSection` geometry proxy with Environment safe area insets.
* In `AddProductToOrder` and `AddProductVariationToOrder`, the search header and lists (real and ghost/loading views) now have horizontal padding with safe area insets.

## Testing

1. Go to the Order tab and create a new order.
2. On the new order screen, confirm the Products section has the expected margin in portrait and landscape (no visual change).
3. Select "Add Product."
4. Confirm the search header and product list respect the device safe area margin in portrait and landscape (nothing hidden by the device notch).
5. Select a variable product to open its list of variations.
6. Confirm the variation list respects the device safe area margin in portrait and landscape (nothing hidden by the device notch).

## Screenshots

Before|After
-|-
![ProductList-Before](https://user-images.githubusercontent.com/8658164/159471772-89fa9ff6-efe1-44d6-a318-7f5c35e85146.png)|![ProductList-After](https://user-images.githubusercontent.com/8658164/159471781-55b81dec-b780-49a3-83ac-69dd9452554a.png)
![VariationsList-Before](https://user-images.githubusercontent.com/8658164/159471808-388acbc0-72e6-4587-90e5-703c8a601439.png)|![VariationsList-After](https://user-images.githubusercontent.com/8658164/159471822-fce6b6cd-21c9-45e2-b3d6-d5fbb0e8b6fa.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
