### PR TITLE
Initial implementation of Coupon add/editing view

### DIFF
--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -17,11 +17,65 @@ extension Coupon.DiscountType {
         }
     }
 
+    /// Localized title to be displayed for the discount type in `AddEditCoupon` when in creation mode.
+    ///
+    var titleCreateCoupon: String {
+        switch self {
+        case .percent:
+            return Localization.titleCreatePercentageDiscount
+        case .fixedCart:
+            return Localization.titleCreateFixedCardDiscount
+        case .fixedProduct:
+            return Localization.titleCreateFixedProductDiscount
+        default:
+            return Localization.titleCreateGenericDiscount
+        }
+    }
+
+    /// Localized title to be displayed for the discount type in `AddEditCoupon` when in editing mode.
+    ///
+    var titleEditCoupon: String {
+        switch self {
+        case .percent:
+            return Localization.titleEditPercentageDiscount
+        case .fixedCart:
+            return Localization.titleEditFixedCardDiscount
+        case .fixedProduct:
+            return Localization.titleEditFixedProductDiscount
+        default:
+            return Localization.titleEditGenericDiscount
+        }
+    }
+
     private enum Localization {
         static let percentageDiscount = NSLocalizedString("Percentage Discount", comment: "Name of percentage discount type")
         static let fixedCartDiscount = NSLocalizedString("Fixed Cart Discount", comment: "Name of fixed cart discount type")
         static let fixedProductDiscount = NSLocalizedString("Fixed Product Discount", comment: "Name of fixed product discount type")
         static let otherDiscount = NSLocalizedString("Other", comment: "Generic name of non-default discount types")
+        static let titleEditPercentageDiscount = NSLocalizedString(
+            "Edit percentage discount",
+            comment: "Title of the view for editing a coupon with percentage discount.")
+        static let titleEditFixedCardDiscount = NSLocalizedString(
+            "Edit fixed card discount",
+            comment: "Title of the view for editing a coupon with fixed card discount.")
+        static let titleEditFixedProductDiscount = NSLocalizedString(
+            "Edit fixed product discount",
+            comment: "Title of the view for editing a coupon with fixed product discount.")
+        static let titleEditGenericDiscount = NSLocalizedString(
+            "Edit discount",
+            comment: "Title of the view for editing a coupon with generic discount.")
+        static let titleCreatePercentageDiscount = NSLocalizedString(
+            "Create percentage discount",
+            comment: "Title of the view for creating a coupon with percentage discount.")
+        static let titleCreateFixedCardDiscount = NSLocalizedString(
+            "Create fixed card discount",
+            comment: "Title of the view for creating a coupon with fixed card discount.")
+        static let titleCreateFixedProductDiscount = NSLocalizedString(
+            "Create fixed product discount",
+            comment: "Title of the view for creating a coupon with fixed product discount.")
+        static let titleCreateGenericDiscount = NSLocalizedString(
+            "Create discount",
+            comment: "Title of the view for creating a coupon with generic discount.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -5,7 +5,7 @@ import Yosemite
 ///
 struct AddEditCoupon: View {
 
-    @ObservedObject private(set) var viewModel: AddEditCouponViewModel
+    @ObservedObject private var viewModel: AddEditCouponViewModel
     @Environment(\.presentationMode) var presentation
 
     init(_ viewModel: AddEditCouponViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -1,8 +1,9 @@
 import SwiftUI
+import Yosemite
 
 struct AddEditCoupon: View {
 
-    let viewModel: AddEditCouponViewModel
+    @ObservedObject private(set) var viewModel: AddEditCouponViewModel
 
     init(_ viewModel: AddEditCouponViewModel) {
         self.viewModel = viewModel
@@ -10,12 +11,19 @@ struct AddEditCoupon: View {
     }
 
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        }
+
     }
 }
 
 struct AddEditCoupon_Previews: PreviewProvider {
     static var previews: some View {
-        AddEditCoupon(AddEditCouponViewModel())
+
+        /// Edit Coupon
+        ///
+        let editingViewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon)
+        AddEditCoupon(editingViewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct AddEditCoupon: View {
+
+    let viewModel: AddEditCouponViewModel
+
+    init(_ viewModel: AddEditCouponViewModel) {
+        self.viewModel = viewModel
+
+        //TODO: add analytics
+    }
+
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct AddEditCoupon_Previews: PreviewProvider {
+    static var previews: some View {
+        AddEditCoupon(AddEditCouponViewModel())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -26,7 +26,7 @@ struct AddEditCoupon: View {
                                     }
                                 }
         }
-        .navigationTitle(viewModel.titleView)
+        .navigationTitle(viewModel.title)
         .wooNavigationBarStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -6,7 +6,6 @@ struct AddEditCoupon: View {
 
     init(_ viewModel: AddEditCouponViewModel) {
         self.viewModel = viewModel
-
         //TODO: add analytics
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -12,9 +12,9 @@ struct AddEditCoupon: View {
 
     var body: some View {
         NavigationView {
-            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            Text("Hello, World!")
         }
-
+        .navigationTitle(viewModel.titleView)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -4,6 +4,7 @@ import Yosemite
 struct AddEditCoupon: View {
 
     @ObservedObject private(set) var viewModel: AddEditCouponViewModel
+    @Environment(\.presentationMode) var presentation
 
     init(_ viewModel: AddEditCouponViewModel) {
         self.viewModel = viewModel
@@ -12,9 +13,29 @@ struct AddEditCoupon: View {
 
     var body: some View {
         NavigationView {
+
+            //TODO: implement the content of the view
             Text("Hello, World!")
+                .toolbar {
+                                    ToolbarItem(placement: .cancellationAction) {
+                                        Button("Cancel", action: {
+                                            presentation.wrappedValue.dismiss()
+                                        })
+                                    }
+                                }
         }
         .navigationTitle(viewModel.titleView)
+        .wooNavigationBarStyle()
+    }
+}
+
+// MARK: - Constants
+//
+private extension AddEditCoupon {
+    enum Localization {
+        static let titleEditPercentageDiscount = NSLocalizedString(
+            "Cancel",
+            comment: "Cancel button in the navigation bar of the view for adding or editing a coupon.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import Yosemite
 
+/// A view for Adding or Editing a Coupon.
+///
 struct AddEditCoupon: View {
 
     @ObservedObject private(set) var viewModel: AddEditCouponViewModel

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// View model for `AddEditCoupon` view
+///
+final class AddEditCouponViewModel: ObservableObject {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -6,8 +6,8 @@ import Yosemite
 final class AddEditCouponViewModel: ObservableObject {
 
     private let siteID: Int64
-    let editingOption: EditingOption
-    let discountType: Coupon.DiscountType
+    private let editingOption: EditingOption
+    private let discountType: Coupon.DiscountType
     var titleView: String {
         switch editingOption {
         case .creation:

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -1,7 +1,35 @@
 import Foundation
+import Yosemite
 
 /// View model for `AddEditCoupon` view
 ///
 final class AddEditCouponViewModel: ObservableObject {
 
+    let editingOption: EditingOption
+    let siteID: Int64
+    @Published private(set) var coupon: Coupon?
+
+    /// Init method for coupon creation
+    ///
+    init(siteID: Int64,
+         discountType: Coupon.DiscountType) {
+        self.siteID = siteID
+        editingOption = .creation
+    }
+
+    /// Init method for coupon editing
+    ///
+    init(existingCoupon: Coupon) {
+        siteID = existingCoupon.siteID
+        coupon = existingCoupon
+        editingOption = .editing
+    }
+
+
+    enum EditingOption {
+        case creation
+        case editing
+    }
 }
+
+

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -5,8 +5,36 @@ import Yosemite
 ///
 final class AddEditCouponViewModel: ObservableObject {
 
+    private let siteID: Int64
     let editingOption: EditingOption
-    let siteID: Int64
+    let discountType: Coupon.DiscountType
+    var titleView: String {
+        switch editingOption {
+        case .creation:
+            switch discountType {
+            case .percent:
+                return Localization.titleCreatePercentageDiscount
+            case .fixedCart:
+                return Localization.titleCreateFixedCardDiscount
+            case .fixedProduct:
+                return Localization.titleCreateFixedProductDiscount
+            default:
+                return String()
+            }
+        case .editing:
+            switch discountType {
+            case .percent:
+                return Localization.titleEditPercentageDiscount
+            case .fixedCart:
+                return Localization.titleEditFixedCardDiscount
+            case .fixedProduct:
+                return Localization.titleEditFixedProductDiscount
+            default:
+                return String()
+            }
+        }
+    }
+
     @Published private(set) var coupon: Coupon?
 
     /// Init method for coupon creation
@@ -15,6 +43,7 @@ final class AddEditCouponViewModel: ObservableObject {
          discountType: Coupon.DiscountType) {
         self.siteID = siteID
         editingOption = .creation
+        self.discountType = discountType
     }
 
     /// Init method for coupon editing
@@ -23,11 +52,36 @@ final class AddEditCouponViewModel: ObservableObject {
         siteID = existingCoupon.siteID
         coupon = existingCoupon
         editingOption = .editing
+        discountType = existingCoupon.discountType
     }
-
 
     enum EditingOption {
         case creation
         case editing
+    }
+}
+
+// MARK: - Constants
+//
+private extension AddEditCouponViewModel {
+    enum Localization {
+        static let titleEditPercentageDiscount = NSLocalizedString(
+            "Edit percentage discount",
+            comment: "Title of the view for editing a coupon with percentage discount.")
+        static let titleEditFixedCardDiscount = NSLocalizedString(
+            "Edit fixed card discount",
+            comment: "Title of the view for editing a coupon with fixed card discount.")
+        static let titleEditFixedProductDiscount = NSLocalizedString(
+            "Edit fixed product discount",
+            comment: "Title of the view for editing a coupon with fixed product discount.")
+        static let titleCreatePercentageDiscount = NSLocalizedString(
+            "Create percentage discount",
+            comment: "Title of the view for creating a coupon with percentage discount.")
+        static let titleCreateFixedCardDiscount = NSLocalizedString(
+            "Create fixed card discount",
+            comment: "Title of the view for creating a coupon with fixed card discount.")
+        static let titleCreateFixedProductDiscount = NSLocalizedString(
+            "Create fixed product discount",
+            comment: "Title of the view for creating a coupon with fixed product discount.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -19,7 +19,7 @@ final class AddEditCouponViewModel: ObservableObject {
             case .fixedProduct:
                 return Localization.titleCreateFixedProductDiscount
             default:
-                return String()
+                return Localization.titleCreateGenericDiscount
             }
         case .editing:
             switch discountType {
@@ -30,7 +30,7 @@ final class AddEditCouponViewModel: ObservableObject {
             case .fixedProduct:
                 return Localization.titleEditFixedProductDiscount
             default:
-                return String()
+                return Localization.titleEditGenericDiscount
             }
         }
     }
@@ -74,6 +74,9 @@ private extension AddEditCouponViewModel {
         static let titleEditFixedProductDiscount = NSLocalizedString(
             "Edit fixed product discount",
             comment: "Title of the view for editing a coupon with fixed product discount.")
+        static let titleEditGenericDiscount = NSLocalizedString(
+            "Edit discount",
+            comment: "Title of the view for editing a coupon with generic discount.")
         static let titleCreatePercentageDiscount = NSLocalizedString(
             "Create percentage discount",
             comment: "Title of the view for creating a coupon with percentage discount.")
@@ -83,5 +86,8 @@ private extension AddEditCouponViewModel {
         static let titleCreateFixedProductDiscount = NSLocalizedString(
             "Create fixed product discount",
             comment: "Title of the view for creating a coupon with fixed product discount.")
+        static let titleCreateGenericDiscount = NSLocalizedString(
+            "Create discount",
+            comment: "Title of the view for creating a coupon with generic discount.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -31,5 +31,3 @@ final class AddEditCouponViewModel: ObservableObject {
         case editing
     }
 }
-
-

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -6,8 +6,13 @@ import Yosemite
 final class AddEditCouponViewModel: ObservableObject {
 
     private let siteID: Int64
+
+    /// Based on the Editing Option, the `AddEditCoupon` view can be in Creation or Editing mode.
+    ///
     private let editingOption: EditingOption
+
     private let discountType: Coupon.DiscountType
+
     var titleView: String {
         switch editingOption {
         case .creation:

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -13,7 +13,7 @@ final class AddEditCouponViewModel: ObservableObject {
 
     private let discountType: Coupon.DiscountType
 
-    var titleView: String {
+    var title: String {
         switch editingOption {
         case .creation:
             switch discountType {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -16,27 +16,9 @@ final class AddEditCouponViewModel: ObservableObject {
     var title: String {
         switch editingOption {
         case .creation:
-            switch discountType {
-            case .percent:
-                return Localization.titleCreatePercentageDiscount
-            case .fixedCart:
-                return Localization.titleCreateFixedCardDiscount
-            case .fixedProduct:
-                return Localization.titleCreateFixedProductDiscount
-            default:
-                return Localization.titleCreateGenericDiscount
-            }
+            return discountType.titleCreateCoupon
         case .editing:
-            switch discountType {
-            case .percent:
-                return Localization.titleEditPercentageDiscount
-            case .fixedCart:
-                return Localization.titleEditFixedCardDiscount
-            case .fixedProduct:
-                return Localization.titleEditFixedProductDiscount
-            default:
-                return Localization.titleEditGenericDiscount
-            }
+            return discountType.titleEditCoupon
         }
     }
 
@@ -63,36 +45,5 @@ final class AddEditCouponViewModel: ObservableObject {
     enum EditingOption {
         case creation
         case editing
-    }
-}
-
-// MARK: - Constants
-//
-private extension AddEditCouponViewModel {
-    enum Localization {
-        static let titleEditPercentageDiscount = NSLocalizedString(
-            "Edit percentage discount",
-            comment: "Title of the view for editing a coupon with percentage discount.")
-        static let titleEditFixedCardDiscount = NSLocalizedString(
-            "Edit fixed card discount",
-            comment: "Title of the view for editing a coupon with fixed card discount.")
-        static let titleEditFixedProductDiscount = NSLocalizedString(
-            "Edit fixed product discount",
-            comment: "Title of the view for editing a coupon with fixed product discount.")
-        static let titleEditGenericDiscount = NSLocalizedString(
-            "Edit discount",
-            comment: "Title of the view for editing a coupon with generic discount.")
-        static let titleCreatePercentageDiscount = NSLocalizedString(
-            "Create percentage discount",
-            comment: "Title of the view for creating a coupon with percentage discount.")
-        static let titleCreateFixedCardDiscount = NSLocalizedString(
-            "Create fixed card discount",
-            comment: "Title of the view for creating a coupon with fixed card discount.")
-        static let titleCreateFixedProductDiscount = NSLocalizedString(
-            "Create fixed product discount",
-            comment: "Title of the view for creating a coupon with fixed product discount.")
-        static let titleCreateGenericDiscount = NSLocalizedString(
-            "Create discount",
-            comment: "Title of the view for creating a coupon with generic discount.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -42,7 +42,7 @@ final class AddEditCouponViewModel: ObservableObject {
         discountType = existingCoupon.discountType
     }
 
-    enum EditingOption {
+    private enum EditingOption {
         case creation
         case editing
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -25,6 +25,7 @@ struct CouponDetails: View {
     @State private var showingActionSheet: Bool = false
     @State private var showingShareSheet: Bool = false
     @State private var showingUsageDetails: Bool = false
+    @State private var showingEditCoupon: Bool = false
     @State private var showingAmountLoadingErrorPrompt: Bool = false
     @State private var showingEnableAnalytics: Bool = false
 
@@ -162,6 +163,9 @@ struct CouponDetails: View {
                     viewModel.loadCouponReport()
                 })
             }
+            .sheet(isPresented: $showingEditCoupon) {
+                AddEditCoupon(AddEditCouponViewModel(existingCoupon: viewModel.coupon))
+            }
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -245,7 +249,7 @@ struct CouponDetails: View {
             actions.append(contentsOf: [
                 .default(Text(Localization.editCoupon), action: {
                     // TODO: add analytics
-                    // TODO: open the editing screen
+                    showingEditCoupon = true
                 })
             ])
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -742,6 +742,8 @@
 		456CB50E2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */; };
 		457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */; };
 		457151AC243B6E8000EB2DFA /* ProductSlugViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */; };
+		4572641727F1EB0D004E1F95 /* AddEditCoupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4572641627F1EB0D004E1F95 /* AddEditCoupon.swift */; };
+		4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4572641827F1EB27004E1F95 /* AddEditCouponViewModel.swift */; };
 		4574745D24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4574745C24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift */; };
 		4574745F24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */; };
 		457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457509E2267B9E91005FA2EA /* AggregatedProductListViewController.swift */; };
@@ -2396,6 +2398,8 @@
 		456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductPurchaseNoteViewController.xib; sourceTree = "<group>"; };
 		457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSlugViewController.swift; sourceTree = "<group>"; };
 		457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSlugViewController.xib; sourceTree = "<group>"; };
+		4572641627F1EB0D004E1F95 /* AddEditCoupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditCoupon.swift; sourceTree = "<group>"; };
+		4572641827F1EB27004E1F95 /* AddEditCouponViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditCouponViewModel.swift; sourceTree = "<group>"; };
 		4574745C24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTypeBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		457509E2267B9E91005FA2EA /* AggregatedProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedProductListViewController.swift; sourceTree = "<group>"; };
@@ -4368,6 +4372,7 @@
 				DE74F2A127E41D4F0002FE59 /* EnableAnalytics */,
 				DE69C54B27BB7163000BB888 /* UsageDetails */,
 				DE7B479127A38ABC0018742E /* CouponDetails */,
+				4572641527F1EABE004E1F95 /* Add and Edit Coupons */,
 				03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */,
 				03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */,
 				03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */,
@@ -5072,6 +5077,15 @@
 				457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */,
 			);
 			path = Slug;
+			sourceTree = "<group>";
+		};
+		4572641527F1EABE004E1F95 /* Add and Edit Coupons */ = {
+			isa = PBXGroup;
+			children = (
+				4572641627F1EB0D004E1F95 /* AddEditCoupon.swift */,
+				4572641827F1EB27004E1F95 /* AddEditCouponViewModel.swift */,
+			);
+			path = "Add and Edit Coupons";
 			sourceTree = "<group>";
 		};
 		45739F2E2436302600480C95 /* Catalog Visibility */ = {
@@ -9208,6 +9222,7 @@
 				744F00D221B582A9007EFA93 /* StarRatingView.swift in Sources */,
 				45F627B9253603AE00894B86 /* ProductDownloadSettingsViewModel.swift in Sources */,
 				031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */,
+				4572641727F1EB0D004E1F95 /* AddEditCoupon.swift in Sources */,
 				318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */,
 				DE26B52C277DA11800A2EA0A /* CouponListView.swift in Sources */,
 				AEA622B2274669D3002A9B57 /* AddOrderCoordinator.swift in Sources */,
@@ -9292,6 +9307,7 @@
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
+				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,
 				31E6F21F26B3577800227E6F /* CardReaderConnectionController.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 		457151AC243B6E8000EB2DFA /* ProductSlugViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */; };
 		4572641727F1EB0D004E1F95 /* AddEditCoupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4572641627F1EB0D004E1F95 /* AddEditCoupon.swift */; };
 		4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4572641827F1EB27004E1F95 /* AddEditCouponViewModel.swift */; };
+		4572641B27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4572641A27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift */; };
 		4574745D24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4574745C24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift */; };
 		4574745F24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */; };
 		457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457509E2267B9E91005FA2EA /* AggregatedProductListViewController.swift */; };
@@ -2400,6 +2401,7 @@
 		457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSlugViewController.xib; sourceTree = "<group>"; };
 		4572641627F1EB0D004E1F95 /* AddEditCoupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditCoupon.swift; sourceTree = "<group>"; };
 		4572641827F1EB27004E1F95 /* AddEditCouponViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditCouponViewModel.swift; sourceTree = "<group>"; };
+		4572641A27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditCouponViewModelTests.swift; sourceTree = "<group>"; };
 		4574745C24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTypeBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		457509E2267B9E91005FA2EA /* AggregatedProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedProductListViewController.swift; sourceTree = "<group>"; };
@@ -4389,6 +4391,7 @@
 				DE7B479627A3C4980018742E /* CouponDetailsViewModelTests.swift */,
 				DE69C54E27BCB4B6000BB888 /* CouponUsageDetailsViewModelTests.swift */,
 				DE74F2A627E47F620002FE59 /* EnableAnalyticsViewModelTests.swift */,
+				4572641A27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift */,
 			);
 			path = Coupons;
 			sourceTree = "<group>";
@@ -9599,6 +9602,7 @@
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,
 				E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */,
 				D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */,
+				4572641B27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift in Sources */,
 				AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */,
 				02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */,
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -6,29 +6,29 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_titleView_property_return_expected_values_on_creation_depending_on_discountType() {
         let viewModel1 = AddEditCouponViewModel(siteID: 123, discountType: .percent)
-        XCTAssertEqual(viewModel1.titleView, "Create percentage discount")
+        XCTAssertEqual(viewModel1.title, "Create percentage discount")
 
         let viewModel2 = AddEditCouponViewModel(siteID: 123, discountType: .fixedCart)
-        XCTAssertEqual(viewModel2.titleView, "Create fixed card discount")
+        XCTAssertEqual(viewModel2.title, "Create fixed card discount")
 
         let viewModel3 = AddEditCouponViewModel(siteID: 123, discountType: .fixedProduct)
-        XCTAssertEqual(viewModel3.titleView, "Create fixed product discount")
+        XCTAssertEqual(viewModel3.title, "Create fixed product discount")
 
         let viewModel4 = AddEditCouponViewModel(siteID: 123, discountType: .other)
-        XCTAssertEqual(viewModel4.titleView, "Create discount")
+        XCTAssertEqual(viewModel4.title, "Create discount")
     }
 
     func test_titleView_property_return_expected_values_on_editing_depending_on_discountType() {
         let viewModel1 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent))
-        XCTAssertEqual(viewModel1.titleView, "Edit percentage discount")
+        XCTAssertEqual(viewModel1.title, "Edit percentage discount")
 
         let viewModel2 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedCart))
-        XCTAssertEqual(viewModel2.titleView, "Edit fixed card discount")
+        XCTAssertEqual(viewModel2.title, "Edit fixed card discount")
 
         let viewModel3 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedProduct))
-        XCTAssertEqual(viewModel3.titleView, "Edit fixed product discount")
+        XCTAssertEqual(viewModel3.title, "Edit fixed product discount")
 
         let viewModel4 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .other))
-        XCTAssertEqual(viewModel4.titleView, "Edit discount")
+        XCTAssertEqual(viewModel4.title, "Edit discount")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Yosemite
+@testable import WooCommerce
+
+final class AddEditCouponViewModelTests: XCTestCase {
+
+    func test_titleView_property_return_expected_values_on_creation_depending_on_discountType() {
+        let viewModel1 = AddEditCouponViewModel(siteID: 123, discountType: .percent)
+        XCTAssertEqual(viewModel1.titleView, "Create percentage discount")
+
+        let viewModel2 = AddEditCouponViewModel(siteID: 123, discountType: .fixedCart)
+        XCTAssertEqual(viewModel2.titleView, "Create fixed card discount")
+
+        let viewModel3 = AddEditCouponViewModel(siteID: 123, discountType: .fixedProduct)
+        XCTAssertEqual(viewModel3.titleView, "Create fixed product discount")
+
+        let viewModel4 = AddEditCouponViewModel(siteID: 123, discountType: .other)
+        XCTAssertEqual(viewModel4.titleView, "Create discount")
+    }
+
+    func test_titleView_property_return_expected_values_on_editing_depending_on_discountType() {
+        let viewModel1 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent))
+        XCTAssertEqual(viewModel1.titleView, "Edit percentage discount")
+
+        let viewModel2 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedCart))
+        XCTAssertEqual(viewModel2.titleView, "Edit fixed card discount")
+
+        let viewModel3 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedProduct))
+        XCTAssertEqual(viewModel3.titleView, "Edit fixed product discount")
+
+        let viewModel4 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .other))
+        XCTAssertEqual(viewModel4.titleView, "Edit discount")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -6,29 +6,56 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_titleView_property_return_expected_values_on_creation_depending_on_discountType() {
         let viewModel1 = AddEditCouponViewModel(siteID: 123, discountType: .percent)
-        XCTAssertEqual(viewModel1.title, "Create percentage discount")
+        XCTAssertEqual(viewModel1.title, Localization.titleCreatePercentageDiscount)
 
         let viewModel2 = AddEditCouponViewModel(siteID: 123, discountType: .fixedCart)
-        XCTAssertEqual(viewModel2.title, "Create fixed card discount")
+        XCTAssertEqual(viewModel2.title, Localization.titleCreateFixedCardDiscount)
 
         let viewModel3 = AddEditCouponViewModel(siteID: 123, discountType: .fixedProduct)
-        XCTAssertEqual(viewModel3.title, "Create fixed product discount")
+        XCTAssertEqual(viewModel3.title, Localization.titleCreateFixedProductDiscount)
 
         let viewModel4 = AddEditCouponViewModel(siteID: 123, discountType: .other)
-        XCTAssertEqual(viewModel4.title, "Create discount")
+        XCTAssertEqual(viewModel4.title, Localization.titleCreateGenericDiscount)
     }
 
     func test_titleView_property_return_expected_values_on_editing_depending_on_discountType() {
         let viewModel1 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent))
