### PR TITLE
Coupons: Implement coupon deletion

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -27,6 +27,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInOrdersTab:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .couponEditAndDelete:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -27,7 +27,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInOrdersTab:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .couponDelete:
+        case .couponDeletion:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .couponEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -56,7 +56,7 @@ public enum FeatureFlag: Int {
 
     /// Displays the option to delete coupons
     ///
-    case couponDelete
+    case couponDeletion
 
     /// Displays the option to edit a coupon
     ///

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -53,4 +53,8 @@ public enum FeatureFlag: Int {
     /// Displays the Orders tab in a split view
     ///
     case splitViewInOrdersTab
+
+    /// Displays the option to edit and delete coupons (Coupons M2)
+    ///
+    case couponEditAndDelete
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -57,6 +57,30 @@ struct CouponDetails: View {
         ]
     }
 
+    private var actionSheetButtons: [ActionSheet.Button] {
+        var buttons: [ActionSheet.Button] = [
+            .default(Text(Localization.copyCode), action: {
+                UIPasteboard.general.string = viewModel.couponCode
+                let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
+                noticePresenter.enqueue(notice: notice)
+                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "copied_code"])
+            }),
+            .default(Text(Localization.shareCoupon), action: {
+                showingShareSheet = true
+                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
+            }),
+        ]
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponEditAndDelete) {
+            buttons.append(.destructive(Text(Localization.deleteCoupon), action: {
+                showingDeletionConfirmAlert = true
+            }))
+        }
+
+        buttons.append(.cancel())
+        return buttons
+    }
+
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
@@ -66,22 +90,7 @@ struct CouponDetails: View {
                         .actionSheet(isPresented: $showingActionSheet) {
                             ActionSheet(
                                 title: Text(Localization.manageCoupon),
-                                buttons: [
-                                    .default(Text(Localization.copyCode), action: {
-                                        UIPasteboard.general.string = viewModel.couponCode
-                                        let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
-                                        noticePresenter.enqueue(notice: notice)
-                                        ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "copied_code"])
-                                    }),
-                                    .default(Text(Localization.shareCoupon), action: {
-                                        showingShareSheet = true
-                                        ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
-                                    }),
-                                    .destructive(Text(Localization.deleteCoupon), action: {
-                                        showingDeletionConfirmAlert = true
-                                    }),
-                                    .cancel()
-                                ]
+                                buttons: actionSheetButtons
                             )
                         }
                         .shareSheet(isPresented: $showingShareSheet) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -178,6 +178,15 @@ struct CouponDetails: View {
                     viewModel.loadCouponReport()
                 })
             }
