### PR TITLE
Order Creation: Various accessibility improvements (VoiceOver)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -97,6 +97,7 @@ private struct OrderCustomerSectionContent: View {
                     .bodyStyle()
             }
         }
+        .accessibilityElement(children: .combine)
         .padding()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -40,6 +40,8 @@ struct AddProductToOrder: View {
                     List(viewModel.ghostRows) { rowViewModel in
                         ProductRow(viewModel: rowViewModel)
                             .redacted(reason: .placeholder)
+                            .accessibilityRemoveTraits(.isButton)
+                            .accessibilityLabel(Localization.loadingRowsAccessibilityLabel)
                             .shimmering()
                     }
                     .padding(.horizontal, insets: safeAreaInsets)
@@ -110,6 +112,8 @@ private extension AddProductToOrder {
             "Opens list of product variations.",
             comment: "Accessibility hint for selecting a variable product in the Add Product screen"
         )
+        static let loadingRowsAccessibilityLabel = NSLocalizedString("Loading products",
+                                                                     comment: "Accessibility label for placeholder rows while products are loading")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductVariationToOrder.swift
@@ -44,6 +44,8 @@ struct AddProductVariationToOrder: View {
                 List(viewModel.ghostRows) { rowViewModel in
                     ProductRow(viewModel: rowViewModel)
                         .redacted(reason: .placeholder)
+                        .accessibilityRemoveTraits(.isButton)
+                        .accessibilityLabel(Localization.loadingRowsAccessibilityLabel)
                         .shimmering()
                 }
                 .padding(.horizontal, insets: safeAreaInsets)
@@ -88,6 +90,8 @@ private extension AddProductVariationToOrder {
         static let backButtonAccessibilityLabel = NSLocalizedString("Back", comment: "Accessibility label for Back button in the navigation bar")
         static let productRowAccessibilityHint = NSLocalizedString("Adds variation to order.",
                                                                    comment: "Accessibility hint for selecting a variation in a list of product variations")
+        static let loadingRowsAccessibilityLabel = NSLocalizedString("Loading product variations",
+                                                                     comment: "Accessibility label for placeholder rows while product variations are loading")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
@@ -16,6 +16,7 @@ struct EmptyState: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: Constants.width)
+                    .accessibility(hidden: true)
             }
             if let description = description {
                 Text(description)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollIndicator.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollIndicator.swift
@@ -19,9 +19,17 @@ struct InfiniteScrollIndicator: View {
             .frame(maxWidth: .infinity, alignment: .center)
             .listRowInsets(EdgeInsets())
             .listRowBackground(Color(.listBackground))
+            .accessibilityElement()
+            .accessibilityLabel(Localization.accessibilityLabel)
             .if(!showContent) { progressView in
                 progressView.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger the load action when needed
             }
+    }
+}
+
+private extension InfiniteScrollIndicator {
+    enum Localization {
+        static let accessibilityLabel = NSLocalizedString("Loading", comment: "Accessibility label for loading indicator (spinner) at the bottom of a list")
     }
 }
 


### PR DESCRIPTION
Closes: #6070 
Closes: #6076

## Description/Changes

This adds various accessibility improvements for VoiceOver during order creation:

* Products: Adds a "Loading" label for the loading indicator in infinite scroll lists (`InfiniteScrollIndicator`), e.g. in the product and variation lists.
* Products: Replaces the default accessibility labels for ghost rows in the product and variation lists (which were reading out placeholder data) with generic "Loading products" and "Loading product variations" labels (in `AddProductToOrder` and `AddProductVariationToOrder`).
* Products: Hides the decorative image on the Empty State screen (`EmptyState`) from VoiceOver.
* Customer: Groups the "Shipping Address" and "Billing Address" headings with their respective addresses for VoiceOver on the new order screen (`OrderCustomerSection`).

## Testing

1. Enable VoiceOver on your device (or use the Accessibility Inspector in a simulator).
2. Go to the Orders tab and create a new order.
3. Select "Add Products."
4. Notice that when the first page of products syncs, or while searching products, VoiceOver reads the label "Loading products."
5. Scroll down in the list and notice that when the infinite scroll loading indicator appears at the bottom of the list, VoiceOver reads the label "Loading." (I found this was most apparent when I used the Network Link Conditioner to simulator a very bad network.)
6. Perform a product search with no results, and notice that VoiceOver reads the empty state message but ignores the decorative image.
7. Select a variable product from the list and notice that when the first page of product variations syncs, VoiceOver reads the label "Loading product variations."
8. Go back to the new order screen and select "Add Customer Details."
9. Add some customer details and select "Done" to save them.
10. On the new order screen, notice that VoiceOver reads the address heading (e.g. "Shipping Address") together with the corresponding name and address, instead of separating the heading and address.

## Screenshots

**Infinite scroll loading indicator**

<img src="https://user-images.githubusercontent.com/8658164/159531879-5d9de164-e049-457e-bcd0-beaf725fcd53.PNG" width="300px">

**Ghost rows (products & variations)**

<img src="https://user-images.githubusercontent.com/8658164/159532167-3990cd78-04cd-4aff-8b5b-0f506be71245.PNG" width="300px">

<img src="https://user-images.githubusercontent.com/8658164/159532223-1263d2f3-ca4d-4ed3-b980-8d436cc498dd.PNG" width="300px">


**Empty state screen**

<img src="https://user-images.githubusercontent.com/8658164/159531983-8764f468-2c3d-4430-9b29-635df1893665.PNG" width="300px">

**Customer details**

<img src="https://user-images.githubusercontent.com/8658164/159532032-122d1e2c-a8a8-4c66-9be4-15f61706822d.PNG" width="300px">


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
