### PR TITLE
Issue: avoid adding multiple empty state views in ShipmentProvidersViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -8,7 +8,7 @@ protocol ShipmentProviderListDelegate: AnyObject {
 final class ShipmentProvidersViewController: UIViewController {
     private let viewModel: ShippingProvidersViewModel
     private weak var delegate: ShipmentProviderListDelegate?
-    private var emptyStateView: EmptyListMessageWithActionView?
+    private weak var emptyStateView: EmptyListMessageWithActionView?
 
     @IBOutlet weak var table: UITableView!
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -281,7 +281,7 @@ private extension ShipmentProvidersViewController {
 
     func presentEmptyStateIfNecessary(term: String = "") {
         guard viewModel.isListEmpty else {
-            removeEmptyState()
+            removeEmptyStateView()
             return
         }
 
@@ -292,15 +292,15 @@ private extension ShipmentProvidersViewController {
             return
         }
 
-        addEmptyState(with: term)
+        configureAndAddEmptyStateView(with: term)
     }
 
-    func removeEmptyState() {
+    func removeEmptyStateView() {
         emptyStateView?.removeFromSuperview()
         emptyStateView = nil
     }
 
-    func addEmptyState(with term: String = "") {
+    func configureAndAddEmptyStateView(with term: String = "") {
         emptyStateView = EmptyListMessageWithActionView.instantiateFromNib()
         updateEmptyStateView(with: term)
         emptyStateView?.actionText = NSLocalizedString("Custom Carrier",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -8,6 +8,7 @@ protocol ShipmentProviderListDelegate: AnyObject {
 final class ShipmentProvidersViewController: UIViewController {
     private let viewModel: ShippingProvidersViewModel
     private weak var delegate: ShipmentProviderListDelegate?
+    private var emptyStateView: EmptyListMessageWithActionView?
 
     @IBOutlet weak var table: UITableView!
 
@@ -284,29 +285,43 @@ private extension ShipmentProvidersViewController {
             return
         }
 
-        let emptyState: EmptyListMessageWithActionView = EmptyListMessageWithActionView.instantiateFromNib()
+        guard emptyStateView == nil else {
+            // When we search for terms without results sequentially the empty state view is already there.
+            // We do not have to add it again, we just have to update that view with the new term
+            updateEmptyStateView(with: term)
+            return
+        }
+
+        addEmptyState(with: term)
+    }
+
+    func removeEmptyState() {
+        emptyStateView?.removeFromSuperview()
+        emptyStateView = nil
+    }
+
+    func addEmptyState(with term: String = "") {
+        emptyStateView = EmptyListMessageWithActionView.instantiateFromNib()
+        updateEmptyStateView(with: term)
+        emptyStateView?.actionText = NSLocalizedString("Custom Carrier",
+                                                  comment: "Title of button to add a custom tracking carrier if filtering the list yields no results."
+        )
+
+        emptyStateView?.onAction = { [weak self] in
+            self?.addCustomProvider()
+        }
+
+        emptyStateView?.attach(to: view)
+    }
+
+    func updateEmptyStateView(with term: String) {
         let messageFormat = NSLocalizedString(
             "No results found for %1$@\nAdd a custom carrier",
             comment: "Empty state for the list of shipment carriers. "
                 + "It reads: 'No results for DHL. Add a custom carrier'. "
                 + "Parameters: %1$@ - carrier name"
         )
-        emptyState.messageText = String.localizedStringWithFormat(messageFormat, term)
-        emptyState.actionText = NSLocalizedString("Custom Carrier",
-                                                  comment: "Title of button to add a custom tracking carrier if filtering the list yields no results."
-        )
-
-        emptyState.onAction = { [weak self] in
-            self?.addCustomProvider()
-        }
-
-        emptyState.attach(to: view)
-    }
-
-    func removeEmptyState() {
-        for subview in view.subviews where subview is EmptyListMessageWithActionView {
-            subview.removeFromSuperview()
-        }
+        emptyStateView?.messageText = String.localizedStringWithFormat(messageFormat, term)
     }
 
     func addCustomProvider() {


### PR DESCRIPTION
Closes: #1049
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Before, when searching for multiple terms without results on a row in the Shipping Carriers screen within the Orders, we used to recreate and add the empty state view as many times as we searched a term, ending up with a pile of unnecessary views.
![issue-1049-before-fix](https://user-images.githubusercontent.com/1864060/160092565-7320aa49-8d97-4cab-8c81-5c234087d25a.png)

Now, with the fix included on this PR, we keep a (weak) optional reference to the view, to avoid having to recreate the case above. If searching for terms without results sequentially we just update the `EmptyListMessageWithActionView` with a new message, but we do not recreate it again:
![issue-1049-after-fix](https://user-images.githubusercontent.com/1864060/160094492-d9a6210f-f9f9-42c3-b478-22e89d43424a.png)

## Changes
- Add a weak reference to the `EmptyListMessageWithActionView` view
- When showing the empty state view, check if we already created it. If so, we just update it with the new term, else, we create, configure, and add it.
- Extract code to its own functions

### Testing instructions
#### Prerequisites
- The store has [Shipping Tracking extension](https://woocommerce.com/products/shipment-tracking/) installed and activated. 
- The store should have at least one order.

#### Steps
- Open the app
- Go to Orders
- Select the processing order
- Scroll down to "Add Tracking". Tap on it
- On the next screen, tap on "Select Carrier"
- Start searching for terms without results. E.g "Paco", "Pacom", "Pacome" ...
- On Xcode, open the Debug View Hierarchy. Check that only one instance of `EmptyListMessageWithActionView` is added. If necessary repeat these steps on `trunk`  to compare the process.

### Screenshots
<img width="490" alt="Screenshot 2022-03-25 at 10 19 29" src="https://user-images.githubusercontent.com/1864060/160095185-525a536c-7bb9-4331-bd3a-b41622363f75.png">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
