### PR TITLE
Display the edit action in Coupon Detail view if the feature flag `couponEditing` is enabled

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -27,6 +27,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInOrdersTab:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .couponEditing:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -53,4 +53,8 @@ public enum FeatureFlag: Int {
     /// Displays the Orders tab in a split view
     ///
     case splitViewInOrdersTab
+
+    /// Displays the option to edit a coupon
+    ///
+    case couponEditing
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -245,6 +245,7 @@ struct CouponDetails: View {
             actions.append(contentsOf: [
                 .default(Text(Localization.editCoupon), action: {
                     // TODO: add analytics
+                    // TODO: open the editing screen
                 })
             ])
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -63,19 +63,7 @@ struct CouponDetails: View {
                         .actionSheet(isPresented: $showingActionSheet) {
                             ActionSheet(
                                 title: Text(Localization.manageCoupon),
-                                buttons: [
-                                    .default(Text(Localization.copyCode), action: {
-                                        UIPasteboard.general.string = viewModel.couponCode
-                                        let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
-                                        noticePresenter.enqueue(notice: notice)
-                                        ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "copied_code"])
-                                    }),
-                                    .default(Text(Localization.shareCoupon), action: {
-                                        showingShareSheet = true
-                                        ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
-                                    }),
-                                    .cancel()
-                                ]
+                                buttons: generateActionSheetActions()
                             )
                         }
                         .shareSheet(isPresented: $showingShareSheet) {
@@ -237,6 +225,34 @@ struct CouponDetails: View {
             showingAmountLoadingErrorPrompt = true
         }
     }
+
+    private func generateActionSheetActions() -> [Alert.Button] {
+        var actions: [Alert.Button] =
+        [
+            .default(Text(Localization.copyCode), action: {
+                UIPasteboard.general.string = viewModel.couponCode
+                let notice = Notice(title: Localization.couponCopied, feedbackType: .success)
+                noticePresenter.enqueue(notice: notice)
+                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "copied_code"])
+            }),
+            .default(Text(Localization.shareCoupon), action: {
+                showingShareSheet = true
+                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "shared_code"])
+            })
+        ]
+
+        if viewModel.isEditingEnabled {
+            actions.append(contentsOf: [
+                .default(Text(Localization.editCoupon), action: {
+                    // TODO: add analytics
+                })
+            ])
+        }
+
+        actions.append(.cancel())
+
+        return actions
+    }
 }
 
 // MARK: - Subtypes
@@ -261,6 +277,7 @@ private extension CouponDetails {
         static let couponCopied = NSLocalizedString("Coupon copied", comment: "Notice message displayed when a coupon code is " +
                                                     "copied from the Coupon Details screen")
         static let shareCoupon = NSLocalizedString("Share Coupon", comment: "Action title for sharing coupon from the Coupon Details screen")
+        static let editCoupon = NSLocalizedString("Edit Coupon", comment: "Action title for editing a coupon from the Coupon Details screen")
         static let performance = NSLocalizedString("Performance", comment: "Title of the Performance section on Coupons Details screen")
         static let discountedOrders = NSLocalizedString("Discounted Orders", comment: "Title of the Discounted Orders label on Coupon Details screen")
         static let amount = NSLocalizedString("Amount", comment: "Title of the Amount label on Coupon Details screen")

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import Experiments
 
 /// View model for `CouponDetails` view
 ///
@@ -68,14 +69,17 @@ final class CouponDetailsViewModel: ObservableObject {
 
     private let stores: StoresManager
     private let currencySettings: CurrencySettings
+    let isEditingEnabled: Bool
 
     init(coupon: Coupon,
          stores: StoresManager = ServiceLocator.stores,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         featureFlags: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = coupon.siteID
         self.coupon = coupon
         self.stores = stores
         self.currencySettings = currencySettings
+        isEditingEnabled = featureFlags.isFeatureFlagEnabled(.couponEditing)
         populateDetails()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -79,7 +79,7 @@ final class CouponDetailsViewModel: ObservableObject {
         self.coupon = coupon
         self.stores = stores
         self.currencySettings = currencySettings
-        isEditingEnabled = featureFlags.isFeatureFlagEnabled(.couponEditing)
+        isEditingEnabled = featureFlags.isFeatureFlagEnabled(.couponEditing) && coupon.discountType != .other
         populateDetails()
     }
 


### PR DESCRIPTION
Part of #6488 

### Description
As part of the feature for editing an existing coupon, I introduced a new feature flag that for the moment will be enabled only in develop, and that will display an edit action if the user press the ellipsis button in a coupon detail screen.

As part of @toupper's onboarding, I added him between the reviewers 👍 

### Testing instructions

#### Case 1
1. Launch the app with the new feature flag `couponEditing` **enabled**.
2. Navigate to a coupon detail.
3. Press the ellipsis button in the navigation bar.
4. You should be able to see the new action "Edit Coupon".

#### Case 2
1. Launch the app with the new feature flag `couponEditing` **disabled**.
2. Navigate to a coupon detail.
3. Press the ellipsis button in the navigation bar.
4. You shouldn't be able to see the new action "Edit Coupon".


### Screenshots
| Feature flag enabled            |  Feature flag disabled |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-28 at 14 44 22](https://user-images.githubusercontent.com/495617/160401654-67625f4e-0185-4ff6-b37e-d57b865f7920.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-28 at 14 44 56](https://user-images.githubusercontent.com/495617/160401672-9840002f-d7cb-49b2-9eea-e3092f6bfc5e.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
