### PR TITLE
Add Unit Tests for ShippingLineDetails, NewOrder, and PriceFieldFormatter

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -479,6 +479,42 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
 
+    func test_payment_section_values_correct_when_shipping_line_is_negative() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, currencySettings: currencySettings)
+
+        // When
+        viewModel.addProductViewModel.selectProduct(product.productID)
+        let testShippingLine = ShippingLine(shippingID: 0,
+                                            methodTitle: "Flat Rate",
+                                            methodID: "other",
+                                            total: "-5",
+                                            totalTax: "",
+                                            taxes: [])
+        viewModel.saveShippingLine(testShippingLine)
+
+        // Then
+        XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "-£5.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£3.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 3.50)
+
+        // When
+        viewModel.saveShippingLine(nil)
+
+        // Then
+        XCTAssertFalse(viewModel.paymentDataViewModel.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
+    }
+
     func test_payment_section_loading_indicator_is_enabled_while_order_syncs() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -748,6 +748,19 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChanges)
     }
 
+    func test_hasChanges_returns_true_when_fee_line_is_updated() {
+        // Given
+        let storageManager = MockStorageManager()
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+        let feeLine = OrderFeeLine.fake()
+
+        // When
+        viewModel.saveFeeLine(feeLine)
+
+        // Then
+        XCTAssertTrue(viewModel.hasChanges)
+    }
+
     func test_shipping_method_tracked_when_added() throws {
         // Given
         let analytics = MockAnalyticsProvider()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -552,6 +552,56 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
+
+    func test_payment_section_is_correct_when_shipping_line_and_fee_line_are_added() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, currencySettings: currencySettings)
+
+        // When
+        viewModel.addProductViewModel.selectProduct(product.productID)
+
+        let testShippingLine = ShippingLine(shippingID: 0,
+                                            methodTitle: "Flat Rate",
+                                            methodID: "other",
+                                            total: "-5",
+                                            totalTax: "",
+                                            taxes: [])
+        viewModel.saveShippingLine(testShippingLine)
+
+        let testFeeLine = OrderFeeLine(feeID: 0,
+                                       name: "Fee",
+                                       taxClass: "",
+                                       taxStatus: .none,
+                                       total: "10",
+                                       totalTax: "",
+                                       taxes: [],
+                                       attributes: [])
+        viewModel.saveFeeLine(testFeeLine)
+
+        // Then
+        XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "-£5.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£13.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£10.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 3.50)
+
+        // When
+        viewModel.saveShippingLine(nil)
+
+        // Then
+        XCTAssertFalse(viewModel.paymentDataViewModel.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£18.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£10.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
+    }
+
     func test_payment_section_loading_indicator_is_enabled_while_order_syncs() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -735,6 +735,19 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChanges)
     }
 
+    func test_hasChanges_returns_true_when_shipping_line_is_updated() {
+        // Given
+        let storageManager = MockStorageManager()
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+        let shippingLine = ShippingLine.fake()
+
+        // When
+        viewModel.saveShippingLine(shippingLine)
+
+        // Then
+        XCTAssertTrue(viewModel.hasChanges)
+    }
+
     func test_shipping_method_tracked_when_added() throws {
         // Given
         let analytics = MockAnalyticsProvider()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -515,6 +515,43 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
 
+    func test_payment_section_values_correct_when_fee_line_is_negative() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, currencySettings: currencySettings)
+
+        // When
+        viewModel.addProductViewModel.selectProduct(product.productID)
+        let testFeeLine = OrderFeeLine(feeID: 0,
+                                       name: "Fee",
+                                       taxClass: "",
+                                       taxStatus: .none,
+                                       total: "-5",
+                                       totalTax: "",
+                                       taxes: [],
+                                       attributes: [])
+        viewModel.saveFeeLine(testFeeLine)
+
+        // Then
+        XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowFees)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "-£5.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£3.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
+
+        // When
+        viewModel.saveFeeLine(nil)
+
+        // Then
+        XCTAssertFalse(viewModel.paymentDataViewModel.shouldShowFees)
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
+    }
     func test_payment_section_loading_indicator_is_enabled_while_order_syncs() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -386,6 +386,8 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
     }
 
+    // MARK: - Payment Section Tests
+
     func test_payment_section_is_updated_when_products_update() {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
@@ -656,19 +658,7 @@ final class NewOrderViewModelTests: XCTestCase {
 
     }
 
-    func test_customer_note_section_is_updated_when_note_is_added_to_order() {
-        // Given
-        let storageManager = MockStorageManager()
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
-        let expectedCustomerNote = "Test"
-
-        //When
-        viewModel.noteViewModel.newNote = expectedCustomerNote
-        viewModel.updateCustomerNote()
-
-        //Then
-        XCTAssertEqual(viewModel.customerNoteDataViewModel.customerNote, expectedCustomerNote)
-    }
+    // MARK: - hasChanges Tests
 
     func test_hasChanges_returns_false_initially() {
         // Given
@@ -760,6 +750,8 @@ final class NewOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.hasChanges)
     }
