### PR TITLE
Order Creation: Add basic Order Creation UI test for an empty order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -151,6 +151,7 @@ struct HubMenu: View {
                             }
                         }
                     }
+                    .accessibilityIdentifier("dashboard-settings-button")
                     Spacer()
                 }
                 .fixedSize()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
@@ -40,6 +40,17 @@ public enum BottomSheetOrderType: Hashable {
             return UIImage.pagesImage
         }
     }
+
+    /// Accessibility identifiers for the action sheet.
+    ///
+    var actionSheetAccessibilityID: String {
+        switch self {
+        case .simple:
+            return "new_order_simple_payment"
+        case .full:
+            return "new_order_full_manual_order"
+        }
+    }
 }
 
 final class OrderTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCommand {
@@ -60,6 +71,7 @@ final class OrderTypeBottomSheetListSelectorCommand: BottomSheetListSelectorComm
     }
 
     func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: BottomSheetOrderType) {
+        cell.accessibilityIdentifier = model.actionSheetAccessibilityID
         let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.actionSheetTitle,
                                                                     text: model.actionSheetDescription,
                                                                     image: model.actionSheetImage,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrder.swift
@@ -120,6 +120,7 @@ struct NewOrder: View {
                         viewModel.createOrder()
                     }
                     .id(navigationButtonID)
+                    .accessibilityIdentifier("new-order-create-button")
                     .disabled(viewModel.disabled)
 
                 case .loading:

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -1,0 +1,24 @@
+import ScreenObject
+import XCTest
+
+public final class NewOrderScreen: ScreenObject {
+
+    private let createButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["new-order-create-button"]
+    }
+
+    private var createButton: XCUIElement { createButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ createButtonGetter ],
+            app: app
+        )
+    }
+
+    @discardableResult
+    public func createOrder() throws -> SingleOrderScreen {
+        createButton.tap()
+        return try SingleOrderScreen()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -14,13 +14,30 @@ public final class OrdersScreen: ScreenObject {
         $0.buttons["Filter"]
     }
 
+    private let createButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["new-order-type-sheet-button"]
+    }
+
+    private let newOrderCellGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["new_order_full_manual_order"]
+    }
+
     private var searchButton: XCUIElement { searchButtonGetter(app) }
+
+    /// Button (`+`) to create a new order or simple payment
+    ///
+    private var createButton: XCUIElement { createButtonGetter(app) }
+
+    /// Button (on the Orders bottom sheet) to create a full manual order
+    ///
+    private var newOrderButton: XCUIElement { newOrderCellGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 searchButtonGetter,
-                filterButtonGetter
+                filterButtonGetter,
+                createButtonGetter
             ],
             app: app
         )
