### PR TITLE
IPP Analytics: add `country` property to onboarding events and a case for `card_present_collect_payment_canceled` 

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -818,11 +818,21 @@ extension WooAnalyticsEvent {
             )
         }
 
+        /// Tracked when the "learn more" button in the In-Person Payments onboarding is tapped.
+        ///
+        /// - Parameter countryCode: the country code of the store.
+        ///
         static func cardPresentOnboardingLearnMoreTapped(countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingLearnMoreTapped,
                               properties: [Keys.countryCode: countryCode])
         }
 
+        /// Tracked when the In-Person Payments onboarding cannot be completed for some reason.
+        ///
+        /// - Parameters:
+        ///   - reason: the reason why the onboarding is not completed.
+        ///   - countryCode: the country code of the store.
+        ///
         static func cardPresentOnboardingNotCompleted(reason: String, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingNotCompleted,
                               properties: [

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -817,5 +817,18 @@ extension WooAnalyticsEvent {
                               ]
             )
         }
+
+        static func cardPresentOnboardingLearnMoreTapped(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardPresentOnboardingLearnMoreTapped,
+                              properties: [Keys.countryCode: countryCode])
+        }
+
+        static func cardPresentOnboardingNotCompleted(reason: String, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardPresentOnboardingNotCompleted,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                "reason": reason
+                              ])
+        }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -43,12 +43,14 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
 
     private let paymentGatewayAccountID: String?
     private let countryCode: String
+    private let analytics: Analytics
 
-    init(name: String, amount: String, paymentGatewayAccountID: String?, countryCode: String) {
+    init(name: String, amount: String, paymentGatewayAccountID: String?, countryCode: String, analytics: Analytics = ServiceLocator.analytics) {
         self.name = name
         self.amount = amount
         self.paymentGatewayAccountID = paymentGatewayAccountID
         self.countryCode = countryCode
+        self.analytics = analytics
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -56,7 +58,7 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments
                                         .collectPaymentCanceled(forGatewayID: paymentGatewayAccountID,
                                                                 countryCode: countryCode))
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -41,9 +41,14 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
         return topTitle + bottomTitle
     }
 
