### PR TITLE
Issue: Keep the minus sign when deleting negative numbers on the product inventory quantity

### DIFF
--- a/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
@@ -29,6 +29,7 @@ struct IntegerInputFormatter: UnitInputFormatter {
             return defaultValue
         }
 
+        // No need to apply formatting when we only have the minus sign
         guard text != "\(minus)" else {
             return text
         }

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
@@ -29,6 +29,10 @@ struct IntegerInputFormatter: UnitInputFormatter {
             return defaultValue
         }
 
+        guard text != "\(minus)" else {
+            return text
+        }
+
         var formattedText = numberFormatter.number(from: text)?.stringValue ?? defaultValue
 
         // The minus sign is maintained if present

--- a/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
@@ -7,37 +7,37 @@ final class IntegerInputFormatterTests: XCTestCase {
 
     // MARK: test cases for `isValid(input:)`
 
-    func test_isValid_with_empty_input_then_returns_true() {
+    func test_empty_input_is_valid() {
         let input = ""
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func test_isValid_with_alphanumeric_input_then_returns_false() {
+    func test_alphanumeric_input_is_not_valid() {
         let input = "06two"
         XCTAssertFalse(formatter.isValid(input: input))
     }
 
-    func test_isValid_with_decimal_input_then_returns_false() {
+    func test_decimal_input_is_not_valid() {
         let input = "9990.52"
         XCTAssertFalse(formatter.isValid(input: input))
     }
 
-    func test_isValid_with_trailing_point_input_then_returns_false() {
+    func test_input_with_trailing_point_is_not_valid() {
         let input = "9990."
         XCTAssertFalse(formatter.isValid(input: input))
     }
 
-    func test_isValid_with_integer_input_then_returns_true() {
+    func test_integer_input_is_valid() {
         let input = "888888"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func test_isValid_with_negative_input_then_returns_true() {
+    func test_negative_input_is_valid() {
         let input = "-888888"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func test_isValid_with_minus_sign_input_then_returns_true() {
+    func test_only_minus_sign_input_is_valid() {
         let input = "-"
         XCTAssertTrue(formatter.isValid(input: input))
     }

--- a/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
@@ -7,69 +7,69 @@ final class IntegerInputFormatterTests: XCTestCase {
 
     // MARK: test cases for `isValid(input:)`
 
-    func testEmptyInputIsValid() {
+    func test_isValid_with_empty_input_then_returns_true() {
         let input = ""
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func testAlphanumericInputIsNotValid() {
+    func test_isValid_with_alphanumeric_input_then_returns_false() {
         let input = "06two"
         XCTAssertFalse(formatter.isValid(input: input))
     }
 
-    func testDecimalInputIsNotValid() {
+    func test_isValid_with_decimal_input_then_returns_false() {
         let input = "9990.52"
         XCTAssertFalse(formatter.isValid(input: input))
     }
 
-    func testTrailingPointInputIsValid() {
+    func test_isValid_with_trailing_point_input_then_returns_false() {
         let input = "9990."
         XCTAssertFalse(formatter.isValid(input: input))
     }
 
-    func testIntegerInputIsValid() {
+    func test_isValid_with_integer_input_then_returns_true() {
         let input = "888888"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func testNegativeIntegerInputIsValid() {
+    func test_isValid_with_negative_input_then_returns_true() {
         let input = "-888888"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func testMinusSignInputIsValid() {
+    func test_isValid_with_minus_sign_input_then_returns_true() {
         let input = "-"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
     // MARK: test cases for `format(input:)`
 
-    func testFormattingEmptyInput() {
+    func test_format_with_empty_input_returns_default_value() {
         let input = ""
         XCTAssertEqual(formatter.format(input: input), "1")
     }
 
-    func testFormattingInputWithLeadingZeros() {
+    func test_format_with_leading_zeroes_input_returns_input_without_leading_zeroes() {
         let input = "0012391"
         XCTAssertEqual(formatter.format(input: input), "12391")
     }
 
-    func testFormattingIntegerInput() {
+    func test_format_with_integer_input_returns_same_input() {
         let input = "314200"
         XCTAssertEqual(formatter.format(input: input), "314200")
     }
 
-    func testFormattingNegativeIntegerInput() {
+    func test_format_with_negative_integer_input_returns_same_input() {
         let input = "-3412424214"
         XCTAssertEqual(formatter.format(input: input), "-3412424214")
     }
 
-    func testFormattingMinusSignInput() {
+    func test_format_with_single_minus_sign_input_returns_same_input() {
         let input = "-"
-        XCTAssertEqual(formatter.format(input: input), "-1")
+        XCTAssertEqual(formatter.format(input: input), input)
     }
 
-    func testFormattingMultipleMinusSignInput() {
+    func test_format_with_multiple_minus_sign_input_returns_default_value() {
         let input = "--"
         XCTAssertEqual(formatter.format(input: input), "-1")
     }


### PR DESCRIPTION
Closes: #3710 

### Description
With this Pull Request, we fix the issue specified [here](https://github.com/woocommerce/woocommerce-ios/issues/3710), where the user couldn't delete a "-0" quantity reached after deleting a negative quantity (e.g -12) in the Product Inventory Detail Screen (Negative inventory values can happen if products are back-ordered). Because of this behavior, the user had to tap right between "-" and "0" to be able to delete the minus sign if the user wanted to add a positive quantity, which is suboptimal:

https://user-images.githubusercontent.com/198826/108557970-88394100-72b6-11eb-8860-8d3053b345ef.mp4

### Fix
With the fix introduced by this Pull Request, the user can further delete the last number of a negative quantity (e.g "1" of "-1"), thus reaching a point where only "-" appears in the text field. At this point, the user can further delete the "-" if they want to add a positive value or start typing if they want a negative value with the already present "-" sign.

https://user-images.githubusercontent.com/1864060/159524072-73f13911-c38f-4e8d-898e-26d30b028479.mov

### Code Changes
- Return "-" in `IntegerInputFormatter` `format` function when the input is "-" so it can be further edited.
- Update the unit tests matching this logic.
- Update the test functions naming to match the latest convention.

### Testing instructions
#### Negative Quantity on a Product Inventory
- Set a negative quantity for a product inventory in your testing site wp-admin
- Open the app. Go to products and select the product with that negative quantity. Open the products detail screen and go to inventory.
- Tap on the right side of the negative quantity and start deleting by pressing the delete button.

##### Test Cases

- Before when reaching only the "-", the value was converted automatically to "-0" and it couldn't be deleted. Now you can delete forward until "-", and start typing again.
- If you only the "-" character and delete it, the text field automatically shows the default value ("0").
- If you only the "-" character and press the navigation bar "Done" button, the value is converted to the default value ("0") and so is shown on the product detail page.
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

### Notes
For the stock quantity we use a `numberPad` that only allows input from 0 to 9 (not negative values). This goes counter to the wp-admin logic, where we could add negative values. We might want to fix this so we can also enter negative values on the iOS app.