### PR TITLE
Jetpack CP: Prevent access to browser with invalid WP Admin URL

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 8.9
 -----
 - [*] Coupons: Fixed issue loading the coupon list from the local storage on initial load. [https://github.com/woocommerce/woocommerce-ios/pull/6463]
-- [*] Jetpack CP: Fixed crash when attempting to access WP-Admin with an invalid URL. [https://github.com/woocommerce/woocommerce-ios/pull/6502]
+- [*] Jetpack CP: Fixed crash when attempting to access WP-Admin with an invalid URL that has an unsupported scheme. [https://github.com/woocommerce/woocommerce-ios/pull/6502]
 
 8.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 8.9
 -----
 - [*] Coupons: Fixed issue loading the coupon list from the local storage on initial load. [https://github.com/woocommerce/woocommerce-ios/pull/6463]
-
+- [*] Jetpack CP: Fixed crash when attempting to access WP-Admin with an invalid URL. [https://github.com/woocommerce/woocommerce-ios/pull/6502]
 
 8.8
 -----

--- a/WooCommerce/Classes/Extensions/String+Woo.swift
+++ b/WooCommerce/Classes/Extensions/String+Woo.swift
@@ -27,7 +27,7 @@ extension String {
     }
 
     func addHTTPSSchemeIfNecessary() -> String {
-        if self.hasPrefix("http://") || self.hasPrefix("https://") {
+        if hasValidSchemeForBrowser {
             return self
         }
 

--- a/WooCommerce/Classes/Extensions/String+Woo.swift
+++ b/WooCommerce/Classes/Extensions/String+Woo.swift
@@ -22,6 +22,10 @@ extension String {
 /// String: URL manipulation
 ///
 extension String {
+    var hasValidSchemeForBrowser: Bool {
+        hasPrefix("http://") || hasPrefix("https://")
+    }
+
     func addHTTPSSchemeIfNecessary() -> String {
         if self.hasPrefix("http://") || self.hasPrefix("https://") {
             return self

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct JetpackInstallStepsView: View {
     /// The presenter to display notice when an error occurs.
-    /// It is kept internal so that the hosting controller can update its presenting controller to itself.
     private let noticePresenter: DefaultNoticePresenter
 
     // Closure invoked when Contact Support button is tapped

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsView.swift
@@ -170,10 +170,12 @@ struct JetpackInstallStepsView: View {
                 .padding(Constants.actionButtonMargin)
             }
         }
-        .safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminURL, onDismiss: {
-            showingWPAdminWebview = false
-            viewModel.checkJetpackPluginDetails()
-        })
+        .if(viewModel.wpAdminURL != nil) { view in
+            view.safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminURL, onDismiss: {
+                showingWPAdminWebview = false
+                viewModel.checkJetpackPluginDetails()
+            })
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -35,7 +35,6 @@ final class JetpackInstallStepsViewModel: ObservableObject {
             if siteURL.hasValidSchemeForBrowser {
                 path = siteURL + Constants.wpAdminPath
             } else {
-                // silent failure - merchant won't be able to install in WP Admin
                 return nil
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModel.swift
@@ -13,6 +13,12 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
+    /// The site for which Jetpack should be installed
+    let siteURL: String
+
+    /// URL for the site's admin page
+    private let siteAdminURL: String
+
     /// Current step of the installation
     ///
     @Published private(set) var currentStep: JetpackInstallStep?
@@ -20,6 +26,28 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     /// Whether the install failed. This will be observed by `JetpackInstallStepsView` to present error modal.
     ///
     @Published private(set) var installFailed: Bool = false
+
+    /// WPAdmin URL to navigate user when install fails.
+    var wpAdminURL: URL? {
+        var path = siteAdminURL
+        if !path.hasValidSchemeForBrowser {
+            // fall back to constructing the path from siteURL and WP admin path
+            if siteURL.hasValidSchemeForBrowser {
+                path = siteURL + Constants.wpAdminPath
+            } else {
+                // silent failure - merchant won't be able to install in WP Admin
+                return nil
+            }
+        }
+        switch currentStep {
+        case .installation:
+            return URL(string: "\(path)\(Constants.wpAdminInstallPath)")
+        case .activation:
+            return URL(string: "\(path)\(Constants.wpAdminPluginsPath)")
+        default:
+            return nil
+        }
+    }
 
     /// Number of retries done for current step.
     ///
@@ -29,9 +57,14 @@ final class JetpackInstallStepsViewModel: ObservableObject {
     ///
     private var installError: Error?
 
-    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64,
+         siteURL: String,
+         siteAdminURL: String,
+         stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.stores = stores
+        self.siteURL = siteURL
+        self.siteAdminURL = siteAdminURL
     }
 
     /// Starts the steps by checking Jetpack-the-plugin.
@@ -160,5 +193,8 @@ private extension JetpackInstallStepsViewModel {
         static let jetpackSlug: String = "jetpack"
         static let jetpackPluginName: String = "jetpack/jetpack"
         static let maxRetryCount: Int = 2
+        static let wpAdminPath: String = "/wp-admin/"
+        static let wpAdminInstallPath: String = "plugin-install.php?tab=plugin-information&plugin=jetpack"
+        static let wpAdminPluginsPath: String = "plugins.php"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
@@ -42,14 +42,12 @@ struct JetpackInstallView: View {
     init(siteID: Int64, siteURL: String, siteAdminURL: String) {
         self.siteURL = siteURL
         self.siteAdminURL = siteAdminURL
-        self.installStepsViewModel = JetpackInstallStepsViewModel(siteID: siteID)
+        self.installStepsViewModel = JetpackInstallStepsViewModel(siteID: siteID, siteURL: siteURL, siteAdminURL: siteAdminURL)
     }
 
     var body: some View {
         if hasStarted {
-            JetpackInstallStepsView(siteURL: siteURL,
-                                    siteAdminURL: siteAdminURL,
-                                    viewModel: installStepsViewModel,
+            JetpackInstallStepsView(viewModel: installStepsViewModel,
                                     supportAction: supportAction,
                                     dismissAction: dismissAction)
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
@@ -8,6 +8,9 @@ final class JetpackInstallHostingController: UIHostingController<JetpackInstallV
         rootView.supportAction = { [unowned self] in
             ZendeskProvider.shared.showNewRequestIfPossible(from: self)
         }
+
+        // Set presenting view controller to show the notice presenter here
+        rootView.noticePresenter.presentingViewController = self
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -22,6 +25,10 @@ final class JetpackInstallHostingController: UIHostingController<JetpackInstallV
 /// Displays Jetpack Install flow.
 ///
 struct JetpackInstallView: View {
+    /// The presenter to display notice when an error occurs.
+    /// It is kept internal so that the hosting controller can update its presenting controller to itself.
+    let noticePresenter: DefaultNoticePresenter = .init()
+
     // Closure invoked when Contact Support button is tapped
     var supportAction: () -> Void = {}
 
@@ -48,6 +55,7 @@ struct JetpackInstallView: View {
     var body: some View {
         if hasStarted {
             JetpackInstallStepsView(viewModel: installStepsViewModel,
+                                    noticePresenter: noticePresenter,
                                     supportAction: supportAction,
                                     dismissAction: dismissAction)
         } else {

--- a/WooCommerce/WooCommerceTests/Extensions/StringWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/StringWooTests.swift
@@ -42,4 +42,18 @@ final class StringWooTests: XCTestCase {
 
         XCTAssertEqual(notAURL.trimHTTPScheme(), expectedResult)
     }
+
+    func test_hasValidSchemeForBrowser_returns_correct_value() {
+        // Given
+        let pathWithoutScheme = "test.com"
+
+        // Then
+        XCTAssertFalse(pathWithoutScheme.hasValidSchemeForBrowser)
+
+        // Given
+        let pathWithScheme = "https://test.com"
+
+        // Then
+        XCTAssertTrue(pathWithScheme.hasValidSchemeForBrowser)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackInstallStepsViewModelTests.swift
@@ -5,11 +5,13 @@ import XCTest
 final class JetpackInstallStepsViewModelTests: XCTestCase {
 
     private let testSiteID: Int64 = 1232
+    private let testSiteURL = "https://test.com"
+    private let testWPAdminURL = "https://test.com/wp-admin/"
 
     func test_startInstallation_dispatches_installSitePlugin_action_if_getPluginDetails_fails() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         var pluginDetailsSiteID: Int64?
@@ -41,7 +43,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_activateSitePlugin_is_dispatched_when_installSitePlugin_succeeds() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         var activatedSiteID: Int64?
@@ -69,7 +71,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_startInstallation_skips_installSitePlugin_action_if_getPluginDetails_succeeds() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         var installedSiteID: Int64?
@@ -100,7 +102,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_installSitePlugin_is_retried_2_times_if_continuously_fails() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         var installedPluginInvokedCount = 0
@@ -125,7 +127,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_loadAndSynchronizeSite_is_dispatched_when_activating_plugin_succeeds() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         var checkedSiteID: Int64?
@@ -164,7 +166,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_currentStep_is_installation_on_startInstallation() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
@@ -184,7 +186,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_currentStep_is_activate_when_installation_succeeds() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
@@ -206,7 +208,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_currentStep_is_connection_when_installation_and_activation_succeeds() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
@@ -230,7 +232,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_currentStep_is_done_when_site_has_isWooCommerceActive_and_not_isJetpackCPConnected() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
@@ -268,7 +270,7 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
     func test_currentStep_is_not_done_when_site_does_not_have_isWooCommerceActive() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, stores: storesManager)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
 
         // When
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
@@ -301,5 +303,69 @@ final class JetpackInstallStepsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentStep, .connection)
         XCTAssertTrue(viewModel.installFailed)
         XCTAssertEqual(checkConnectionInvokedCount, 3) // 1 initial time plus 2 retries
+    }
+
+    func test_wpAdminURL_returns_siteAdminURL_if_it_has_valid_scheme() {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: testWPAdminURL, stores: storesManager)
+
+        // When
+        storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            switch action {
+            case .getPluginDetails(_, _, let onCompletion):
+                onCompletion(.failure(NSError(domain: "Not Found", code: 404)))
+            default:
+                break
+            }
+        }
+        viewModel.startInstallation() // force the installation step to get non-nil url
+
+        // Then
+        XCTAssertEqual(viewModel.wpAdminURL?.absoluteString.hasPrefix(testWPAdminURL), true)
+    }
+
+    func test_wpAdminURL_returns_url_constructed_from_siteURL_if_it_does_not_have_valid_scheme() {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        let invalidAdminURL = ""
+        let constructedPath = testSiteURL + "/wp-admin/"
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: testSiteURL, siteAdminURL: invalidAdminURL, stores: storesManager)
+
+        // When
+        storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            switch action {
+            case .getPluginDetails(_, _, let onCompletion):
+                onCompletion(.failure(NSError(domain: "Not Found", code: 404)))
+            default:
+                break
+            }
+        }
+        viewModel.startInstallation() // force the installation step to get non-nil url
+
+        // Then
+        XCTAssertEqual(viewModel.wpAdminURL?.absoluteString.hasPrefix(constructedPath), true)
+    }
+
+    func test_wpAdminURL_returns_nil_if_both_siteURL_and_siteAdminURL_do_not_have_valid_scheme() {
+        // Given
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        let invalidSiteURL = ""
+        let invalidAdminURL = ""
+        let viewModel = JetpackInstallStepsViewModel(siteID: testSiteID, siteURL: invalidSiteURL, siteAdminURL: invalidAdminURL, stores: storesManager)
+
+        // When
+        storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            switch action {
+            case .getPluginDetails(_, _, let onCompletion):
+                onCompletion(.failure(NSError(domain: "Not Found", code: 404)))
+            default:
+                break
+            }
+        }
+        viewModel.startInstallation() // force the installation step to get non-nil url
+
+        // Then
+        XCTAssertNil(viewModel.wpAdminURL)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Attempting to fix #6501 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the setup for the WP Admin URLs for installing/activating Jetpack plugin on the web.

The crash log shows that the user's site might have an issue with their connection (a lot of errors in synchronization of data, some saying network connection was lost). The site information might not have been fetched properly either, so no valid site admin URL was found and therefore they got an invalid URL when trying to navigate to WP Admin to install Jetpack.

The solution is to check for a valid scheme supported for web browser (HTTP or HTTPS) in the admin URL; if not, fall back to constructing the URL from the site URL. If the site URL is invalid too, no URL will be returned and the user will not be able to navigate to the WP Admin page (a notice will be displayed saying there's an error).

I've also moved the setup for the admin URL to the view model so that the logic can be easily tested.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
I cannot reproduce the case when WP-Admin URL is invalid, so I hope the unit tests help with confidence. Please make sure that the WP-Admin URL is accessible in normal circumstances though, following these steps:
- Make sure to set up a JCP site (setup tips in p1636091588189400-slack-C6H8C3G23).
- Launch the app and switch to said store.
- Turn off your network connection and select Install Jetpack from the My Store tab or Settings screen.
- Proceed to install Jetpack. Without the network connection, an error page should be displayed with option to install Jetpack in WP-Admin.
- Turn on the network connection again and select Install Jetpack in WP-Admin. Notice that a web view is displayed with the correct address of your site's WP-Admin.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
When the WP-Admin URL is invalid, the following notice should be displayed. Please feel free to suggest another message if you think it works better.

<img src="https://user-images.githubusercontent.com/5533851/159868518-d32ea832-a874-4980-b96f-0d0ceff75c73.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
