### PR TITLE
Charts: set interval labels calculation after setting stats intervals as an attempted crash fix

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -63,7 +63,12 @@ final class StoreStatsV4PeriodViewController: UIViewController {
         return ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
     }
 
-    private var orderStatsIntervals: [OrderStatsV4Interval] = []
+    private var orderStatsIntervals: [OrderStatsV4Interval] = [] {
+        didSet {
+            orderStatsIntervalLabels = createOrderStatsIntervalLabels(orderStatsIntervals: orderStatsIntervals)
+        }
+    }
+    private var orderStatsIntervalLabels: [String] = []
 
     private var revenueItems: [Double] {
         orderStatsIntervals.map({ ($0.revenueValue as NSDecimalNumber).doubleValue })
@@ -485,7 +490,7 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
         }
 
         if axis is XAxis {
-            let intervalLabels = createOrderStatsIntervalLabels()
+            let intervalLabels = orderStatsIntervalLabels
             let index = Int(value)
             if index >= intervalLabels.count {
                 DDLogInfo("🔴 orderStatsIntervals count: \(orderStatsIntervals.count); value: \(value); index: \(index); interval labels: \(intervalLabels)")
@@ -508,7 +513,7 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
         }
     }
 
-    private func createOrderStatsIntervalLabels() -> [String] {
+    private func createOrderStatsIntervalLabels(orderStatsIntervals: [OrderStatsV4Interval]) -> [String] {
         let helper = StoreStatsV4ChartAxisHelper()
         let intervalDates = orderStatsIntervals.map({ $0.dateStart(timeZone: siteTimezone) })
         return helper.generateLabelText(for: intervalDates,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Attempted fix for #6333 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Thanks to @itsmeichigo's suggestion https://github.com/woocommerce/woocommerce-ios/issues/6333#issuecomment-1084400834, this PR is an attempted fix for a crash on out-of-bound access of x-axis labels. Now the x-axis interval labels are set right after `orderStatsIntervals` is set, which was the behavior before Home Screen updates.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Since we can't reproduce this crash, we can just do a confidence check on the charts:
- Launch the app --> after the charts are loaded, make sure the x-axis labels are shown as before


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
