### PR TITLE
Show product review detail from products

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
@@ -39,7 +39,8 @@ final class ProductReviewsDataSource: NSObject, ReviewsDataSource {
         return reviewsResultsController.isEmpty
     }
 
-    /// Notifications
+    /// With this `ResultsController` we retrieve the WordPress.com notifications associated with the product reviews.
+    /// Later we can filter them and pass it to the review detail view so it can be marked as read.
     ///
     private lazy var notificationsResultsController: ResultsController<StorageNote> = {
         let storageManager = ServiceLocator.storageManager
@@ -60,7 +61,8 @@ final class ProductReviewsDataSource: NSObject, ReviewsDataSource {
                                                                    notDeletedPredicate])
     }()
 
-    /// Notifications associated with the reviews. In this case, we don't want to show notifications.
+    /// Notifications associated with the reviews.
+    /// To be filtered and marked as read in the review detail view if they are linked to the review.
     ///
     var notifications: [Note] {
         return notificationsResultsController.fetchedObjects

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
@@ -142,7 +142,12 @@ private extension ProductReviewsDataSource {
 //
 extension ProductReviewsDataSource: ReviewsInteractionDelegate {
     func didSelectItem(at indexPath: IndexPath, in viewController: UIViewController) {
-        // no-op: we don't want to catch the selected item in Products
+        let review = reviewsResultsController.object(at: indexPath)
+
+        let detailsViewController = ReviewDetailsViewController(productReview: review,
+                                                                product: product,
+                                                                notification: nil)
+        viewController.navigationController?.pushViewController(detailsViewController, animated: true)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -108,7 +108,6 @@ private extension ProductReviewsViewController {
         tableView.delegate = self
         tableView.tableFooterView = footerSpinnerView
         tableView.sectionFooterHeight = .leastNonzeroMagnitude
-        tableView.allowsSelection = false
     }
 
     /// Setup: ResultsController


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6425 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As already implemented on [Android](https://github.com/woocommerce/woocommerce-android/issues/5210), we wanted to be able to open a review detail view from the reviews list of a specific product. 
Furthermore, we pass hereby the notification information linked to that review, so the reviews detail screen can process the notification as expected (e.g marking it as read)

### Changes
- Allow selection on `ProductReviewsViewController` by removing statement
- Add logic for selection on `ProductReviewsDataSource`
- Add logic for notifications on `ProductReviewsDataSource`

### Notes
- The code on ProductReviewsDataSource is fairly duplicated compared with DefaultReviewsDataSource. I created a technical debt issue to address this problem: https://github.com/woocommerce/woocommerce-ios/issues/6523
- We only show approved reviews on the Product tab. That means that, if we open a review detail, set it on hold by pressing on Accept and go back, the review is removed from the list.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to Product List
2. Open detail of a product with reviews
3. Open the list of product reviews for that product
4. Tap on one of the reviews
5. Review Details Screen View is opened


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1864060/160375131-1c93b15e-43b8-4867-8afe-784404777601.mov



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
