### PR TITLE
Order Creation: Swap billing info and shipping info order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -78,10 +78,11 @@ private struct OrderCustomerSectionContent: View {
 
     private var customerDataView: some View {
         Group {
-            addressDetails(title: Localization.shippingTitle, formattedAddress: viewModel.shippingAddressFormatted)
+            addressDetails(title: Localization.billingTitle, formattedAddress: viewModel.billingAddressFormatted)
             Divider()
                 .padding(.leading)
-            addressDetails(title: Localization.billingTitle, formattedAddress: viewModel.billingAddressFormatted)
+            addressDetails(title: Localization.shippingTitle, formattedAddress: viewModel.shippingAddressFormatted)
+
         }
     }
 


### PR DESCRIPTION
Closes: #6036 

# Why

There was a minor inconsistency in the shipping/billing order between the addresses form and the order form.

This PR fixes that by making sure the billing address is always displayed first than the shipping address in the order screen.

# Screenshots

##  Before
 Address Form | Order Form
---- | ----
<img alt="weird-1" src="https://user-images.githubusercontent.com/562080/151980880-f7d41562-8d64-4648-a0b1-bf88ddd6619a.png"> | <img alt="weird-2" src="https://user-images.githubusercontent.com/562080/151980884-d2ba5e8e-3a97-44b8-a6e0-6a20a0a19caa.png"> 



##  Now
Address Form | Order Form
---- | ---
<img width="433" alt="address-form" src="https://user-images.githubusercontent.com/562080/159580004-a9db5417-0273-4a0e-b85a-6e373b32a220.png"> | <img width="433" alt="order-form" src="https://user-images.githubusercontent.com/562080/159580011-a843114d-2468-4274-ae06-40cbdfb7e69a.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