-    init(name: String, amount: String) {
+    private let paymentGatewayAccountID: String?
+    private let countryCode: String
+
+    init(name: String, amount: String, paymentGatewayAccountID: String?, countryCode: String) {
         self.name = name
         self.amount = amount
+        self.paymentGatewayAccountID = paymentGatewayAccountID
+        self.countryCode = countryCode
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -51,7 +56,9 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        ServiceLocator.analytics.track(.collectPaymentCanceled)
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments
+                                        .collectPaymentCanceled(forGatewayID: paymentGatewayAccountID,
+                                                                countryCode: countryCode))
 
         let action = CardPresentPaymentAction.cancelPayment(onCompletion: nil)
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -24,8 +24,13 @@ final class OrderDetailsPaymentAlerts {
     private var name: String = ""
     private var amount: String = ""
 
-    init(presentingController: UIViewController) {
+    private let paymentGatewayAccountID: String?
+    private let countryCode: String
+
+    init(presentingController: UIViewController, paymentGatewayAccountID: String?, countryCode: String) {
         self.presentingController = presentingController
+        self.paymentGatewayAccountID = paymentGatewayAccountID
+        self.countryCode = countryCode
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
@@ -89,7 +94,7 @@ final class OrderDetailsPaymentAlerts {
 
 private extension OrderDetailsPaymentAlerts {
     func readerIsReady() -> CardPresentPaymentsModalViewModel {
-        CardPresentModalReaderIsReady(name: name, amount: amount)
+        CardPresentModalReaderIsReady(name: name, amount: amount, paymentGatewayAccountID: paymentGatewayAccountID, countryCode: countryCode)
     }
 
     func tapOrInsert(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -21,7 +21,9 @@ final class CardReaderSettingsConnectedViewController: UIViewController, CardRea
 
     /// Card Present Payments alerts
     private lazy var paymentAlerts: OrderDetailsPaymentAlerts = {
-        OrderDetailsPaymentAlerts(presentingController: self)
+        OrderDetailsPaymentAlerts(presentingController: self,
+                                  paymentGatewayAccountID: viewModel?.dataSource.cardPresentPaymentGatewayID(),
+                                  countryCode: CardPresentConfigurationLoader().configuration.countryCode)
     }()
 
     private let settingsAlerts = CardReaderSettingsAlerts()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -15,7 +15,8 @@ struct InPersonPaymentsLearnMore: View {
         }
             .padding(.vertical, Constants.verticalPadding)
             .onTapGesture {
-                ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
+                ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments
+                                                .cardPresentOnboardingLearnMoreTapped(countryCode: SiteAddress().countryCode))
                 customOpenURL?(InPersonPaymentsLearnMore.learnMoreURL)
             }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -4,6 +4,8 @@ struct InPersonPaymentsLearnMore: View {
     static let learnMoreURL = URL(string: "woocommerce://in-person-payments/learn-more")!
     @Environment(\.customOpenURL) var customOpenURL
 
+    private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
+
     var body: some View {
         HStack(spacing: 16) {
             Image(uiImage: .infoOutlineImage)
@@ -16,7 +18,7 @@ struct InPersonPaymentsLearnMore: View {
             .padding(.vertical, Constants.verticalPadding)
             .onTapGesture {
                 ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments
-                                                .cardPresentOnboardingLearnMoreTapped(countryCode: SiteAddress().countryCode))
+                                                .cardPresentOnboardingLearnMoreTapped(countryCode: cardPresentConfiguration.countryCode))
                 customOpenURL?(InPersonPaymentsLearnMore.learnMoreURL)
             }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -74,12 +74,14 @@ final class InPersonPaymentsViewModel: ObservableObject {
     }
 }
 
-private func trackState(_ state: CardPresentPaymentOnboardingState) {
-    guard let reason = state.reasonForAnalytics else {
-        return
+private extension InPersonPaymentsViewModel {
+    func trackState(_ state: CardPresentPaymentOnboardingState) {
+        guard let reason = state.reasonForAnalytics else {
+            return
+        }
+        ServiceLocator.analytics
+            .track(event: .InPersonPayments
+                    .cardPresentOnboardingNotCompleted(reason: reason,
+                                                       countryCode: useCase.configurationLoader.configuration.countryCode))
     }
-    let properties = [
-        "reason": reason
-    ]
-    ServiceLocator.analytics.track(.cardPresentOnboardingNotCompleted, withProperties: properties)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -60,7 +60,9 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 
     /// Alert manager to inform merchants about reader & card actions.
     ///
-    private lazy var alerts = OrderDetailsPaymentAlerts(presentingController: rootViewController)
+    private lazy var alerts = OrderDetailsPaymentAlerts(presentingController: rootViewController,
+                                                        paymentGatewayAccountID: paymentGatewayAccount.gatewayID,
+                                                        countryCode: configurationLoader.configuration.countryCode)
 
     /// IPP payments collector.
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5984 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since we are adding `country` property to all IPP events, this PR added this property to two onboarding events and fixed the `card_present_collect_payment_canceled` entry point from the alert. Hopefully, this is the second last PR for the `country` property - the remaining events are `receipt_*` events that will be a separate PR as I still need to figure out how to test all the scenarios.

I was hoping to DI the country code everywhere, but since `InPersonPaymentsLearnMore` is used in several places without a `CardPresentPaymentsConfiguration` I ended up passing `SiteAddress()` (even though `CardPresentConfigurationLoader` also uses this internally).

The affected events are:
- `*_card_present_onboarding_learn_more_tapped`
- `*_card_present_onboarding_not_completed`
- `*_card_present_collect_payment_canceled` - the entry point from the "ready" alert

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

For each event, there should be a new `country` property that shows the country code of the store:
- `*_card_present_onboarding_learn_more_tapped`: Settings > In-Person Payments > tap “Learn more …” link near the bottom
- `*_card_present_onboarding_not_completed`: switch to a store that is using USD but not set up for IPP > Settings > In-Person Payments
- `*_card_present_collect_payment_canceled`: Orders tab > Simply payment or order details to collect payment --> after the card reader is connected and the alert is shown to insert card, tap "Cancel" (I noticed that when using a simulated card reader, the payment still went through 😓 )

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
