### PR TITLE
Use GhostableViewController for all cases, part 1

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -12,6 +12,13 @@ final class CouponListViewController: UIViewController {
     ///
     private var emptyStateViewController: UIViewController?
 
+    /// A child view controller that is shown when `displayGhostContent()` is called.
+    ///
+    private lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
+                                                                                                        cellClass: TitleAndSubtitleAndStatusTableViewCell.self,
+                                                                                                        rowsPerSection: Constants.placeholderRowsPerSection,
+                                                                                                        estimatedRowHeight: Constants.estimatedRowHeight))
+
     /// Pull To Refresh Support.
     ///
     private lazy var refreshControl: UIRefreshControl = {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -15,7 +15,8 @@ final class CouponListViewController: UIViewController, GhostableViewController 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
                                                                                                 cellClass: TitleAndSubtitleAndStatusTableViewCell.self,
                                                                                                 rowsPerSection: Constants.placeholderRowsPerSection,
-                                                                                                estimatedRowHeight: Constants.estimatedRowHeight))
+                                                                                                estimatedRowHeight: Constants.estimatedRowHeight,
+                                                                                                separatorStyle: .singleLine))
 
     /// Pull To Refresh Support.
     ///

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import WordPressUI
 import class SwiftUI.UIHostingController
 
-final class CouponListViewController: UIViewController {
+final class CouponListViewController: UIViewController, GhostableViewController {
     @IBOutlet private weak var tableView: UITableView!
     private let viewModel: CouponListViewModel
     private let siteID: Int64
@@ -12,9 +12,7 @@ final class CouponListViewController: UIViewController {
     ///
     private var emptyStateViewController: UIViewController?
 
-    /// A child view controller that is shown when `displayGhostContent()` is called.
-    ///
-    private lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
                                                                                                         cellClass: TitleAndSubtitleAndStatusTableViewCell.self,
                                                                                                         rowsPerSection: Constants.placeholderRowsPerSection,
                                                                                                         estimatedRowHeight: Constants.estimatedRowHeight))
@@ -262,17 +260,13 @@ extension CouponListViewController {
     /// Renders the Placeholder Coupons
     ///
     func displayPlaceholderCoupons() {
-        let options = GhostOptions(displaysSectionHeader: false,
-                                   reuseIdentifier: TitleAndSubtitleAndStatusTableViewCell.reuseIdentifier,
-                                   rowsPerSection: Constants.placeholderRowsPerSection)
-        tableView.displayGhostContent(options: options,
-                                       style: .wooDefaultGhostStyle)
+        displayGhostContent()
     }
 
     /// Removes the Placeholder Coupons
     ///
     func removePlaceholderCoupons() {
-        tableView.removeGhostContent()
+        removeGhostContent()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -13,9 +13,9 @@ final class CouponListViewController: UIViewController, GhostableViewController 
     private var emptyStateViewController: UIViewController?
 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
-                                                                                                        cellClass: TitleAndSubtitleAndStatusTableViewCell.self,
-                                                                                                        rowsPerSection: Constants.placeholderRowsPerSection,
-                                                                                                        estimatedRowHeight: Constants.estimatedRowHeight))
+                                                                                                cellClass: TitleAndSubtitleAndStatusTableViewCell.self,
+                                                                                                rowsPerSection: Constants.placeholderRowsPerSection,
+                                                                                                estimatedRowHeight: Constants.estimatedRowHeight))
 
     /// Pull To Refresh Support.
     ///

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -16,7 +16,7 @@ final class CouponListViewController: UIViewController, GhostableViewController 
                                                                                                 cellClass: TitleAndSubtitleAndStatusTableViewCell.self,
                                                                                                 rowsPerSection: Constants.placeholderRowsPerSection,
                                                                                                 estimatedRowHeight: Constants.estimatedRowHeight,
-                                                                                                separatorStyle: .singleLine))
+                                                                                                backgroundColor: .basicBackground))
 
     /// Pull To Refresh Support.
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -27,7 +27,9 @@ final class TopPerformerDataViewController: UIViewController, GhostableViewContr
     ///
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
                                                                                                 cellClass: ProductTableViewCell.self,
