### PR TITLE
Installable Build: Fix build by limiting AddEditCoupon preview to debug builds

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -41,6 +41,7 @@ private extension AddEditCoupon {
     }
 }
 
+#if DEBUG
 struct AddEditCoupon_Previews: PreviewProvider {
     static var previews: some View {
 
@@ -50,3 +51,4 @@ struct AddEditCoupon_Previews: PreviewProvider {
         AddEditCoupon(editingViewModel)
     }
 }
+#endif


### PR DESCRIPTION
## Description

The installable build was broken by a SwiftUI preview using sample data that was only available in the debug build (see https://github.com/woocommerce/woocommerce-ios/pull/6531#issuecomment-1082164422). This resolves the build error by limiting that preview to debug builds.

## Changes

* Adds a debug check to `AddEditCoupon_Previews`.

## Testing

Confirm the Installable Build can be built without errors on CI.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
