### PR TITLE
Order Creation: Add unit tests for test coverage gaps in the Products section

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrder.swift
@@ -72,8 +72,7 @@ struct AddProductToOrder: View {
     /// Creates the `ProductRow` for a product, depending on whether the product is variable.
     ///
     @ViewBuilder private func createProductRow(rowViewModel: ProductRowViewModel) -> some View {
-        if rowViewModel.numberOfVariations > 0,
-           let addVariationToOrderVM = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
+        if let addVariationToOrderVM = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
             LazyNavigationLink(destination: AddProductVariationToOrder(isPresented: $isPresented, viewModel: addVariationToOrderVM)) {
                 HStack {
                     ProductRow(viewModel: rowViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/AddProductToOrderViewModel.swift
@@ -119,7 +119,7 @@ final class AddProductToOrderViewModel: ObservableObject {
     /// Get the view model for a list of product variations to add to the order
     ///
     func getVariationsViewModel(for productID: Int64) -> AddProductVariationToOrderViewModel? {
-        guard let variableProduct = products.first(where: { $0.productID == productID }) else {
+        guard let variableProduct = products.first(where: { $0.productID == productID }), variableProduct.variations.isNotEmpty else {
             return nil
         }
         return AddProductVariationToOrderViewModel(siteID: siteID, product: variableProduct, onVariationSelected: onVariationSelected)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -16,11 +16,4 @@ final class ProductInOrderViewModel: Identifiable {
         self.productRowViewModel = productRowViewModel
         self.onRemoveProduct = onRemoveProduct
     }
-
-    convenience init(product: Product,
-         onRemoveProduct: @escaping () -> Void) {
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
-        self.init(productRowViewModel: viewModel,
-                  onRemoveProduct: onRemoveProduct)
-    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -295,6 +295,35 @@ class AddProductToOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(selectedProduct, product.productID)
     }
+
+    func test_getVariationsViewModel_returns_expected_view_model_for_variable_product() throws {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true, variations: [1, 2])
+        insert(product)
+        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID,
+                                                   storageManager: storageManager)
+
+        // When
+        let variationsViewModel = viewModel.getVariationsViewModel(for: product.productID)
+
+        // Then
+        let actualViewModel = try XCTUnwrap(variationsViewModel)
+        XCTAssertEqual(actualViewModel.productName, product.name)
+    }
+
+    func test_getVariationsViewModel_returns_nil_for_simple_product() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true)
+        insert(product)
+        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID,
+                                                   storageManager: storageManager)
+
+        // When
+        let variationsViewModel = viewModel.getVariationsViewModel(for: product.productID)
+
+        // Then
+        XCTAssertNil(variationsViewModel)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductToOrderViewModelTests.swift
@@ -279,6 +279,22 @@ class AddProductToOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(notice, AddProductToOrderViewModel.NoticeFactory.productSearchNotice(retryAction: {}))
     }
+
+    func test_selectProduct_invokes_onProductSelected_closure_for_existing_product() {
+        // Given
+        var selectedProduct: Int64?
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = AddProductToOrderViewModel(siteID: sampleSiteID,
+                                                   storageManager: storageManager,
+                                                   onProductSelected: { selectedProduct = $0.productID })
+
+        // When
+        viewModel.selectProduct(product.productID)
+
+        // Then
+        XCTAssertEqual(selectedProduct, product.productID)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/AddProductVariationToOrderViewModelTests.swift
@@ -204,6 +204,24 @@ class AddProductVariationToOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.notice, AddProductVariationToOrderViewModel.NoticeFactory.productVariationSyncNotice(retryAction: {}))
     }
+
+    func test_selectVariation_invokes_onVariationSelected_closure_for_existing_variation() {
+        // Given
+        var selectedVariationID: Int64?
+        let product = Product.fake().copy(productID: sampleProductID)
+        let productVariation = sampleProductVariation.copy(productVariationID: 1)
+        insert(productVariation)
+        let viewModel = AddProductVariationToOrderViewModel(siteID: sampleSiteID,
+                                                            product: product,
+                                                            storageManager: storageManager,
+                                                            onVariationSelected: { selectedVariationID = $0.productVariationID })
+
+        // When
+        viewModel.selectVariation(productVariation.productVariationID)
+
+        // Then
+        XCTAssertEqual(selectedVariationID, productVariation.productVariationID)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -221,6 +221,24 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows[safe: 1]?.quantity, 1)
     }
 
+    func test_product_is_selected_when_quantity_is_decremented_below_1() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // Product quantity is 1
+        viewModel.addProductViewModel.selectProduct(product.productID)
+        XCTAssertEqual(viewModel.productRows[0].quantity, 1)
+
+        // When
+        viewModel.productRows[0].decrementQuantity()
+
+        // Then
+        XCTAssertNotNil(viewModel.selectedProductViewModel)
+    }
+
     func test_selectOrderItem_selects_expected_order_item() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -268,4 +268,17 @@ class ProductRowViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(productRemoved)
     }
+
+    func test_productAccessibilityLabel_is_created_with_expected_details_from_product() {
+        // Given
+        let product = Product.fake().copy(name: "Test Product", sku: "123456", price: "10", stockStatusKey: "instock", variations: [1, 2])
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+
+        // Then
+        let expectedLabel = "Test Product. In stock. $10.00. 2 variations. SKU: 123456"
+        XCTAssertEqual(viewModel.productAccessibilityLabel, expectedLabel)
+    }
 }


### PR DESCRIPTION
Closes: #6509

## Description/Changes

Adds unit tests for the following view model behavior (which were identified as gaps in test coverage for these view models):

* NewOrderViewModel:
   * Decreasing an order item quantity when the quantity is 1 selects the order item.
* AddProductToOrderViewModel:
   * `getVariationsViewModel` returns the expected `AddProductVariationToOrderViewModel` for variable products.
   * `selectProduct` calls the provided `onProductSelected` closure.
* AddProductVariationToOrderViewModel:
   * `selectVariation` calls the provided `onVariationSelected` closure.
* ProductRowViewModel:
   * `productAccessibilityLabel` combines the product details into a single label as expected.

This PR also makes the following changes:

* AddProductToOrderViewModel:
   * Previously, we checked whether a product row was variable or not in the `AddProductToOrder` view directly. This check is now in the view model, as part of `getVariationsViewModel(for:)`, and is unit tested.
* ProductInOrderViewModel:
   * Removes an unused convenience init method.

## Testing

Confirm tests pass in CI.

To test the change to `AddProductToOrder`:

1. Go to the Orders tab and create a new order.
2. Select "Add Product."
3. Confirm that the product list shows the expected rows for variable and non-variable products (and that variable product rows are tappable and take you to a list of the product variations).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
