### PR TITLE
Improve bottom sheet VoiceOver support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,8 +47,8 @@ target 'WooCommerce' do
 
   pod 'WordPressShared', '~> 1.15'
 
-  pod 'WordPressUI', '~> 1.12.4'
-  # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
+  # pod 'WordPressUI', '~> 1.12.4'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'add/bottom-sheet-accessibility'
 
   aztec
 

--- a/Podfile
+++ b/Podfile
@@ -47,8 +47,8 @@ target 'WooCommerce' do
 
   pod 'WordPressShared', '~> 1.15'
 
-  # pod 'WordPressUI', '~> 1.12.4'
-  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'add/bottom-sheet-accessibility'
+  pod 'WordPressUI', '~> 1.12.5-beta.1'
+  # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
 
   aztec
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -102,7 +102,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 2.0.0)
   - WordPressKit (~> 4.46.0)
   - WordPressShared (~> 1.15)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, branch `add/bottom-sheet-accessibility`)
+  - WordPressUI (~> 1.12.5-beta.1)
   - Wormholy (~> 1.6.5)
   - WPMediaPicker (~> 1.8.1)
   - XLPagerTabStrip (~> 9.0)
@@ -111,6 +111,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressUI
   trunk:
     - Alamofire
     - AppAuth
@@ -149,16 +150,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressUI:
-    :branch: add/bottom-sheet-accessibility
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressUI:
-    :commit: 4b8fb33d7a8b1e1d957cd6465d6beeb95e91a994
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -186,7 +177,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
   WordPressKit: 67cc1b0bda0d114c806a631ad726027d535d28a8
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
-  WordPressUI: dfaf30d9cb2546cffe6b8af21deaa04524cd84de
+  WordPressUI: 7d66c40df76299e1b2140363419a7e950bf68038
   Wormholy: 3252bc3e55a1847ef9a0976c1377bd77bf3635fa
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
@@ -199,6 +190,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: d52031569b2ae20c5e0d8b24d9419f301817f5a0
+PODFILE CHECKSUM: 5deeda4fca1a39746eb2d3135ba10d0f9deb5471
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -68,7 +68,7 @@ PODS:
   - WordPressShared (1.16.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
-  - WordPressUI (1.12.4)
+  - WordPressUI (1.12.5-beta.1)
   - Wormholy (1.6.5)
   - WPMediaPicker (1.8.1)
   - wpxmlrpc (0.9.0)
@@ -102,7 +102,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 2.0.0)
   - WordPressKit (~> 4.46.0)
   - WordPressShared (~> 1.15)
-  - WordPressUI (~> 1.12.4)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, branch `add/bottom-sheet-accessibility`)
   - Wormholy (~> 1.6.5)
   - WPMediaPicker (~> 1.8.1)
   - XLPagerTabStrip (~> 9.0)
@@ -137,7 +137,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressKit
     - WordPressShared
-    - WordPressUI
     - Wormholy
     - WPMediaPicker
     - wpxmlrpc
@@ -149,6 +148,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressUI:
+    :branch: add/bottom-sheet-accessibility
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressUI:
+    :commit: 4b8fb33d7a8b1e1d957cd6465d6beeb95e91a994
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -177,7 +186,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
   WordPressKit: 67cc1b0bda0d114c806a631ad726027d535d28a8
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
-  WordPressUI: 9e470758bc3a4a25e94478c2babe106f4ae7315a
+  WordPressUI: dfaf30d9cb2546cffe6b8af21deaa04524cd84de
   Wormholy: 3252bc3e55a1847ef9a0976c1377bd77bf3635fa
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
@@ -190,6 +199,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 62bb62f4855413dd2647646dcd3a2f6ad7c36e0f
+PODFILE CHECKSUM: d52031569b2ae20c5e0d8b24d9419f301817f5a0
 
 COCOAPODS: 1.11.2

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -63,6 +63,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(Cell.self, for: indexPath)
         let model = command.data[indexPath.row]
+        cell.accessibilityTraits.insert(.button)
         command.configureCell(cell: cell, model: model)
 
         return cell


### PR DESCRIPTION
Closes: #6066 
Closes: #6068 

Depends on https://github.com/wordpress-mobile/WordPressUI-iOS/pull/110
Before merging this PR:
- [x] Update Podfile to use the WordPressUI 1.12.5-beta.1 release instead of the feature branch.

## Description

Improves the VoiceOver support in the bottom sheet. This bottom sheet is used in various places in the app:

* Selecting what kind of order to create (new order or simple payment)
* Selecting what kind of product to create (simple physical, simple virtual, variable, etc.)
* Sorting product list
* Adding more details when creating/editing a product
* Selecting the upload method to add a file to a downloadable product
* Providing information about the WCServices discount when purchasing a shipping label for an order

There are two improvements:

* Adds the accessibility label "Dismiss" to the button that dismisses the bottom sheet.
* Marks options in the bottom sheet lists as buttons. (This applies to all the bottom sheets noted above except the last informational bottom sheet.)

## Changes

* Updates the `WordPressUI` pod to get the "Dismiss" accessibility label for the dismiss button in all bottom sheets.
* Adds the `button` accessibility trait to cells in `BottomSheetListSelectorViewController`.

## Testing

Enable VoiceOver on your device (or use the Accessibility Inspector in a simulator).
Go to the Orders tab and tap the "+" button.
In the bottom sheet that appears, confirm the grip button at the top of the sheet is labelled "Dismiss."
Confirm that each of the order types is labeled as a button.

You can repeat these steps to check each of the bottom sheets in the the app:

* Go to the Products tab and tap the "+" button.
* Select "Sort by" on the Products tab.
* Add or edit a product and select "Add more details."
* While editing a product, go to the Product Settings and enable "Downloadable Product." Then, select the "Downloadable files" section of the product details and select "Add File."
* Go to the Orders tab and select an order eligible for shipping labels. Select "Create Shipping Label," complete the shipping label form, and tap the "WooCommerce Discount" row.

## Screenshots

Before|After
-|-
![image](https://user-images.githubusercontent.com/8658164/159551923-fb354907-ad09-4c05-8347-4df33fea339e.png)|![NewOrder-Dismiss](https://user-images.githubusercontent.com/8658164/159551968-2043c2a4-35c6-477a-a7b5-7308ab84d89c.PNG)
![image](https://user-images.githubusercontent.com/8658164/159551952-8f15bc5e-c237-4361-ba9e-638d76327c3f.png)|![NewOrder-Button](https://user-images.githubusercontent.com/8658164/159551983-b3d49982-a652-4d8a-b5d4-5a7f2c5f49cf.PNG)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
