### PR TITLE
Log info about stats intervals for x-axis labels when the index is out of bound to help with crash debugging

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -488,7 +488,7 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
             let intervalLabels = createOrderStatsIntervalLabels()
             let index = Int(value)
             if index >= intervalLabels.count {
-                DDLogInfo("orderStatsIntervals count: \(orderStatsIntervals.count); value: \(value); interval labels: \(intervalLabels)")
+                DDLogInfo("🔴 orderStatsIntervals count: \(orderStatsIntervals.count); value: \(value); interval labels: \(intervalLabels)")
             }
             return intervalLabels[index]
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -488,7 +488,7 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
             let intervalLabels = createOrderStatsIntervalLabels()
             let index = Int(value)
             if index >= intervalLabels.count {
-                DDLogInfo("🔴 orderStatsIntervals count: \(orderStatsIntervals.count); value: \(value); interval labels: \(intervalLabels)")
+                DDLogInfo("🔴 orderStatsIntervals count: \(orderStatsIntervals.count); value: \(value); index: \(index); interval labels: \(intervalLabels)")
             }
             return intervalLabels[index]
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -485,7 +485,12 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
         }
 
         if axis is XAxis {
-            return createOrderStatsIntervalLabels()[Int(value)]
+            let intervalLabels = createOrderStatsIntervalLabels()
+            let index = Int(value)
+            if index >= intervalLabels.count {
+                DDLogInfo("orderStatsIntervals count: \(orderStatsIntervals.count); value: \(value); interval labels: \(intervalLabels)")
+            }
+            return intervalLabels[index]
         } else {
             if value == 0.0 {
                 // Do not show the "0" label on the Y axis


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

For debugging crash #6333 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After an unsuccessful attempted fix for an out-of-bound crash #6333, I added logging in this PR so that we can see more information about the stats intervals index issue in encrypted logs from future crashes. This logging is only done when there is an out-of-bound issue.

We can close this PR if we find a better fix for the crash in release 8.9!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can test that this info isn't logged normally:
- Launch the app --> after the charts are loaded, make sure there are no logs like `🔴 orderStatsIntervals count: ...` in the console

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