-        XCTAssertEqual(viewModel1.title, "Edit percentage discount")
+        XCTAssertEqual(viewModel1.title, Localization.titleEditPercentageDiscount)
 
         let viewModel2 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedCart))
-        XCTAssertEqual(viewModel2.title, "Edit fixed card discount")
+        XCTAssertEqual(viewModel2.title, Localization.titleEditFixedCardDiscount)
 
         let viewModel3 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedProduct))
-        XCTAssertEqual(viewModel3.title, "Edit fixed product discount")
+        XCTAssertEqual(viewModel3.title, Localization.titleEditFixedProductDiscount)
 
         let viewModel4 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .other))
-        XCTAssertEqual(viewModel4.title, "Edit discount")
+        XCTAssertEqual(viewModel4.title, Localization.titleEditGenericDiscount)
+    }
+
+    private enum Localization {
+        static let titleCreatePercentageDiscount = NSLocalizedString(
+            "Create percentage discount",
+            comment: "Title of the view for creating a coupon with percentage discount.")
+        static let titleCreateFixedCardDiscount = NSLocalizedString(
+            "Create fixed card discount",
+            comment: "Title of the view for creating a coupon with fixed card discount.")
+        static let titleCreateFixedProductDiscount = NSLocalizedString(
+            "Create fixed product discount",
+            comment: "Title of the view for creating a coupon with fixed product discount.")
+        static let titleCreateGenericDiscount = NSLocalizedString(
+            "Create discount",
+            comment: "Title of the view for creating a coupon with generic discount.")
+        static let titleEditPercentageDiscount = NSLocalizedString(
+            "Edit percentage discount",
+            comment: "Title of the view for editing a coupon with percentage discount.")
+        static let titleEditFixedCardDiscount = NSLocalizedString(
+            "Edit fixed card discount",
+            comment: "Title of the view for editing a coupon with fixed card discount.")
+        static let titleEditFixedProductDiscount = NSLocalizedString(
+            "Edit fixed product discount",
+            comment: "Title of the view for editing a coupon with fixed product discount.")
+        static let titleEditGenericDiscount = NSLocalizedString(
+            "Edit discount",
+            comment: "Title of the view for editing a coupon with generic discount.")
     }
 }


### PR DESCRIPTION
Part of #6488 and #6492

### Description
This is an initial implementation of the add/editing screen of Coupons, with its view model. A super basic screen that could be presented from the ellipsis menu from a coupon detail view. For the moment the only logic implemented is related to the title of the view (that will not be displayed because in the next PRs we will remove the `NavigationView`, which is probably not needed with the current design of the view).

### Testing instructions
1. Launch the app with the new feature flag `couponEditing` enabled.
2. Navigate to a coupon detail.
3. Press the ellipsis button in the navigation bar.
4. You should be able to see the new action "Edit Coupon".
5. Press the "Edit Coupon" action -> The new screen should be presented. 

### Screenshots
<img src="https://user-images.githubusercontent.com/495617/160437276-670b83cb-b837-473b-bea8-4cc4b7c72890.png" width=300 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
