### PR TITLE
IPP analytics: add `card_reader_model` property to reader connection and payment collection events

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderType.swift
+++ b/Hardware/Hardware/CardReader/CardReaderType.swift
@@ -14,7 +14,7 @@ public enum CardReaderType {
 extension CardReaderType {
     /// A human-readable model name for the reader.
     ///
-    var model: String {
+    public var model: String {
         /// This should match the Android SDK deviceName, to simplify Analytics use
         /// https://stripe.dev/stripe-terminal-android/external/external/com.stripe.stripeterminal.external.models/-device-type/index.html
         /// pbUcTB-r9-p2#comment-2164

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -612,7 +612,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderConnectionSuccess(forGatewayID: String?, batteryLevel: Float?, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
+        static func cardReaderConnectionSuccess(forGatewayID: String?,
+                                                batteryLevel: Float?,
+                                                countryCode: String,
+                                                cardReaderModel: String) -> WooAnalyticsEvent {
             var properties = [
                 Keys.cardReaderModel: cardReaderModel,
                 Keys.countryCode: countryCode,
@@ -632,10 +635,12 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - error: the error to be included in the event properties.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderConnectionFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderConnectionFailed(forGatewayID: String?, error: Error, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderConnectionFailed,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription
@@ -649,10 +654,12 @@ extension WooAnalyticsEvent {
         /// - Parameters:
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDisconnectTapped,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -573,6 +573,7 @@ extension WooAnalyticsEvent {
 
         enum Keys {
             static let batteryLevel = "battery_level"
+            static let cardReaderModel = "card_reader_model"
             static let countryCode = "country"
             static let gatewayID = "plugin_slug"
             static let errorDescription = "error_description"
@@ -609,9 +610,11 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - batteryLevel: the battery level (if available) to be included in the event properties in Tracks, e.g. 0.75 = 75%.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderConnectionSuccess(forGatewayID: String?, batteryLevel: Float?, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderConnectionSuccess(forGatewayID: String?, batteryLevel: Float?, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             var properties = [
+                Keys.cardReaderModel: cardReaderModel,
                 Keys.countryCode: countryCode,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
             ]
@@ -769,14 +772,15 @@ extension WooAnalyticsEvent {
         /// - Parameters:
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func collectPaymentTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func collectPaymentTapped(forGatewayID: String?, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentTapped,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
-                              ]
-            )
+                              ])
         }
 
         /// Tracked when the payment collection fails
@@ -785,8 +789,9 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - error: the error to be included in the event properties.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader, if available.
         ///
-        static func collectPaymentFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
+        static func collectPaymentFailed(forGatewayID: String?, error: Error, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
             let paymentMethod: PaymentMethod? = {
                 guard case let CardReaderServiceError.paymentCaptureWithPaymentMethod(_, paymentMethod) = error else {
                     return nil
@@ -813,6 +818,7 @@ extension WooAnalyticsEvent {
                 }
             }()
             let properties: [String: WooAnalyticsEventPropertyType] = [
+                Keys.cardReaderModel: cardReaderModel,
                 Keys.countryCode: countryCode,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                 Keys.paymentMethodType: paymentMethod?.analyticsValue,
@@ -827,10 +833,12 @@ extension WooAnalyticsEvent {
         /// - Parameters:
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func collectPaymentCanceled(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func collectPaymentCanceled(forGatewayID: String?, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentCanceled,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
@@ -843,10 +851,15 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
         ///   - paymentMethod: the payment method of the captured payment.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func collectPaymentSuccess(forGatewayID: String?, countryCode: String, paymentMethod: PaymentMethod) -> WooAnalyticsEvent {
+        static func collectPaymentSuccess(forGatewayID: String?,
+                                          countryCode: String,
+                                          paymentMethod: PaymentMethod,
+                                          cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.paymentMethodType: paymentMethod.analyticsValue

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -43,13 +43,20 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
 
     private let paymentGatewayAccountID: String?
     private let countryCode: String
+    private let cardReaderModel: String
     private let analytics: Analytics
 
-    init(name: String, amount: String, paymentGatewayAccountID: String?, countryCode: String, analytics: Analytics = ServiceLocator.analytics) {
+    init(name: String,
+         amount: String,
+         paymentGatewayAccountID: String?,
+         countryCode: String,
+         cardReaderModel: String,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.name = name
         self.amount = amount
         self.paymentGatewayAccountID = paymentGatewayAccountID
         self.countryCode = countryCode
+        self.cardReaderModel = cardReaderModel
         self.analytics = analytics
     }
 
@@ -60,7 +67,8 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
     func didTapSecondaryButton(in viewController: UIViewController?) {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
                                         .collectPaymentCanceled(forGatewayID: paymentGatewayAccountID,
-                                                                countryCode: countryCode))
+                                                                countryCode: countryCode,
+                                                                cardReaderModel: cardReaderModel))
 
         let action = CardPresentPaymentAction.cancelPayment(onCompletion: nil)
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -26,11 +26,13 @@ final class OrderDetailsPaymentAlerts {
 
     private let paymentGatewayAccountID: String?
     private let countryCode: String
+    private let cardReaderModel: String
 
-    init(presentingController: UIViewController, paymentGatewayAccountID: String?, countryCode: String) {
+    init(presentingController: UIViewController, paymentGatewayAccountID: String?, countryCode: String, cardReaderModel: String) {
         self.presentingController = presentingController
         self.paymentGatewayAccountID = paymentGatewayAccountID
         self.countryCode = countryCode
+        self.cardReaderModel = cardReaderModel
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
@@ -94,7 +96,11 @@ final class OrderDetailsPaymentAlerts {
 
 private extension OrderDetailsPaymentAlerts {
     func readerIsReady() -> CardPresentPaymentsModalViewModel {
-        CardPresentModalReaderIsReady(name: name, amount: amount, paymentGatewayAccountID: paymentGatewayAccountID, countryCode: countryCode)
+        CardPresentModalReaderIsReady(name: name,
+                                      amount: amount,
+                                      paymentGatewayAccountID: paymentGatewayAccountID,
+                                      countryCode: countryCode,
+                                      cardReaderModel: cardReaderModel)
     }
 
     func tapOrInsert(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -577,7 +577,8 @@ private extension CardReaderConnectionController {
                     event: WooAnalyticsEvent.InPersonPayments
                         .cardReaderConnectionSuccess(forGatewayID: self.gatewayID,
                                                      batteryLevel: reader.batteryLevel,
-                                                     countryCode: self.configuration.countryCode)
+                                                     countryCode: self.configuration.countryCode,
+                                                     cardReaderModel: reader.readerType.model)
                 )
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -594,7 +594,8 @@ private extension CardReaderConnectionController {
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
                                                                                          error: error,
-                                                                                         countryCode: self.configuration.countryCode)
+                                                                                         countryCode: self.configuration.countryCode,
+                                                                                         cardReaderModel: candidateReader.readerType.model)
                 )
                 self.state = .connectingFailed(error)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -23,7 +23,8 @@ final class CardReaderSettingsConnectedViewController: UIViewController, CardRea
     private lazy var paymentAlerts: OrderDetailsPaymentAlerts = {
         OrderDetailsPaymentAlerts(presentingController: self,
                                   paymentGatewayAccountID: viewModel?.dataSource.cardPresentPaymentGatewayID(),
-                                  countryCode: CardPresentConfigurationLoader().configuration.countryCode)
+                                  countryCode: CardPresentConfigurationLoader().configuration.countryCode,
+                                  cardReaderModel: viewModel?.connectedReaderModel ?? "")
     }()
 
     private let settingsAlerts = CardReaderSettingsAlerts()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -28,6 +28,9 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     var connectedReaderID: String?
     var connectedReaderBatteryLevel: String?
     var connectedReaderSoftwareVersion: String?
+    var connectedReaderModel: String? {
+        connectedReaders.first?.readerType.model
+    }
 
     /// The connected gateway ID (plugin slug) - useful for the view controller's tracks events
     var connectedGatewayID: String?

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -250,7 +250,9 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     func disconnectReader() {
         ServiceLocator.analytics.track(
             event: WooAnalyticsEvent.InPersonPayments.cardReaderDisconnectTapped(
-                forGatewayID: connectedGatewayID, countryCode: configuration.countryCode
+                forGatewayID: connectedGatewayID,
+                countryCode: configuration.countryCode,
+                cardReaderModel: connectedReaderModel ?? ""
             )
         )
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -53,6 +53,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private var readerSubscription: AnyCancellable?
 
+    private var connectedReader: CardReader?
+
     /// Closure to inform when the full flow has been completed, after receipt management.
     /// Needed to be saved as an instance variable because it needs to be referenced from the `MailComposer` delegate.
     ///
@@ -62,7 +64,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private lazy var alerts = OrderDetailsPaymentAlerts(presentingController: rootViewController,
                                                         paymentGatewayAccountID: paymentGatewayAccount.gatewayID,
-                                                        countryCode: configurationLoader.configuration.countryCode)
+                                                        countryCode: configurationLoader.configuration.countryCode,
+                                                        cardReaderModel: connectedReader?.readerType.model ?? "")
 
     /// IPP payments collector.
     ///
@@ -110,6 +113,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed, Currently after merchant has handled the receipt.
     func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
         configureBackend()
+        observeConnectedReadersForAnalytics()
         connectReader { [weak self] in
             self?.attemptPayment(onCompletion: { [weak self] result in
                 // Inform about the collect payment state
@@ -172,7 +176,8 @@ private extension CollectOrderPaymentUseCase {
     func attemptPayment(onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
         // Track tapped event
         analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentTapped(forGatewayID: paymentGatewayAccount.gatewayID,
-                                                                                       countryCode: configurationLoader.configuration.countryCode))
+                                                                                       countryCode: configurationLoader.configuration.countryCode,
+                                                                                       cardReaderModel: connectedReader?.readerType.model ?? ""))
 
         // Show reader ready alert
         alerts.readerIsReady(title: Localization.collectPaymentTitle(username: order.billingAddress?.firstName), amount: formattedAmount)
@@ -215,7 +220,8 @@ private extension CollectOrderPaymentUseCase {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
                             .collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,
                                                    countryCode: configurationLoader.configuration.countryCode,
-                                                   paymentMethod: capturedPaymentData.paymentMethod))
+                                                   paymentMethod: capturedPaymentData.paymentMethod,
+                                                   cardReaderModel: connectedReader?.readerType.model ?? ""))
 
         // Success Callback
         onCompletion(.success(capturedPaymentData))
@@ -227,7 +233,8 @@ private extension CollectOrderPaymentUseCase {
         // Record error
         analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentFailed(forGatewayID: paymentGatewayAccount.gatewayID,
                                                                                        error: error,
-                                                                                       countryCode: configurationLoader.configuration.countryCode))
+                                                                                       countryCode: configurationLoader.configuration.countryCode,
+                                                                                       cardReaderModel: connectedReader?.readerType.model))
         DDLogError("Failed to collect payment: \(error.localizedDescription)")
 
         // Inform about the error
@@ -257,7 +264,8 @@ private extension CollectOrderPaymentUseCase {
         paymentOrchestrator.cancelPayment { [weak self, analytics] _ in
             guard let self = self else { return }
             analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentCanceled(forGatewayID: self.paymentGatewayAccount.gatewayID,
-                                                                                             countryCode: self.configurationLoader.configuration.countryCode))
+                                                                                             countryCode: self.configurationLoader.configuration.countryCode,
+                                                                                             cardReaderModel: self.connectedReader?.readerType.model ?? ""))
         }
     }
 
@@ -306,6 +314,16 @@ private extension CollectOrderPaymentUseCase {
         }
 
         rootViewController.present(mail, animated: true)
+    }
+}
+
+// MARK: Connected Card Readers
+private extension CollectOrderPaymentUseCase {
+    func observeConnectedReadersForAnalytics() {
+        let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
+            self?.connectedReader = readers.first
+        }
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -53,6 +53,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private var readerSubscription: AnyCancellable?
 
+    /// Stores the connected card reader for analytics.
     private var connectedReader: CardReader?
 
     /// Closure to inform when the full flow has been completed, after receipt management.

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReader.swift
@@ -33,4 +33,15 @@ struct MockCardReader {
                    readerType: .chipper,
                    locationId: "st_simulated")
     }
+
+    static func wisePad3() -> CardReader {
+        CardReader(serial: "WPC323026000412",
+                   vendorIdentifier: "SIMULATOR",
+                   name: "Simulated WISEPAD 3",
+                   status: .init(connected: false, remembered: false),
+                   softwareVersion: nil,
+                   batteryLevel: 0.5,
+                   readerType: .wisepad3,
+                   locationId: nil)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
@@ -17,6 +17,7 @@ final class CardPresentModalReaderIsReadyTests: XCTestCase {
                                                   amount: Expectations.amount,
                                                   paymentGatewayAccountID: Expectations.paymentGatewayAccountID,
                                                   countryCode: Expectations.countryCode,
+                                                  cardReaderModel: Expectations.cardReaderModel,
                                                   analytics: analytics)
     }
 
@@ -92,6 +93,7 @@ final class CardPresentModalReaderIsReadyTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "card_present_collect_payment_canceled")
 
         let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch["card_reader_model"] as? String, Expectations.cardReaderModel)
         XCTAssertEqual(firstPropertiesBatch["country"] as? String, Expectations.countryCode)
         XCTAssertEqual(firstPropertiesBatch["plugin_slug"] as? String, Expectations.paymentGatewayAccountID)
     }
@@ -103,6 +105,7 @@ private extension CardPresentModalReaderIsReadyTests {
         static let name = "name"
         static let amount = "amount"
         static let image = UIImage.cardPresentImage
+        static let cardReaderModel = "WISEPAD_3"
         static let countryCode = "CA"
         static let paymentGatewayAccountID = "woocommerce-payments"
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -410,6 +410,50 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.optionalReaderUpdateAvailable)
     }
+
+    func test_when_connected_to_one_reader_it_sets_connectedReaderModel() {
+        XCTAssertEqual(viewModel.connectedReaderModel, MockCardReader.bbposChipper2XBT().readerType.model)
+    }
+
+    func test_when_connected_to_two_readers_it_sets_connectedReaderModel_from_the_first_reader() {
+        // Given
+        mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [MockCardReader.wisePad3(), MockCardReader.bbposChipper2XBT()],
+            discoveredReaders: [],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        analyticsProvider = MockAnalyticsProvider()
+        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
+
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         configuration: Mocks.configuration,
+                                                         delayToShowUpdateSuccessMessage: .milliseconds(1))
+
+        // Then
+        XCTAssertEqual(viewModel.connectedReaderModel, "WISEPAD_3")
+    }
+
+    func test_when_not_connected_to_any_readers_it_sets_connectedReaderModel_to_nil() {
+        // Given
+        mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [],
+            discoveredReaders: [],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        analyticsProvider = MockAnalyticsProvider()
+        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
+
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         configuration: Mocks.configuration,
+                                                         delayToShowUpdateSuccessMessage: .milliseconds(1))
+
+        // Then
+        XCTAssertNil(viewModel.connectedReaderModel)
+    }
 }
 
 private extension CardReaderSettingsConnectedViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5984 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR added `card_reader_model` property to card reader connection and payment collection events. Other events will be in separate PRs due to some bigger changes for software update events and dependency on another PR for receipt events. The affected events are:

- `card_reader_connection_success`
- `card_reader_connection_failed`
- `card_reader_disconnect_tapped`
- `card_present_collect_payment_tapped`
- `card_present_collect_payment_canceled`
- `card_present_collect_payment_failed`
- `card_present_collect_payment_success`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please feel free to test as many events as possible (I tested all events) to make sure that the correct `card_reader_model` property is included in the events in the console

- Connect to a reader
  - You can connect a WisePad 3 reader to a US store to trigger `card_reader_connection_failed`
  - Connect to an eligible reader:  `card_reader_connection_success`
  - Then disconnect the reader: `card_reader_disconnect_tapped`
- Collect payment from order details or simple payment
  - Make sure the reader is connected before
  - Tap to collect a payment `card_present_collect_payment_tapped`
  - Quickly cancel a payment to trigger `card_present_collect_payment_canceled`
  - Quickly turn off Bluetooth to trigger `card_present_collect_payment_failed`
  - Finally, collect payment successfully to trigger `card_present_collect_payment_success`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
