### PR TITLE
Make GhostTableViewController configurable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -25,7 +25,10 @@ final class TopPerformerDataViewController: UIViewController {
 
     /// A child view controller that is shown when `displayGhostContent()` is called.
     ///
-    private lazy var ghostTableViewController = GhostTableViewController(cellClass: ProductTableViewCell.self)
+    private lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
+                                                                                                        cellClass: ProductTableViewCell.self,
+                                                                                                        rowsPerSection: Constants.placeholderRowsPerSection,
+                                                                                                        estimatedRowHeight: Constants.estimatedRowHeight))
 
     /// ResultsController: Loads TopEarnerStats for the current granularity from the Storage Layer
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -26,9 +26,9 @@ final class TopPerformerDataViewController: UIViewController, GhostableViewContr
     /// A child view controller that is shown when `displayGhostContent()` is called.
     ///
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
-                                                                                                        cellClass: ProductTableViewCell.self,
-                                                                                                        rowsPerSection: Constants.placeholderRowsPerSection,
-                                                                                                        estimatedRowHeight: Constants.estimatedRowHeight))
+                                                                                                cellClass: ProductTableViewCell.self,
+                                                                                                rowsPerSection: Constants.placeholderRowsPerSection,
+                                                                                                estimatedRowHeight: Constants.estimatedRowHeight))
 
     /// ResultsController: Loads TopEarnerStats for the current granularity from the Storage Layer
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -7,7 +7,7 @@ import WordPressUI
 import class AutomatticTracks.CrashLogging
 
 
-final class TopPerformerDataViewController: UIViewController {
+final class TopPerformerDataViewController: UIViewController, GhostableViewController {
 
     // MARK: - Properties
 
@@ -25,7 +25,7 @@ final class TopPerformerDataViewController: UIViewController {
 
     /// A child view controller that is shown when `displayGhostContent()` is called.
     ///
-    private lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
                                                                                                         cellClass: ProductTableViewCell.self,
                                                                                                         rowsPerSection: Constants.placeholderRowsPerSection,
                                                                                                         estimatedRowHeight: Constants.estimatedRowHeight))
@@ -108,44 +108,6 @@ final class TopPerformerDataViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         trackChangedTabIfNeeded()
-    }
-}
-
-
-// MARK: - Public Interface
-//
-extension TopPerformerDataViewController {
-
-    /// Renders Placeholder Content.
-    ///
-    /// Why is this public? Because the `syncTopPerformers` method is actually called from TopPerformersViewController.
-    /// We coordinate multiple placeholder animations from that spot!
-    ///
-    func displayGhostContent() {
-        guard let ghostView = ghostTableViewController.view else {
-            return
-        }
-
-        ghostView.translatesAutoresizingMaskIntoConstraints = false
-        addChild(ghostTableViewController)
-        view.addSubview(ghostView)
-        view.pinSubviewToAllEdges(ghostView)
-        ghostTableViewController.didMove(toParent: self)
-    }
-
-    /// Removes the Placeholder Content.
-    ///
-    /// Why is this public? Because the `syncTopPerformers` method is actually called from TopPerformersViewController.
-    /// We coordinate multiple placeholder animations from that spot!
-    ///
-    func removeGhostContent() {
-        guard let ghostView = ghostTableViewController.view else {
-            return
-        }
-
-        ghostTableViewController.willMove(toParent: nil)
-        ghostView.removeFromSuperview()
-        ghostTableViewController.removeFromParent()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -27,7 +27,6 @@ final class TopPerformerDataViewController: UIViewController, GhostableViewContr
     ///
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
                                                                                                 cellClass: ProductTableViewCell.self,
-                                                                                                rowsPerSection: Constants.placeholderRowsPerSection,
                                                                                                 estimatedRowHeight: Constants.estimatedRowHeight))
 
     /// ResultsController: Loads TopEarnerStats for the current granularity from the Storage Layer

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
@@ -1,15 +1,30 @@
 import UIKit
 import WordPressUI
 
