### PR TITLE
Order Creation: Remove currency symbol from Shipping & Fees textfields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -113,7 +113,6 @@ struct FeeLineDetails: View {
                                   text: $viewModel.amount,
                                   focus: $focusFixedAmountInput)
                     .keyboardType(.numbersAndPunctuation)
-                    .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
                     .onTapGesture {
                         focusFixedAmountInput = true
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -111,7 +111,7 @@ private extension ShippingLineDetails {
         static let shipping = NSLocalizedString("Shipping", comment: "Title for the Shipping Line Details screen during order creation")
 
         static let amountField = NSLocalizedString("Amount (%1$@)", comment: "Title for the amount field on the Shipping Details screen during order creation"
-                                                   + "Parameters: %1$@ - fee type (percent sign or currency symbol)")
+                                                   + "Parameters: %1$@ - currency symbol")
         static let nameField = NSLocalizedString("Name", comment: "Title for the name field on the Shipping Line Details screen during order creation")
 
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Shipping Line Details screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -27,14 +27,13 @@ struct ShippingLineDetails: View {
                     Section {
                         Group {
                             AdaptiveStack(horizontalAlignment: .leading) {
-                                Text(Localization.amountField)
+                                Text(String.localizedStringWithFormat(Localization.amountField, viewModel.currencySymbol))
                                     .bodyStyle()
                                     .fixedSize()
                                 HStack {
                                     Spacer()
                                     BindableTextfield(viewModel.amountPlaceholder, text: $viewModel.amount, focus: $focusAmountInput)
                                         .keyboardType(.numbersAndPunctuation)
-                                        .addingCurrencySymbol(viewModel.currencySymbol, on: viewModel.currencyPosition)
                                         .onTapGesture {
                                             focusAmountInput = true
                                         }
@@ -111,7 +110,8 @@ private extension ShippingLineDetails {
         static let addShipping = NSLocalizedString("Add Shipping", comment: "Title for the Shipping Line screen during order creation")
         static let shipping = NSLocalizedString("Shipping", comment: "Title for the Shipping Line Details screen during order creation")
 
-        static let amountField = NSLocalizedString("Amount", comment: "Title for the amount field on the Shipping Line Details screen during order creation")
+        static let amountField = NSLocalizedString("Amount (%1$@)", comment: "Title for the amount field on the Shipping Details screen during order creation"
+                                                   + "Parameters: %1$@ - fee type (percent sign or currency symbol)")
         static let nameField = NSLocalizedString("Name", comment: "Title for the name field on the Shipping Line Details screen during order creation")
 
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Shipping Line Details screen")


### PR DESCRIPTION
Closes: #6409

# Why

There is a small inconsistency in how we display the negative symbol between the Shipping/Fees input screens and the payment summary.

In particular, the inputs fields render the negative symbol(`-`) after the currency symbol and the payment summary renders it before the currency symbol.

Before Currency Simbol | After Currency Symbol
---- | ---
<img width="439" alt="negative-first" src="https://user-images.githubusercontent.com/562080/157130606-67679aa6-4bd7-42e4-ac31-3c6207ece1f7.png"> | <img width="439" alt="negative after" src="https://user-images.githubusercontent.com/562080/157130611-1f719a0e-12cf-4100-ac9d-71cdcbc5e7f1.png">


# How

After inspecting the code, the changes for fixing such a small detail don't appear to be on the simpler side, because the texfield input handling becomes quite complex.

For this reason, I have opted to follow what core does, which is to remove the currency symbol when entering arbitrary amounts, like fees or inputs.

Additionally, I have added the currency symbol next to the shipping amount label to properly indicate the currency. The fees screens already had that label.

# Screenshot

Shipping | Fees | Summary
--- | --- | ---
<img width="440" alt="minus-shipping" src="https://user-images.githubusercontent.com/562080/160152620-f74b9687-9f1c-4599-88b4-8af5d911e363.png"> |  <img width="437" alt="minus-fee" src="https://user-images.githubusercontent.com/562080/160152624-c95a1870-0e66-4874-9090-74708ed7e09a.png"> | <img width="424" alt="minus-consolidated" src="https://user-images.githubusercontent.com/562080/160152609-df975b42-b16b-4fdd-b2de-50c00cb946df.png">

# Testing Steps

- Go to the new order screen
- Add shipping or fees
- See that the currency symbol is not displayed within the input text field.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
