### PR TITLE
Orders: Support searching for orders with # prefix

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -79,6 +79,18 @@ final class OrderSearchUICommand: SearchUICommand {
 
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)
     }
+
+    /// Removes the `#` from the start of the search keyword, if present.
+    ///
+    /// This allows searching for an order with `#123` and getting the results for order `123`.
+    /// See https://github.com/woocommerce/woocommerce-ios/issues/2506
+    ///
+    func sanitize(_ keyword: String) -> String {
+        guard keyword.starts(with: "#") else {
+            return keyword
+        }
+        return keyword.removing(at: keyword.startIndex)
+    }
 }
 
 private extension OrderSearchUICommand {

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -86,10 +86,10 @@ final class OrderSearchUICommand: SearchUICommand {
     /// See https://github.com/woocommerce/woocommerce-ios/issues/2506
     ///
     func sanitizeKeyword(_ keyword: String) -> String {
-        guard keyword.starts(with: "#") else {
-            return keyword
+        if keyword.starts(with: "#") {
+            return keyword.removing(at: keyword.startIndex)
         }
-        return keyword.removing(at: keyword.startIndex)
+        return keyword
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -85,7 +85,7 @@ final class OrderSearchUICommand: SearchUICommand {
     /// This allows searching for an order with `#123` and getting the results for order `123`.
     /// See https://github.com/woocommerce/woocommerce-ios/issues/2506
     ///
-    func sanitize(_ keyword: String) -> String {
+    func sanitizeKeyword(_ keyword: String) -> String {
         guard keyword.starts(with: "#") else {
             return keyword
         }

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -84,12 +84,23 @@ protocol SearchUICommand {
 
     /// The Accessibility Identifier for the cancel button
     var cancelButtonAccessibilityIdentifier: String { get }
+
+    /// Optionally sanitizes the search keyword.
+    ///
+    /// - Parameter keyword: user-entered search keyword.
+    /// - Returns: sanitized search keyword.
+    func sanitizeKeyword(_ keyword: String) -> String
 }
 
 // MARK: - Default implementation
 extension SearchUICommand {
     func configureActionButton(_ button: UIButton, onDismiss: @escaping () -> Void) {
         // If not implemented, keeps the default cancel UI/UX
+    }
+
+    func sanitizeKeyword(_ keyword: String) -> String {
+        // If not implemented, returns the keyword as entered
+        return keyword
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -368,9 +368,10 @@ extension SearchViewController: SyncingCoordinatorDelegate {
                                           pageNumber: pageNumber,
                                           pageSize: pageSize,
                                           onCompletion: { [weak self] isCompleted in
+                                            guard let self = self else { return }
                                             // Disregard OPs that don't really match the latest keyword
-                                            if keyword == self?.searchUICommand.sanitizeKeyword(self?.keyword ?? String()) {
-                                                self?.transitionToResultsUpdatedState()
+                                            if keyword == self.searchUICommand.sanitizeKeyword(self.keyword) {
+                                                self.transitionToResultsUpdatedState()
                                             }
                                             onCompletion?(isCompleted)
         })

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -70,7 +70,7 @@ where Cell.SearchModel == Command.CellViewModel {
     /// Returns the active Keyword
     ///
     private var keyword: String {
-        return searchBar.text ?? String()
+        return searchUICommand.sanitizeKeyword(searchBar.text ?? String())
     }
 
     /// UI Active State
@@ -205,7 +205,8 @@ where Cell.SearchModel == Command.CellViewModel {
     // MARK: - UISearchBarDelegate Conformance
     //
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        synchronizeSearchResults(with: searchText)
+        let sanitizedSearchText = searchUICommand.sanitizeKeyword(searchText)
+        synchronizeSearchResults(with: sanitizedSearchText)
     }
 
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {


### PR DESCRIPTION
Closes: #2506

## Description

On the Orders tab, we have the option to search orders by order number. The REST API only supports searching for orders with a plain order number (e.g. `123`); prefixing the order with a `#` (e.g. `#123`) does not return results.

This removes the `#` before performing the search, so that searching e.g. `123` and `#123` returns the same results.

## Changes

* Adds a `sanitizeKeyword(_:)` method to the `SearchUICommand` protocol, along with a default implementation.
* Sanitizes the keyword in `SearchViewController` before performing the remote search and fetching the results from Storage.
* Adds a `sanitizeKeyword(_:)` implementation to `OrderSearchUICommand` to remove the `#` from the search keyword.

Note: I considered using `searchBar(_:shouldChangeTextIn:replacementText:)` (part of the `UISearchBarDelegate` in `SearchViewController`) to validate and sanitize the search input as it's entered, so that `#` couldn't be entered at all in order searches. However, I think the approach used in this PR works better for cases like this where we know that certain characters need to be stripped for the search to work correctly but there isn't a logical reason to prevent them from being entered in the search field.

## Testing

1. Open the Orders tab.
2. Tap the search icon to start a search.
3. Search for an existing order number on your store, such as `123`.
4. Verify the search results show that order.
5. Search for the same order number with the # symbol included in the search, such as `#123`.
6. Confirm the same search results appear, including that order.

## Screenshots


https://user-images.githubusercontent.com/8658164/161769453-52a3d651-c23b-4255-8722-66b2aba4b8b5.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