@@ -61,5 +78,14 @@ public final class OrdersScreen: ScreenObject {
     public func verifyOrdersScreenLoaded() throws -> Self {
         XCTAssertTrue(isLoaded)
         return self
+    }
+
+    /// Starts the order creation flow by navigating from the Orders screen to the New Order screen.
+    /// - Returns: New Order screen object.
+    @discardableResult
+    public func startOrderCreation() throws -> NewOrderScreen {
+        createButton.tap()
+        newOrderButton.tap()
+        return try NewOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -4,31 +4,44 @@ import XCTest
 // This screen is currently unused. Given the purpose of UITestsFoundation is to provide developers
 // with an easy to use API to write tests, I'm going to keep the screen in the framework anyway, so
 // it'll be already available if someone needs to work with it or on it in the future.
-class BetaFeaturesScreen: ScreenObject {
+public class BetaFeaturesScreen: ScreenObject {
 
-    // `expectedElement` is a `ScreenObject` utility to get the first element from the
-    // `expectedElementGetters` list.
-    private var enableProductsButton: XCUIElement { expectedElement }
+    private let orderCreationGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["beta-features-order-order-creation-cell"]
+    }
+
+    /// Table Cell for Order Creation experimental feature
+    ///
+    private var orderCreation: XCUIElement { orderCreationGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ { $0.cells["beta-features-products-cell"] } ],
+            expectedElementGetters: [
+                orderCreationGetter
+            ],
             app: app
         )
     }
 
     @discardableResult
-    func enableProducts() -> Self {
-        if enableProductsButton.switches.firstMatch.value as? String == "0" {
-            enableProductsButton.tap()
-        }
-
+    public func enableOrderCreation() -> Self {
+        enableBetaFeature(orderCreation)
         return self
     }
 
     @discardableResult
-    func goBackToSettingsScreen() throws -> SettingsScreen {
+    public func goBackToSettingsScreen() throws -> SettingsScreen {
         navBackButton.tap()
         return try SettingsScreen()
+    }
+}
+
+private extension BetaFeaturesScreen {
+    /// Enables the beta feature in the provided cell on the Beta Features screen.
+    ///
+    func enableBetaFeature(_ cell: XCUIElement) {
+        if cell.switches.firstMatch.value as? String == "0" {
+            cell.tap()
+        }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
@@ -11,6 +11,10 @@ public final class SettingsScreen: ScreenObject {
         $0.cells.staticTexts["body-label"]
     }
 
+    private let betaFeaturesGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["settings-beta-features-button"]
+    }
+
     private let logOutButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["settings-log-out-button"]
     }
@@ -18,8 +22,6 @@ public final class SettingsScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
-                selectedStoreNameGetter,
-                selectedSiteUrlGetter,
                 logOutButtonGetter
             ],
             app: app
@@ -48,6 +50,14 @@ public final class SettingsScreen: ScreenObject {
         }
 
         return try PrologueScreen()
+    }
+
+    /// Navigates to the Experimental Features screen.
+    /// - Returns: Experimental Features screen object.
+    @discardableResult
+    public func goToExperimentalFeatures() throws -> BetaFeaturesScreen {
+        betaFeaturesGetter(app).tap()
+        return try BetaFeaturesScreen()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1226,6 +1226,7 @@
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC5C278727EE19A700B25D2A /* NewOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */; };
+		CC5C278B27EE314F00B25D2A /* orders_create.json in Resources */ = {isa = PBXBuildFile; fileRef = CC5C278A27EE314E00B25D2A /* orders_create.json */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
 		CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */; };
 		CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC72BB6327BD842500837876 /* DisclosureIndicator.swift */; };
@@ -2909,6 +2910,7 @@
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderScreen.swift; sourceTree = "<group>"; };
+		CC5C278A27EE314E00B25D2A /* orders_create.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_create.json; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
 		CC72BB6327BD842500837876 /* DisclosureIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclosureIndicator.swift; sourceTree = "<group>"; };
@@ -6665,6 +6667,7 @@
 				800A5BA3275719E5009DE2CD /* orders_2201_refunds.json */,
 				800A5BA2275719E4009DE2CD /* orders_2201_shipment_trackings.json */,
 				800A5B9A2755E0B9009DE2CD /* orders_any.json */,
+				CC5C278A27EE314E00B25D2A /* orders_create.json */,
 				800A5B9F27562EE5009DE2CD /* orders_processing.json */,
 			);
 			path = orders;
@@ -8262,6 +8265,7 @@
 				800A5BB2275869DC009DE2CD /* products_reviews_6154.json in Resources */,
 				800A5BBE27586AEF009DE2CD /* products_reviews_6163.json in Resources */,
 				FE6BCDFC26A9D0E700D96FE2 /* rest_v2_sites_users_me.json in Resources */,
+				CC5C278B27EE314F00B25D2A /* orders_create.json in Resources */,
 				800A5BA027562EE5009DE2CD /* orders_processing.json in Resources */,
 				80AD2CA22782B4EB00A63DE8 /* products_list_1.json in Resources */,
 				80B8D34127859C6F00FE6E6B /* reports_leaderboards_stats_month.json in Resources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1225,6 +1225,7 @@
 		CC53FB402759042600C4CA4F /* AddProductToOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3F2759042600C4CA4F /* AddProductToOrderViewModelTests.swift */; };
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
+		CC5C278727EE19A700B25D2A /* NewOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
 		CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */; };
 		CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC72BB6327BD842500837876 /* DisclosureIndicator.swift */; };
@@ -2907,6 +2908,7 @@
 		CC53FB3F2759042600C4CA4F /* AddProductToOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductToOrderViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
+		CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderScreen.swift; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
 		CC72BB6327BD842500837876 /* DisclosureIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclosureIndicator.swift; sourceTree = "<group>"; };
@@ -7768,6 +7770,7 @@
 			isa = PBXGroup;
 			children = (
 				F997173423DBEB1900592D8E /* OrdersScreen.swift */,
+				CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */,
 				F997173623DBF02400592D8E /* SingleOrderScreen.swift */,
 				F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */,
 			);
