### PR TITLE
Order Creation: Add test coverage for order-related gaps in the Yosemite layer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -11,7 +11,7 @@ struct ShippingInputTransformer {
         // If input is `nil`, then we remove any existing shipping line.
         // We remove a shipping like by setting its `methodID` to nil.
         guard let input = input else {
-            let linesToRemove = order.shippingLines.map { $0.copy(methodID: .some(nil), total: "0") }
+            let linesToRemove = order.shippingLines.map { OrderFactory.deletedShippingLine($0) }
             return order.copy(shippingTotal: "0", shippingLines: linesToRemove)
         }
 

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -74,7 +74,7 @@ public enum OrderFactory {
     /// Creates a shipping line suitable to delete a shipping line already saved remotely in an order.
     ///
     public static func deletedShippingLine(_ shippingLine: ShippingLine) -> ShippingLine {
-        shippingLine.copy(methodID: .some(nil))
+        shippingLine.copy(methodID: .some(nil), total: "0")
     }
 
     /// References a new empty order with constants `Date` values.


### PR DESCRIPTION
Closes: #6508

## Description/Changes

While checking test coverage for Order Creation, we found a couple order-related gaps in the Yosemite layer.

* `OrderFactory.deletedShippingLine` wasn't exercised in testing. This is because we weren't using it to remove the shipping line from an order. `ShippingInputTransformer` now uses it to update the order when a shipping line is removed, and it is exercised in `test_new_input_deletes_shipping_line_from_order()` in `ShippingInputTransformerTests`.
* `OrderNoteAction.addOrderNote` had no test coverage. This isn't used in Order Creation, but it's worth adding coverage since the gap was identified. There are now tests in `OrderNoteStoreTests` to confirm that the expected note is returned and persisted, and that network errors are handled.

## Testing

Confirm tests pass in CI.

You can also test the shipping line change as follows:

1. Go to the Orders tab and create a new order.
2. Select "Add Shipping", add a shipping amount, and tap Done.
3. On the New Order screen, once the order syncs remotely, tap "Shipping."
4. Select "Remove Shipping from Order."
5. Tap "Create" and confirm the order is created without any shipping.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
