### PR TITLE
Hub Menu: Disable multiple taps on menu items

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 8.9
 -----
 - [*] Coupons: Fixed issue loading the coupon list from the local storage on initial load. [https://github.com/woocommerce/woocommerce-ios/pull/6463]
-
+- [*] Hub Menu: Multiple menu items can no longer be tapped simultaneously. [https://github.com/woocommerce/woocommerce-ios/pull/6484]
 
 8.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -17,6 +17,8 @@ struct HubMenu: View {
     /// Make sure to reset the value to false after dismissing sub-flows
     @State private var shouldDisableItemTaps = false
 
+    /// A timer used as a fallback method for resetting disabled state of the menu
+    ///
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     init(siteID: Int64, navigationController: UINavigationController? = nil) {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -17,6 +17,8 @@ struct HubMenu: View {
     /// Make sure to reset the value to false after dismissing sub-flows
     @State private var shouldDisableItemTaps = false
 
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
     init(siteID: Int64, navigationController: UINavigationController? = nil) {
         viewModel = HubMenuViewModel(siteID: siteID, navigationController: navigationController)
     }
@@ -99,6 +101,10 @@ struct HubMenu: View {
         .background(Color(.listBackground).edgesIgnoringSafeArea(.all))
         .onAppear {
             viewModel.setupMenuElements()
+            enableMenuItemTaps()
+        }
+        .onReceive(timer) { _ in
+            // fall back method in case menu disabled state is not reset properly
             enableMenuItemTaps()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -22,6 +22,9 @@ struct HubMenuElement: View {
 
     var body: some View {
         Button {
+            guard !isDisabled else {
+                return
+            }
             isDisabled = true
             onTapGesture()
         } label: {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuElement.swift
@@ -3,14 +3,26 @@ import SwiftUI
 /// This view represent a single element of the HubMenu
 ///
 struct HubMenuElement: View {
-    let image: UIImage
-    let imageColor: UIColor
-    let text: String
-    let badge: Int
-    let onTapGesture: (() -> Void)
+    private let image: UIImage
+    private let imageColor: UIColor
+    private let text: String
+    private let badge: Int
+    private let onTapGesture: (() -> Void)
+
+    @Binding private var isDisabled: Bool
+
+    init(image: UIImage, imageColor: UIColor, text: String, badge: Int, isDisabled: Binding<Bool>, onTapGesture: @escaping (() -> Void)) {
+        self.image = image
+        self.imageColor = imageColor
+        self.text = text
+        self.badge = badge
+        self._isDisabled = isDisabled
+        self.onTapGesture = onTapGesture
+    }
 
     var body: some View {
         Button {
+            isDisabled = true
             onTapGesture()
         } label: {
             ZStack(alignment: .topTrailing) {
@@ -42,6 +54,7 @@ struct HubMenuElement: View {
                     .renderedIf(badge > 0)
             }
         }
+        .disabled(isDisabled)
     }
 
     private struct HubMenuBadge: View {
@@ -62,7 +75,7 @@ struct HubMenuElement: View {
         }
     }
 
-    enum Constants {
+    private enum Constants {
         static let iconTopPadding: CGFloat = 32
         static let paddingBetweenElements: CGFloat = 8
         static let minimumBottomPadding: CGFloat = 2
@@ -80,6 +93,7 @@ struct HubMenuElement_Previews: PreviewProvider {
                        imageColor: .brand,
                        text: "Menu",
                        badge: 1,
+                       isDisabled: .constant(false),
                        onTapGesture: {})
             .previewLayout(.fixed(width: 160, height: 160))
             .previewDisplayName("Hub Menu Element")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6436 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a workaround to disable multiple taps on the items of the Hub Menu.

The solution is:
- Keep a state in the hub menu for whether the menu items should be disabled temporarily
- Send the state as a binding property to each item - the items will have to update this value to false when its button receives a tap event.
- Reset the state to make sure all items are tappable after the view appears again / when modals are dismissed.

The downside of this solution is that there's a potential case when the tap state is not reset properly causing the menu items to be disabled. `onAppear` isn't called when modals are dismissed, so we need to take care of resetting the selection state on the dismissal of every modal. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Launch the app and navigate to the Menu tab.
- Try tapping on any item more than one time or tapping on more items at a time.
- Notice that only one new flow is presented at a time.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/159624770-bcbcb8b3-f02f-499f-a155-9cb1c70f851b.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