@@ -8448,6 +8451,7 @@
 				3F0CF2FF2704490A00EF3D71 /* SettingsScreen.swift in Sources */,
 				3F0CF3052704490A00EF3D71 /* LoginEpilogueScreen.swift in Sources */,
 				C064EE2B2783480000D54B0D /* OrderDataStructs.swift in Sources */,
+				CC5C278727EE19A700B25D2A /* NewOrderScreen.swift in Sources */,
 				3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */,
 				3F0CF3042704490A00EF3D71 /* PeriodStatsTable.swift in Sources */,
 				3F0CF3142704494A00EF3D71 /* TabNavComponent.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_create.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_create.json
@@ -1,0 +1,89 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [ {
+                "matches": ".*path=\/wc\/v3\/orders%26_method%3Dpost.*"
+        } ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 3337,
+                "parent_id": 0,
+                "status": "pending",
+                "currency": "USD",
+                "version": "6.3.1",
+                "prices_include_tax": true,
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified": "{{now offset='-10 minutes' format=customformat}}",
+                "discount_total": "0.00",
+                "discount_tax": "0.00",
+                "shipping_total": "0.00",
+                "shipping_tax": "0.00",
+                "cart_tax": "0.00",
+                "total": "0.00",
+                "total_tax": "0.00",
+                "customer_id": 0,
+                "order_key": "abc123",
+                "billing": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "email": "",
+                    "phone": ""
+                },
+                "shipping": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "phone": ""
+                },
+                "payment_method": "",
+                "payment_method_title": "",
+                "transaction_id": "",
+                "customer_ip_address": "",
+                "customer_user_agent": "",
+                "created_via": "rest-api",
+                "customer_note": "",
+                "date_completed": null,
+                "date_paid": null,
+                "cart_hash": "",
+                "number": "3337",
+                "meta_data": [],
+                "line_items": [],
+                "tax_lines": [],
+                "shipping_lines": [],
+                "fee_lines": [],
+                "coupon_lines": [],
+                "refunds": [],
+                "date_created_gmt": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified_gmt": "{{now offset='-10 minutes' format=customformat}}",
+                "date_completed_gmt": null,
+                "date_paid_gmt": null,
+                "currency_symbol": "$",
+                "_links": {
+                    "self": [{
+                        "href": ""
+                    }],
+                    "collection": [{
+                        "href": ""
+                    }]
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -24,4 +24,17 @@ final class OrdersTests: XCTestCase {
             .goBackToOrdersScreen()
             .verifyOrdersScreenLoaded()
     }
+
+    func test_create_new_order() throws {
+        // Enables experimental Order Creation feature.
+        // This can be removed when Order Creation is released.
+        try TabNavComponent().goToMenuScreen()
+            .openSettingsPane()
+            .goToExperimentalFeatures()
+            .enableOrderCreation()
+
+        try TabNavComponent().goToOrdersScreen()
+            .startOrderCreation()
+            .createOrder()
+    }
 }


### PR DESCRIPTION
Part of: #6524

## Description

This adds a very basic UI test for Order Creation. It tests that the Order Creation experimental feature can be enabled (this can be removed from the test when the feature is released) and that a new, empty order can be created.

## Changes

* Adds accessibility identifiers for the app Settings button (in `HubMenu`), the full order and simple payment options in the Orders bottom sheet (`BottomSheetOrderType`), and the Create button in the `NewOrder` view.
* Updates our UI test screen objects:
   * `SettingsScreen` can now find the Experimental Features row and tap it to navigate to that screen.
   * `BetaFeaturesScreen` can now find the Order Creation row and toggle on that feature. There's also now a generic helper `enableBetaFeature(_:)` to make it easier to add support for other experimental features on that screen.
   * `OrdersScreen` can now find the add order (+) button and the "Create order" option in the bottom sheet, to start the order creation flow.
   * Adds a `NewOrderScreen` object representing the New Order screen, which for now just finds and taps on the Create button.
* Adds a JSON mock for the order creation POST request.
* Adds a basic UI test `test_create_new_order()` that enables the Order Creation experimental feature, navigates to the New Order screen, and creates an order.

## Testing

Confirm UI tests pass on CI. You can also run this test locally:

1. Run `rake mocks` in the console to start the mock server.
2. Go to the Test Navigator and select the UITests test plan.
3. Run `test_create_new_order()` and confirm it passes.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
