### PR TITLE
Issue: Use WebviewHelper to show SFSafariViewController everywhere instead of calling the latter directly

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -10,8 +10,7 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
     static func createWithActions(presenting: UIViewController) -> StorePickerErrorHostingController {
         let viewController = StorePickerErrorHostingController()
         viewController.setActions(troubleshootingAction: {
-            let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-            viewController.present(safariViewController, animated: true)
+            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: viewController, modalPresentationStyle: .automatic)
         },
         contactSupportAction: {
             presenting.dismiss(animated: true) {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -10,7 +10,7 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
     static func createWithActions(presenting: UIViewController) -> StorePickerErrorHostingController {
         let viewController = StorePickerErrorHostingController()
         viewController.setActions(troubleshootingAction: {
-            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: viewController, modalPresentationStyle: .automatic)
+            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: viewController)
         },
         contactSupportAction: {
             presenting.dismiss(animated: true) {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -615,8 +615,11 @@ extension StorePickerViewController: UITableViewDataSource {
             hideActionButton()
             let cell = tableView.dequeueReusableCell(EmptyStoresTableViewCell.self, for: indexPath)
             cell.onJetpackSetupButtonTapped = { [weak self] in
-                let safariViewController = SFSafariViewController(url: WooConstants.URLs.emptyStoresJetpackSetup.asURL())
-                self?.present(safariViewController, animated: true, completion: nil)
+                guard let self = self else {
+                    return
+                }
+
+                WebviewHelper.launch(WooConstants.URLs.emptyStoresJetpackSetup.asURL(), with: self, modalPresentationStyle: .automatic)
             }
             return cell
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -615,9 +615,7 @@ extension StorePickerViewController: UITableViewDataSource {
             hideActionButton()
             let cell = tableView.dequeueReusableCell(EmptyStoresTableViewCell.self, for: indexPath)
             cell.onJetpackSetupButtonTapped = { [weak self] in
-                guard let self = self else {
-                    return
-                }
+                guard let self = self else { return }
 
                 WebviewHelper.launch(WooConstants.URLs.emptyStoresJetpackSetup.asURL(), with: self)
             }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -619,7 +619,7 @@ extension StorePickerViewController: UITableViewDataSource {
                     return
                 }
 
-                WebviewHelper.launch(WooConstants.URLs.emptyStoresJetpackSetup.asURL(), with: self, modalPresentationStyle: .automatic)
+                WebviewHelper.launch(WooConstants.URLs.emptyStoresJetpackSetup.asURL(), with: self)
             }
             return cell
         }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -41,13 +41,12 @@ struct JetpackErrorViewModel: ULErrorViewModel {
 
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        guard let url = URL(string: Strings.instructionsURLString) else {
+        guard let url = URL(string: Strings.instructionsURLString),
+              let viewController = viewController else {
             return
         }
 
-        let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = .pageSheet
-        viewController?.present(safariViewController, animated: true)
+        WebviewHelper.launch(url, with: viewController)
 
         analytics.track(.loginJetpackRequiredViewInstructionsButtonTapped)
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -41,14 +41,17 @@ struct JetpackErrorViewModel: ULErrorViewModel {
 
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
+        showInstructionsScreen(in: viewController)
+        analytics.track(.loginJetpackRequiredViewInstructionsButtonTapped)
+    }
+
+    private func showInstructionsScreen(in viewController: UIViewController?) {
         guard let url = URL(string: Strings.instructionsURLString),
               let viewController = viewController else {
             return
         }
 
         WebviewHelper.launch(url, with: viewController)
-
-        analytics.track(.loginJetpackRequiredViewInstructionsButtonTapped)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Tools/WebviewHelper.swift
+++ b/WooCommerce/Classes/Tools/WebviewHelper.swift
@@ -10,14 +10,14 @@ final class WebviewHelper {
     ///   - stringURL: the unconverted URL string
     ///   - sender: the view controller that will present the webview
     ///
-    static func launch(_ stringURL: String?, with sender: UIViewController) {
+    static func launch(_ stringURL: String?, with sender: UIViewController, modalPresentationStyle: UIModalPresentationStyle = .pageSheet) {
         guard let urlString = stringURL,
             let url = URL(string: urlString) else {
                 DDLogError("Webview Helper Error - could not convert string to URL: \(String(describing: stringURL)).")
                 return
         }
 
-        launch(url, with: sender)
+        launch(url, with: sender, modalPresentationStyle: modalPresentationStyle)
     }
 
     /// Launch webview URLs using a common style.
@@ -26,9 +26,9 @@ final class WebviewHelper {
     ///   - URL: the URL
     ///   - sender: the view controller that will present the webview
     ///
-    static func launch(_ url: URL, with sender: UIViewController) {
+    static func launch(_ url: URL, with sender: UIViewController, modalPresentationStyle: UIModalPresentationStyle = .pageSheet) {
         let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = .pageSheet
+        safariViewController.modalPresentationStyle = modalPresentationStyle
         sender.present(safariViewController, animated: true, completion: nil)
     }
 }

--- a/WooCommerce/Classes/Tools/WebviewHelper.swift
+++ b/WooCommerce/Classes/Tools/WebviewHelper.swift
@@ -10,14 +10,14 @@ final class WebviewHelper {
     ///   - stringURL: the unconverted URL string
     ///   - sender: the view controller that will present the webview
     ///
-    static func launch(_ stringURL: String?, with sender: UIViewController, modalPresentationStyle: UIModalPresentationStyle = .pageSheet) {
+    static func launch(_ stringURL: String?, with sender: UIViewController) {
         guard let urlString = stringURL,
             let url = URL(string: urlString) else {
                 DDLogError("Webview Helper Error - could not convert string to URL: \(String(describing: stringURL)).")
                 return
         }
 
-        launch(url, with: sender, modalPresentationStyle: modalPresentationStyle)
+        launch(url, with: sender)
     }
 
     /// Launch webview URLs using a common style.
@@ -26,9 +26,8 @@ final class WebviewHelper {
     ///   - URL: the URL
     ///   - sender: the view controller that will present the webview
     ///
-    static func launch(_ url: URL, with sender: UIViewController, modalPresentationStyle: UIModalPresentationStyle = .pageSheet) {
+    static func launch(_ url: URL, with sender: UIViewController) {
         let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = modalPresentationStyle
         sender.present(safariViewController, animated: true, completion: nil)
     }
 }

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -229,9 +229,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// For now, link to the online help documentation
     ///
     func showHelpCenter(from controller: UIViewController) {
-        let safariViewController = SFSafariViewController(url: WooConstants.URLs.helpCenter.asURL())
-        safariViewController.modalPresentationStyle = .pageSheet
-        controller.present(safariViewController, animated: true, completion: nil)
+        WebviewHelper.launch(WooConstants.URLs.helpCenter.asURL(), with: controller)
 
         ServiceLocator.analytics.track(.supportHelpCenterViewed)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -3,8 +3,6 @@ import UIKit
 import Gridicons
 import WordPressUI
 import Yosemite
-import SafariServices.SFSafariViewController
-
 
 // MARK: - DashboardViewController
 //
@@ -63,8 +61,9 @@ final class DashboardViewController: UIViewController {
         ErrorTopBannerFactory.createTopBanner(isExpanded: false,
                                               expandedStateChangeHandler: {},
                                               onTroubleshootButtonPressed: { [weak self] in
-                                                let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-                                                self?.present(safariViewController, animated: true, completion: nil)
+                                                guard let self = self else { return }
+
+                                                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
                                               },
                                               onContactSupportButtonPressed: { [weak self] in
                                                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
@@ -65,12 +65,10 @@ extension LicensesViewController: WKNavigationDelegate {
             return
         }
 
-        // Open the link in a modal SFSafariViewController instead of the webview displaying the
+        // Use WebviewHelper instead of the webview displaying the
         // licenses HTML — we don't want to build another browser here
         if let url = navigationAction.request.url {
-            let safariViewController = SFSafariViewController(url: url)
-            safariViewController.modalPresentationStyle = .pageSheet
-            present(safariViewController, animated: true, completion: nil)
+            WebviewHelper.launch(url, with: self)
         }
         decisionHandler(.cancel)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/WooAboutScreenConfiguration.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/WooAboutScreenConfiguration.swift
@@ -84,8 +84,7 @@ private extension WooAboutScreenConfiguration {
     // MARK: - Presentation Actions
 
     func present(url: URL, from viewController: UIViewController) {
-        let vc = SFSafariViewController(url: url)
-        viewController.present(vc, animated: true, completion: nil)
+        WebviewHelper.launch(url, with: viewController, modalPresentationStyle: .automatic)
     }
 
     func presentShareSheet(from viewController: UIViewController, sourceView: UIView?) {
@@ -198,8 +197,7 @@ private extension WooLegalAndMoreSubmenuConfiguration {
     }
 
     func present(url: URL, from viewController: UIViewController) {
-        let vc = SFSafariViewController(url: url)
-        viewController.present(vc, animated: true, completion: nil)
+        WebviewHelper.launch(url, with: viewController, modalPresentationStyle: .automatic)
     }
 
     func presentLicenses(from viewController: UIViewController) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/WooAboutScreenConfiguration.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/WooAboutScreenConfiguration.swift
@@ -84,7 +84,7 @@ private extension WooAboutScreenConfiguration {
     // MARK: - Presentation Actions
 
     func present(url: URL, from viewController: UIViewController) {
-        WebviewHelper.launch(url, with: viewController, modalPresentationStyle: .automatic)
+        WebviewHelper.launch(url, with: viewController)
     }
 
     func presentShareSheet(from viewController: UIViewController, sourceView: UIView?) {
@@ -197,7 +197,7 @@ private extension WooLegalAndMoreSubmenuConfiguration {
     }
 
     func present(url: URL, from viewController: UIViewController) {
-        WebviewHelper.launch(url, with: viewController, modalPresentationStyle: .automatic)
+        WebviewHelper.launch(url, with: viewController)
     }
 
     func presentLicenses(from viewController: UIViewController) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -283,17 +283,13 @@ private extension PrivacySettingsViewController {
     /// Display Automattic's Cookie Policy web page
     ///
     func presentCookiePolicyWebView() {
-        let safariViewController = SFSafariViewController(url: WooConstants.URLs.cookie.asURL())
-        safariViewController.modalPresentationStyle = .pageSheet
-        present(safariViewController, animated: true, completion: nil)
+        WebviewHelper.launch(WooConstants.URLs.cookie.asURL(), with: self)
     }
 
     /// Display Automattic's Privacy Policy web page
     ///
     func presentPrivacyPolicyWebView() {
-        let safariViewController = SFSafariViewController(url: WooConstants.URLs.privacy.asURL())
-        safariViewController.modalPresentationStyle = .pageSheet
-        present(safariViewController, animated: true, completion: nil)
+        WebviewHelper.launch(WooConstants.URLs.privacy.asURL(), with: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -102,9 +102,7 @@ private extension FancyAlertViewController {
                 return
             }
 
-            let safariViewController = SFSafariViewController(url: url)
-            safariViewController.modalPresentationStyle = .pageSheet
-            controller.present(safariViewController, animated: true)
+            WebviewHelper.launch(url, with: controller)
 
             analytics.track(.loginWhatIsJetpackHelpScreenLearnMoreButtonTapped)
         }

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Upgrade.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Upgrade.swift
@@ -69,9 +69,7 @@ private extension FancyAlertViewController {
                 return
             }
 
-            let safariViewController = SFSafariViewController(url: url)
-            safariViewController.modalPresentationStyle = .pageSheet
-            controller.present(safariViewController, animated: true)
+            WebviewHelper.launch(url, with: controller)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -592,7 +592,7 @@ private extension OrderDetailsViewController {
     }
 
     func displayWebView(url: URL) {
-        WebviewHelper.launch(url, with: self, modalPresentationStyle: .automatic)
+        WebviewHelper.launch(url, with: self)
     }
 
     func productsMoreMenuTapped(sourceView: UIView) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -592,8 +592,7 @@ private extension OrderDetailsViewController {
     }
 
     func displayWebView(url: URL) {
-        let safariViewController = SFSafariViewController(url: url)
-        present(safariViewController, animated: true, completion: nil)
+        WebviewHelper.launch(url, with: self, modalPresentationStyle: .automatic)
     }
 
     func productsMoreMenuTapped(sourceView: UIView) {
@@ -657,9 +656,7 @@ private extension OrderDetailsViewController {
             actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelTrackingMoreMenu.trackShipmentAction) { [weak self] _ in
                 guard let self = self else { return }
                 ServiceLocator.analytics.track(event: .shipmentTrackingMenu(action: .track))
-                let safariViewController = SFSafariViewController(url: url)
-                safariViewController.modalPresentationStyle = .pageSheet
-                self.present(safariViewController, animated: true, completion: nil)
+                WebviewHelper.launch(url, with: self)
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -472,7 +472,7 @@ private extension ReviewOrderViewController {
             return
         }
 
-        WebviewHelper.launch(url, with: self, modalPresentationStyle: .automatic)
+        WebviewHelper.launch(url, with: self)
     }
 
     /// Trigger view model to delete specified tracking and then reload data

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -471,8 +471,8 @@ private extension ReviewOrderViewController {
               let url = URL(string: trackingURL) else {
             return
         }
-        let safariViewController = SFSafariViewController(url: url)
-        present(safariViewController, animated: true, completion: nil)
+
+        WebviewHelper.launch(url, with: self, modalPresentationStyle: .automatic)
     }
 
     /// Trigger view model to delete specified tracking and then reload data

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -690,8 +690,9 @@ private extension OrderListViewController {
             self?.tableView.updateHeaderHeight()
         },
         onTroubleshootButtonPressed: { [weak self] in
-            let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-            self?.present(safariViewController, animated: true, completion: nil)
+            guard let self = self else { return }
+
+            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self, modalPresentationStyle: .automatic)
         },
         onContactSupportButtonPressed: { [weak self] in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -692,7 +692,7 @@ private extension OrderListViewController {
         onTroubleshootButtonPressed: { [weak self] in
             guard let self = self else { return }
 
-            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self, modalPresentationStyle: .automatic)
+            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
         },
         onContactSupportButtonPressed: { [weak self] in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -479,7 +479,7 @@ private extension ProductsViewController {
             onTroubleshootButtonPressed: { [weak self] in
                 guard let self = self else { return }
 
-                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self, modalPresentationStyle: .automatic)
+                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
             },
             onContactSupportButtonPressed: { [weak self] in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import WordPressUI
 import Yosemite
-import SafariServices.SFSafariViewController
 
 import class AutomatticTracks.CrashLogging
 
@@ -478,8 +477,9 @@ private extension ProductsViewController {
                 self?.tableView.updateHeaderHeight()
             },
             onTroubleshootButtonPressed: { [weak self] in
-                let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-                self?.present(safariViewController, animated: true, completion: nil)
+                guard let self = self else { return }
+
+                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self, modalPresentationStyle: .automatic)
             },
             onContactSupportButtonPressed: { [weak self] in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -118,9 +118,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
         ErrorTopBannerFactory.createTopBanner(isExpanded: false,
                                               expandedStateChangeHandler: {},
                                               onTroubleshootButtonPressed: { [weak self] in
-                                                guard let self = self else {
-                                                    return
-                                                }
+                                                guard let self = self else { return }
 
                                                 WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
                                               },

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SafariServices.SFSafariViewController
 
 /// A configurable view to display an "empty state".
 ///
@@ -119,8 +118,11 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
         ErrorTopBannerFactory.createTopBanner(isExpanded: false,
                                               expandedStateChangeHandler: {},
                                               onTroubleshootButtonPressed: { [weak self] in
-                                                let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-                                                self?.present(safariViewController, animated: true, completion: nil)
+                                                guard let self = self else {
+                                                    return
+                                                }
+
+                                                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
                                               },
                                               onContactSupportButtonPressed: { [weak self] in
                                                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -102,9 +102,7 @@ final class ReviewsViewController: UIViewController {
                                               onTroubleshootButtonPressed: { [weak self] in
                                                 guard let self = self else { return }
 
-                                                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(),
-                                                                     with: self,
-                                                                     modalPresentationStyle: .automatic)
+                                                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
                                               },
                                               onContactSupportButtonPressed: { [weak self] in
                                                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -1,6 +1,4 @@
 import UIKit
-import SafariServices.SFSafariViewController
-
 
 // MARK: - ReviewsViewController
 //
@@ -102,8 +100,11 @@ final class ReviewsViewController: UIViewController {
                                                 self?.tableView.updateHeaderHeight()
                                               },
                                               onTroubleshootButtonPressed: { [weak self] in
-                                                let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-                                                self?.present(safariViewController, animated: true, completion: nil)
+                                                guard let self = self else { return }
+
+                                                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(),
+                                                                     with: self,
+                                                                     modalPresentationStyle: .automatic)
                                               },
                                               onContactSupportButtonPressed: { [weak self] in
                                                 guard let self = self else { return }


### PR DESCRIPTION
Closes: #2103 

### Description
Since the already existing `WebviewHelper` wrapper class encapsulates the logic of showing the content of an URL using `SFSafariViewController` internally, we want to use it everywhere instead of calling `SFSafariViewController` directly. With this wrapper we gain on the principle of loose coupling hiding the details of how we actually show the URL content, and remove redundant code.

### Decisions
When showing the SFSafariViewController we used indistinctly `automatic` by omission(the default one) or `pageSheet` as the `modalPresentationStyle`. Since for versions iOS13+ `automatic` defaults to `pageSheet` for normal `UIViewController` instances, I decided to simplify the implementation and use always automatic and let the system decide which to use depending on the context. Before iOS13 automatic always used to resort to `fullScreen`, that's why we had to specify `pageSheet` in code. Now that we are on iOS14+, this is not necessary. More about this [here](https://stackoverflow.com/questions/58165069/modalpresentationstyle-default-value-in-ios-13).

### Changes
- Replace `SFSafariViewController` direct calls with `WebViewHelper` calls
- Remove `modalPresentationStyle` assignment as explained above
- Create `showInstructionsScreen` function in `JetpackErrorViewModel` to improve readability

### Testing instructions
Check Web View presentations to verify that the URL content and presentation styles are correct.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.