-                                                                                                estimatedRowHeight: Constants.estimatedRowHeight))
+                                                                                                estimatedRowHeight: Constants.estimatedRowHeight,
+                                                                                                backgroundColor: .basicBackground,
+                                                                                                separatorStyle: .none))
 
     /// ResultsController: Loads TopEarnerStats for the current granularity from the Storage Layer
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -9,8 +9,7 @@ final class PluginListViewController: UIViewController, GhostableViewController 
 
     @IBOutlet private var tableView: UITableView!
 
-    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(
-                                                                                                cellClass: HeadlineLabelTableViewCell.self,
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: HeadlineLabelTableViewCell.self,
                                                                                                 rowsPerSection: [10],
                                                                                                 tableViewStyle: .grouped,
                                                                                                 backgroundColor: .listBackground,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -12,7 +12,7 @@ final class PluginListViewController: UIViewController, GhostableViewController 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(
                                                                                                 cellClass: HeadlineLabelTableViewCell.self,
                                                                                                 rowsPerSection: [10],
-                                                                                                tableViewStyle: .plain,
+                                                                                                tableViewStyle: .grouped,
                                                                                                 backgroundColor: .listBackground,
                                                                                                 separatorStyle: .singleLine,
                                                                                                 isScrollEnabled: false))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -12,8 +12,6 @@ final class PluginListViewController: UIViewController, GhostableViewController 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: HeadlineLabelTableViewCell.self,
                                                                                                 rowsPerSection: [10],
                                                                                                 tableViewStyle: .grouped,
-                                                                                                backgroundColor: .listBackground,
-                                                                                                separatorStyle: .singleLine,
                                                                                                 isScrollEnabled: false))
 
     /// Pull To Refresh Support.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -3,15 +3,19 @@ import WordPressUI
 
 /// View Controller for the Plugin List Screen.
 ///
-final class PluginListViewController: UIViewController {
+final class PluginListViewController: UIViewController, GhostableViewController {
 
     private let viewModel: PluginListViewModel
 
     @IBOutlet private var tableView: UITableView!
 
-    /// Separate table view for ghost animation.
-    ///
-    private let ghostTableView = UITableView(frame: .zero, style: .grouped)
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(
+                                                                                                cellClass: HeadlineLabelTableViewCell.self,
+                                                                                                rowsPerSection: [10],
+                                                                                                tableViewStyle: .plain,
+                                                                                                backgroundColor: .listBackground,
+                                                                                                separatorStyle: .singleLine,
+                                                                                                isScrollEnabled: false))
 
     /// Pull To Refresh Support.
     ///
@@ -42,7 +46,6 @@ final class PluginListViewController: UIViewController {
         super.viewDidLoad()
         configureNavigation()
         configureTableView()
-        configureGhostTableView()
         configureViewModel()
     }
 }
@@ -63,30 +66,6 @@ private extension PluginListViewController {
         tableView.dataSource = self
     }
 
