### PR TITLE
Coupons: Update coupon list items following the latest design

### DIFF
--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -74,7 +74,11 @@ extension Coupon {
         let result = calendar.compare(expiryDate, to: now, toGranularity: .minute)
         return result == .orderedDescending ? .active : .expired
     }
+}
 
+// MARK: - Subtypes
+extension Coupon {
+    /// Expiry status for coupons
     enum ExpiryStatus {
         case active
         case expired
@@ -105,6 +109,36 @@ extension Coupon {
             static let active = NSLocalizedString("Active", comment: "Status of coupons that are active")
             static let expired = NSLocalizedString("Expired", comment: "Status of coupons that are expired")
         }
+    }
+
+    private enum Localization {
+        static let allProducts = NSLocalizedString(
+            "all products",
+            comment: "Text indicating that there's no limit to the number of products that a coupon can be applied for. Displayed on coupon list items and details screen"
+        )
+        static let singleProduct = NSLocalizedString(
+            "%1$d Product",
+            comment: "The number of products allowed for a coupon in singular form. Reads like: 1 Product"
+        )
+        static let multipleProducts = NSLocalizedString(
+            "%1$d Products",
+            comment: "The number of products allowed for a coupon in plural form. " +
+            "Reads like: 10 Products"
+        )
+        static let singleCategory = NSLocalizedString(
+            "%1$d Category",
+            comment: "The number of category allowed for a coupon in singular form. Reads like: 1 Category"
+        )
+        static let multipleCategories = NSLocalizedString(
+            "%1$d Categories",
+            comment: "The number of category allowed for a coupon in plural form. " +
+            "Reads like: 10 Categories"
+        )
+        static let summaryFormat = NSLocalizedString(
+            "%1$@ off %2$@",
+            comment: "Summary line for a coupon, with the discounted amount and number of products and categories that the coupon is limited to. " +
+            "Reads like: '10% off all products' or '$15 off 2 Product 1 Category'"
+        )
     }
 }
 

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -56,7 +56,7 @@ extension Coupon {
                                             excludedProductsCount: excludedProductIds.count,
                                             categoriesCount: productCategories.count,
                                             excludedCategoriesCount: excludedProductCategories.count)
-        return amount.isEmpty ? applyRules.capitalized : String.localizedStringWithFormat(Localization.summaryFormat, amount, applyRules)
+        return amount.isEmpty ? applyRules : String.localizedStringWithFormat(Localization.summaryFormat, amount, applyRules)
     }
 
     /// Formatted amount for the coupon
