### PR TITLE
Order Creation: Expand new order UI test to include editing Order Status

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -35,6 +35,7 @@ struct OrderStatusSection: View {
                 .fixedSize(horizontal: true, vertical: true)
                 .padding(.trailing, -Layout.linkButtonTrailingPadding) // remove trailing padding to align button title to the side
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
+                .accessibilityIdentifier("order-status-section-edit-button")
                 .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
                     OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus) { newStatus in
                         viewModel.updateOrderStatus(newStatus: newStatus)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -74,6 +74,7 @@ final class OrderStatusListViewController: UIViewController {
     func configureTableView() {
         view.backgroundColor = .listBackground
         tableView.backgroundColor = .listBackground
+        tableView.accessibilityIdentifier = "order-status-list"
         tableView.dataSource = self
         tableView.delegate = self
     }
@@ -110,6 +111,7 @@ extension OrderStatusListViewController {
                                              target: self,
                                              action: #selector(applyButtonTapped))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "order-status-list-apply-button"
         deActivateApplyButton()
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -7,18 +7,36 @@ public final class NewOrderScreen: ScreenObject {
         $0.buttons["new-order-create-button"]
     }
 
+    private let orderStatusEditButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-status-section-edit-button"]
+    }
+
     private var createButton: XCUIElement { createButtonGetter(app) }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    /// Edit button in the Order Status section.
+    ///
+    private var orderStatusEditButton: XCUIElement { orderStatusEditButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ createButtonGetter ],
             app: app
         )
     }
 
+    /// Creates a remote order with all of the entered order data.
+    /// - Returns: Single Order Detail screen object.
     @discardableResult
     public func createOrder() throws -> SingleOrderScreen {
         createButton.tap()
         return try SingleOrderScreen()
+    }
+
+    /// Opens the Order Status screen (to set a new order status).
+    /// - Returns: Order Status screen object.
+    @discardableResult
+    public func openOrderStatusScreen() throws -> OrderStatusScreen {
+        orderStatusEditButton.tap()
+        return try OrderStatusScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
@@ -1,0 +1,42 @@
+import ScreenObject
+import XCTest
+
+public final class OrderStatusScreen: ScreenObject {
+
+    private let applyButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-status-list-apply-button"]
+    }
+
+    private let orderStatusTableGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["order-status-list"]
+    }
+
+    private var applyButton: XCUIElement { applyButtonGetter(app) }
+
+    /// Table with list of order statuses.
+    ///
+    private var orderStatusTable: XCUIElement { orderStatusTableGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ orderStatusTableGetter ],
+            app: app
+        )
+    }
+
+    /// Selects a new order status from the list.
+    /// - Returns: Order Status screen object (self).
+    @discardableResult
+    public func selectOrderStatus(atIndex index: Int) throws -> Self {
+        orderStatusTable.cells.element(boundBy: index).tap()
+        return self
+    }
+
+    /// Updates the order with the selected order status.
+    /// - Returns: New Order screen object.
+    @discardableResult
+    public func confirmSelectedOrderStatus() throws -> NewOrderScreen {
+        applyButton.tap()
+        return try NewOrderScreen()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1207,6 +1207,7 @@
 		CC13C0CB278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CA278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift */; };
 		CC13C0CD278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */; };
 		CC1AB56827FC5822003DEF43 /* OrderStatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */; };
+		CC1AB56A27FC60D1003DEF43 /* NewOrderFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1AB56927FC60D1003DEF43 /* NewOrderFlow.swift */; };
 		CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */; };
 		CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */; };
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
@@ -5785,6 +5786,7 @@
 			children = (
 				80E6FC742763579D0086CD67 /* MockDataReader.swift */,
 				800A5B9D275623FC009DE2CD /* LoginFlow.swift */,
+				CC1AB56927FC60D1003DEF43 /* NewOrderFlow.swift */,
 			);
 			path = Flows;
 			sourceTree = "<group>";
@@ -9836,6 +9838,7 @@
 				800A5B58275483D6009DE2CD /* OrdersTests.swift in Sources */,
 				80AD2CA427858BAB00A63DE8 /* StatsTests.swift in Sources */,
 				800A5BCB2759CE4B009DE2CD /* ProductsTests.swift in Sources */,
+				CC1AB56A27FC60D1003DEF43 /* NewOrderFlow.swift in Sources */,
 				800A5B9E275623FC009DE2CD /* LoginFlow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1206,6 +1206,7 @@
 		CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */; };
 		CC13C0CB278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CA278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift */; };
 		CC13C0CD278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */; };
+		CC1AB56827FC5822003DEF43 /* OrderStatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */; };
 		CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */; };
 		CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */; };
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
@@ -2898,6 +2899,8 @@
 		CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		CC13C0CA278E021300C0B5B5 /* AddProductVariationToOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductVariationToOrderViewModel.swift; sourceTree = "<group>"; };
 		CC13C0CC278E086D00C0B5B5 /* AddProductVariationToOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductVariationToOrderViewModelTests.swift; sourceTree = "<group>"; };
+		CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusScreen.swift; sourceTree = "<group>"; };
+		CC1AB56927FC60D1003DEF43 /* NewOrderFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderFlow.swift; sourceTree = "<group>"; };
 		CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentSection.swift; sourceTree = "<group>"; };
 		CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackage.swift; sourceTree = "<group>"; };
@@ -7808,6 +7811,7 @@
 				CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */,
 				F997173623DBF02400592D8E /* SingleOrderScreen.swift */,
 				F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */,
+				CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -8495,6 +8499,7 @@
 				3F0CF30D2704490A00EF3D71 /* LoginSiteAddressScreen.swift in Sources */,
 				80C3626B27704EE1005CEAD3 /* ProductDataStructs.swift in Sources */,
 				80C3627127745737005CEAD3 /* ReviewDataStructs.swift in Sources */,
+				CC1AB56827FC5822003DEF43 /* OrderStatusScreen.swift in Sources */,
 				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
 				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Flows/NewOrderFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/NewOrderFlow.swift
@@ -1,0 +1,16 @@
+import UITestsFoundation
+import XCTest
+
+/// Helpers for actions that flow across different New Order screens.
+///
+class NewOrderFlow {
+
+    /// Changes the new order status to the second status in the Order Status list.
+    /// - Returns: New Order screen object.
+    @discardableResult
+    static func editOrderStatus() throws -> NewOrderScreen {
+        return try NewOrderScreen().openOrderStatusScreen()
+            .selectOrderStatus(atIndex: 1)
+            .confirmSelectedOrderStatus()
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -28,6 +28,8 @@ final class OrdersTests: XCTestCase {
     func test_create_new_order() throws {
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
+
+        try NewOrderFlow.editOrderStatus()
             .createOrder()
     }
 }


### PR DESCRIPTION
Part of: #6524

## Description

We have an existing UI test for Order Creation that creates an empty new order. This PR adds another step to that test to edit the Order Status before creating the new order. (This is part of expanding the UI test to include functionality from Order Creation Milestone 1.)

h/t @thehenrybyrd who paired with me on these changes!

## Changes

* Add `OrderStatusScreen` screen object with helpers for interacting with that screen.
* Add method to navigate from `NewOrderScreen` to `OrderStatusScreen`.
* Add `NewOrderFlow` with method to edit order status, encapsulating individual steps in that user flow.
* Update UI test `test_create_new_order()` to edit the order status using the new flow.

## Testing

Confirm test passes in CI.

## Screenshots

https://user-images.githubusercontent.com/8658164/161765805-af12d725-3819-432e-93a4-110c24f69067.mp4


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