-    func configureGhostTableView() {
-        ghostTableView.registerNib(for: HeadlineLabelTableViewCell.self)
-        ghostTableView.translatesAutoresizingMaskIntoConstraints = false
-        ghostTableView.backgroundColor = .listBackground
-        ghostTableView.isScrollEnabled = false
-        ghostTableView.isHidden = true
-
-        view.addSubview(ghostTableView)
-        view.pinSubviewToAllEdges(ghostTableView)
-    }
-
-    func startGhostAnimation() {
-        let options = GhostOptions(reuseIdentifier: HeadlineLabelTableViewCell.reuseIdentifier, rowsPerSection: [10])
-        ghostTableView.displayGhostContent(options: options, style: .wooDefaultGhostStyle)
-        ghostTableView.startGhostAnimation()
-        ghostTableView.isHidden = false
-    }
-
-    func stopGhostAnimation() {
-        ghostTableView.isHidden = true
-        ghostTableView.stopGhostAnimation()
-        ghostTableView.removeGhostContent()
-    }
-
     func configureViewModel() {
         viewModel.observePlugins { [weak self] in
             self?.tableView.reloadData()
@@ -105,12 +84,12 @@ private extension PluginListViewController {
     @objc func syncPlugins() {
         removeErrorStateView()
         if viewModel.numberOfSections == 0 {
-            startGhostAnimation()
+            displayGhostContent()
         }
         viewModel.syncPlugins { [weak self] result in
             guard let self = self else { return }
             self.refreshControl.endRefreshing()
-            self.stopGhostAnimation()
+            self.removeGhostContent()
             if result.isFailure {
                 self.displayErrorStateView()
             }

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -63,8 +63,8 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
     private let rowType = Cell.self
 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: Cell.self,
-                                                                                                rowsPerSection: placeholderRowsPerSection,
-                                                                                                estimatedRowHeight: estimatedRowHeight))
+                                                                                                backgroundColor: .listBackground,
+                                                                                                separatorStyle: viewProperties.separatorStyle))
 
     private lazy var tableView: UITableView = UITableView(frame: .zero, style: viewProperties.tableViewStyle)
 
@@ -297,10 +297,6 @@ private extension PaginatedListSelectorViewController {
         tableView.sectionFooterHeight = .leastNonzeroMagnitude
 
         tableView.separatorStyle = viewProperties.separatorStyle
-
-        // Removes extra header spacing in ghost content view.
-        tableView.estimatedSectionHeaderHeight = 0
-        tableView.sectionHeaderHeight = 0
 
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -63,7 +63,6 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
     private let rowType = Cell.self
 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: Cell.self,
-                                                                                                backgroundColor: .listBackground,
                                                                                                 separatorStyle: viewProperties.separatorStyle))
 
     private lazy var tableView: UITableView = UITableView(frame: .zero, style: viewProperties.tableViewStyle)

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -54,13 +54,17 @@ extension PaginatedListSelectorDataSource {
 /// Displays a paginated list (implemented by table view) for the user to select a generic model.
 ///
 final class PaginatedListSelectorViewController<DataSource: PaginatedListSelectorDataSource, Model, StorageModel, Cell>: UIViewController,
-    UITableViewDataSource, UITableViewDelegate, UITableViewDragDelegate, PaginationTrackerDelegate
+    UITableViewDataSource, UITableViewDelegate, UITableViewDragDelegate, PaginationTrackerDelegate, GhostableViewController
 where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.ReadOnlyType, Model: Equatable, DataSource.Cell == Cell {
     private let viewProperties: PaginatedListSelectorViewProperties
     private var dataSource: DataSource
     private let onDismiss: (_ selected: Model?) -> Void
 
     private let rowType = Cell.self
+
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: Cell.self,
+                                                                                                rowsPerSection: placeholderRowsPerSection,
+                                                                                                estimatedRowHeight: estimatedRowHeight))
 
     private lazy var tableView: UITableView = UITableView(frame: .zero, style: viewProperties.tableViewStyle)
 
