### PR TITLE
Issue: Use Combine's Cancellable instead of our own declaration

### DIFF
--- a/WooCommerce/Classes/Tools/ImageService/ImageDownloader.swift
+++ b/WooCommerce/Classes/Tools/ImageService/ImageDownloader.swift
@@ -1,11 +1,5 @@
 import UIKit
-
-/// Used for any activity or action that may be canceled.
-/// TODO: `Cancellable` is also available starting iOS 13, please delete when the project is iOS 13+.
-///
-protocol Cancellable {
-    func cancel()
-}
+import Combine
 
 /// A task that downloads an image asynchronously.
 ///

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 final class ProductImageCollectionViewCell: UICollectionViewCell {
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/CancellableMedia.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/CancellableMedia.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import Combine
 
 /// A wrapper of `Media` that includes a cancellable task that is set when the media has an async cancellable task.
 /// Note: this is an `NSObject` class instead of a struct because it has to conform to `WPMediaAsset` protocol defined in

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -1,5 +1,6 @@
 import Photos
 import Yosemite
+import Combine
 
 /// Provides images based on Product image status:
 /// - Requests the image from `PHImageManager` for a `PHASset`

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
@@ -1,5 +1,6 @@
 import Photos
 import Yosemite
+import Combine
 
 /// Provides an image for UI display based on the product image status.
 ///


### PR DESCRIPTION
Closes: #3259 

### Description
Since we have now 14.0 as iOS Deployment Target it means that we can use `Combine`, which was made available starting with iOS 13+. Because of that, we do not need anymore to create our own `Cancellable` protocol declaration, as it is redundant with Combine's one.
With this Pull Request, we get rid of our own `Cancellable` protocol declaration, and in order to use Combine's one, we import it wherever it is used.

### Changes
- Get rid of our own Cancellable protocol declaration
- Import Combine wherever necessary

### Testing instructions
- Cancellable protocol was mostly used for Media download, such as images. We have to make sure that these keep working as expected.
---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

