### PR TITLE
Coupons: Initial UI without real data for the Select Products view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
@@ -7,22 +7,30 @@ struct SelectProducts: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SearchHeader(filterText: $query, filterPlaceholder: "Search Products")
+                SearchHeader(filterText: $query, filterPlaceholder: Localization.searchBarPlaceholder)
             }
             HStack {
-                Button("Select All") {
+                Button(Localization.selectAll) {
                     // TODO: select all item
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
                 Spacer()
-                Button("Filter") {
+                Button(Localization.filter) {
                     // TODO: show filter view
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
             }
         }
+    }
+}
+
+private extension SelectProducts {
+    enum Localization {
+        static let searchBarPlaceholder = NSLocalizedString("Search Products", comment: "Placeholder for the search bar in the Select Products screen")
+        static let selectAll = NSLocalizedString("Select All", comment: "Action button on the Select Products screen to select all products in the list")
+        static let filter = NSLocalizedString("Filter", comment: "Action button on the Select Products screen to filter items in the product list.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
@@ -4,11 +4,15 @@ import SwiftUI
 ///
 struct SelectProducts: View {
     @State private var query: String = ""
+    @ObservedObject private var viewModel: SelectProductsViewModel
+
+    init(viewModel: SelectProductsViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                SearchHeader(filterText: $query, filterPlaceholder: Localization.searchBarPlaceholder)
-            }
+        VStack(alignment: .leading, spacing: 0) {
+            SearchHeader(filterText: $query, filterPlaceholder: Localization.searchBarPlaceholder)
             HStack {
                 Button(Localization.selectAll) {
                     // TODO: select all item
@@ -22,11 +26,23 @@ struct SelectProducts: View {
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
             }
+            Spacer()
+            Button(viewModel.actionTitle) {
+                // TODO: handle completion
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .padding()
+            .renderedIf(viewModel.selectedItemCount > 0)
         }
+        navigationTitle(viewModel.navigationTitle)
     }
 }
 
 private extension SelectProducts {
+    enum Constants {
+        static let horizontalSpacing: CGFloat = 16
+    }
+
     enum Localization {
         static let searchBarPlaceholder = NSLocalizedString("Search Products", comment: "Placeholder for the search bar in the Select Products screen")
         static let selectAll = NSLocalizedString("Select All", comment: "Action button on the Select Products screen to select all products in the list")
@@ -36,6 +52,6 @@ private extension SelectProducts {
 
 struct SelectProducts_Previews: PreviewProvider {
     static var previews: some View {
-        SelectProducts()
+        SelectProducts(viewModel: .init())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct SelectProducts: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct SelectProducts_Previews: PreviewProvider {
+    static var previews: some View {
+        SelectProducts()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
@@ -1,8 +1,28 @@
 import SwiftUI
 
+/// View to select products
+///
 struct SelectProducts: View {
+    @State private var query: String = ""
     var body: some View {
-        Text("Hello, World!")
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SearchHeader(filterText: $query, filterPlaceholder: "Search Products")
+            }
+            HStack {
+                Button("Select All") {
+                    // TODO: select all item
+                }
+                .buttonStyle(LinkButtonStyle())
+                .fixedSize()
+                Spacer()
+                Button("Filter") {
+                    // TODO: show filter view
+                }
+                .buttonStyle(LinkButtonStyle())
+                .fixedSize()
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProducts.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// View to select products
 ///
 struct SelectProducts: View {
-    @State private var query: String = ""
+    @Environment(\.presentationMode) var presentation
     @ObservedObject private var viewModel: SelectProductsViewModel
 
     init(viewModel: SelectProductsViewModel) {
@@ -11,30 +11,42 @@ struct SelectProducts: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            SearchHeader(filterText: $query, filterPlaceholder: Localization.searchBarPlaceholder)
-            HStack {
-                Button(Localization.selectAll) {
-                    // TODO: select all item
+        NavigationView {
+            VStack(alignment: .leading, spacing: 0) {
+                SearchHeader(filterText: $viewModel.searchQuery, filterPlaceholder: Localization.searchBarPlaceholder)
+                HStack {
+                    Button(Localization.selectAll) {
+                        // TODO: select all item
+                    }
+                    .buttonStyle(LinkButtonStyle())
+                    .fixedSize()
+                    Spacer()
+                    Button(Localization.filter) {
+                        // TODO: show filter view
+                    }
+                    .buttonStyle(LinkButtonStyle())
+                    .fixedSize()
                 }
-                .buttonStyle(LinkButtonStyle())
-                .fixedSize()
+                // TODO: add list of products
                 Spacer()
-                Button(Localization.filter) {
-                    // TODO: show filter view
+                Button(viewModel.actionTitle) {
+                    // TODO: handle completion
                 }
-                .buttonStyle(LinkButtonStyle())
-                .fixedSize()
+                .buttonStyle(PrimaryButtonStyle())
+                .padding()
+                .renderedIf(viewModel.selectedItemCount > 0)
             }
-            Spacer()
-            Button(viewModel.actionTitle) {
-                // TODO: handle completion
+            .navigationTitle(viewModel.navigationTitle)
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel, action: {
+                        presentation.wrappedValue.dismiss()
+                    })
+                }
             }
-            .buttonStyle(PrimaryButtonStyle())
-            .padding()
-            .renderedIf(viewModel.selectedItemCount > 0)
+            .wooNavigationBarStyle()
         }
-        navigationTitle(viewModel.navigationTitle)
     }
 }
 
@@ -47,6 +59,7 @@ private extension SelectProducts {
         static let searchBarPlaceholder = NSLocalizedString("Search Products", comment: "Placeholder for the search bar in the Select Products screen")
         static let selectAll = NSLocalizedString("Select All", comment: "Action button on the Select Products screen to select all products in the list")
         static let filter = NSLocalizedString("Filter", comment: "Action button on the Select Products screen to filter items in the product list.")
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the Select Products screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProductsViewModel.swift
@@ -6,6 +6,10 @@ final class SelectProductsViewModel: ObservableObject {
     /// Whether the view is for selecting or excluding products
     private var isExclusion: Bool
 
+    /// The query to search for products
+    @Published var searchQuery: String = ""
+
+    /// TODO: replace this with the real list of selected items
     @Published private(set) var selectedItemCount: Int = 0
 
     /// Title for the navigation bar of the Select Products screen

--- a/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/SelectProducts/SelectProductsViewModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// View Model for `SelectProducts`
+///
+final class SelectProductsViewModel: ObservableObject {
+    /// Whether the view is for selecting or excluding products
+    private var isExclusion: Bool
+
+    @Published private(set) var selectedItemCount: Int = 0
+
+    /// Title for the navigation bar of the Select Products screen
+    ///
+    var navigationTitle: String {
+        isExclusion ? Localization.exclusionTitle : Localization.selectionTitle
+    }
+
+    /// Title for the action button on Select Products screen
+    ///
+    var actionTitle: String {
+        let itemCount = String.pluralize(selectedItemCount, singular: Localization.singleProduct, plural: Localization.multipleProducts)
+
+        let format = isExclusion ? Localization.exclusionActionTitle : Localization.selectionActionTitle
+        return String.localizedStringWithFormat(format, itemCount)
+    }
+
+    init(isExclusion: Bool = false) {
+        self.isExclusion = isExclusion
+    }
+}
+
+private extension SelectProductsViewModel {
+    enum Localization {
+        static let selectionTitle = NSLocalizedString("Select products", comment: "Title for the Select Products screen")
+        static let exclusionTitle = NSLocalizedString("Exclude products", comment: "Title of the Exclude Products screen")
+        static let selectionActionTitle = NSLocalizedString(
+            "Select %1$@",
+            comment: "Title of the action button on the Select Products screen" +
+            "Reads like: Select 1 Product"
+        )
+        static let exclusionActionTitle = NSLocalizedString(
+            "Exclude %1$@",
+            comment: "Title of the action button on the Exclude Products screen" +
+            "Reads like: Exclude 1 Product"
+        )
+        static let singleProduct = NSLocalizedString("%1$d Product", comment: "Count of one product")
+        static let multipleProducts = NSLocalizedString("%1$d Products", comment: "Count of several products, reads like: 2 Products")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1582,6 +1582,7 @@
 		DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
+		DEF0FDC827FD5CBC0080E487 /* SelectProductsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF0FDC727FD5CBC0080E487 /* SelectProductsViewModel.swift */; };
 		DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */; };
 		DEF8B68727FC34690072EDBE /* SelectProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8B68627FC34690072EDBE /* SelectProducts.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -3283,6 +3284,7 @@
 		DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageAttributes.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
+		DEF0FDC727FD5CBC0080E487 /* SelectProductsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectProductsViewModel.swift; sourceTree = "<group>"; };
 		DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSelectedRate.swift; sourceTree = "<group>"; };
 		DEF8B68627FC34690072EDBE /* SelectProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectProducts.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -7665,6 +7667,7 @@
 			isa = PBXGroup;
 			children = (
 				DEF8B68627FC34690072EDBE /* SelectProducts.swift */,
+				DEF0FDC727FD5CBC0080E487 /* SelectProductsViewModel.swift */,
 			);
 			path = SelectProducts;
 			sourceTree = "<group>";
@@ -9088,6 +9091,7 @@
 				021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */,
 				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,
 				DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */,
+				DEF0FDC827FD5CBC0080E487 /* SelectProductsViewModel.swift in Sources */,
 				26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1511,6 +1511,7 @@
 		DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */; };
 		DE19BB1A26C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1926C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift */; };
 		DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1C26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift */; };
+		DE1A2B4327FD7A6F000D2318 /* SelectProductsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1A2B4227FD7A6F000D2318 /* SelectProductsViewModelTests.swift */; };
 		DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */; };
 		DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */; };
 		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
@@ -3213,6 +3214,7 @@
 		DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetails.swift; sourceTree = "<group>"; };
 		DE19BB1926C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModel.swift; sourceTree = "<group>"; };
 		DE19BB1C26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModelTests.swift; sourceTree = "<group>"; };
+		DE1A2B4227FD7A6F000D2318 /* SelectProductsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectProductsViewModelTests.swift; sourceTree = "<group>"; };
 		DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewController.swift; sourceTree = "<group>"; };
 		DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewOrderViewController.xib; sourceTree = "<group>"; };
 		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
@@ -4407,6 +4409,7 @@
 				DE69C54E27BCB4B6000BB888 /* CouponRestrictionsViewModelTests.swift */,
 				DE74F2A627E47F620002FE59 /* EnableAnalyticsViewModelTests.swift */,
 				4572641A27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift */,
+				DE1A2B4227FD7A6F000D2318 /* SelectProductsViewModelTests.swift */,
 			);
 			path = Coupons;
 			sourceTree = "<group>";
@@ -9778,6 +9781,7 @@
 				AEA622B727468790002A9B57 /* AddOrderCoordinatorTests.swift in Sources */,
 				D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */,
 				A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */,
+				DE1A2B4327FD7A6F000D2318 /* SelectProductsViewModelTests.swift in Sources */,
 				D83A6A7A23792B2400419D48 /* UIColor+Muriel-Tests.swift in Sources */,
 				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1583,6 +1583,7 @@
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */; };
+		DEF8B68727FC34690072EDBE /* SelectProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8B68627FC34690072EDBE /* SelectProducts.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
@@ -3283,6 +3284,7 @@
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSelectedRate.swift; sourceTree = "<group>"; };
+		DEF8B68627FC34690072EDBE /* SelectProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectProducts.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
@@ -4381,6 +4383,7 @@
 		03FBDA9B263AD47200ACE257 /* Coupons */ = {
 			isa = PBXGroup;
 			children = (
+				DEF8B68527FC344C0072EDBE /* SelectProducts */,
 				DE74F2A127E41D4F0002FE59 /* EnableAnalytics */,
 				DE69C54B27BB7163000BB888 /* UsageDetails */,
 				DE7B479127A38ABC0018742E /* CouponDetails */,
@@ -7658,6 +7661,14 @@
 			path = "Print Customs Form";
 			sourceTree = "<group>";
 		};
+		DEF8B68527FC344C0072EDBE /* SelectProducts */ = {
+			isa = PBXGroup;
+			children = (
+				DEF8B68627FC34690072EDBE /* SelectProducts.swift */,
+			);
+			path = SelectProducts;
+			sourceTree = "<group>";
+		};
 		DEFD6E5F264990DD00E51E0D /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -9387,6 +9398,7 @@
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
+				DEF8B68727FC34690072EDBE /* SelectProducts.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
 				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/SelectProductsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/SelectProductsViewModelTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import WooCommerce
+
+final class SelectProductsViewModelTests: XCTestCase {
+
+    func test_navigationTitle_is_correct_for_default_screen() {
+        // Given
+        let viewModel = SelectProductsViewModel()
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTitle, NSLocalizedString("Select products", comment: ""))
+    }
+
+    func test_navigationTitle_is_correct_for_exclusion_screen() {
+        // Given
+        let viewModel = SelectProductsViewModel(isExclusion: true)
+
+        // Then
+        XCTAssertEqual(viewModel.navigationTitle, NSLocalizedString("Exclude products", comment: ""))
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6489 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new view for the new Select Products view. The initial UI includes only the search bar and some buttons without actions. The view is configured so that it can be reused for both selecting and excluding products. 

Further updates will be added in the next PRs.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The view hasn't been integrated yet, so please use Xcode preview to have an idea of what the WIP looks like.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="369" alt="Screen Shot 2022-04-06 at 14 33 26" src="https://user-images.githubusercontent.com/5533851/161925462-f14d91e7-00f0-4a51-8ac9-8ce42a4fe3d5.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