+            .alert(isPresented: $showingDeletionConfirmAlert, content: {
+                Alert(title: Text(Localization.deleteCoupon),
+                      message: Text(Localization.deleteCouponConfirm),
+                      primaryButton: .destructive(Text(Localization.deleteButton), action: {
+                    // TODO
+                }),
+                      secondaryButton: .cancel())
+            })
+
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -285,10 +294,6 @@ private extension CouponDetails {
         static let deleteCouponConfirm = NSLocalizedString(
             "Are you sure you want to delete this coupon?",
             comment: "Confirm message for deleting coupon on the Coupon Details screen"
-        )
-        static let cancelButton = NSLocalizedString(
-            "Cancel",
-            comment: "Title for the cancel button on the confirm alert for deleting coupon on the Coupon Details screen"
         )
         static let deleteButton = NSLocalizedString(
             "Delete",

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -27,6 +27,7 @@ struct CouponDetails: View {
     @State private var showingUsageDetails: Bool = false
     @State private var showingAmountLoadingErrorPrompt: Bool = false
     @State private var showingEnableAnalytics: Bool = false
+    @State private var showingDeletionConfirmAlert: Bool = false
 
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
@@ -73,6 +74,9 @@ struct CouponDetails: View {
                                     .default(Text(Localization.shareCoupon), action: {
                                         showingShareSheet = true
                                         ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
+                                    }),
+                                    .destructive(Text(Localization.deleteCoupon), action: {
+                                        showingDeletionConfirmAlert = true
                                     }),
                                     .cancel()
                                 ]

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -212,7 +212,7 @@ struct CouponDetails: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                if viewModel.isLoading {
+                if viewModel.isDeletionInProgress {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
                     Button(action: {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -190,12 +190,16 @@ struct CouponDetails: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    showingActionSheet = true
-                }, label: {
-                    Image(uiImage: .moreImage)
-                        .renderingMode(.template)
-                })
+                if viewModel.isLoading {
+                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                } else {
+                    Button(action: {
+                        showingActionSheet = true
+                    }, label: {
+                        Image(uiImage: .moreImage)
+                            .renderingMode(.template)
+                    })
+                }
             }
         }
         .wooNavigationBarStyle()

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -277,6 +277,20 @@ private extension CouponDetails {
             "Try Again",
             comment: "Action displayed in the error prompt when loading total discounted amount in Coupon Details screen fails"
         )
+        static let deleteCoupon = NSLocalizedString("Delete Coupon", comment: "Action title for deleting coupon on the Coupon Details screen")
+        static let deleteCouponConfirm = NSLocalizedString(
+            "Are you sure you want to delete this coupon?",
+            comment: "Confirm message for deleting coupon on the Coupon Details screen"
+        )
+        static let cancelButton = NSLocalizedString(
+            "Cancel",
+            comment: "Title for the cancel button on the confirm alert for deleting coupon on the Coupon Details screen"
+        )
+        static let deleteButton = NSLocalizedString(
+            "Delete",
+            comment: "Title for the action button on the confirm alert for deleting coupon on the Coupon Details screen"
+        )
+        static let couponDeleted = NSLocalizedString("Coupon deleted", comment: "Notice message after deleting coupon on the Coupon Details screen")
     }
 
     struct DetailRow: Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -32,6 +32,8 @@ struct CouponDetails: View {
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
+    @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
+
     /// The presenter to display notice when the coupon code is copied.
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
     let noticePresenter: DefaultNoticePresenter
@@ -181,9 +183,7 @@ struct CouponDetails: View {
             .alert(isPresented: $showingDeletionConfirmAlert, content: {
                 Alert(title: Text(Localization.deleteCoupon),
                       message: Text(Localization.deleteCouponConfirm),
-                      primaryButton: .destructive(Text(Localization.deleteButton), action: {
-                    // TODO
-                }),
+                      primaryButton: .destructive(Text(Localization.deleteButton), action: handleCouponDeletion),
                       secondaryButton: .cancel())
             })
 
@@ -250,6 +250,18 @@ struct CouponDetails: View {
             showingAmountLoadingErrorPrompt = true
         }
     }
+
+    private func handleCouponDeletion() {
+        viewModel.deleteCoupon {
+            let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
+            noticePresenter.enqueue(notice: notice)
+            presentationMode.wrappedValue.dismiss()
+        } onFailure: {
+            let notice = Notice(title: Localization.errorDeletingCoupon, feedbackType: .error)
+            noticePresenter.enqueue(notice: notice)
+        }
+
+    }
 }
 
 // MARK: - Subtypes
@@ -300,6 +312,10 @@ private extension CouponDetails {
             comment: "Title for the action button on the confirm alert for deleting coupon on the Coupon Details screen"
         )
         static let couponDeleted = NSLocalizedString("Coupon deleted", comment: "Notice message after deleting coupon on the Coupon Details screen")
+        static let errorDeletingCoupon = NSLocalizedString(
+            "Failed to delete coupon. Please try again.",
+            comment: "Error message on the Coupon Details screen when deleting coupon fails"
+        )
     }
 
     struct DetailRow: Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -59,6 +59,41 @@ struct CouponDetails: View {
         ]
     }
 
