### PR TITLE
[Mobile Payments] Enable IPP from order details for eligible stores in Canada

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -211,7 +211,7 @@ public class CurrencyFormatter {
 
         // If we are here, the human readable version of the amount param is a "large" number *OR* a small number but rounding has been requested,
         // so let's just put the currency symbol on the correct side of the string with proper spacing (based on the site settings).
-        let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
+        let code = CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
         let symbol = currencySettings.symbol(from: code)
         let position = currencySettings.currencyPosition
         let isNegative = amount.isNegative()
@@ -233,7 +233,7 @@ public class CurrencyFormatter {
     func formatAmount(_ amount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current, numberOfDecimals: Int? = nil) -> String? {
         let currency = currency ?? currencySettings.currencyCode.rawValue
         // Get the currency code
-        let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
+        let code = CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
         // Grab the read-only currency options. These are set by the user in Site > Settings.
         let symbol = currencySettings.symbol(from: code)
         let separator = currencySettings.decimalSeparator

--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -7,63 +7,6 @@ public class CurrencySettings {
 
     // MARK: - Enums
 
-    /// The 3-letter country code for supported currencies
-    ///
-    public enum CurrencyCode: String, CaseIterable {
-        // A
-        case AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN,
-        // B
-        BAM, BBD, BDT, BGN, BHD, BIF, BMD, BND, BOB, BRL, BSD, BTC, BTN, BWP, BYR, BYN, BZD,
-        // C
-        CAD, CDF, CHF, CLP, CNY, COP, CRC, CUC, CUP, CVE, CZK,
-        // D
-        DJF, DKK, DOP, DZD,
-        // E
-        EGP, ERN, ETB, EUR, FJD,
-        // F
-        FKP,
-        // G
-        GBP, GEL, GGP, GHS, GIP, GMD, GNF, GTQ, GYD,
-        // H
-        HKD, HNL, HRK, HTG, HUF,
-        // I
-        IDR, ILS, IMP, INR, IQD, IRR, IRT, ISK,
-        // J
-        JEP, JMD, JOD, JPY,
-        // K
-        KES, KGS, KHR, KMF, KPW, KRW, KWD, KYD, KZT,
-        // L
-        LAK, LBP, LKR, LRD, LSL, LYD,
-        // M
-        MAD, MDL, MGA, MKD, MMK, MNT, MOP, MRO, MUR, MVR, MWK, MXN, MYR, MZN,
-        // N
-        NAD, NGN, NIO, NOK, NPR, NZD,
-        // O
-        OMR,
-        // P
-        PAB, PEN, PGK, PHP, PKR, PLN, PRB, PYG,
-        // Q
-        QAR,
-        // R
-        RMB, RON, RSD, RUB, RWF,
-        // S
-        SAR, SBD, SCR, SDG, SEK, SGD, SHP, SLL, SOS, SRD, SSP, STD, SYP, SZL,
-        // T
-        THB, TJS, TMT, TND, TOP, TRY, TTD, TWD, TZS,
-        // U
-        UAH, UGX, USD, UYU, UZS,
-        // V
-        VEF, VND, VUV,
-        // W
-        WST,
-        // X
-        XAF, XCD, XOF, XPF,
-        // Y
-        YER,
-        // Z
-        ZAR, ZMW
-    }
-
     /// Designates where the currency symbol is located on a formatted price
     ///
     public enum CurrencyPosition: String {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -205,9 +205,15 @@ final class OrderDetailsDataSource: NSObject {
 
     private let imageService: ImageService = ServiceLocator.imageService
 
-    init(order: Order, storageManager: StorageManagerType = ServiceLocator.storageManager) {
+    /// IPP Configuration loader
+    private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
+
+    init(order: Order,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration) {
         self.storageManager = storageManager
         self.order = order
+        self.cardPresentPaymentsConfiguration = cardPresentPaymentsConfiguration
         self.couponLines = order.coupons
 
         super.init()
@@ -1504,7 +1510,10 @@ private extension OrderDetailsDataSource {
     }
 
     func isOrderCurrencyEligibleForCardPayment() -> Bool {
-        CurrencyCode(rawValue: order.currency) == .USD
+        guard let currency = CurrencyCode(caseInsensitiveRawValue: order.currency) else {
+            return false
+        }
+        return cardPresentPaymentsConfiguration.currencies.contains(currency)
     }
 
     func isOrderStatusEligibleForCardPayment() -> Bool {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -205,7 +205,7 @@ final class OrderDetailsDataSource: NSObject {
 
     private let imageService: ImageService = ServiceLocator.imageService
 
-    /// IPP Configuration loader
+    /// IPP Configuration
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     init(order: Order,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1504,7 +1504,7 @@ private extension OrderDetailsDataSource {
     }
 
     func isOrderCurrencyEligibleForCardPayment() -> Bool {
-        CurrencySettings.CurrencyCode(rawValue: order.currency) == .USD
+        CurrencyCode(rawValue: order.currency) == .USD
     }
 
     func isOrderStatusEligibleForCardPayment() -> Bool {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -72,10 +72,16 @@ final class OrderDetailsViewModel {
         }
     }
 
+    /// IPP Configuration loader
+    private lazy var configurationLoader = {
+        CardPresentConfigurationLoader(stores: stores)
+    }()
+
     /// The datasource that will be used to render the Order Details screen
     ///
     private(set) lazy var dataSource: OrderDetailsDataSource = {
-        return OrderDetailsDataSource(order: order)
+        return OrderDetailsDataSource(order: order,
+                                      cardPresentPaymentsConfiguration: configurationLoader.configuration)
     }()
 
     /// Order Notes

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -73,9 +73,7 @@ final class OrderDetailsViewModel {
     }
 
     /// IPP Configuration loader
-    private lazy var configurationLoader = {
-        CardPresentConfigurationLoader(stores: stores)
-    }()
+    private lazy var configurationLoader = CardPresentConfigurationLoader(stores: stores)
 
     /// The datasource that will be used to render the Order Details screen
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -64,7 +64,7 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
         self.allCountries = countries
         self.destinationCountry = destinationCountry
         let currencySymbol: String = {
-            guard let currencyCode = CurrencySettings.CurrencyCode(rawValue: order.currency) else {
+            guard let currencyCode = CurrencyCode(rawValue: order.currency) else {
                 return ""
             }
             return ServiceLocator.currencySettings.symbol(from: currencyCode)

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import WooCommerce
 @testable import Networking
-
+import Yosemite
 
 /// Currency Formatter Tests - Decimals
 ///
@@ -14,7 +14,7 @@ class CurrencyFormatterTests: XCTestCase {
     ///
     private func setUpSampleSiteSettings() -> [SiteSetting] {
         let settings = mapLoadGeneralSiteSettingsResponse()
-        var siteSettings = [SiteSetting]()
+        var siteSettings: [SiteSetting] = []
 
         siteSettings.append(settings[14])
         siteSettings.append(settings[15])
@@ -216,7 +216,7 @@ class CurrencyFormatterTests: XCTestCase {
         let thousandSeparator = "."
         let decimalPosition = 3
         let currencyPosition = CurrencySettings.CurrencyPosition.rightSpace
-        let currencyCode = CurrencySettings.CurrencyCode.GBP
+        let currencyCode = CurrencyCode.GBP
         let stringAmount = "-7867818684.64"
         let expectedResult = "-7.867.818.684,640 £"
 
@@ -257,7 +257,7 @@ class CurrencyFormatterTests: XCTestCase {
         let thousandSeparator = "."
         let decimalPosition = 3
         let currencyPosition = CurrencySettings.CurrencyPosition.rightSpace
-        let currencyCode = CurrencySettings.CurrencyCode.GBP
+        let currencyCode = CurrencyCode.GBP
         let decimalAmount = NSDecimalNumber(floatLiteral: -7867818684.64)
         let expectedResult = "-7.867.818.684,640 £"
 
@@ -288,7 +288,7 @@ class CurrencyFormatterTests: XCTestCase {
     /// This use case is for the y-axis values in the dashboard charts.
     func testFormattingANegativeValueInHumanReadableString() {
         let currencyPosition = CurrencySettings.CurrencyPosition.rightSpace
-        let currencyCode = CurrencySettings.CurrencyCode.GBP
+        let currencyCode = CurrencyCode.GBP
         let value = Double(-7867818684.64)
         let stringAmount = value.humanReadableString()
         let expectedResult = "-7.9b £"

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -154,7 +154,7 @@ final class CurrencySettingsTests: XCTestCase {
     ///
     func testCurrencySymbol() {
         moneyFormat = CurrencySettings()
-        let symbol = moneyFormat?.symbol(from: CurrencySettings.CurrencyCode.AED)
+        let symbol = moneyFormat?.symbol(from: CurrencyCode.AED)
         XCTAssertEqual("د.إ", symbol)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductTableViewCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductTableViewCellViewModelTests.swift
@@ -8,7 +8,7 @@ final class ProductTableViewCellViewModelTests: XCTestCase {
         let statsItem = TopEarnerStatsItem.fake().copy(productName: "Kiwi 🥝",
                                                        quantity: 5,
                                                        total: 3888.822,
-                                                       currency: CurrencySettings.CurrencyCode.USD.rawValue,
+                                                       currency: CurrencyCode.USD.rawValue,
                                                        imageUrl: "wp.com/kiwi-image")
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -36,7 +36,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         insert(refund: makeRefund(orderID: order.orderID, siteID: order.siteID))
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -59,7 +59,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_refund_button_is_visible() throws {
         // Given
         let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
         dataSource.reloadSections()
@@ -73,7 +73,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_refund_button_is_not_visible_when_the_order_is_refunded() throws {
         // Given
         let order = MockOrders().makeOrder(status: .refunded, items: [makeOrderItem()])
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
         dataSource.reloadSections()
@@ -87,7 +87,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_markOrderComplete_button_is_visible_and_primary_style_if_order_is_processing_and_not_eligible_for_shipping_label_creation() throws {
         // Given
         let order = makeOrder().copy(status: .processing)
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = false
 
         // When
@@ -101,7 +101,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() throws {
         // Given
         let order = makeOrder().copy(status: .processing)
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -116,7 +116,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_markOrderComplete_button_is_hidden_if_order_is_not_processing() throws {
         // Given
         let order = makeOrder().copy(status: .onHold)
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
         dataSource.reloadSections()
@@ -134,7 +134,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -156,7 +156,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .onHold, datePaid: .some(nil), paymentMethodID: "woocommerce_payments")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -178,7 +178,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "stripe")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -200,7 +200,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "stripe")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -222,7 +222,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -244,7 +244,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "1", paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -266,7 +266,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "wc-booking-gateway")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -288,7 +288,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "1", paymentMethodID: "wc-booking-gateway")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -311,7 +311,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: Date(), total: "0", paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -333,7 +333,53 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Given
         let order = makeOrder().copy(status: .processing, currency: "usd", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+    func test_collect_payment_button_is_visible_if_order_is_eligible_and_currency_is_in_configuration() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: true)
+        let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: configuration)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+    func test_collect_payment_button_is_not_visible_if_order_currency_is_not_in_configuration() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
+        let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -348,14 +394,15 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
     }
 
-    func test_collect_payment_button_is_not_visible_if_order_currency_is_not_usd() throws {
+    func test_collect_payment_button_is_not_visible_if_order_currency_would_be_in_configuration_but_not_enabled() throws {
         // Setup
         let account = storageManager.insertCardPresentEligibleAccount()
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
+        let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: false)
         let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: configuration)
         dataSource.configureResultsControllers { }
 
         // When
@@ -373,7 +420,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_create_shipping_label_button_is_visible_for_eligible_order_with_no_labels() throws {
         // Given
         let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -391,7 +438,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: ShippingLabelRefund.fake())
         insert(shippingLabel: refundedShippingLabel)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -410,7 +457,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let shippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID)
         insert(shippingLabel: shippingLabel)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -426,7 +473,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_create_shipping_label_button_is_not_visible_for_ineligible_order() throws {
         // Given
         let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = false
 
         // When
@@ -443,7 +490,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100", paymentMethodID: "cod")
         storageManager.insertCardPresentEligibleAccount()
         storageManager.viewStorage.saveIfNeeded()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -462,7 +509,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let shippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID)
         insert(shippingLabel: shippingLabel)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -483,7 +530,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: ShippingLabelRefund.fake())
         insert(shippingLabel: refundedShippingLabel)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -502,7 +549,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let order = makeOrder()
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -521,7 +568,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let order = makeOrder()
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = false
         dataSource.configureResultsControllers { }
 
@@ -541,7 +588,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100", paymentMethodID: "cod")
         storageManager.insertCardPresentEligibleAccount()
         storageManager.viewStorage.saveIfNeeded()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -689,5 +736,12 @@ private final class MockPaymentGatewayAccountStoresManager: MockStorageManager {
         newAccount.isCardPresentEligible = false
 
         return newAccount
+    }
+}
+
+
+private extension OrderDetailsDataSourceTests {
+    enum Mocks {
+        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
     }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		031C1EAE27B1877000298699 /* WCPayCardPresentPaymentDetails+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031C1EAD27B1877000298699 /* WCPayCardPresentPaymentDetails+ReadOnlyConvertible.swift */; };
 		031C1EB027B1879C00298699 /* WCPayCardPaymentDetails+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031C1EAF27B1879C00298699 /* WCPayCardPaymentDetails+ReadOnlyConvertible.swift */; };
 		031FD8A026FC970400B315C7 /* RosettaTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */; };
+		035CDFEF27EB412B00F36D86 /* CurrencyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035CDFEE27EB412B00F36D86 /* CurrencyCode.swift */; };
 		03FBDA222631521100ACE257 /* CouponAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA212631521100ACE257 /* CouponAction.swift */; };
 		03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA25263296A100ACE257 /* CouponStore.swift */; };
 		03FBDA2A263296C400ACE257 /* CouponStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA29263296C400ACE257 /* CouponStoreTests.swift */; };
@@ -500,6 +501,7 @@
 		031C1EAD27B1877000298699 /* WCPayCardPresentPaymentDetails+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardPresentPaymentDetails+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		031C1EAF27B1879C00298699 /* WCPayCardPaymentDetails+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardPaymentDetails+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosettaTestingHelper.swift; sourceTree = "<group>"; };
+		035CDFEE27EB412B00F36D86 /* CurrencyCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyCode.swift; sourceTree = "<group>"; };
 		03FBDA212631521100ACE257 /* CouponAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAction.swift; sourceTree = "<group>"; };
 		03FBDA25263296A100ACE257 /* CouponStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStore.swift; sourceTree = "<group>"; };
 		03FBDA29263296C400ACE257 /* CouponStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreTests.swift; sourceTree = "<group>"; };
@@ -890,6 +892,7 @@
 			children = (
 				0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */,
 				E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */,
+				035CDFEE27EB412B00F36D86 /* CurrencyCode.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1882,6 +1885,7 @@
 				E1BD4D0027ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift in Sources */,
 				CE3B7AD52225EBF10050FE4B /* OrderStatusAction.swift in Sources */,
 				7493750C224987D9007D85D1 /* ProductAttribute+ReadOnlyConvertible.swift in Sources */,
+				035CDFEF27EB412B00F36D86 /* CurrencyCode.swift in Sources */,
 				744A3219216D55F80051439B /* SiteVisitStatsItem+ReadOnlyConvertible.swift in Sources */,
 				45151A8F27B156E40080845F /* InboxNotesAction.swift in Sources */,
 				45E462122684C7A400011BF2 /* DataAction.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Enums/CurrencyCode.swift
+++ b/Yosemite/Yosemite/Model/Enums/CurrencyCode.swift
@@ -53,4 +53,8 @@ public enum CurrencyCode: String, CaseIterable {
     YER,
     // Z
     ZAR, ZMW
+
+    public init?(caseInsensitiveRawValue: String) {
+        self.init(rawValue: caseInsensitiveRawValue.uppercased())
+    }
 }

--- a/Yosemite/Yosemite/Model/Enums/CurrencyCode.swift
+++ b/Yosemite/Yosemite/Model/Enums/CurrencyCode.swift
@@ -1,0 +1,56 @@
+/// The 3-letter country code for supported currencies
+///
+public enum CurrencyCode: String, CaseIterable {
+    // A
+    case AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN,
+    // B
+    BAM, BBD, BDT, BGN, BHD, BIF, BMD, BND, BOB, BRL, BSD, BTC, BTN, BWP, BYR, BYN, BZD,
+    // C
+    CAD, CDF, CHF, CLP, CNY, COP, CRC, CUC, CUP, CVE, CZK,
+    // D
+    DJF, DKK, DOP, DZD,
+    // E
+    EGP, ERN, ETB, EUR, FJD,
+    // F
+    FKP,
+    // G
+    GBP, GEL, GGP, GHS, GIP, GMD, GNF, GTQ, GYD,
+    // H
+    HKD, HNL, HRK, HTG, HUF,
+    // I
+    IDR, ILS, IMP, INR, IQD, IRR, IRT, ISK,
+    // J
+    JEP, JMD, JOD, JPY,
+    // K
+    KES, KGS, KHR, KMF, KPW, KRW, KWD, KYD, KZT,
+    // L
+    LAK, LBP, LKR, LRD, LSL, LYD,
+    // M
+    MAD, MDL, MGA, MKD, MMK, MNT, MOP, MRO, MUR, MVR, MWK, MXN, MYR, MZN,
+    // N
+    NAD, NGN, NIO, NOK, NPR, NZD,
+    // O
+    OMR,
+    // P
+    PAB, PEN, PGK, PHP, PKR, PLN, PRB, PYG,
+    // Q
+    QAR,
+    // R
+    RMB, RON, RSD, RUB, RWF,
+    // S
+    SAR, SBD, SCR, SDG, SEK, SGD, SHP, SLL, SOS, SRD, SSP, STD, SYP, SZL,
+    // T
+    THB, TJS, TMT, TND, TOP, TRY, TTD, TWD, TZS,
+    // U
+    UAH, UGX, USD, UYU, UZS,
+    // V
+    VEF, VND, VUV,
+    // W
+    WST,
+    // X
+    XAF, XCD, XOF, XPF,
+    // Y
+    YER,
+    // Z
+    ZAR, ZMW
+}

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -5,14 +5,14 @@ public struct CardPresentPaymentsConfiguration {
 
     public let countryCode: String
     public let paymentMethods: [WCPayPaymentMethodType]
-    public let currencies: [String]
+    public let currencies: [CurrencyCode]
     public let paymentGateways: [String]
     public let supportedReaders: [CardReaderType]
 
     init(countryCode: String,
          stripeTerminalforCanadaEnabled: Bool,
          paymentMethods: [WCPayPaymentMethodType],
-         currencies: [String],
+         currencies: [CurrencyCode],
          paymentGateways: [String],
          supportedReaders: [CardReaderType]) {
         self.countryCode = countryCode
@@ -30,7 +30,7 @@ public struct CardPresentPaymentsConfiguration {
                 countryCode: country,
                 stripeTerminalforCanadaEnabled: canadaEnabled,
                 paymentMethods: [.cardPresent],
-                currencies: ["USD"],
+                currencies: [.USD],
                 paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
                 supportedReaders: [.chipper, .stripeM2]
             )
@@ -39,7 +39,7 @@ public struct CardPresentPaymentsConfiguration {
                 countryCode: country,
                 stripeTerminalforCanadaEnabled: true,
                 paymentMethods: [.cardPresent, .interacPresent],
-                currencies: ["CAD"],
+                currencies: [.CAD],
                 paymentGateways: [WCPayAccount.gatewayID],
                 supportedReaders: [.wisepad3]
             )

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -7,7 +7,7 @@ class CardPresentConfigurationTests: XCTestCase {
     func test_configuration_for_US_with_Canada_enabled() throws {
         let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
         XCTAssertTrue(configuration.isSupportedCountry)
-        XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
+        XCTAssertEqual(configuration.currencies, [.USD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
         XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
@@ -17,7 +17,7 @@ class CardPresentConfigurationTests: XCTestCase {
     func test_configuration_for_US_with_Canada_disabled() throws {
         let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: false)
         XCTAssertTrue(configuration.isSupportedCountry)
-        XCTAssertEqual(configuration.currencies, [Constants.Currency.usd])
+        XCTAssertEqual(configuration.currencies, [.USD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
         XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
@@ -28,7 +28,7 @@ class CardPresentConfigurationTests: XCTestCase {
     func test_configuration_for_Canada_with_Canada_enabled() throws {
         let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: true)
         XCTAssertTrue(configuration.isSupportedCountry)
-        XCTAssertEqual(configuration.currencies, [Constants.Currency.cad])
+        XCTAssertEqual(configuration.currencies, [.CAD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
         XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
@@ -43,10 +43,6 @@ class CardPresentConfigurationTests: XCTestCase {
     }
 
     private enum Constants {
-        enum Currency {
-            static let usd = "USD"
-            static let cad = "CAD"
-        }
 
         enum PaymentGateway {
             static let wcpay = "woocommerce-payments"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6494 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The [Moose on the Loose](https://github.com/orgs/woocommerce/projects/48/views/7) project adds support for IPP in Canada. Previous work in this project enabled payments to be accepted for 🇨🇦 stores, however the payment button was not enabled on the Order Details screen.

This prevented IPP payment for orders taken on the web, using the cash on delivery payment method. The only way to make an IPP on a Canada store was to use the Simple Payments feature, which does not go via the Order Details screen.

This was due to an unchanged check on whether the currency for the order was USD, which 🇨🇦 payments are unlikely to be. The changes here use the configuration object to decide whether an order's currency is acceptable for IPP.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Using a 🇨🇦 IPP-ready store
With the `In-Person Payments in Canada` experimental features switch on:
1. Add an order from the web, using the COD payment method
2. Open the order in the app
3. Observe that the `Collect Payment` button is visible and can be used to take payment

With the switch off:
Repeat the above steps, and observe that `Collect Payment` is not shown, instead `Issue Refund` is shown.

#### Using a 🇺🇸 IPP-ready store
With the `In-Person Payments in Canada` experimental features switch on:
1. Add an order from the web, using the COD payment method
2. Open the order in the app
3. Observe that the `Collect Payment` button is visible and can be used to take payment

With the switch off:
Repeat the above steps, and observe that `Collect Payment` is still shown

#### Using a store from another country
Repeat the above steps, both with the switch on and off, and observe that `Collect Payment` is not shown, instead `Issue Refund` is shown.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
