### PR TITLE
Order Creation: Add heading accessibility trait to New Order section headings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
@@ -45,6 +45,7 @@ private struct CustomerNoteSectionContent: View {
         VStack(alignment: .leading, spacing: .zero) {
             HStack(alignment: .top) {
                 Text(Localization.notes)
+                    .accessibilityAddTraits(.isHeader)
                     .headlineStyle()
                 Spacer()
                 if viewModel.customerNote.isNotEmpty {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -39,6 +39,7 @@ private struct OrderCustomerSectionContent: View {
         VStack(alignment: .leading, spacing: .zero) {
             HStack(alignment: .top) {
                 Text(Localization.customer)
+                    .accessibilityAddTraits(.isHeader)
                     .headlineStyle()
 
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -162,6 +162,7 @@ private struct ProductsSection: View {
 
             VStack(alignment: .leading, spacing: NewOrder.Layout.verticalSpacing) {
                 Text(NewOrder.Localization.products)
+                    .accessibilityAddTraits(.isHeader)
                     .headlineStyle()
 
                 ForEach(viewModel.productRows) { productRow in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -25,6 +25,7 @@ struct OrderPaymentSection: View {
         VStack(alignment: .leading, spacing: .zero) {
             HStack {
                 Text(Localization.payment)
+                    .accessibilityAddTraits(.isHeader)
                     .headlineStyle()
 
                 Spacer()


### PR DESCRIPTION
Closes: #6065

## Description

Adds an accessibility trait to each of the section headings on the New Order screen, so that VoiceOver identifies them as headings (e.g. "Products, Heading" for the Products section).

## Changes

Adds the `.accessibilityAddTraits(.isHeader)` SwiftUI modifier to the text for each of the `NewOrder` view section headings.

Note: I was tempted to add this trait to our `.headlineStyle()` modifier, but we also use that style in various places that aren't actually headings. I stuck with just adding the trait to the specific text elements on this screen.

## Testing

1. Enable VoiceOver on your device or use the Accessibility Inspector with a simulator.
2. Go to the Orders tab and create a new order.
3. On the New Order screen, confirm that each of the section headings is identified by VoiceOver as "Heading."

## Screenshots

Products|Payment|Customer|Customer Note
-|-|-|-
![IMG_9123](https://user-images.githubusercontent.com/8658164/159960751-bc2e45eb-d13d-4f12-a99a-54762a8e953b.PNG)|![IMG_9124](https://user-images.githubusercontent.com/8658164/159960743-10e0214d-47a1-4ebf-b9a0-60247e2bcaff.PNG)|![IMG_9125](https://user-images.githubusercontent.com/8658164/159960738-e3a44ef2-2d4b-48ba-80b0-348e928ae0c3.PNG)|![IMG_9126](https://user-images.githubusercontent.com/8658164/159960721-755540af-2d3d-457b-ba1d-8087bf20c8ca.PNG)


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