@@ -381,9 +385,7 @@ private extension PaginatedListSelectorViewController {
     /// Renders the Placeholder Orders: For safety reasons, we'll also halt ResultsController <> UITableView glue.
     ///
     func displayPlaceholderProducts() {
-        let options = GhostOptions(reuseIdentifier: Cell.reuseIdentifier, rowsPerSection: placeholderRowsPerSection)
-        tableView.displayGhostContent(options: options,
-                                      style: .wooDefaultGhostStyle)
+        displayGhostContent()
 
         resultsController.stopForwardingEvents()
     }
@@ -391,7 +393,7 @@ private extension PaginatedListSelectorViewController {
     /// Removes the Placeholder Products (and restores the ResultsController <> UITableView link).
     ///
     func removePlaceholderProducts() {
-        tableView.removeGhostContent()
+        removeGhostContent()
         resultsController.startForwardingEvents(to: tableView)
         tableView.reloadData()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -55,8 +55,6 @@ final class OrderListViewController: UIViewController, GhostableViewController {
                                                                                                 cellClass: OrderTableViewCell.self,
                                                                                                 estimatedRowHeight: Settings.estimatedRowHeight,
                                                                                                 tableViewStyle: .grouped,
-                                                                                                backgroundColor: .listBackground,
-                                                                                                separatorStyle: .singleLine,
                                                                                                 isScrollEnabled: false))
 
     /// Pull To Refresh Support.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -27,7 +27,7 @@ protocol OrderListViewControllerDelegate: AnyObject {
 
 /// OrderListViewController: Displays the list of Orders associated to the active Store / Account.
 ///
-final class OrderListViewController: UIViewController {
+final class OrderListViewController: UIViewController, GhostableViewController {
 
     weak var delegate: OrderListViewControllerDelegate?
 
@@ -51,9 +51,13 @@ final class OrderListViewController: UIViewController {
         return dataSource
     }()
 
-    /// Ghostable TableView.
-    ///
-    private(set) var ghostableTableView = UITableView(frame: .zero, style: .grouped)
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(displaysSectionHeader: false,
+                                                                                                cellClass: OrderTableViewCell.self,
+                                                                                                estimatedRowHeight: Settings.estimatedRowHeight,
+                                                                                                tableViewStyle: .grouped,
+                                                                                                backgroundColor: .listBackground,
+                                                                                                separatorStyle: .singleLine,
+                                                                                                isScrollEnabled: false))
 
     /// Pull To Refresh Support.
     ///
@@ -152,7 +156,6 @@ final class OrderListViewController: UIViewController {
 
         registerTableViewHeadersAndCells()
         configureTableView()
-        configureGhostableTableView()
 
         configureViewModel()
         configureSyncingCoordinator()
@@ -174,8 +177,6 @@ final class OrderListViewController: UIViewController {
         //
         // We can remove this once we've replaced XLPagerTabStrip.
         tableView.reloadData()
-
-        restartPlaceholderAnimation()
     }
 
     override func viewDidLayoutSubviews() {
@@ -280,30 +281,10 @@ private extension OrderListViewController {
         view.pinSubviewToAllEdges(tableView)
     }
 
-    /// Setup: Ghostable TableView
-    ///
-    func configureGhostableTableView() {
-        view.addSubview(ghostableTableView)
-        ghostableTableView.isHidden = true
-
-        ghostableTableView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            ghostableTableView.widthAnchor.constraint(equalTo: tableView.widthAnchor),
-            ghostableTableView.heightAnchor.constraint(equalTo: tableView.heightAnchor),
-            ghostableTableView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
-            ghostableTableView.topAnchor.constraint(equalTo: tableView.topAnchor)
-        ])
-
-        view.backgroundColor = .listBackground
-        ghostableTableView.backgroundColor = .listBackground
-        ghostableTableView.isScrollEnabled = false
-    }
-
     /// Registers all of the available table view cells and headers
     ///
     func registerTableViewHeadersAndCells() {
         tableView.registerNib(for: OrderTableViewCell.self)
-        ghostableTableView.registerNib(for: OrderTableViewCell.self)
 
         let headerType = TwoColumnSectionHeaderView.self
         tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
@@ -452,33 +433,13 @@ private extension OrderListViewController {
     /// Renders the Placeholder Orders
     ///
     func displayPlaceholderOrders() {
-        let options = GhostOptions(displaysSectionHeader: false,
-                                   reuseIdentifier: OrderTableViewCell.reuseIdentifier,
-                                   rowsPerSection: Settings.placeholderRowsPerSection)
-
-        // If the ghostable table view gets stuck for any reason,
-        // let's reset the state before using it again
-        ghostableTableView.removeGhostContent()
-        ghostableTableView.displayGhostContent(options: options,
-                                               style: Constants.ghostStyle)
-        ghostableTableView.startGhostAnimation()
-        ghostableTableView.isHidden = false
+        displayGhostContent()
     }
 
     /// Removes the Placeholder Orders (and restores the ResultsController <> UITableView link).
     ///
     func removePlaceholderOrders() {
-        ghostableTableView.isHidden = true
-        ghostableTableView.stopGhostAnimation()
-        ghostableTableView.removeGhostContent()
-    }
-
-    /// After returning to the screen, `restartGhostAnimation` is required to resume ghost animation.
-    func restartPlaceholderAnimation() {
-        guard ghostableTableView.isHidden == false else {
-            return
-        }
-        ghostableTableView.restartGhostAnimation(style: Constants.ghostStyle)
+        removeGhostContent()
     }
 
     /// Shows the EmptyStateViewController
@@ -737,9 +698,5 @@ private extension OrderListViewController {
         case syncing
         case results
         case empty
-    }
-
-    enum Constants {
-        static let ghostStyle: GhostStyle = .wooDefaultGhostStyle
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
@@ -172,7 +172,7 @@ extension ProductReviewsDataSource: ReviewsInteractionDelegate {
 }
 
 
-private extension ProductReviewsDataSource {
+extension ProductReviewsDataSource {
     enum Settings {
         static let estimatedRowHeight = CGFloat(88)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -11,9 +11,7 @@ final class ProductReviewsViewController: UIViewController, GhostableViewControl
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: ProductReviewTableViewCell.self,
                                                                                                 estimatedRowHeight: ProductReviewsDataSource
                                                                                                                     .Settings
-                                                                                                                    .estimatedRowHeight,
-                                                                                                backgroundColor: .listBackground,
-                                                                                                separatorStyle: .singleLine))
+                                                                                                                    .estimatedRowHeight))
 
     /// Pull To Refresh Support.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -2,11 +2,18 @@ import UIKit
 import Yosemite
 
 /// The UI that shows the approved Reviews related to a specific product.
-final class ProductReviewsViewController: UIViewController {
+final class ProductReviewsViewController: UIViewController, GhostableViewController {
 
     private let product: Product
 
     private let viewModel: ProductReviewsViewModel
+
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: ProductReviewTableViewCell.self,
+                                                                                                estimatedRowHeight: ProductReviewsDataSource
+                                                                                                                    .Settings
+                                                                                                                    .estimatedRowHeight,
+                                                                                                backgroundColor: .listBackground,
+                                                                                                separatorStyle: .singleLine))
 
     /// Pull To Refresh Support.
     ///
@@ -170,13 +177,15 @@ private extension ProductReviewsViewController {
     /// Renders Placeholder Reviews.
     ///
     func displayPlaceholderReviews() {
-        viewModel.displayPlaceholderReviews(tableView: tableView)
+        displayGhostContent()
+        viewModel.didDisplayPlaceholderReviews()
     }
 
     /// Removes Placeholder Reviews.
     ///
     func removePlaceholderReviews() {
-        viewModel.removePlaceholderReviews(tableView: tableView)
+        removeGhostContent()
+        viewModel.didRemovePlaceholderReviews(tableView: tableView)
     }
 
     /// Displays the EmptyStateViewController.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -27,18 +27,13 @@ final class ProductReviewsViewModel {
         self.data = data
     }
 
-    func displayPlaceholderReviews(tableView: UITableView) {
-        let options = GhostOptions(reuseIdentifier: ProductReviewTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
-        tableView.displayGhostContent(options: options,
-                                      style: .wooDefaultGhostStyle)
-
+    func didDisplayPlaceholderReviews() {
         data.stopForwardingEvents()
     }
 
     /// Removes Placeholder Notes (and restores the ResultsController <> UITableView link).
     ///
-    func removePlaceholderReviews(tableView: UITableView) {
-        tableView.removeGhostContent()
+    func didRemovePlaceholderReviews(tableView: UITableView) {
         data.startForwardingEvents(to: tableView)
     }
 
@@ -101,7 +96,6 @@ extension ProductReviewsViewModel {
 
 private extension ProductReviewsViewModel {
     enum Settings {
-        static let placeholderRowsPerSection = [3]
         static let firstPage = 1
         static let pageSize = 25
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/GhostTableViewController.swift
@@ -16,8 +16,8 @@ struct GhostTableViewOptions {
          rowsPerSection: [Int] = [3],
          estimatedRowHeight: CGFloat = 44,
          tableViewStyle: UITableView.Style = .plain,
-         backgroundColor: UIColor = .basicBackground,
-         separatorStyle: UITableViewCell.SeparatorStyle = .none,
+         backgroundColor: UIColor = .listBackground,
+         separatorStyle: UITableViewCell.SeparatorStyle = .singleLine,
          isScrollEnabled: Bool = true) {
         // By just passing the cellClass in the initializer we enforce that the GhostOptions reuseIdentifier is always that of the cellClass
         ghostOptions = GhostOptions(displaysSectionHeader: displaysSectionHeader, reuseIdentifier: cellClass.reuseIdentifier, rowsPerSection: rowsPerSection)

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -2,13 +2,18 @@ import UIKit
 
 // MARK: - ReviewsViewController
 //
-final class ReviewsViewController: UIViewController {
+final class ReviewsViewController: UIViewController, GhostableViewController {
 
     typealias ViewModel = ReviewsViewModelOutput & ReviewsViewModelActionsHandler
 
     /// Main TableView.
     ///
     @IBOutlet private weak var tableView: UITableView!
+
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: ProductReviewTableViewCell.self,
+                                                                                                estimatedRowHeight: Settings.estimatedRowHeight,
+                                                                                                backgroundColor: .listBackground,
+                                                                                                separatorStyle: .singleLine))
 
     /// Mark all as read nav bar button
     ///
@@ -337,13 +342,15 @@ private extension ReviewsViewController {
     /// Renders Placeholder Reviews.
     ///
     func displayPlaceholderReviews() {
-        viewModel.displayPlaceholderReviews(tableView: tableView)
+        displayGhostContent()
+        viewModel.didDisplayPlaceholderReviews()
     }
 
     /// Removes Placeholder Reviews.
     ///
     func removePlaceholderReviews() {
-        viewModel.removePlaceholderReviews(tableView: tableView)
+        removeGhostContent()
+        viewModel.didRemovePlaceholderReviews(tableView: tableView)
     }
 
     /// Displays the EmptyStateViewController.

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -11,9 +11,7 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
     @IBOutlet private weak var tableView: UITableView!
 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: ProductReviewTableViewCell.self,
-                                                                                                estimatedRowHeight: Settings.estimatedRowHeight,
-                                                                                                backgroundColor: .listBackground,
-                                                                                                separatorStyle: .singleLine))
+                                                                                                estimatedRowHeight: Settings.estimatedRowHeight))
 
     /// Mark all as read nav bar button
     ///

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -236,7 +236,6 @@ private extension ReviewsViewModel {
 
 private extension ReviewsViewModel {
     enum Settings {
-        static let placeholderRowsPerSection = [3]
         static let firstPage = 1
         static let pageSize = 25
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -26,9 +26,9 @@ protocol ReviewsViewModelOutput {
 /// Handles actions related to Reviews screen
 ///
 protocol ReviewsViewModelActionsHandler {
-    func displayPlaceholderReviews(tableView: UITableView)
+    func didDisplayPlaceholderReviews()
 
-    func removePlaceholderReviews(tableView: UITableView)
+    func didRemovePlaceholderReviews(tableView: UITableView)
 
     func configureResultsController(tableView: UITableView)
 
@@ -88,18 +88,13 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
         self.stores = stores
     }
 
-    func displayPlaceholderReviews(tableView: UITableView) {
-        let options = GhostOptions(reuseIdentifier: ProductReviewTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
-        tableView.displayGhostContent(options: options,
-                                      style: .wooDefaultGhostStyle)
-
+    func didDisplayPlaceholderReviews() {
         data.stopForwardingEvents()
     }
 
-    /// Removes Placeholder Notes (and restores the ResultsController <> UITableView link).
+    /// Restores the ResultsController <> UITableView link after the placeholder was removed from the view.
     ///
-    func removePlaceholderReviews(tableView: UITableView) {
-        tableView.removeGhostContent()
+    func didRemovePlaceholderReviews(tableView: UITableView) {
         data.startForwardingEvents(to: tableView)
         tableView.reloadData()
     }

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -42,10 +42,9 @@ final class ReviewsViewModelTests: XCTestCase {
 
     func testDisplayPlaceHolderReviewsStopsForWardingEventsInDataSource() {
         // Given
-        let table = UITableView()
         let mockDataSource = MockReviewsDataSource()
         let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
-        viewModel.displayPlaceholderReviews(tableView: table)
+        viewModel.didDisplayPlaceholderReviews()
 
         // Then
         XCTAssertTrue(mockDataSource.stopsForwardingEventsWasHit)
@@ -58,7 +57,7 @@ final class ReviewsViewModelTests: XCTestCase {
         let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
 
         // When
-        viewModel.removePlaceholderReviews(tableView: table)
+        viewModel.didRemovePlaceholderReviews(tableView: table)
 
         // Then
         XCTAssertTrue(mockDataSource.startForwardingEventsWasHit)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
@@ -34,20 +34,19 @@ final class ProductReviewsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.isEmpty, mockDataSource.isEmpty)
     }
 
-    func test_display_placeHolder_reviews_stops_forwarding_events_in_dataSource() {
-        let table = UITableView()
+    func test_did_display_placeHolder_reviews_stops_forwarding_events_in_dataSource() {
         let ds = mockDataSource as! MockProductReviewsDataSource
 
-        viewModel.displayPlaceholderReviews(tableView: table)
+        viewModel.didDisplayPlaceholderReviews()
 
         XCTAssertTrue(ds.stopsForwardingEventsWasHit)
     }
 
-    func test_remove_placeHolder_reviews_starts_forwarding_events_in_dataSource() {
+    func test_did_remove_placeHolder_reviews_starts_forwarding_events_in_dataSource() {
         let table = UITableView()
         let ds = mockDataSource as! MockProductReviewsDataSource
 
-        viewModel.removePlaceholderReviews(tableView: table)
+        viewModel.didRemovePlaceholderReviews(tableView: table)
 
         XCTAssertTrue(ds.startForwardingEventsWasHit)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewsViewControllerTests.swift
@@ -85,9 +85,9 @@ private final class MockReviewsViewModel: ReviewsViewModelOutput, ReviewsViewMod
 
     // Empty methods for `ReviewsViewModelActionsHandler` conformance
     //
-    func displayPlaceholderReviews(tableView: UITableView) {}
+    func didDisplayPlaceholderReviews() {}
 
-    func removePlaceholderReviews(tableView: UITableView) {}
+    func didRemovePlaceholderReviews(tableView: UITableView) {}
 
     func configureResultsController(tableView: UITableView) {}
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #2448 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we start using the GhostTableViewController and GhostableViewController protocol created in https://github.com/woocommerce/woocommerce-ios/pull/6529 to address all cases where a ghosting animation is rendered on top of a `UITableView`. These cases are:
- `CouponsListViewController`
- `PaginatedListSelectorViewController`
- `PluginListViewController`
- `OrdersListViewController`
- `ReviewsViewController`
- `ProductReviewsViewController`
Some of them used the extension on their data table view directly while others used a similar approach of `GhostTableViewController` by creating a new table view on top. For all cases we use the new approach to avoid crashes and keep the logic consistent along the codebase.
On top of that, unit tests are added when appropriate.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Next, I will add the steps to show the refactored ghosting views, and screenshots before and after.

#### Coupons

1. Open App
2. Go to Menu
3. Open Coupons (if not enabled please do so in Settings > Experimental Features)

#### Orders
1. Open App
2. Go to Orders
#### Paginated List Selected

1. Open App
2. Go to Products
3. Open Product with price
4. Open price
5. Open Tax Class
#### Plugins

1. Open App
2. Go to Menu
3. Go to Settings
4. Open Plugins
#### Reviews

1. Open App
2. Go to Menu
3. Open Reviews
or

1. Open App
2. Go to Products
3. Open Product with Reviews
4. Open Reviews

### Notes
As you can see below, some header sizes slightly differ when comparing before and after. The reason behind that is the way GhostTableViewHandler renders the header when displaysSectionHeader is true in `WordPressUI`:
```
func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
        return options.displaysSectionHeader ? " " : nil
    }
```
We could tweak that by adding the height manually or forking the pod, but I think the difference is too small to add that complexity.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before            |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1864060/160629312-1a830dd6-43b5-403b-a092-4599f41ba147.gif)  |  ![](https://user-images.githubusercontent.com/1864060/160629423-1d384833-a4c2-4bfa-972c-3b734ba19b44.gif)
![](https://user-images.githubusercontent.com/1864060/160629904-d8ff25ff-3a34-4f66-a25e-ae7006634f9e.gif)  |  ![orders-after](https://user-images.githubusercontent.com/1864060/160629935-e6726d36-f69b-4b5e-ab5d-e6b04b80d06e.gif)
![paginated-list-selector-before](https://user-images.githubusercontent.com/1864060/160631080-eb952844-d02f-4651-b6fc-cda53816af87.gif) | ![paginated-list-selector-after](https://user-images.githubusercontent.com/1864060/160631147-7bbec3a2-d9cd-47f4-91d3-260a6fd1de53.gif)
![plugins-before](https://user-images.githubusercontent.com/1864060/160631710-38028dff-15d5-47bc-ac18-b6c90e649262.gif) | ![plugins-after](https://user-images.githubusercontent.com/1864060/160631896-98dda0be-33bf-4a1a-948a-d62228ff8197.gif)
![reviews-before](https://user-images.githubusercontent.com/1864060/160632307-ecb9dcc4-d916-49db-91a1-58387b73f933.gif) | ![reviews-after](https://user-images.githubusercontent.com/1864060/160632367-58a1381a-682e-4604-b9de-26ba42619e59.gif)

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
