### PR TITLE
IPP analytics: add `country` property to receipt events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -876,6 +876,84 @@ extension WooAnalyticsEvent {
                                 "reason": reason
                               ])
         }
+
+        /// Tracked when the user taps on the "See Receipt" button to view a receipt.
+        /// - Parameter countryCode: the country code of the store.
+        ///
+        static func receiptViewTapped(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptViewTapped,
+                              properties: [Keys.countryCode: countryCode])
+        }
+
+        /// Tracked when the user taps on the "Email receipt" button after successfully collecting a payment to email a receipt.
+        /// - Parameter countryCode: the country code of the store.
+        ///
+        static func receiptEmailTapped(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptEmailTapped,
+                              properties: [Keys.countryCode: countryCode])
+        }
+
+        /// Tracked when sending or saving the receipt email failed.
+        /// - Parameters:
+        ///   - error: the error to be included in the event properties.
+        ///   - countryCode: the country code of the store.
+        ///
+        static func receiptEmailFailed(error: Error, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptEmailFailed,
+                              properties: [Keys.countryCode: countryCode],
+                              error: error)
+        }
+
+        /// Tracked when the user canceled sending the receipt by email.
+        /// - Parameter countryCode: the country code of the store.
+        ///
+        static func receiptEmailCanceled(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptEmailCanceled,
+                              properties: [Keys.countryCode: countryCode])
+        }
+
+        /// Tracked when the receipt was sent by email.
+        /// - Parameter countryCode: the country code of the store.
+        ///
+        static func receiptEmailSuccess(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptEmailSuccess,
+                              properties: [Keys.countryCode: countryCode])
+        }
+
+        /// Tracked when the user tapped on the button to print a receipt.
+        /// - Parameter countryCode: the country code of the store.
+        ///
+        static func receiptPrintTapped(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptPrintTapped,
+                              properties: [Keys.countryCode: countryCode])
+        }
+
+        /// Tracked when printing the receipt failed.
+        /// - Parameters:
+        ///   - error: the error to be included in the event properties.
+        ///   - countryCode: the country code of the store.
+        ///
+        static func receiptPrintFailed(error: Error, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptPrintFailed,
+                              properties: [Keys.countryCode: countryCode],
+                              error: error)
+        }
+
+        /// Tracked when the user canceled printing the receipt.
+        /// - Parameter countryCode: the country code of the store.
+        ///
+        static func receiptPrintCanceled(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptPrintCanceled,
+                              properties: [Keys.countryCode: countryCode])
+        }
+
+        /// Tracked when the receipt was successfully sent to the printer. iOS won't guarantee that the receipt has actually printed.
+        /// - Parameter countryCode: the country code of the store.
+        ///
+        static func receiptPrintSuccess(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .receiptPrintSuccess,
+                              properties: [Keys.countryCode: countryCode])
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
@@ -2,17 +2,17 @@ import Foundation
 import Yosemite
 
 struct ReceiptActionCoordinator {
-    static func printReceipt(for order: Order, params: CardPresentReceiptParameters) {
-        ServiceLocator.analytics.track(.receiptPrintTapped)
+    static func printReceipt(for order: Order, params: CardPresentReceiptParameters, countryCode: String) {
+        ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintTapped(countryCode: countryCode))
 
         let action = ReceiptAction.print(order: order, parameters: params) { (result) in
             switch result {
             case .success:
-                ServiceLocator.analytics.track(.receiptPrintSuccess)
+                ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintSuccess(countryCode: countryCode))
             case .cancel:
-                ServiceLocator.analytics.track(.receiptPrintCanceled)
+                ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintCanceled(countryCode: countryCode))
             case .failure(let error):
-                ServiceLocator.analytics.track(.receiptPrintFailed, withError: error)
+                ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintFailed(error: error, countryCode: countryCode))
                 DDLogError("⛔️ Failed to print receipt: \(error.localizedDescription)")
             }
         }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -4,15 +4,18 @@ import Yosemite
 final class ReceiptViewModel {
     private let order: Order
     private let receipt: CardPresentReceiptParameters
+    private let countryCode: String
 
 
     /// Initializer
     /// - Parameters:
-    ///   - order: The order associated with the receipt
+    ///   - order: the order associated with the receipt
     ///   - receipt: the receipt metadata
-    init(order: Order, receipt: CardPresentReceiptParameters) {
+    ///   - countryCode: the country code of the store
+    init(order: Order, receipt: CardPresentReceiptParameters, countryCode: String) {
         self.order = order
         self.receipt = receipt
+        self.countryCode = countryCode
     }
 
 
@@ -29,6 +32,6 @@ final class ReceiptViewModel {
 
     /// Prints the receipt
     func printReceipt() {
-        ReceiptActionCoordinator.printReceipt(for: order, params: receipt)
+        ReceiptActionCoordinator.printReceipt(for: order, params: receipt, countryCode: countryCode)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -264,11 +264,12 @@ extension OrderDetailsViewModel {
             let billingInformationViewController = BillingInformationViewController(order: order, editingEnabled: true)
             viewController.navigationController?.pushViewController(billingInformationViewController, animated: true)
         case .seeReceipt:
-            ServiceLocator.analytics.track(.receiptViewTapped)
+            let countryCode = configurationLoader.configuration.countryCode
+            ServiceLocator.analytics.track(event: .InPersonPayments.receiptViewTapped(countryCode: countryCode))
             guard let receipt = receipt else {
                 return
             }
-            let viewModel = ReceiptViewModel(order: order, receipt: receipt)
+            let viewModel = ReceiptViewModel(order: order, receipt: receipt, countryCode: countryCode)
             let receiptViewController = ReceiptViewController(viewModel: viewModel)
             viewController.navigationController?.pushViewController(receiptViewController, animated: true)
         case .refund:

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/ReceiptActionCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/ReceiptActionCoordinatorTests.swift
@@ -13,7 +13,7 @@ class ReceiptActionCoordinatorTests: XCTestCase {
         let params = CardPresentReceiptParameters.makeParams()
 
         // When
-        ReceiptActionCoordinator.printReceipt(for: order, params: params)
+        ReceiptActionCoordinator.printReceipt(for: order, params: params, countryCode: "CA")
 
         // Then
         let analytics = ServiceLocator.analytics.analyticsProvider as! MockAnalyticsProvider
@@ -35,7 +35,7 @@ class ReceiptActionCoordinatorTests: XCTestCase {
         assertEmpty(storesManager.receivedActions)
 
         // When
-        ReceiptActionCoordinator.printReceipt(for: order, params: params)
+        ReceiptActionCoordinator.printReceipt(for: order, params: params, countryCode: "CA")
 
         //Then
         XCTAssertEqual(storesManager.receivedActions.count, 1)
@@ -75,7 +75,7 @@ extension ReceiptActionCoordinatorTests {
         ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: MockAnalyticsProvider()))
 
         // When
-        ReceiptActionCoordinator.printReceipt(for: order, params: params)
+        ReceiptActionCoordinator.printReceipt(for: order, params: params, countryCode: "CA")
 
         //Then
         let action = try XCTUnwrap(storesManager.receivedActions.first as? ReceiptAction)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5984 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The receipt events are the last few existing events that we're adding `country` property to. In this PR, I added the receipt events to `WooAnalyticsEvent.InPersonPayments` and added a `country` parameter to log this new property.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

In the console, there should be a `country` property for all the events below.

(Borrowing the testing instructions from https://github.com/woocommerce/woocommerce-ios/pull/4213) Please note that the failure events are not easy to test and feel free to skip them, I haven't seen any failed events in Tracks.

- After completing payment:
  -  Tap on Email receipt: `receipt_email_tapped `
      - Send email: `receipt_email_success`
      - Cancel and save as draft: `receipt_email_success`
      - Cancel and discard draft: `receipt_email_canceled`
      - ❓Make the email fail: `receipt_email_failed`
  - Tap on Print receipt: `receipt_print_tapped `
      - Print receipt: `receipt_print_success`
      - Cancel printing: `receipt_print_canceled`
      - ❓Make printing fail: `receipt_print_failed`
- From an order with a saved receipt:
  - Tap See Receipt: `receipt_view_tapped`
    - Tap on Print receipt: `receipt_print_tapped `
        - Print receipt: `receipt_print_success`
        - Cancel printing: `receipt_print_canceled`
        - ❓Make printing fail: `receipt_print_failed`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