+    private var actionSheetButtons: [Alert.Button] {
+        var buttons: [Alert.Button] =
+        [
+            .default(Text(Localization.copyCode), action: {
+                UIPasteboard.general.string = viewModel.couponCode
+                let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
+                noticePresenter.enqueue(notice: notice)
+                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "copied_code"])
+            }),
+            .default(Text(Localization.shareCoupon), action: {
+                showingShareSheet = true
+                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
+            })
+        ]
+
+        if viewModel.isEditingEnabled {
+            buttons.append(contentsOf: [
+                .default(Text(Localization.editCoupon), action: {
+                    // TODO: add analytics
+                    // TODO: open the editing screen
+                })
+            ])
+        }
+
+        if viewModel.isDeletingEnabled {
+            buttons.append(.destructive(Text(Localization.deleteCoupon), action: {
+                showingDeletionConfirmAlert = true
+            }))
+        }
+
+        buttons.append(.cancel())
+
+        return buttons
+    }
+
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
@@ -68,7 +103,7 @@ struct CouponDetails: View {
                         .actionSheet(isPresented: $showingActionSheet) {
                             ActionSheet(
                                 title: Text(Localization.manageCoupon),
-                                buttons: generateActionSheetActions()
+                                buttons: actionSheetButtons
                             )
                         }
                         .shareSheet(isPresented: $showingShareSheet) {
@@ -247,41 +282,6 @@ struct CouponDetails: View {
             let notice = Notice(title: Localization.errorDeletingCoupon, feedbackType: .error)
             noticePresenter.enqueue(notice: notice)
         })
-    }
-
-    private func generateActionSheetActions() -> [Alert.Button] {
-        var actions: [Alert.Button] =
-        [
-            .default(Text(Localization.copyCode), action: {
-                UIPasteboard.general.string = viewModel.couponCode
-                let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
-                noticePresenter.enqueue(notice: notice)
-                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "copied_code"])
-            }),
-            .default(Text(Localization.shareCoupon), action: {
-                showingShareSheet = true
-                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
-            })
-        ]
-
-        if viewModel.isEditingEnabled {
-            actions.append(contentsOf: [
-                .default(Text(Localization.editCoupon), action: {
-                    // TODO: add analytics
-                    // TODO: open the editing screen
-                })
-            ])
-        }
-
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponEditAndDelete) {
-            buttons.append(.destructive(Text(Localization.deleteCoupon), action: {
-                showingDeletionConfirmAlert = true
-            }))
-        }
-
-        actions.append(.cancel())
-
-        return actions
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -73,7 +73,9 @@ final class CouponDetailsViewModel: ObservableObject {
 
     private let stores: StoresManager
     private let currencySettings: CurrencySettings
+
     let isEditingEnabled: Bool
+    let isDeletingEnabled: Bool
 
     init(coupon: Coupon,
          stores: StoresManager = ServiceLocator.stores,
@@ -84,6 +86,7 @@ final class CouponDetailsViewModel: ObservableObject {
         self.stores = stores
         self.currencySettings = currencySettings
         isEditingEnabled = featureFlags.isFeatureFlagEnabled(.couponEditing) && coupon.discountType != .other
+        isDeletingEnabled = featureFlags.isFeatureFlagEnabled(.couponDeletion)
         populateDetails()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -37,7 +37,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     /// Indicates whether a network call is in progress
     ///
-    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var isDeletionInProgress: Bool = false
 
     /// The message to be shared about the coupon
     ///
@@ -139,9 +139,9 @@ final class CouponDetailsViewModel: ObservableObject {
     }
 
     func deleteCoupon(onSuccess: @escaping () -> Void, onFailure: @escaping () -> Void) {
-        isLoading = true
+        isDeletionInProgress = true
         let action = CouponAction.deleteCoupon(siteID: siteID, couponID: coupon.couponID) { [weak self] result in
-            self?.isLoading = false
+            self?.isDeletionInProgress = false
             switch result {
             case .success:
                 onSuccess()

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -126,6 +126,19 @@ final class CouponDetailsViewModel: ObservableObject {
         }
         stores.dispatch(action)
     }
+
+    func deleteCoupon(onSuccess: @escaping () -> Void, onFailure: @escaping () -> Void) {
+        let action = CouponAction.deleteCoupon(siteID: siteID, couponID: coupon.couponID) { result in
+            switch result {
+            case .success:
+                onSuccess()
+            case .failure(let error):
+                DDLogError("⛔️ Error deleting coupon: \(error)")
+                onFailure()
+            }
+        }
+        stores.dispatch(action)
+    }
 }
 
 // MARK: - Private helpers

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -34,6 +34,10 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var hasWCAnalyticsDisabled: Bool = false
 
+    /// Indicates whether a network call is in progress
+    ///
+    @Published private(set) var isLoading: Bool = false
+
     /// The message to be shared about the coupon
     ///
     var shareMessage: String {
@@ -128,7 +132,9 @@ final class CouponDetailsViewModel: ObservableObject {
     }
 
     func deleteCoupon(onSuccess: @escaping () -> Void, onFailure: @escaping () -> Void) {
-        let action = CouponAction.deleteCoupon(siteID: siteID, couponID: coupon.couponID) { result in
+        isLoading = true
+        let action = CouponAction.deleteCoupon(siteID: siteID, couponID: coupon.couponID) { [weak self] result in
+            self?.isLoading = false
             switch result {
             case .success:
                 onSuccess()

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -84,7 +84,9 @@ final class CouponListViewController: UIViewController {
                 case .loading:
                     self.displayPlaceholderCoupons()
                 case .coupons:
-                    self.tableView.reloadData()
+                    // the table view is reloaded when coupon view models are updated
+                    // so there's no need to reload here
+                    break
                 case .refreshing:
                     self.refreshControl.beginRefreshing()
                 case .loadingNextPage:
@@ -121,6 +123,12 @@ final class CouponListViewController: UIViewController {
             .removeDuplicates()
             .sink { [weak self] hasData in
                 self?.configureNavigationBarItems(hasCoupons: hasData)
+            }
+            .store(in: &subscriptions)
+
+        viewModel.$couponViewModels
+            .sink { [weak self] _ in
+                self?.tableView.reloadData()
             }
             .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -47,6 +47,12 @@ final class CouponListViewController: UIViewController {
 
     private lazy var topBannerView: TopBannerView = createFeedbackBannerView()
 
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     init(siteID: Int64) {
         self.siteID = siteID
         self.viewModel = CouponListViewModel(siteID: siteID)
@@ -170,7 +176,12 @@ extension CouponListViewController: UITableViewDelegate {
             return
         }
         let detailsViewModel = CouponDetailsViewModel(coupon: coupon)
-        let hostingController = CouponDetailsHostingController(viewModel: detailsViewModel)
+        let hostingController = CouponDetailsHostingController(viewModel: detailsViewModel) { [weak self] in
+            guard let self = self else { return }
+            self.navigationController?.popViewController(animated: true)
+            let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
+            self.noticePresenter.enqueue(notice: notice)
+        }
         navigationController?.pushViewController(hostingController, animated: true)
     }
 }
@@ -394,5 +405,6 @@ private extension CouponListViewController {
         )
         static let giveFeedbackAction = NSLocalizedString("Give Feedback", comment: "Title of the feedback action button on the coupon list screen")
         static let dismissAction = NSLocalizedString("Dismiss", comment: "Title of the dismiss action button on the coupon list screen")
+        static let couponDeleted = NSLocalizedString("Coupon deleted", comment: "Notice message after deleting coupon from the Coupon Details screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -25,7 +25,7 @@ enum CouponListState {
 
 final class CouponListViewModel {
 
-    typealias CouponListCellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
+    typealias CellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
 
     /// Active state
     ///
@@ -37,7 +37,7 @@ final class CouponListViewModel {
 
     /// couponViewModels: ViewModels for the cells representing Coupons
     ///
-    @Published private(set) var couponViewModels: [CouponListCellViewModel] = []
+    @Published private(set) var couponViewModels: [CellViewModel] = []
 
     /// siteID: siteID of the currently active site, used for fetching and storing coupons
     ///
@@ -79,11 +79,11 @@ final class CouponListViewModel {
 
     func buildCouponViewModels() {
         couponViewModels = resultsController.fetchedObjects.map { coupon in
-            CouponListCellViewModel(title: coupon.code,
-                                    subtitle: coupon.summary(),
-                                    accessibilityLabel: coupon.description.isEmpty ? coupon.description : coupon.code,
-                                    status: coupon.expiryStatus().localizedName,
-                                    statusBackgroundColor: coupon.expiryStatus().statusBackgroundColor)
+            CellViewModel(title: coupon.code,
+                          subtitle: coupon.summary(), // to be updated after UI is finalized
+                          accessibilityLabel: coupon.description.isEmpty ? coupon.description : coupon.code,
+                          status: coupon.expiryStatus().localizedName,
+                          statusBackgroundColor: coupon.expiryStatus().statusBackgroundColor)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -49,7 +49,13 @@ final class CouponSearchUICommand: SearchUICommand {
 
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
         let detailsViewModel = CouponDetailsViewModel(coupon: model)
-        let couponDetails = CouponDetails(viewModel: detailsViewModel)
+        let couponDetails = CouponDetails(viewModel: detailsViewModel) {
+            viewController.navigationController?.popViewController(animated: true)
+            let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
+            let noticePresenter = DefaultNoticePresenter()
+            noticePresenter.presentingViewController = viewController
+            noticePresenter.enqueue(notice: notice)
+        }
         let hostingController = UIHostingController(rootView: couponDetails)
         viewController.navigationController?.pushViewController(hostingController, animated: true)
     }
@@ -75,5 +81,6 @@ private extension CouponSearchUICommand {
         static let emptyResultMessage = NSLocalizedString("We're sorry, we couldn't find results for “%@”",
                                                           comment: "Message for empty Coupons search results. The %@ is a " +
                                                           "placeholder for the text entered by the user.")
+        static let couponDeleted = NSLocalizedString("Coupon deleted", comment: "Notice message after deleting coupon from the Coupon Details screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.swift
@@ -35,7 +35,7 @@ final class TitleAndSubtitleAndStatusTableViewCell: UITableViewCell, SearchResul
 // MARK: - CellViewModel subtype
 //
 extension TitleAndSubtitleAndStatusTableViewCell {
-    struct ViewModel {
+    struct ViewModel: Hashable {
         let title: String
         let subtitle: String
         let accessibilityLabel: String

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -438,13 +438,13 @@ final class CouponDetailsViewModelTests: XCTestCase {
         let sampleCoupon = Coupon.fake().copy(siteID: 123, couponID: 456)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = CouponDetailsViewModel(coupon: sampleCoupon, stores: stores)
-        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isDeletionInProgress)
 
         // When
         stores.whenReceivingAction(ofType: CouponAction.self) { action in
             switch action {
             case let .deleteCoupon(_, _, onCompletion):
-                XCTAssertTrue(viewModel.isLoading)
+                XCTAssertTrue(viewModel.isDeletionInProgress)
                 onCompletion(.success(()))
             default:
                 break
@@ -453,6 +453,6 @@ final class CouponDetailsViewModelTests: XCTestCase {
         viewModel.deleteCoupon(onSuccess: {}, onFailure: {})
 
         // Then
-        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isDeletionInProgress)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5773 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As the title suggests, this PR adds the implementation for deleting coupons. Changes include:
- Add a new feature flag for coupons M2: `couponEditAndDelete`.
- Add a new button on the coupon details screen's action sheet for deleting coupons if the feature flag for M2 is enabled.
- Add a confirm alert when coupon deletion is selected.
- Implement deleting a coupon.
- Show network progress on the navigation bar item and notice when the request succeeds or fails.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Precondition: your test store should have coupons enabled (WP Admin > WC Settings > General > Enable Coupon) and has set up at least one coupon (WP Admin > Marketing > Coupons).
- With the `couponEditAndDelete` feature flag enabled, build and launch the app.
- Navigate to Menu > Coupons > select a coupon.
- On the coupon details screen, select the ellipsis (…) button, notice that there's a new destructive button Delete Coupon.
- Select the button, notice that there's an alert presented to confirm the deletion.
- Confirm deleting coupon, notice that a loading indicator is displayed on the trailing navigation bar item.
- If the request succeeds, notice that the coupon details screen is dismissed and a notice is presented on the coupon list saying "Coupon deleted". Otherwise, there should be a notice presented on the coupon details screen for the error.
- Please feel free to test with the feature flag off - the delete coupon button should not be present in that case.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/159666674-684f45e9-cf51-4242-9cca-1b9740b2a076.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
