### PR TITLE
Order Creation: Fixes crash when choosing an autocomplete suggestion while selecting a country

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -30,10 +30,29 @@ struct FilterListSelector<ViewModel: FilterListSelectorViewModelable>: View {
     ///
     @StateObject var viewModel: ViewModel
 
+    /// Header search term.
+    ///
+    /// We don't use `$viewModel.searchTerm` directly because there appears to be a bug where the **search term** assignment
+    /// enters into an infinite loop after choosing an autocomplete suggestion. https://github.com/woocommerce/woocommerce-ios/issues/6211
+    ///
+    /// A **fix**  is to provide this local binding and use the `onChange(of:)` modifier to relay changes to the view model.
+    ///
+    @State private var searchTerm = ""
+
+    /// Custom init to provide an initial value to the local `searchTerm` from `viewModel.searchTerm`.
+    ///
+    init(viewModel: ViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.searchTerm = viewModel.searchTerm
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            SearchHeader(filterText: $viewModel.searchTerm, filterPlaceholder: viewModel.filterPlaceholder)
+            SearchHeader(filterText: $searchTerm, filterPlaceholder: viewModel.filterPlaceholder)
                 .background(Color(.listForeground))
+                .onChange(of: searchTerm) { newValue in
+                    viewModel.searchTerm = newValue
+                }
 
             ListSelector(command: viewModel.command, tableStyle: .plain)
         }


### PR DESCRIPTION
Closes: #6211 

I think this also fixes #6214

# Why

There is a weird bug (that only happens on a device) where while searching for a country if the merchants select an autocomplete suggestion the app will enter into an infinite assignment loop of the `search term` binding, the app will become unresponsive and will eventually crash.

I'm not completely sure why this happens but after debugging it seems that the loop goes like:

- Merchants select autocomplete suggestion -> App updates the view model `search term` binding
- iOS triggers `layoutSubviews` -> App Reads value from binding (old value)
- iOS detects that the autocomplete suggestion was overridden -> iOS Resets binding with autocomplete suggestion
- Infinite loop.

https://user-images.githubusercontent.com/562080/159923233-cfa61a6b-7bd3-4730-b70c-3c74b25a1ae1.mov

#  How

This PR attempts to fix this situation by providing a local binding/state to the view and use the `onChange(of:)` modifier to relay changes to the view model.

My hypothesis is that this doesn't cause a loop because we relay the changes to the view model in a different run loop which does not forces the autocomplete system to re-assign the suggestion.

# Demo

https://user-images.githubusercontent.com/562080/159923717-1586ad96-20ab-48f5-a504-e527d493f903.mov

# Testing Steps

- Head to Orders and create a new order.
- Tap "Add customer details" and then "Country"
- Tap the search bar and note that there are some auto-correct options populated
- Tap any auto-correct option.
- See that the app does not crash or becomes unresponsive.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
