### PR TITLE
Coupons: Add tracks for coupon setting

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -573,6 +573,8 @@ public enum WooAnalyticsStat: String {
     case couponsLoadedFailed = "coupons_loaded_failed"
     case couponsListSearchTapped = "coupons_list_search_tapped"
     case couponDetails = "coupon_details"
+    case couponSettingDisabled = "coupon_settings_disabled"
+    case couponSettingEnabled = "coupon_settings_enabled"
 
     // MARK: Inbox Notes
     case inboxNotesLoaded = "inbox_notes_loaded"

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -130,6 +130,8 @@ final class CouponListViewModel {
     /// Enable coupons for the store
     ///
     func enableCoupons() {
+        ServiceLocator.analytics.track(.couponSettingEnabled)
+
         state = .loading
         let action = SettingAction.enableCouponSetting(siteID: siteID) { [weak self] result in
             guard let self = self else { return }
@@ -203,7 +205,12 @@ private extension CouponListViewModel {
     /// Check whether coupons are enabled for this store.
     ///
     func loadCouponSetting(completionHandler: @escaping ((Result<Bool, Error>) -> Void)) {
-        let action = SettingAction.retrieveCouponSetting(siteID: siteID, onCompletion: completionHandler)
+        let action = SettingAction.retrieveCouponSetting(siteID: siteID) { result in
+            if let isEnabled = try? result.get(), !isEnabled {
+                ServiceLocator.analytics.track(.couponSettingDisabled)
+            }
+            completionHandler(result)
+        }
         storesManager.dispatch(action)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6250 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds missing Tracks events for coupon settings, specifically:
- When user attempts to load the coupon list while coupons are disabled for their store
- When user taps on the action button to enable coupons for their store. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Disable coupons for your test store (WP Admin > WC Settings > General > Enable Coupons)
- Enable Coupons Management in Experimental Features on the app.
- Navigate to Menu > Coupons. Notice that when the error state view is displayed, in the console there's a log for the disabled state of coupons: `🔵 Tracked coupon_settings_disabled`
- Select the action button on the error state view to enable coupons again. Notice in the console there's a log for that: `🔵 Tracked coupon_settings_enabled`


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