+/// This struct encapsulates the necessary data to configure an instance of `GhostTableViewController`
+struct GhostTableViewOptions {
+    let ghostOptions: GhostOptions
+    let estimatedRowHeight: CGFloat
+    let cellClass: UITableViewCell.Type
+
+    init(displaysSectionHeader: Bool = true,
+         cellClass: UITableViewCell.Type,
+         rowsPerSection: [Int],
+         estimatedRowHeight: CGFloat) {
+        // By just passing the cellClass in the initializer we enforce that the GhostOptions reuseIdentifier is always that of the cellClass
+        ghostOptions = GhostOptions(displaysSectionHeader: displaysSectionHeader, reuseIdentifier: cellClass.reuseIdentifier, rowsPerSection: rowsPerSection)
+        self.estimatedRowHeight = estimatedRowHeight
+        self.cellClass = cellClass
+    }
+}
+
 /// A view controller to display ghost animation over a table view
 ///
 final class GhostTableViewController: UITableViewController {
+    private let options: GhostTableViewOptions
 
-    /// Cell class for the table view cells
-    private let cellClass: UITableViewCell.Type
-
-    init(cellClass: UITableViewCell.Type = WooBasicTableViewCell.self) {
-        self.cellClass = cellClass
+    init(options: GhostTableViewOptions) {
+        self.options = options
         super.init(style: .plain)
     }
 
@@ -28,9 +43,9 @@ final class GhostTableViewController: UITableViewController {
 
         tableView.backgroundColor = UIColor.basicBackground
         tableView.separatorStyle = .none
-        tableView.estimatedRowHeight = Constants.estimatedRowHeight
+        tableView.estimatedRowHeight = options.estimatedRowHeight
         tableView.applyFooterViewForHidingExtraRowPlaceholders()
-        tableView.registerNib(for: cellClass)
+        tableView.registerNib(for: options.cellClass)
     }
 
     /// Activate the ghost if this view is added to the parent.
@@ -38,10 +53,7 @@ final class GhostTableViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        let options = GhostOptions(displaysSectionHeader: false,
-                                   reuseIdentifier: cellClass.reuseIdentifier,
-                                   rowsPerSection: Constants.placeholderRowsPerSection)
-        tableView.displayGhostContent(options: options,
+        tableView.displayGhostContent(options: options.ghostOptions,
                                       style: .wooDefaultGhostStyle)
     }
 
@@ -52,8 +64,4 @@ final class GhostTableViewController: UITableViewController {
         tableView.removeGhostContent()
     }
 
-    private enum Constants {
-        static let estimatedRowHeight = CGFloat(80)
-        static let placeholderRowsPerSection = [3]
-    }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
@@ -63,5 +63,4 @@ final class GhostTableViewController: UITableViewController {
         super.viewWillDisappear(animated)
         tableView.removeGhostContent()
     }
-
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
@@ -6,15 +6,18 @@ struct GhostTableViewOptions {
     fileprivate let ghostOptions: GhostOptions
     fileprivate let estimatedRowHeight: CGFloat
     fileprivate let cellClass: UITableViewCell.Type
+    fileprivate let tableViewStyle: UITableView.Style
 
     init(displaysSectionHeader: Bool = true,
          cellClass: UITableViewCell.Type,
-         rowsPerSection: [Int],
-         estimatedRowHeight: CGFloat) {
+         rowsPerSection: [Int] = [3],
+         estimatedRowHeight: CGFloat = 44,
+         tableViewStyle: UITableView.Style = .plain) {
         // By just passing the cellClass in the initializer we enforce that the GhostOptions reuseIdentifier is always that of the cellClass
         ghostOptions = GhostOptions(displaysSectionHeader: displaysSectionHeader, reuseIdentifier: cellClass.reuseIdentifier, rowsPerSection: rowsPerSection)
         self.estimatedRowHeight = estimatedRowHeight
         self.cellClass = cellClass
+        self.tableViewStyle = tableViewStyle
     }
 }
 
@@ -25,7 +28,7 @@ final class GhostTableViewController: UITableViewController {
 
     init(options: GhostTableViewOptions) {
         self.options = options
-        super.init(style: .plain)
+        super.init(style: options.tableViewStyle)
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
@@ -9,6 +9,7 @@ struct GhostTableViewOptions {
     fileprivate let tableViewStyle: UITableView.Style
     fileprivate let backgroundColor: UIColor
     fileprivate let separatorStyle: UITableViewCell.SeparatorStyle
+    fileprivate let isScrollEnabled: Bool
 
     init(displaysSectionHeader: Bool = true,
          cellClass: UITableViewCell.Type,
@@ -16,7 +17,8 @@ struct GhostTableViewOptions {
          estimatedRowHeight: CGFloat = 44,
          tableViewStyle: UITableView.Style = .plain,
          backgroundColor: UIColor = .basicBackground,
-         separatorStyle: UITableViewCell.SeparatorStyle = .none) {
+         separatorStyle: UITableViewCell.SeparatorStyle = .none,
+         isScrollEnabled: Bool = true) {
         // By just passing the cellClass in the initializer we enforce that the GhostOptions reuseIdentifier is always that of the cellClass
         ghostOptions = GhostOptions(displaysSectionHeader: displaysSectionHeader, reuseIdentifier: cellClass.reuseIdentifier, rowsPerSection: rowsPerSection)
         self.estimatedRowHeight = estimatedRowHeight
@@ -24,6 +26,7 @@ struct GhostTableViewOptions {
         self.tableViewStyle = tableViewStyle
         self.backgroundColor = backgroundColor
         self.separatorStyle = separatorStyle
+        self.isScrollEnabled = isScrollEnabled
     }
 }
 
@@ -53,6 +56,7 @@ final class GhostTableViewController: UITableViewController {
         tableView.backgroundColor = options.backgroundColor
         tableView.separatorStyle = options.separatorStyle
         tableView.estimatedRowHeight = options.estimatedRowHeight
+        tableView.isScrollEnabled = options.isScrollEnabled
         tableView.applyFooterViewForHidingExtraRowPlaceholders()
         tableView.registerNib(for: options.cellClass)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
@@ -7,17 +7,23 @@ struct GhostTableViewOptions {
     fileprivate let estimatedRowHeight: CGFloat
     fileprivate let cellClass: UITableViewCell.Type
     fileprivate let tableViewStyle: UITableView.Style
+    fileprivate let backgroundColor: UIColor
+    fileprivate let separatorStyle: UITableViewCell.SeparatorStyle
 
     init(displaysSectionHeader: Bool = true,
          cellClass: UITableViewCell.Type,
          rowsPerSection: [Int] = [3],
          estimatedRowHeight: CGFloat = 44,
-         tableViewStyle: UITableView.Style = .plain) {
+         tableViewStyle: UITableView.Style = .plain,
+         backgroundColor: UIColor = .basicBackground,
+         separatorStyle: UITableViewCell.SeparatorStyle = .none) {
         // By just passing the cellClass in the initializer we enforce that the GhostOptions reuseIdentifier is always that of the cellClass
         ghostOptions = GhostOptions(displaysSectionHeader: displaysSectionHeader, reuseIdentifier: cellClass.reuseIdentifier, rowsPerSection: rowsPerSection)
         self.estimatedRowHeight = estimatedRowHeight
         self.cellClass = cellClass
         self.tableViewStyle = tableViewStyle
+        self.backgroundColor = backgroundColor
+        self.separatorStyle = separatorStyle
     }
 }
 
@@ -44,8 +50,8 @@ final class GhostTableViewController: UITableViewController {
         tableView.dataSource = nil
         tableView.delegate = nil
 
-        tableView.backgroundColor = UIColor.basicBackground
-        tableView.separatorStyle = .none
+        tableView.backgroundColor = options.backgroundColor
+        tableView.separatorStyle = options.separatorStyle
         tableView.estimatedRowHeight = options.estimatedRowHeight
         tableView.applyFooterViewForHidingExtraRowPlaceholders()
         tableView.registerNib(for: options.cellClass)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
@@ -3,9 +3,9 @@ import WordPressUI
 
 /// This struct encapsulates the necessary data to configure an instance of `GhostTableViewController`
 struct GhostTableViewOptions {
-    let ghostOptions: GhostOptions
-    let estimatedRowHeight: CGFloat
-    let cellClass: UITableViewCell.Type
+    fileprivate let ghostOptions: GhostOptions
+    fileprivate let estimatedRowHeight: CGFloat
+    fileprivate let cellClass: UITableViewCell.Type
 
     init(displaysSectionHeader: Bool = true,
          cellClass: UITableViewCell.Type,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostableViewController.swift
@@ -1,10 +1,3 @@
-//
-//  GhostableViewController.swift
-//  WooCommerce
-//
-//  Created by César Vargas Casaseca on 28/3/22.
-//  Copyright © 2022 Automattic. All rights reserved.
-//
 
 import Foundation
 import UIKit

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostableViewController.swift
@@ -1,0 +1,42 @@
+//
+//  GhostableViewController.swift
+//  WooCommerce
+//
+//  Created by César Vargas Casaseca on 28/3/22.
+//  Copyright © 2022 Automattic. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// Make your `UIViewController` instance implement this protocol if you want to display/hide a ghost animation on top of it
+protocol GhostableViewController: UIViewController {
+    /// The `GhostTableViewController` to be displayed on top of the view. Configure as wished.
+    var ghostTableViewController: GhostTableViewController { get }
+}
+
+extension GhostableViewController {
+    /// Displays the animated ghost view by adding the `GhostTableViewController` as child
+    func displayGhostContent() {
+        guard let ghostView = ghostTableViewController.view else {
+            return
+        }
+
+        ghostView.translatesAutoresizingMaskIntoConstraints = false
+        addChild(ghostTableViewController)
+        view.addSubview(ghostView)
+        view.pinSubviewToAllEdges(ghostView)
+        ghostTableViewController.didMove(toParent: self)
+    }
+
+    /// Removes the animated ghost
+    func removeGhostContent() {
+        guard let ghostView = ghostTableViewController.view else {
+            return
+        }
+
+        ghostTableViewController.willMove(toParent: nil)
+        ghostView.removeFromSuperview()
+        ghostTableViewController.removeFromParent()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1192,6 +1192,7 @@
 		B6E851F5276330200041D1BA /* RefundFeesDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */; };
 		B6E851F7276331110041D1BA /* RefundFeesDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
+		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		BAA34C202787494300846F3C /* ReviewsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */; };
 		BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE4F8422734325C00871344 /* SettingsViewModel.swift */; };
 		BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */; };
@@ -2873,6 +2874,7 @@
 		B6E851F2276320C70041D1BA /* RefundFeesDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsViewModel.swift; sourceTree = "<group>"; };
 		B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundFeesDetailsTableViewCell.xib; sourceTree = "<group>"; };
+		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewsViewControllerTests.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAE4F8422734325C00871344 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
@@ -7219,6 +7221,7 @@
 				DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */,
 				DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */,
 				DE6906E227D7121800735E3B /* GhostTableViewController.swift */,
+				B910685F27F1F28F00AD0575 /* GhostableViewController.swift */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -9239,6 +9242,7 @@
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,
 				4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */,
 				77E53EBF2510C153003D385F /* ProductDownloadListViewModel.swift in Sources */,
+				B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */,
 				DE19BB1A26C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift in Sources */,
 				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #2448 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As part of #2448 we want to make the `GhostTableViewController` configurable so it can be used in different places, and not only on `TopPerformerDataViewController`. For that we create a new struct `GhostTableViewOptions`, that encapsulates the `GhostOptions` used in the tableView extension plus other relevant parameters (`cellClass`, `estimatedRowHeight`)
Furthermore, we create a new protocol, `GhostableViewController`, and move the display/hide logic to an extension so it can be used everywhere. That way we avoid the duplication of that code.

### Decisions
- Because of the`GhostableViewController` protocol the `ghostTableViewController` property should be made public. I think it is a good trade-off for having the ghost view display/hide logic in one place.
-  `GhostableViewController` might be very similar to `GhostTableViewController`. I consider `GhostingViewController`, but that sounds like having a different meaning. Let me know your opinions :)
- I considered adding a `GhostOptions` parameter to the `GhostTableViewOptions` initializer. However, I decided not to because I wanted to enforce that the reuse identifier we pass to the `GhostOptions` is that of the `cellClass`. Otherwise, we could have a different cell reuse identifier, something that does not happen in any case where will use the  `GhostTableViewController`. Also thanks to that we simplify the implementation and hide the `GhostOptions` type from outside the `GhostTableViewController`

### Changes
- Create a new struct `GhostTableViewOptions`
- Add it as a property to the `GhostTableViewController` and adapt the initializer
- Remove the constants to the `GhostTableViewController` as now it is configurable
- Adapt code to the new `GhostTableViewController` in `TopPerformerDataViewController`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open App
2. While the Top Performers view in My Store tab is loading, you can observe the Ghost view as before

### Screenshots
(Scrolled to show that we use 3 rows as before)
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 13 - 2022-03-28 at 15 18 44](https://user-images.githubusercontent.com/1864060/160406530-373fa4d5-5c2a-4c18-81ea-c96263c37e59.gif)


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