@@ -154,7 +154,7 @@ extension Coupon {
 
     private enum Localization {
         static let allProducts = NSLocalizedString(
-            "all products",
+            "All Products",
             comment: "Text indicating that there's no limit to the number of products that a coupon can be applied for. " +
             "Displayed on coupon list items and details screen"
         )
@@ -182,8 +182,8 @@ extension Coupon {
             "Reads like: '10% off all products' or '$15 off 2 Product 1 Category'"
         )
         static let allWithException = NSLocalizedString(
-            "all products excl. %1$@",
-            comment: "Exception rule for a coupon. Reads like: all products excl. 2 Products"
+            "All Products excl. %1$@",
+            comment: "Exception rule for a coupon. Reads like: All Products excl. 2 Products"
         )
         static let ruleWithException = NSLocalizedString(
             "%1$@ excl. %2$@",

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -25,9 +25,37 @@ extension Coupon.DiscountType {
     }
 }
 
-// MARK: - Coupon expiry status
+// MARK: - Coupon details
 //
 extension Coupon {
+
+    /// Summary line for the coupon
+    ///
+    var summary: String {
+        return ""
+    }
+
+    /// Formatted amount for the coupon
+    ///
+    func formattedAmount(currencySettings: CurrencySettings) -> String {
+        var amountString: String = ""
+        switch discountType {
+        case .percent:
+            let percentFormatter = NumberFormatter()
+            percentFormatter.numberStyle = .percent
+            if let amountDouble = Double(amount) {
+                let amountNumber = NSNumber(value: amountDouble / 100)
+                amountString = percentFormatter.string(from: amountNumber) ?? ""
+            }
+        case .fixedCart, .fixedProduct:
+            let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+            amountString = currencyFormatter.formatAmount(amount) ?? ""
+        case .other:
+            break // skip formatting for unsupported types
+        }
+        return amountString
+    }
+
     /// Expiry status for Coupons.
     ///
     func expiryStatus(now: Date = Date()) -> ExpiryStatus {

--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -50,7 +50,7 @@ extension Coupon {
 
     /// Summary line for the coupon
     ///
-    func summary(currencySettings: CurrencySettings) -> String {
+    func summary(currencySettings: CurrencySettings = ServiceLocator.currencySettings) -> String {
         let amount = formattedAmount(currencySettings: currencySettings)
         let applyRules = localizeApplyRules(productsCount: productIds.count,
                                             excludedProductsCount: excludedProductIds.count,

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -140,7 +140,20 @@ private extension CouponDetailsViewModel {
             discountedAmount = formatStringAmount("0")
         }
 
-        amount = coupon.formattedAmount(currencySettings: currencySettings)
+        switch coupon.discountType {
+        case .percent:
+            let percentFormatter = NumberFormatter()
+            percentFormatter.numberStyle = .percent
+            if let amountDouble = Double(coupon.amount) {
+                let amountNumber = NSNumber(value: amountDouble / 100)
+                amount = percentFormatter.string(from: amountNumber) ?? ""
+            }
+        case .fixedCart, .fixedProduct:
+            amount = formatStringAmount(coupon.amount)
+        case .other:
+            amount = coupon.amount
+        }
+
         productsAppliedTo = localizeApplyRules(productsCount: coupon.productIds.count,
                                                excludedProductsCount: coupon.excludedProductIds.count,
                                                categoriesCount: coupon.productCategories.count,

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -140,20 +140,7 @@ private extension CouponDetailsViewModel {
             discountedAmount = formatStringAmount("0")
         }
 
-        switch coupon.discountType {
-        case .percent:
-            let percentFormatter = NumberFormatter()
-            percentFormatter.numberStyle = .percent
-            if let amountDouble = Double(coupon.amount) {
-                let amountNumber = NSNumber(value: amountDouble / 100)
-                amount = percentFormatter.string(from: amountNumber) ?? ""
-            }
-        case .fixedCart, .fixedProduct:
-            amount = formatStringAmount(coupon.amount)
-        case .other:
-            amount = coupon.amount
-        }
-
+        amount = coupon.formattedAmount(currencySettings: currencySettings)
         productsAppliedTo = localizeApplyRules(productsCount: coupon.productIds.count,
                                                excludedProductsCount: coupon.excludedProductIds.count,
                                                categoriesCount: coupon.productCategories.count,

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -60,22 +60,16 @@ final class CouponListViewModel {
     ///
     private let storageManager: StorageManagerType
 
-    /// Currency settings to format amount of coupons
-    ///
-    private let currencySettings: CurrencySettings
-
     // MARK: - Initialization and setup
     //
     init(siteID: Int64,
          syncingCoordinator: SyncingCoordinatorProtocol = SyncingCoordinator(),
          storesManager: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
         self.syncingCoordinator = syncingCoordinator
         self.storesManager = storesManager
         self.storageManager = storageManager
-        self.currencySettings = currencySettings
         self.resultsController = Self.createResultsController(siteID: siteID,
                                                               storageManager: storageManager)
         configureSyncingCoordinator()
@@ -86,7 +80,7 @@ final class CouponListViewModel {
     func buildCouponViewModels() {
         couponViewModels = resultsController.fetchedObjects.map { coupon in
             CouponListCellViewModel(title: coupon.code,
-                                    subtitle: coupon.summary(currencySettings: currencySettings),
+                                    subtitle: coupon.summary(),
                                     accessibilityLabel: coupon.description.isEmpty ? coupon.description : coupon.code,
                                     status: coupon.expiryStatus().localizedName,
                                     statusBackgroundColor: coupon.expiryStatus().statusBackgroundColor)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -60,16 +60,22 @@ final class CouponListViewModel {
     ///
     private let storageManager: StorageManagerType
 
+    /// Currency settings to format amount of coupons
+    ///
+    private let currencySettings: CurrencySettings
+
     // MARK: - Initialization and setup
     //
     init(siteID: Int64,
          syncingCoordinator: SyncingCoordinatorProtocol = SyncingCoordinator(),
          storesManager: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.siteID = siteID
         self.syncingCoordinator = syncingCoordinator
         self.storesManager = storesManager
         self.storageManager = storageManager
+        self.currencySettings = currencySettings
         self.resultsController = Self.createResultsController(siteID: siteID,
                                                               storageManager: storageManager)
         configureSyncingCoordinator()
@@ -80,7 +86,7 @@ final class CouponListViewModel {
     func buildCouponViewModels() {
         couponViewModels = resultsController.fetchedObjects.map { coupon in
             CouponListCellViewModel(title: coupon.code,
-                                    subtitle: coupon.discountType.localizedName, // to be updated after UI is finalized
+                                    subtitle: coupon.summary(currencySettings: currencySettings),
                                     accessibilityLabel: coupon.description.isEmpty ? coupon.description : coupon.code,
                                     status: coupon.expiryStatus().localizedName,
                                     statusBackgroundColor: coupon.expiryStatus().statusBackgroundColor)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,21 +14,21 @@
             <rect key="frame" x="0.0" y="0.0" width="351" height="90"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="321.5" height="90"/>
+                <rect key="frame" x="0.0" y="0.0" width="322.5" height="90"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="zx0-L0-tSe">
-                        <rect key="frame" x="16" y="8" width="288" height="74"/>
+                        <rect key="frame" x="16" y="8" width="290.5" height="74"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Fixed product discount " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kxr-JD-qZr" userLabel="Date Label">
-                                <rect key="frame" x="0.0" y="0.0" width="133.5" height="14.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Jan2022Sale" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j1w-V3-ltS">
+                                <rect key="frame" x="0.0" y="0.0" width="99.5" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Jan2022Sale" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j1w-V3-ltS">
-                                <rect key="frame" x="0.0" y="20.5" width="99.5" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Fixed product discount " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kxr-JD-qZr" userLabel="Date Label">
+                                <rect key="frame" x="0.0" y="26.5" width="133.5" height="14.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/WooCommerce/WooCommerceTests/Model/CouponWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CouponWooTests.swift
@@ -34,4 +34,98 @@ final class CouponWooTests: XCTestCase {
         // Then
         XCTAssertEqual(coupon.expiryStatus(now: now), .expired)
     }
+
+    func test_summary_returns_correct_amount_fixedProduct_discount_type() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(
+            amount: "10.00",
+            discountType: .fixedProduct
+        )
+        let currencySettings = CurrencySettings()
+
+        // Then
+        XCTAssertTrue(sampleCoupon.summary(currencySettings: currencySettings).contains("$10.00"))
+    }
+
+    func test_summary_returns_correct_amount_percentage_discount_type() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(
+            amount: "10.00",
+            discountType: .percent
+        )
+
+        // Then
+        XCTAssertTrue(sampleCoupon.summary().contains("10%"))
+    }
+
+    func test_coupon_apply_rule_with_no_limit() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [], excludedProductIds: [], productCategories: [], excludedProductCategories: [])
+
+        // Then
+        XCTAssertTrue(sampleCoupon.summary().contains(NSLocalizedString("All Products", comment: "")))
+    }
+
+    func test_coupon_apply_rule_with_one_productId() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [12], excludedProductIds: [], productCategories: [], excludedProductCategories: [])
+
+        // Then
+        let appliedTo = String(format: NSLocalizedString("%d Product", comment: ""), 1)
+        XCTAssertTrue(sampleCoupon.summary().contains(appliedTo))
+    }
+
+    func test_coupon_apply_rule_with_multiple_productIds() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [12, 23, 45], excludedProductIds: [], productCategories: [], excludedProductCategories: [])
+
+        // Then
+        let appliedTo = String(format: NSLocalizedString("%d Products", comment: ""), 3)
+        XCTAssertTrue(sampleCoupon.summary().contains(appliedTo))
+    }
+
+    func test_coupon_apply_rule_with_multiple_productIds_and_categories() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [12, 23, 45], excludedProductIds: [], productCategories: [22, 33], excludedProductCategories: [])
+
+        // Then
+        let appliedTo = String(format: NSLocalizedString("%d Products, %d Categories", comment: ""), 3, 2)
+        XCTAssertTrue(sampleCoupon.summary().contains(appliedTo))
+    }
+
+    func test_coupon_apply_rule_with_productIds_and_excluded_categories() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [12, 23, 45], excludedProductIds: [], productCategories: [], excludedProductCategories: [11])
+
+        // Then
+        let appliedTo = String(format: NSLocalizedString("%d Products excl. %d Category", comment: ""), 3, 1)
+        XCTAssertTrue(sampleCoupon.summary().contains(appliedTo))
+    }
+
+    func test_coupon_apply_rule_with_categories_and_excluded_products() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [], excludedProductIds: [11, 22], productCategories: [1, 2, 3], excludedProductCategories: [])
+
+        // Then
+        let appliedTo = String(format: NSLocalizedString("%d Categories excl. %d Products", comment: ""), 3, 2)
+        XCTAssertTrue(sampleCoupon.summary().contains(appliedTo))
+    }
+
+    func test_coupon_apply_rule_with_excluded_products() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [], excludedProductIds: [11, 22], productCategories: [], excludedProductCategories: [])
+
+        // Then
+        let appliedTo = String(format: NSLocalizedString("All Products excl. %d Products", comment: ""), 2)
+        XCTAssertTrue(sampleCoupon.summary().contains(appliedTo))
+    }
+
+    func test_coupon_apply_rule_with_excluded_categories() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(productIds: [], excludedProductIds: [], productCategories: [], excludedProductCategories: [11, 22])
+
+        // Then
+        let appliedTo = String(format: NSLocalizedString("All Products excl. %d Categories", comment: ""), 2)
+        XCTAssertTrue(sampleCoupon.summary().contains(appliedTo))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6486 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the layout and content of coupon list items following the latest design.
Previously we were showing only the discount type for the subtitle of the items. In this update, it's replaced with a summary line of the formatted discount amount and apply rules.

I've moved the logic for the formatted amount and apply rules from the coupon details view model to the extension of `Coupon` to make it easier to reuse. The duplicated logic will be removed in the next PR when the coupon details screen layout is updated.

There's a grey area for formatting the discount amount of unsupported discount types. In this PR I'm removing the amount for simplicity.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Please make sure that your test store has coupons enabled and set up a few coupons.
- Launch the app, make sure that you have Coupon Management enabled in Menu > Settings > Experimental Features.
- Navigate to Menu > Coupons. Notice that the coupon items in the list are updated with new layout and display correct information for each coupon. 

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/160051774-4367dd57-6361-4c05-a730-07ab700e4f32.PNG" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/160050495-f5339ba3-29ef-4a67-847a-c451a101bd41.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
