### PR TITLE
Improvements to the Edit Coupon view UI

### DIFF
--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -24,7 +24,7 @@ extension Coupon.DiscountType {
         case .percent:
             return Localization.titleCreatePercentageDiscount
         case .fixedCart:
-            return Localization.titleCreateFixedCardDiscount
+            return Localization.titleCreateFixedCartDiscount
         case .fixedProduct:
             return Localization.titleCreateFixedProductDiscount
         default:
@@ -39,7 +39,7 @@ extension Coupon.DiscountType {
         case .percent:
             return Localization.titleEditPercentageDiscount
         case .fixedCart:
-            return Localization.titleEditFixedCardDiscount
+            return Localization.titleEditFixedCartDiscount
         case .fixedProduct:
             return Localization.titleEditFixedProductDiscount
         default:
@@ -55,9 +55,9 @@ extension Coupon.DiscountType {
         static let titleEditPercentageDiscount = NSLocalizedString(
             "Edit percentage discount",
             comment: "Title of the view for editing a coupon with percentage discount.")
-        static let titleEditFixedCardDiscount = NSLocalizedString(
-            "Edit fixed card discount",
-            comment: "Title of the view for editing a coupon with fixed card discount.")
+        static let titleEditFixedCartDiscount = NSLocalizedString(
+            "Edit fixed cart discount",
+            comment: "Title of the view for editing a coupon with fixed cart discount.")
         static let titleEditFixedProductDiscount = NSLocalizedString(
             "Edit fixed product discount",
             comment: "Title of the view for editing a coupon with fixed product discount.")
@@ -67,9 +67,9 @@ extension Coupon.DiscountType {
         static let titleCreatePercentageDiscount = NSLocalizedString(
             "Create percentage discount",
             comment: "Title of the view for creating a coupon with percentage discount.")
-        static let titleCreateFixedCardDiscount = NSLocalizedString(
-            "Create fixed card discount",
-            comment: "Title of the view for creating a coupon with fixed card discount.")
+        static let titleCreateFixedCartDiscount = NSLocalizedString(
+            "Create fixed cart discount",
+            comment: "Title of the view for creating a coupon with fixed cart discount.")
         static let titleCreateFixedProductDiscount = NSLocalizedString(
             "Create fixed product discount",
             comment: "Title of the view for creating a coupon with fixed product discount.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -51,14 +51,16 @@ struct AddEditCoupon: View {
                                 .subheadlineStyle()
                                 .padding(.horizontal, Constants.margin)
 
-                            //TODO: leading aligning for this button
-                            Button {
-                                //TODO: handle action
-                            } label: {
-                                Text(Localization.regenerateCouponCodeButton)
+                            HStack {
+                                Button {
+                                    //TODO: handle action
+                                } label: {
+                                    Text(Localization.regenerateCouponCodeButton)
+                                }
+                                .buttonStyle(LinkButtonStyle())
+                                .fixedSize()
+                                Spacer().frame(maxWidth: .infinity)
                             }
-                            .buttonStyle(LinkButtonStyle())
-                            .padding(.horizontal, Constants.margin)
 
                             Button {
                                 //TODO: handle action

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -37,7 +37,6 @@ struct AddEditCoupon: View {
                             }
                             .padding(.bottom, Constants.verticalSpacing)
 
-
                             Group {
                                 TitleAndTextFieldRow(title: Localization.couponCode,
                                                      placeholder: Localization.couponCodePlaceholder,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -17,39 +17,43 @@ struct AddEditCoupon: View {
         NavigationView {
             GeometryReader { geometry in
                 ScrollView {
-                    VStack (alignment: .leading) {
+                    VStack (alignment: .leading, spacing: 0) {
                         Group {
                             ListHeaderView(text: Localization.headerCouponDetails.uppercased(), alignment: .left)
 
                             Group {
                                 TitleAndTextFieldRow(title: viewModel.amountText,
-                                                     placeholder: Localization.couponAmountPlaceholder,
+                                                     placeholder: "0",
                                                      text: $viewModel.amountField,
                                                      editable: true,
                                                      fieldAlignment: .leading,
                                                      keyboardType: .decimalPad)
                                 Divider()
                                     .padding(.leading, Constants.margin)
-                            }
 
-                            Text(viewModel.amountSubtitleText)
-                                .subheadlineStyle()
-                                .padding(.horizontal, Constants.margin)
+                                Text(viewModel.amountSubtitleText)
+                                    .subheadlineStyle()
+                                    .padding(.horizontal, Constants.margin)
+                            }
+                            .padding([.bottom], Constants.verticalSpacing)
+
 
                             Group {
                                 TitleAndTextFieldRow(title: Localization.couponCode,
-                                                     placeholder: Localization.couponCode,
+                                                     placeholder: couponCodePlaceholder,
                                                      text: $viewModel.codeField,
                                                      editable: true,
                                                      fieldAlignment: .leading,
                                                      keyboardType: .default)
                                 Divider()
                                     .padding(.leading, Constants.margin)
+                                    .padding([.bottom], Constants.verticalSpacing)
+                                Text(Localization.footerCouponCode)
+                                    .subheadlineStyle()
+                                    .padding(.horizontal, Constants.margin)
                             }
+                            .padding([.bottom], Constants.verticalSpacing)
 
-                            Text(Localization.footerCouponCode)
-                                .subheadlineStyle()
-                                .padding(.horizontal, Constants.margin)
 
                             HStack {
                                 Button {
@@ -169,12 +173,12 @@ private extension AddEditCoupon {
         static let headerCouponDetails = NSLocalizedString(
             "Coupon details",
             comment: "Header of the coupon details in the view for adding or editing a coupon.")
-        static let couponAmountPlaceholder = NSLocalizedString(
-            "Coupon amount",
-            comment: "Text field placeholder for the amount in the view for adding or editing a coupon.")
         static let couponCode = NSLocalizedString(
             "Coupon Code",
             comment: "Text field coupon code in the view for adding or editing a coupon.")
+        static let couponCodePlaceholder = NSLocalizedString(
+            "Enter a coupon",
+            comment: "Text field coupon code placeholder in the view for adding or editing a coupon.")
         static let footerCouponCode = NSLocalizedString(
             "Customers need to enter this code to use the coupon.",
             comment: "The footer of the text field coupon code in the view for adding or editing a coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -69,8 +69,11 @@ struct AddEditCoupon: View {
                             Button {
                                 //TODO: handle action
                             } label: {
-                                Text(Localization.addDescriptionButton)
-                                    .bodyStyle()
+                                HStack {
+                                    Image(uiImage: .plusImage)
+                                    Text(Localization.addDescriptionButton)
+                                        .bodyStyle()
+                                }
                             }
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.horizontal, Constants.margin)
@@ -192,7 +195,7 @@ private extension AddEditCoupon {
             "Regenerate Coupon Code",
             comment: "Button in the view for adding or editing a coupon.")
         static let addDescriptionButton = NSLocalizedString(
-            "+ Add Description (Optional)",
+            "Add Description (Optional)",
             comment: "Button for adding a description to a coupon in the view for adding or editing a coupon.")
         static let couponExpiryDate = NSLocalizedString(
             "Coupon Expiry Date",

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -91,22 +91,27 @@ struct AddEditCoupon: View {
                         Group {
                             ListHeaderView(text: Localization.headerApplyCouponTo.uppercased(), alignment: .left)
 
-                            // TODO: add a new style with the icon on the left side
                             Button {
                                 //TODO: handle action
                             } label: {
-                                Text(Localization.editProductsButton)
-                                    .bodyStyle()
+                                HStack {
+                                    Image(uiImage: .pencilImage).colorMultiply(Color(.text))
+                                    Text(Localization.editProductsButton)
+                                        .bodyStyle()
+                                }
                             }
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.horizontal, Constants.margin)
 
-                            // TODO: add a new style with the icon on the left side
                             Button {
                                 //TODO: handle action
                             } label: {
-                                Text(Localization.editProductCategoriesButton)
-                                    .bodyStyle()
+                                HStack {
+                                    Image(uiImage: .pencilImage)
+                                        .colorMultiply(Color(.text))
+                                    Text(Localization.editProductCategoriesButton)
+                                        .bodyStyle()
+                                }
                             }
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.horizontal, Constants.margin)

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -65,6 +65,7 @@ struct AddEditCoupon: View {
                                 .fixedSize()
                                 Spacer().frame(maxWidth: .infinity)
                             }
+                            .padding([.bottom], Constants.verticalSpacing)
 
                             Button {
                                 //TODO: handle action
@@ -83,6 +84,7 @@ struct AddEditCoupon: View {
                                 Divider()
                                     .padding(.leading, Constants.margin)
                             }
+                            .padding([.bottom], Constants.verticalSpacing)
 
                             Group {
                                 TitleAndToggleRow(title: Localization.includeFreeShipping, isOn: .constant(false))
@@ -90,10 +92,12 @@ struct AddEditCoupon: View {
                                 Divider()
                                     .padding(.leading, Constants.margin)
                             }
+                            .padding([.bottom], Constants.verticalSpacing)
                         }
 
                         Group {
                             ListHeaderView(text: Localization.headerApplyCouponTo.uppercased(), alignment: .left)
+                                .padding([.bottom], Constants.verticalSpacing)
 
                             Button {
                                 //TODO: handle action
@@ -106,6 +110,7 @@ struct AddEditCoupon: View {
                             }
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.horizontal, Constants.margin)
+                            .padding([.bottom], Constants.verticalSpacing)
 
                             Button {
                                 //TODO: handle action
@@ -120,6 +125,7 @@ struct AddEditCoupon: View {
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.horizontal, Constants.margin)
                         }
+                        .padding([.bottom], Constants.verticalSpacing)
 
                         Group {
                             ListHeaderView(text: Localization.headerUsageDetails.uppercased(), alignment: .left)
@@ -130,6 +136,7 @@ struct AddEditCoupon: View {
                             Divider()
                                 .padding(.leading, Constants.margin)
                         }
+                        .padding([.bottom], Constants.verticalSpacing)
 
                         Button {
                             //TODO: handle action
@@ -138,7 +145,7 @@ struct AddEditCoupon: View {
                         }
                         .buttonStyle(PrimaryButtonStyle())
                         .padding(.horizontal, Constants.margin)
-                        .padding(.top, Constants.verticalSpacing)
+                        .padding([.top, .bottom], Constants.verticalSpacing)
                     }
                 }
                 .ignoresSafeArea(.container, edges: [.horizontal, .bottom])

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -54,7 +54,6 @@ struct AddEditCoupon: View {
                             }
                             .padding([.bottom], Constants.verticalSpacing)
 
-
                             HStack {
                                 Button {
                                     //TODO: handle action

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -54,16 +54,14 @@ struct AddEditCoupon: View {
                             }
                             .padding(.bottom, Constants.verticalSpacing)
 
-                            HStack {
-                                Button {
-                                    //TODO: handle action
-                                } label: {
-                                    Text(Localization.regenerateCouponCodeButton)
-                                }
-                                .buttonStyle(LinkButtonStyle())
-                                .fixedSize()
-                                Spacer().frame(maxWidth: .infinity)
+                            Button {
+                                //TODO: handle action
+                            } label: {
+                                Text(Localization.regenerateCouponCodeButton)
                             }
+                            .buttonStyle(LinkButtonStyle())
+                            .fixedSize()
+                            .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.bottom, Constants.verticalSpacing)
 
                             Button {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -22,8 +22,8 @@ struct AddEditCoupon: View {
                             ListHeaderView(text: Localization.headerCouponDetails.uppercased(), alignment: .left)
 
                             Group {
-                                TitleAndTextFieldRow(title: Localization.couponAmountPercentage,
-                                                     placeholder: Localization.couponAmountPercentage,
+                                TitleAndTextFieldRow(title: viewModel.amountText,
+                                                     placeholder: Localization.couponAmountPlaceholder,
                                                      text: $viewModel.amountField,
                                                      editable: true,
                                                      fieldAlignment: .leading,
@@ -162,9 +162,9 @@ private extension AddEditCoupon {
         static let headerCouponDetails = NSLocalizedString(
             "Coupon details",
             comment: "Header of the coupon details in the view for adding or editing a coupon.")
-        static let couponAmountPercentage = NSLocalizedString(
-            "Amount (%)",
-            comment: "Text field Amount in percentage in the view for adding or editing a coupon.")
+        static let couponAmountPlaceholder = NSLocalizedString(
+            "Coupon amount",
+            comment: "Text field placeholder for the amount in the view for adding or editing a coupon.")
         static let footerCouponAmountPercentage = NSLocalizedString(
             "Set the percentage of the discount you want to offer.",
             comment: "The footer of the text field Amount in percentage in the view for adding or editing a coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -69,6 +69,7 @@ struct AddEditCoupon: View {
                             } label: {
                                 HStack {
                                     Image(uiImage: .plusImage)
+                                        .frame(width: Constants.iconSize, height: Constants.iconSize)
                                     Text(Localization.addDescriptionButton)
                                         .bodyStyle()
                                 }
@@ -104,6 +105,7 @@ struct AddEditCoupon: View {
                             } label: {
                                 HStack {
                                     Image(uiImage: .pencilImage).colorMultiply(Color(.text))
+                                        .frame(width: Constants.iconSize, height: Constants.iconSize)
                                     Text(Localization.editProductsButton)
                                         .bodyStyle()
                                 }
@@ -118,6 +120,7 @@ struct AddEditCoupon: View {
                                 HStack {
                                     Image(uiImage: .pencilImage)
                                         .colorMultiply(Color(.text))
+                                        .frame(width: Constants.iconSize, height: Constants.iconSize)
                                     Text(Localization.editProductCategoriesButton)
                                         .bodyStyle()
                                 }
@@ -171,6 +174,7 @@ private extension AddEditCoupon {
     enum Constants {
         static let margin: CGFloat = 16
         static let verticalSpacing: CGFloat = 8
+        static let iconSize: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -27,12 +27,12 @@ struct AddEditCoupon: View {
                                                      text: $viewModel.amountField,
                                                      editable: true,
                                                      fieldAlignment: .leading,
-                                                     keyboardType: .asciiCapableNumberPad)
+                                                     keyboardType: .decimalPad)
                                 Divider()
                                     .padding(.leading, Constants.margin)
                             }
 
-                            Text(Localization.footerCouponAmountPercentage)
+                            Text(viewModel.amountSubtitleText)
                                 .subheadlineStyle()
                                 .padding(.horizontal, Constants.margin)
 
@@ -165,9 +165,6 @@ private extension AddEditCoupon {
         static let couponAmountPlaceholder = NSLocalizedString(
             "Coupon amount",
             comment: "Text field placeholder for the amount in the view for adding or editing a coupon.")
-        static let footerCouponAmountPercentage = NSLocalizedString(
-            "Set the percentage of the discount you want to offer.",
-            comment: "The footer of the text field Amount in percentage in the view for adding or editing a coupon.")
         static let couponCode = NSLocalizedString(
             "Coupon Code",
             comment: "Text field coupon code in the view for adding or editing a coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -40,7 +40,7 @@ struct AddEditCoupon: View {
 
                             Group {
                                 TitleAndTextFieldRow(title: Localization.couponCode,
-                                                     placeholder: couponCodePlaceholder,
+                                                     placeholder: Localization.couponCodePlaceholder,
                                                      text: $viewModel.codeField,
                                                      editable: true,
                                                      fieldAlignment: .leading,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -25,7 +25,7 @@ struct AddEditCoupon: View {
                                 TitleAndTextFieldRow(title: Localization.couponAmountPercentage,
                                                      placeholder: Localization.couponAmountPercentage,
                                                      text: $viewModel.amountField,
-                                                     editable: false,
+                                                     editable: true,
                                                      fieldAlignment: .leading,
                                                      keyboardType: .asciiCapableNumberPad)
                                 Divider()
@@ -40,9 +40,9 @@ struct AddEditCoupon: View {
                                 TitleAndTextFieldRow(title: Localization.couponCode,
                                                      placeholder: Localization.couponCode,
                                                      text: $viewModel.codeField,
-                                                     editable: false,
+                                                     editable: true,
                                                      fieldAlignment: .leading,
-                                                     keyboardType: .asciiCapableNumberPad)
+                                                     keyboardType: .default)
                                 Divider()
                                     .padding(.leading, Constants.margin)
                             }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -35,7 +35,7 @@ struct AddEditCoupon: View {
                                     .subheadlineStyle()
                                     .padding(.horizontal, Constants.margin)
                             }
-                            .padding([.bottom], Constants.verticalSpacing)
+                            .padding(.bottom, Constants.verticalSpacing)
 
 
                             Group {
@@ -47,12 +47,12 @@ struct AddEditCoupon: View {
                                                      keyboardType: .default)
                                 Divider()
                                     .padding(.leading, Constants.margin)
-                                    .padding([.bottom], Constants.verticalSpacing)
+                                    .padding(.bottom, Constants.verticalSpacing)
                                 Text(Localization.footerCouponCode)
                                     .subheadlineStyle()
                                     .padding(.horizontal, Constants.margin)
                             }
-                            .padding([.bottom], Constants.verticalSpacing)
+                            .padding(.bottom, Constants.verticalSpacing)
 
                             HStack {
                                 Button {
@@ -64,7 +64,7 @@ struct AddEditCoupon: View {
                                 .fixedSize()
                                 Spacer().frame(maxWidth: .infinity)
                             }
-                            .padding([.bottom], Constants.verticalSpacing)
+                            .padding(.bottom, Constants.verticalSpacing)
 
                             Button {
                                 //TODO: handle action
@@ -86,7 +86,7 @@ struct AddEditCoupon: View {
                                 Divider()
                                     .padding(.leading, Constants.margin)
                             }
-                            .padding([.bottom], Constants.verticalSpacing)
+                            .padding(.bottom, Constants.verticalSpacing)
 
                             Group {
                                 TitleAndToggleRow(title: Localization.includeFreeShipping, isOn: .constant(false))
@@ -94,12 +94,12 @@ struct AddEditCoupon: View {
                                 Divider()
                                     .padding(.leading, Constants.margin)
                             }
-                            .padding([.bottom], Constants.verticalSpacing)
+                            .padding(.bottom, Constants.verticalSpacing)
                         }
 
                         Group {
                             ListHeaderView(text: Localization.headerApplyCouponTo.uppercased(), alignment: .left)
-                                .padding([.bottom], Constants.verticalSpacing)
+                                .padding(.bottom, Constants.verticalSpacing)
 
                             Button {
                                 //TODO: handle action
@@ -112,7 +112,7 @@ struct AddEditCoupon: View {
                             }
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.horizontal, Constants.margin)
-                            .padding([.bottom], Constants.verticalSpacing)
+                            .padding(.bottom, Constants.verticalSpacing)
 
                             Button {
                                 //TODO: handle action
@@ -127,7 +127,7 @@ struct AddEditCoupon: View {
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.horizontal, Constants.margin)
                         }
-                        .padding([.bottom], Constants.verticalSpacing)
+                        .padding(.bottom, Constants.verticalSpacing)
 
                         Group {
                             ListHeaderView(text: Localization.headerUsageDetails.uppercased(), alignment: .left)
@@ -138,7 +138,7 @@ struct AddEditCoupon: View {
                             Divider()
                                 .padding(.leading, Constants.margin)
                         }
-                        .padding([.bottom], Constants.verticalSpacing)
+                        .padding(.bottom, Constants.verticalSpacing)
 
                         Button {
                             //TODO: handle action

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -22,7 +22,7 @@ struct AddEditCoupon: View {
                             ListHeaderView(text: Localization.headerCouponDetails.uppercased(), alignment: .left)
 
                             Group {
-                                TitleAndTextFieldRow(title: viewModel.amountText,
+                                TitleAndTextFieldRow(title: viewModel.amountLabel,
                                                      placeholder: "0",
                                                      text: $viewModel.amountField,
                                                      editable: true,
@@ -31,7 +31,7 @@ struct AddEditCoupon: View {
                                 Divider()
                                     .padding(.leading, Constants.margin)
 
-                                Text(viewModel.amountSubtitleText)
+                                Text(viewModel.amountSubtitleLabel)
                                     .subheadlineStyle()
                                     .padding(.horizontal, Constants.margin)
                             }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -84,13 +84,16 @@ private extension AddEditCouponViewModel {
 
     enum Localization {
         static let amountPercent = NSLocalizedString("Amount (%)",
-                                                     comment: "Text field Amount in percentage in the view for adding or editing a coupon.")
+                                                     comment: "Title of the Amount field in the Coupon Edit" +
+                                                     " or Creation screen for a percentage discount coupon.")
         static let amountFixedDiscount = NSLocalizedString("Amount (fixed discount)",
-                                                     comment: "Text field Amount with fixed discount in the view for adding or editing a coupon.")
+                                                           comment: "Title of the Amount field on the Coupon Edit" +
+                                                           " or Creation screen for a fixed amount discount coupon.")
         static let amountPercentSubtitle = NSLocalizedString("Set the percentage of the discount you want to offer.",
-                                                     comment: "The footer of the text field Amount in percentage in the view for adding or editing a coupon.")
+                                                             comment: "Subtitle of the Amount field in the Coupon Edit" +
+                                                             " or Creation screen for a percentage discount coupon.")
         static let amountFixedDiscountSubtitle = NSLocalizedString("Set the fixed amount of the discount you want to offer.",
-                                                                   comment: "The footer of the text field Amount with fixed" +
-                                                                   "discount in the view for adding or editing a coupon.")
+                                                                   comment: "Subtitle of the Amount field on the Coupon Edit" +
+                                                                   " or Creation screen for a fixed amount discount coupon.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -86,6 +86,7 @@ private extension AddEditCouponViewModel {
         static let amountPercentSubtitle = NSLocalizedString("Set the percentage of the discount you want to offer.",
                                                      comment: "The footer of the text field Amount in percentage in the view for adding or editing a coupon.")
         static let amountFixedDiscountSubtitle = NSLocalizedString("Set the fixed amount of the discount you want to offer.",
-                                                                   comment: "The footer of the text field Amount with fixed discount in the view for adding or editing a coupon.")
+                                                                   comment: "The footer of the text field Amount with fixed" +
+                                                                   "discount in the view for adding or editing a coupon.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -29,7 +29,9 @@ final class AddEditCouponViewModel: ObservableObject {
         case .percent:
             return Localization.amountPercent
         default:
-            return Localization.amountFixedDiscount
+            let currencyCode = ServiceLocator.currencySettings.currencyCode
+            let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
+            return String.localizedStringWithFormat(Localization.amountFixedDiscount, unit)
         }
     }
 
@@ -86,9 +88,10 @@ private extension AddEditCouponViewModel {
         static let amountPercent = NSLocalizedString("Amount (%)",
                                                      comment: "Title of the Amount field in the Coupon Edit" +
                                                      " or Creation screen for a percentage discount coupon.")
-        static let amountFixedDiscount = NSLocalizedString("Amount (fixed discount)",
+        static let amountFixedDiscount = NSLocalizedString("Amount (%@)",
                                                            comment: "Title of the Amount field on the Coupon Edit" +
-                                                           " or Creation screen for a fixed amount discount coupon.")
+                                                           " or Creation screen for a fixed amount discount coupon." +
+                                                           "Reads like: Amount ($)")
         static let amountPercentSubtitle = NSLocalizedString("Set the percentage of the discount you want to offer.",
                                                              comment: "Subtitle of the Amount field in the Coupon Edit" +
                                                              " or Creation screen for a percentage discount coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -22,6 +22,8 @@ final class AddEditCouponViewModel: ObservableObject {
         }
     }
 
+    /// Text representing the label of the amount field, localized based on discount type.
+    ///
     var amountText: String {
         switch discountType {
         case .percent:
@@ -31,6 +33,8 @@ final class AddEditCouponViewModel: ObservableObject {
         }
     }
 
+    /// Text representing the label of the amount textfield subtitle, localized based on discount type.
+    ///
     var amountSubtitleText: String {
         switch discountType {
         case .percent:

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -22,7 +22,7 @@ final class AddEditCouponViewModel: ObservableObject {
         }
     }
 
-    /// Text representing the label of the amount field, localized based on discount type.
+    /// Label representing the label of the amount field, localized based on discount type.
     ///
     var amountLabel: String {
         switch discountType {
@@ -35,7 +35,7 @@ final class AddEditCouponViewModel: ObservableObject {
         }
     }
 
-    /// Text representing the label of the amount textfield subtitle, localized based on discount type.
+    /// Label representing the label of the amount textfield subtitle, localized based on discount type.
     ///
     var amountSubtitleLabel: String {
         switch discountType {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -22,12 +22,7 @@ final class AddEditCouponViewModel: ObservableObject {
         }
     }
 
-    private var coupon: Coupon? {
-        didSet {
-            amountField = coupon?.amount ?? ""
-            codeField = coupon?.code ?? ""
-        }
-    }
+    private var coupon: Coupon?
 
     // Fields
     @Published var amountField = String()
@@ -49,6 +44,10 @@ final class AddEditCouponViewModel: ObservableObject {
         coupon = existingCoupon
         editingOption = .editing
         discountType = existingCoupon.discountType
+
+        // Populate fields
+        amountField = existingCoupon.amount
+        codeField = existingCoupon.code
     }
 
     private enum EditingOption {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -24,7 +24,7 @@ final class AddEditCouponViewModel: ObservableObject {
 
     /// Text representing the label of the amount field, localized based on discount type.
     ///
-    var amountText: String {
+    var amountLabel: String {
         switch discountType {
         case .percent:
             return Localization.amountPercent
@@ -35,7 +35,7 @@ final class AddEditCouponViewModel: ObservableObject {
 
     /// Text representing the label of the amount textfield subtitle, localized based on discount type.
     ///
-    var amountSubtitleText: String {
+    var amountSubtitleLabel: String {
         switch discountType {
         case .percent:
             return Localization.amountPercentSubtitle

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -86,6 +86,6 @@ private extension AddEditCouponViewModel {
         static let amountPercentSubtitle = NSLocalizedString("Set the percentage of the discount you want to offer.",
                                                      comment: "The footer of the text field Amount in percentage in the view for adding or editing a coupon.")
         static let amountFixedDiscountSubtitle = NSLocalizedString("Set the fixed amount of the discount you want to offer.",
-                                                     comment: "The footer of the text field Amount with fixed discount in the view for adding or editing a coupon.")
+                                                                   comment: "The footer of the text field Amount with fixed discount in the view for adding or editing a coupon.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -22,6 +22,15 @@ final class AddEditCouponViewModel: ObservableObject {
         }
     }
 
+    var amountText: String {
+        switch discountType {
+        case .percent:
+            return Localization.amountPercent
+        default:
+            return Localization.amountFixedDiscount
+        }
+    }
+
     private var coupon: Coupon?
 
     // Fields
@@ -53,5 +62,17 @@ final class AddEditCouponViewModel: ObservableObject {
     private enum EditingOption {
         case creation
         case editing
+    }
+}
+
+// MARK: - Constants
+//
+private extension AddEditCouponViewModel {
+
+    enum Localization {
+        static let amountPercent = NSLocalizedString("Amount (%)",
+                                                     comment: "Text field Amount in percentage in the view for adding or editing a coupon.")
+        static let amountFixedDiscount = NSLocalizedString("Amount (fixed discount)",
+                                                     comment: "Text field Amount with fixed discount in the view for adding or editing a coupon.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -31,6 +31,15 @@ final class AddEditCouponViewModel: ObservableObject {
         }
     }
 
+    var amountSubtitleText: String {
+        switch discountType {
+        case .percent:
+            return Localization.amountPercentSubtitle
+        default:
+            return Localization.amountFixedDiscountSubtitle
+        }
+    }
+
     private var coupon: Coupon?
 
     // Fields
@@ -74,5 +83,9 @@ private extension AddEditCouponViewModel {
                                                      comment: "Text field Amount in percentage in the view for adding or editing a coupon.")
         static let amountFixedDiscount = NSLocalizedString("Amount (fixed discount)",
                                                      comment: "Text field Amount with fixed discount in the view for adding or editing a coupon.")
+        static let amountPercentSubtitle = NSLocalizedString("Set the percentage of the discount you want to offer.",
+                                                     comment: "The footer of the text field Amount in percentage in the view for adding or editing a coupon.")
+        static let amountFixedDiscountSubtitle = NSLocalizedString("Set the fixed amount of the discount you want to offer.",
+                                                     comment: "The footer of the text field Amount with fixed discount in the view for adding or editing a coupon.")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -9,7 +9,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel1.title, Localization.titleCreatePercentageDiscount)
 
         let viewModel2 = AddEditCouponViewModel(siteID: 123, discountType: .fixedCart)
-        XCTAssertEqual(viewModel2.title, Localization.titleCreateFixedCardDiscount)
+        XCTAssertEqual(viewModel2.title, Localization.titleCreateFixedCartDiscount)
 
         let viewModel3 = AddEditCouponViewModel(siteID: 123, discountType: .fixedProduct)
         XCTAssertEqual(viewModel3.title, Localization.titleCreateFixedProductDiscount)
@@ -23,7 +23,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel1.title, Localization.titleEditPercentageDiscount)
 
         let viewModel2 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedCart))
-        XCTAssertEqual(viewModel2.title, Localization.titleEditFixedCardDiscount)
+        XCTAssertEqual(viewModel2.title, Localization.titleEditFixedCartDiscount)
 
         let viewModel3 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedProduct))
         XCTAssertEqual(viewModel3.title, Localization.titleEditFixedProductDiscount)
@@ -36,9 +36,9 @@ final class AddEditCouponViewModelTests: XCTestCase {
         static let titleCreatePercentageDiscount = NSLocalizedString(
             "Create percentage discount",
             comment: "Title of the view for creating a coupon with percentage discount.")
-        static let titleCreateFixedCardDiscount = NSLocalizedString(
-            "Create fixed card discount",
-            comment: "Title of the view for creating a coupon with fixed card discount.")
+        static let titleCreateFixedCartDiscount = NSLocalizedString(
+            "Create fixed cart discount",
+            comment: "Title of the view for creating a coupon with fixed cart discount.")
         static let titleCreateFixedProductDiscount = NSLocalizedString(
             "Create fixed product discount",
             comment: "Title of the view for creating a coupon with fixed product discount.")
@@ -48,9 +48,9 @@ final class AddEditCouponViewModelTests: XCTestCase {
         static let titleEditPercentageDiscount = NSLocalizedString(
             "Edit percentage discount",
             comment: "Title of the view for editing a coupon with percentage discount.")
-        static let titleEditFixedCardDiscount = NSLocalizedString(
-            "Edit fixed card discount",
-            comment: "Title of the view for editing a coupon with fixed card discount.")
+        static let titleEditFixedCartDiscount = NSLocalizedString(
+            "Edit fixed cart discount",
+            comment: "Title of the view for editing a coupon with fixed cart discount.")
         static let titleEditFixedProductDiscount = NSLocalizedString(
             "Edit fixed product discount",
             comment: "Title of the view for editing a coupon with fixed product discount.")


### PR DESCRIPTION
Part of #6488 

### Description
In this PR I made some changes improving some things in the Edit Coupon View (still WIP). 
- Improved localization based on discount type.
- Fixed the spacing between the elements.
- Now the text fields are editable, with the correct placeholder and the correct keyboard type.
- Aligned the button for regenerating the coupon code to the left side.
- Added the icon on the left side on buttons for editing products and product categories.

Still in todo (next PRs):
- [ ] Keep the content inside the safe area in the landscape mode.

### Testing instructions
1. Launch the app with the new feature flag `couponEditing` enabled.
2. Navigate to a coupon detail.
3. Press the ellipsis button in the navigation bar.
4. You should be able to see the new action "Edit Coupon".
5. Press the "Edit Coupon" action -> The new screen should be presented. 


### Screenshots
<img src="https://user-images.githubusercontent.com/495617/161764667-e56622f9-6dec-4a78-853d-6ba5cd5e3e59.png" width=300 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
