### PR TITLE
Order Creation: Properly render Status List on landscape orientation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -38,7 +38,7 @@ struct OrderStatusSection: View {
                 .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
                     OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus) { newStatus in
                         viewModel.updateOrderStatus(newStatus: newStatus)
-                    }
+                    }.ignoresSafeArea()
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,20 +20,25 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="nub-3J-oyN">
-                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
-                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                 </tableView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="nub-3J-oyN" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="OAZ-zF-Tlf"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="nub-3J-oyN" secondAttribute="bottom" id="ZGZ-77-ugQ"/>
-                <constraint firstItem="nub-3J-oyN" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="b4z-FV-WgC"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="nub-3J-oyN" secondAttribute="trailing" id="fAh-9n-PAY"/>
+                <constraint firstItem="nub-3J-oyN" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="OAZ-zF-Tlf"/>
+                <constraint firstAttribute="bottom" secondItem="nub-3J-oyN" secondAttribute="bottom" id="ZGZ-77-ugQ"/>
+                <constraint firstItem="nub-3J-oyN" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="b4z-FV-WgC"/>
+                <constraint firstAttribute="trailing" secondItem="nub-3J-oyN" secondAttribute="trailing" id="fAh-9n-PAY"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="53.600000000000001" y="66.11694152923539"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
Closes: #6468 

# Why

The order status list screen didn't render properly on Landscape orientation, in particular, it did not extend edge to edge.

This PR fixes that by:

- Updating the underlying `ViewController xib` to make its table view to not be constrained to the view safe area. This is "safe" because the table view automatically insets its content to respect the safe area.

- Use the `ignoresSafeArea()` modifier when presenting the `StatusList` view because all handling is done by the table view now.

# Screenshots

Before | After
--- | --- 
<img width="889" alt="no-safe-areas" src="https://user-images.githubusercontent.com/8658164/159263308-6b82c75f-0600-4c07-b33d-4eaad399f5c7.png"> |  <img width="886" alt="safe-areas-scrolled" src="https://user-images.githubusercontent.com/562080/159728277-62cf68e7-bcb9-4e09-a663-85e490e1525b.png">

# Testing Steps

- Go to the **New Order** screen
- Tap on the **Edit Status** button.
- Rotate the device
- See that the **Order Status** cells go edge-to-edge.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
