### PR TITLE
IPP: add simulator configuration setup for testing different scenarios

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -72,14 +72,14 @@ extension StripeCardReaderService: CardReaderService {
 
         if shouldUseSimulatedCardReader {
             // You can test with different reader software update scenarios.
-            // Stripe doc: https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPSimulatorConfiguration.html#/c:objc(cs)SCPSimulatorConfiguration(py)availableReaderUpdate
+            // https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPSimulatorConfiguration.html#/c:objc(cs)SCPSimulatorConfiguration(py)availableReaderUpdate
             Terminal.shared.simulatorConfiguration.availableReaderUpdate = .none
 
             // You can use simulated test cards with a card type, or a card number with different brands and in various success
             // and error cases: https://stripe.com/docs/terminal/references/testing#simulated-test-cards
             // Example with `charge_declined` error:
             // Terminal.shared.simulatorConfiguration.simulatedCard = .init(testCardNumber: "4000000000000002")
-            // Stripe doc: https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPSimulatorConfiguration.html#/c:objc(cs)SCPSimulatorConfiguration(py)simulatedCard
+            // https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPSimulatorConfiguration.html#/c:objc(cs)SCPSimulatorConfiguration(py)simulatedCard
             Terminal.shared.simulatorConfiguration.simulatedCard = .init(type: .amex)
         }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -70,6 +70,19 @@ extension StripeCardReaderService: CardReaderService {
         }
         Terminal.shared.logLevel = terminalLogLevel
 
+        if shouldUseSimulatedCardReader {
+            // You can test with different reader software update scenarios.
+            // Stripe doc: https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPSimulatorConfiguration.html#/c:objc(cs)SCPSimulatorConfiguration(py)availableReaderUpdate
+            Terminal.shared.simulatorConfiguration.availableReaderUpdate = .none
+
+            // You can use simulated test cards with a card type, or a card number with different brands and in various success
+            // and error cases: https://stripe.com/docs/terminal/references/testing#simulated-test-cards
+            // Example with `charge_declined` error:
+            // Terminal.shared.simulatorConfiguration.simulatedCard = .init(testCardNumber: "4000000000000002")
+            // Stripe doc: https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPSimulatorConfiguration.html#/c:objc(cs)SCPSimulatorConfiguration(py)simulatedCard
+            Terminal.shared.simulatorConfiguration.simulatedCard = .init(type: .amex)
+        }
+
         let config = DiscoveryConfiguration(
             discoveryMethod: .bluetoothScan,
             simulated: shouldUseSimulatedCardReader


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to 177-gh-woocommerce/woomobile-private - I will update the ultimate testing guide PdfdoF-D-p2 to include simulator configuration in this PR
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Stripe Terminal SDK provides two configurations for the simulated card reader:
- `availableReaderUpdate`: different reader software update scenarios
- `simulatedCard`: different card brands in success or error cases

This PR added a default configuration so that developers can just update the configuration if they prefer when testing with a simulated card reader.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to test the default configuration:

- In WooCommerce build scheme, enable `-simulate-stripe-card-reader` argument
- Launch the app
- Go to the Orders tab
- Create a simple payment and tap to pay, or tap "Collect Payment" from an eligible order --> the reader should not require any updates, and the payment is captured successfully with an Amex card in the receipt

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->