+
+    // MARK: - Tracking Tests
 
     func test_shipping_method_tracked_when_added() throws {
         // Given
@@ -878,6 +870,22 @@ final class NewOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(analytics.receivedEvents.isEmpty)
+    }
+
+    // MARK: -
+
+    func test_customer_note_section_is_updated_when_note_is_added_to_order() {
+        // Given
+        let storageManager = MockStorageManager()
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+        let expectedCustomerNote = "Test"
+
+        //When
+        viewModel.noteViewModel.newNote = expectedCustomerNote
+        viewModel.updateCustomerNote()
+
+        //Then
+        XCTAssertEqual(viewModel.customerNoteDataViewModel.customerNote, expectedCustomerNote)
     }
 
     func test_discard_order_deletes_order_if_order_exists_remotely() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
@@ -208,4 +208,31 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(savedShippingLine?.total, "11.30")
         XCTAssertNotEqual(savedShippingLine?.methodTitle, "") // "Shipping" placeholder string is localized -> not reliable for comparison here.
     }
+
+    func test_view_model_amount_placeholder_has_expected_value() {
+        // Given
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.amountPlaceholder, "0")
+    }
+
+    func test_view_model_initializes_correctly_with_no_existing_shipping_line() {
+        // Given
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isExistingShippingLine)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/PriceFieldFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/PriceFieldFormatterTests.swift
@@ -126,4 +126,17 @@ final class PriceFieldFormatterTests: XCTestCase {
         _ = priceFieldFormatter.formatAmount("-hi:11.3030-")
         XCTAssertEqual(priceFieldFormatter.formattedAmount, "-$11.30")
     }
+
+    func test_formatter_disallows_negative_numbers_by_default() {
+        // Given
+        let priceFieldFormatter = PriceFieldFormatter(locale: usLocale, storeCurrencySettings: usStoreSettings)
+
+        // When & Then
+        _ = priceFieldFormatter.formatAmount("-12")
+        XCTAssertEqual(priceFieldFormatter.formattedAmount, "$12")
+
+        // When & Then
+        _ = priceFieldFormatter.formatAmount("-hi:11.3030-")
+        XCTAssertEqual(priceFieldFormatter.formattedAmount, "$11.30")
+    }
 }


### PR DESCRIPTION
### Description
This PR adds several tests to enhance Order Creation's unit testing coverage.

**ShippingLineDetailsViewModelTests**
- `test_view_model_amount_placeholder_has_expected_value()` checks that `amountPlaceholder` is `"0"`
- `test_view_model_initializes_correctly_with_no_existing_shipping_line()` checks that `.isExistingShippingLine` is false when initialized with no shipping line.

**PriceFieldFormatterTests**
- `test_formatter_disallows_negative_numbers_by_default()` checks that negative numbers are not allowed in the price field when no `allowNegativeNumber` value is passed (as `allowNegativeNumber` is false by default).

**NewOrderViewModelTests**
NewOrderViewModelTests had no tests with negative values. I've added three, including one which checks the interaction when both shipping and fee lines exist:
- Negative Shipping Line: `test_payment_section_values_correct_when_shipping_line_is_negative()`
- Negative Fee Line: `test_payment_section_values_correct_when_fee_line_is_negative()`
- Both Shipping and Fee Lines: `test_payment_section_is_correct_when_shipping_line_and_fee_line_are_added()`

In addition, I added two tests for `hasChanges`, for updates to shipping and fees.
- `test_hasChanges_returns_true_when_shipping_line_is_updated()`
- `test_hasChanges_returns_true_when_fee_line_is_updated()`

### Testing instructions
All tests should pass when each test file is run, as well as when the whole unit tests set is run.

The tests I'm least certain about are `test_payment_section_is_correct_when_shipping_line_and_fee_line_are_added()` (shipping + fees in NewOrder) and `test_formatter_disallows_negative_numbers_by_default()` (negative numbers in PriceFieldFormatter). 
I'd appreciate your thoughtful feedback on these two tests especially.

For PriceFieldFormatter, my concern is: we're not really testing that negative numbers are disallowed, but that they're sanitized/removed. In the UI, I'd expect the `-` to simply not be inputted in a field that doesn't allow negative numbers. So, is there a better/different way to test that (maybe in a ViewModel)? 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

