### PR TITLE
Fix failed unit test for AddProductCoordinator on iPad

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/AddOrderCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/AddOrderCoordinator.swift
@@ -25,6 +25,17 @@ final class AddOrderCoordinator: Coordinator {
         self.navigationController = sourceNavigationController
     }
 
+    init(siteID: Int64,
+         isOrderCreationEnabled: Bool,
+         sourceView: UIView,
+         sourceNavigationController: UINavigationController) {
+        self.siteID = siteID
+        self.isOrderCreationEnabled = isOrderCreationEnabled
+        self.sourceBarButtonItem = nil
+        self.sourceView = sourceView
+        self.navigationController = sourceNavigationController
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddOrderCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddOrderCoordinatorTests.swift
@@ -60,10 +60,10 @@ final class AddOrderCoordinatorTests: XCTestCase {
 
 private extension AddOrderCoordinatorTests {
     func makeAddProductCoordinator(isOrderCreationEnabled: Bool) -> AddOrderCoordinator {
-        let sourceBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
+        let sourceView = UIView()
         return AddOrderCoordinator(siteID: 100,
                                    isOrderCreationEnabled: isOrderCreationEnabled,
-                                   sourceBarButtonItem: sourceBarButtonItem,
+                                   sourceView: sourceView,
                                    sourceNavigationController: navigationController)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
@@ -40,7 +40,7 @@ final class AddProductCoordinatorTests: XCTestCase {
 
 private extension AddProductCoordinatorTests {
     func makeAddProductCoordinator() -> AddProductCoordinator {
-        let sourceBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
-        return AddProductCoordinator(siteID: 100, sourceBarButtonItem: sourceBarButtonItem, sourceNavigationController: navigationController)
+        let view = UIView()
+        return AddProductCoordinator(siteID: 100, sourceView: view, sourceNavigationController: navigationController)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6408 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the failed unit test for AddProductCoordinator on iPad. Previously the coordinator was set up with a bar button item - my take is that this item needs to be associated with a navigation bar/navigation controller to make it possible to present the popover from.

The solution is to set up the test with a source view instead of source bar button item.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please make sure that the test succeeds.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
