### PR TITLE
IPP Analytics: add `card_reader_model` property to card reader software update events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -672,10 +672,15 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - updateType: `.required` or `.optional`.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderSoftwareUpdateTapped(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateTapped(forGatewayID: String?,
+                                                   updateType: SoftwareUpdateTypeProperty,
+                                                   countryCode: String,
+                                                   cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateTapped,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -689,10 +694,15 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - updateType: `.required` or `.optional`.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderSoftwareUpdateStarted(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateStarted(forGatewayID: String?,
+                                                    updateType: SoftwareUpdateTypeProperty,
+                                                    countryCode: String,
+                                                    cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateStarted,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -707,12 +717,17 @@ extension WooAnalyticsEvent {
         ///   - updateType: `.required` or `.optional`.
         ///   - error: the error to be included in the event properties.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderSoftwareUpdateFailed(
-            forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, error: Error, countryCode: String
+        static func cardReaderSoftwareUpdateFailed(forGatewayID: String?,
+                                                   updateType: SoftwareUpdateTypeProperty,
+                                                   error: Error,
+                                                   countryCode: String,
+                                                   cardReaderModel: String
         ) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateFailed,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue,
@@ -727,10 +742,12 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - updateType: `.required` or `.optional`.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateSuccess,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -744,12 +761,15 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - updateType: `.required` or `.optional`.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
         static func cardReaderSoftwareUpdateCancelTapped(forGatewayID: String?,
                                                          updateType: SoftwareUpdateTypeProperty,
-                                                         countryCode: String) -> WooAnalyticsEvent {
+                                                         countryCode: String,
+                                                         cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCancelTapped,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -763,10 +783,12 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - updateType: `.required` or `.optional`.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCanceled,
                               properties: [
+                                Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -744,7 +744,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?,
+                                                    updateType: SoftwareUpdateTypeProperty,
+                                                    countryCode: String,
+                                                    cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateSuccess,
                               properties: [
                                 Keys.cardReaderModel: cardReaderModel,
@@ -785,7 +788,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?, updateType: SoftwareUpdateTypeProperty, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
+        static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?,
+                                                     updateType: SoftwareUpdateTypeProperty,
+                                                     countryCode: String,
+                                                     cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCanceled,
                               properties: [
                                 Keys.cardReaderModel: cardReaderModel,

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -1,0 +1,126 @@
+import Combine
+import Foundation
+import Yosemite
+
+/// Tracks events during card reader connection flow, including reader connection and optional/required software update events.
+final class CardReaderConnectionAnalyticsTracker {
+    /// The reader the user has connected.
+    private var connectedReader: CardReader?
+
+    /// The reader the user is trying to connect.
+    private let candidateReader: CardReader
+
+    private var updateType: SoftwareUpdateTypeProperty {
+        optionalReaderUpdateAvailable ? .optional : .required
+    }
+
+    private var cardReaderModel: String {
+        (connectedReader ?? candidateReader).readerType.model
+    }
+
+    private(set) var optionalReaderUpdateAvailable: Bool = false
+
+    /// Gateway ID to include in tracks events, which could be set in initialization and/or externally.
+    private var gatewayID: String?
+
+    private var softwareUpdateCancelable: FallibleCancelable? = nil
+    private var subscriptions = Set<AnyCancellable>()
+
+    private let configuration: CardPresentPaymentsConfiguration
+    private let stores: StoresManager
+    private let analytics: Analytics
+
+    init(candidateReader: CardReader,
+         configuration: CardPresentPaymentsConfiguration,
+         gatewayID: String?,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.candidateReader = candidateReader
+        self.configuration = configuration
+        self.gatewayID = gatewayID
+        self.stores = stores
+        self.analytics = analytics
+
+        observeConnectedReaderAndSoftwareUpdate()
+    }
+
+    /// Since gateway ID could be fetched asynchronously, this can also be set externally in addition to the initializer.
+    func setGatewayID(gatewayID: String?) {
+        self.gatewayID = gatewayID
+    }
+
+    /// Called when the user taps to cancel card reader software update.
+    func softwareUpdateCancelTapped() {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments
+            .cardReaderSoftwareUpdateCancelTapped(forGatewayID: gatewayID,
+                                                  updateType: .required,
+                                                  countryCode: configuration.countryCode,
+                                                  cardReaderModel: cardReaderModel))
+    }
+
+    /// Called after the card reader software update is canceled.
+    func softwareUpdateCanceled() {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments
+            .cardReaderSoftwareUpdateCanceled(forGatewayID: gatewayID,
+                                              updateType: .required,
+                                              countryCode: configuration.countryCode,
+                                              cardReaderModel: cardReaderModel))
+    }
+}
+
+private extension CardReaderConnectionAnalyticsTracker {
+    /// Dispatches actions to the CardPresentPaymentStore so that we can monitor changes to the list of
+    /// connected readers and software update states.
+    func observeConnectedReaderAndSoftwareUpdate() {
+        let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
+            self?.connectedReader = readers.first
+        }
+        stores.dispatch(action)
+
+        let softwareUpdateAction = CardPresentPaymentAction.observeCardReaderUpdateState { softwareUpdateEvents in
+            softwareUpdateEvents
+                .sink { [weak self] state in
+                    guard let self = self else { return }
+
+                    switch state {
+                    case .started(cancelable: let cancelable):
+                        self.softwareUpdateCancelable = cancelable
+                        self.analytics.track(
+                            event: WooAnalyticsEvent.InPersonPayments
+                                .cardReaderSoftwareUpdateStarted(forGatewayID: self.gatewayID,
+                                                                 updateType: self.updateType,
+                                                                 countryCode: self.configuration.countryCode,
+                                                                 cardReaderModel: self.cardReaderModel)
+                        )
+                    case .failed(error: let error):
+                        if case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: _) = error,
+                           underlyingError == .readerSoftwareUpdateFailedInterrupted {
+                            // Update was cancelled, don't treat this as an error
+                            break
+                        }
+                        self.analytics.track(event: WooAnalyticsEvent.InPersonPayments
+                            .cardReaderSoftwareUpdateFailed(forGatewayID: self.gatewayID,
+                                                            updateType: self.updateType,
+                                                            error: error,
+                                                            countryCode: self.configuration.countryCode,
+                                                            cardReaderModel: self.cardReaderModel))
+                    case .completed:
+                        self.softwareUpdateCancelable = nil
+                        self.analytics.track(event: WooAnalyticsEvent.InPersonPayments
+                            .cardReaderSoftwareUpdateSuccess(forGatewayID: self.gatewayID,
+                                                             updateType: self.updateType,
+                                                             countryCode: self.configuration.countryCode,
+                                                             cardReaderModel: self.cardReaderModel))
+                    case .available:
+                        self.optionalReaderUpdateAvailable = true
+                    case .none:
+                        self.optionalReaderUpdateAvailable = false
+                    default:
+                        break
+                    }
+                }
+                .store(in: &self.subscriptions)
+        }
+        stores.dispatch(softwareUpdateAction)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -491,12 +491,12 @@ private extension CardReaderConnectionController {
             return { [weak self] in
                 guard let self = self else { return }
                 self.state = .cancel
-                self.analyticsTracker.softwareUpdateCancelTapped()
+                self.analyticsTracker.cardReaderSoftwareUpdateCancelTapped()
                 cancelable.cancel { [weak self] result in
                     if case .failure(let error) = result {
                         DDLogError("💳 Error: canceling software update \(error)")
                     } else {
-                        self?.analyticsTracker.softwareUpdateCanceled()
+                        self?.analyticsTracker.cardReaderSoftwareUpdateCanceled()
                     }
                 }
             }
@@ -544,7 +544,9 @@ private extension CardReaderConnectionController {
         let softwareUpdateAction = CardPresentPaymentAction.observeCardReaderUpdateState { [weak self] softwareUpdateEvents in
             guard let self = self else { return }
 
-            softwareUpdateEvents.sink { event in
+            softwareUpdateEvents.sink { [weak self] event in
+                guard let self = self else { return }
+
                 switch event {
                 case .started(cancelable: let cancelable):
                     self.softwareUpdateCancelable = cancelable

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -8,7 +8,11 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     var didUpdate: (() -> Void)?
 
     private var didGetConnectedReaders: Bool = false
-    private var connectedReaders = [CardReader]()
+    private var connectedReaders = [CardReader]() {
+        didSet {
+            analyticsTracker.setCandidateReader(connectedReaders.first)
+        }
+    }
     private let knownReaderProvider: CardReaderSettingsKnownReaderProvider?
     private let configuration: CardPresentPaymentsConfiguration
     private(set) var siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -47,14 +47,18 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         optionalReaderUpdateAvailable ? .optional : .required
     }
 
+    private let analyticsTracker: CardReaderConnectionAnalyticsTracker
+
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
          knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil,
          configuration: CardPresentPaymentsConfiguration,
+         analyticsTracker: CardReaderConnectionAnalyticsTracker,
          delayToShowUpdateSuccessMessage: DispatchTimeInterval = .seconds(1)) {
         self.didChangeShouldShow = didChangeShouldShow
         self.knownReaderProvider = knownReaderProvider
         self.siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
         self.configuration = configuration
+        self.analyticsTracker = analyticsTracker
         self.delayToShowUpdateSuccessMessage = delayToShowUpdateSuccessMessage
 
         configureResultsControllers()
@@ -194,12 +198,14 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         }
         return { [weak self] in
             guard let self = self else { return }
+            self.analyticsTracker.softwareUpdateCancelTapped()
             self.softwareUpdateCancelable?.cancel(completion: { [weak self] result in
                 guard let self = self else { return }
 
                 if case .failure(let error) = result {
                     DDLogError("💳 Error: canceling software update \(error)")
                 } else {
+                    self.analyticsTracker.softwareUpdateCanceled()
                     self.completeCardReaderUpdate(success: false)
                 }
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -21,7 +21,8 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
             forSiteID: viewModel.siteID,
             knownReaderProvider: knownReaderProvider,
             alertsProvider: CardReaderSettingsAlerts(),
-            configuration: viewModel.configuration
+            configuration: viewModel.configuration,
+            analyticsTracker: viewModel.cardReaderConnectionAnalyticsTracker
         )
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
@@ -31,15 +31,18 @@ final class CardReaderSettingsSearchingViewModel: CardReaderSettingsPresentedVie
     }
 
     let configuration: CardPresentPaymentsConfiguration
+    let cardReaderConnectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
          knownReaderProvider: CardReaderSettingsKnownReaderProvider? = nil,
          stores: StoresManager = ServiceLocator.stores,
-         configuration: CardPresentPaymentsConfiguration) {
+         configuration: CardPresentPaymentsConfiguration,
+         cardReaderConnectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker) {
         self.didChangeShouldShow = didChangeShouldShow
         self.siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
         self.knownReaderProvider = knownReaderProvider
         self.configuration = configuration
+        self.cardReaderConnectionAnalyticsTracker = cardReaderConnectionAnalyticsTracker
 
         beginKnownReaderObservation()
         beginConnectedReaderObservation()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -18,10 +18,14 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
 
     private var knownReaderProvider: CardReaderSettingsKnownReaderProvider?
 
+    private let cardReaderConnectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
+
     init(configuration: CardPresentPaymentsConfiguration) {
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
         knownReaderProvider = CardReaderSettingsKnownReaderStorage()
+
+        cardReaderConnectionAnalyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration)
 
         /// Instantiate and add each viewmodel related to card reader settings to the
         /// array. Viewmodels will be evaluated for shouldShow starting at the top
@@ -36,7 +40,8 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
                         self?.onDidChangeShouldShow(state)
                     },
                     knownReaderProvider: knownReaderProvider,
-                    configuration: configuration
+                    configuration: configuration,
+                    cardReaderConnectionAnalyticsTracker: cardReaderConnectionAnalyticsTracker
                 ),
                 viewIdentifier: "CardReaderSettingsSearchingViewController"
             )
@@ -49,7 +54,8 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
                         self?.onDidChangeShouldShow(state)
                     },
                     knownReaderProvider: knownReaderProvider,
-                    configuration: configuration
+                    configuration: configuration,
+                    analyticsTracker: cardReaderConnectionAnalyticsTracker
                 ),
                 viewIdentifier: "CardReaderSettingsConnectedViewController"
             )

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -78,7 +78,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         CardReaderConnectionController(forSiteID: siteID,
                                        knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
                                        alertsProvider: CardReaderSettingsAlerts(),
-                                       configuration: configurationLoader.configuration)
+                                       configuration: configurationLoader.configuration,
+                                       analyticsTracker: CardReaderConnectionAnalyticsTracker(configuration: configurationLoader.configuration))
     }()
 
     /// IPP Configuration loader

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206483923FA4160008441BB /* OrdersRootViewController.swift */; };
 		02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */; };
 		020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020886562499E642001D784E /* ProductExternalLinkViewController.swift */; };
+		020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */; };
 		020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */; };
 		020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */; };
 		020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */; };
@@ -1727,6 +1728,7 @@
 		0206483923FA4160008441BB /* OrdersRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRootViewController.swift; sourceTree = "<group>"; };
 		02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+ReadonlyProductTests.swift"; sourceTree = "<group>"; };
 		020886562499E642001D784E /* ProductExternalLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductExternalLinkViewController.swift; sourceTree = "<group>"; };
+		020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionAnalyticsTracker.swift; sourceTree = "<group>"; };
 		020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatter.swift; sourceTree = "<group>"; };
 		020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatterTests.swift; sourceTree = "<group>"; };
 		020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductUpdateError+UI.swift"; sourceTree = "<group>"; };
@@ -7433,6 +7435,7 @@
 				31C21FA326D9949000916E2E /* SeveralReadersFoundViewController.swift */,
 				31C21FA526D994B700916E2E /* SeveralReadersFoundViewController.xib */,
 				0379C51627BFCE9800A7E284 /* WCPayCardBrand+icons.swift */,
+				020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -9401,6 +9404,7 @@
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
+				020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */,
 				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -49,7 +49,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -84,7 +86,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -127,7 +131,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -163,7 +169,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -200,7 +208,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -239,7 +249,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -282,7 +294,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -318,7 +332,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -357,7 +373,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When
@@ -396,7 +414,9 @@ class CardReaderConnectionControllerTests: XCTestCase {
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
             alertsProvider: mockAlerts,
-            configuration: Mocks.configuration
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
         )
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -17,10 +17,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         ServiceLocator.setStores(mockStoresManager)
 
         analyticsProvider = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        ServiceLocator.setAnalytics(analytics)
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                          configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager,
+                                                                                 analytics: analytics),
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
     }
 
@@ -38,6 +42,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
             expectation.fulfill()
         },
                                                      configuration: Mocks.configuration,
+                                                     analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                             stores: mockStoresManager),
                                                      delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
@@ -51,13 +57,18 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
             expectation.fulfill()
         },
                                                          configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager),
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
     func test_view_model_correctly_formats_connected_card_reader_battery_level() {
-        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil, configuration: Mocks.configuration)
+        viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
+                                                         configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "50% Battery")
     }
 
@@ -71,6 +82,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                          configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager),
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "Unknown Battery Level")
     }
@@ -78,6 +91,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
     func test_view_model_correctly_formats_connected_card_reader_software_version() {
         let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                              configuration: Mocks.configuration,
+                                                             analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                     stores: mockStoresManager),
                                                              delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Version: 1.00.03.34-SZZZ_Generic_v45-300001")
     }
@@ -92,6 +107,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                          configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager),
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Unknown Software Version")
     }
@@ -138,6 +155,8 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                          configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager),
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         var updateDidBegin = false
@@ -424,11 +443,10 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        analyticsProvider = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
-
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                          configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager),
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         // Then
@@ -444,11 +462,10 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         )
         ServiceLocator.setStores(mockStoresManager)
 
-        analyticsProvider = MockAnalyticsProvider()
-        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
-
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                          configuration: Mocks.configuration,
+                                                         analyticsTracker: .init(configuration: Mocks.configuration,
+                                                                                 stores: mockStoresManager),
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -5,6 +5,7 @@ import XCTest
 final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
     private var mockStoresManager: MockCardPresentPaymentsStoresManager!
     private var analyticsProvider: MockAnalyticsProvider!
+    private var analyticsTracker: CardReaderConnectionAnalyticsTracker!
 
     private var viewModel: CardReaderSettingsConnectedViewModel!
 
@@ -20,11 +21,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         ServiceLocator.setAnalytics(analytics)
 
+        analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: Mocks.configuration,
+                                                                stores: mockStoresManager,
+                                                                analytics: analytics)
+        analyticsTracker.setCandidateReader(MockCardReader.wisePad3())
+
         viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil,
                                                          configuration: Mocks.configuration,
-                                                         analyticsTracker: .init(configuration: Mocks.configuration,
-                                                                                 stores: mockStoresManager,
-                                                                                 analytics: analytics),
+                                                         analyticsTracker: analyticsTracker,
                                                          delayToShowUpdateSuccessMessage: .milliseconds(1))
     }
 
@@ -182,7 +186,7 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    func test_startCardReaderUpdate_viewModel_logs_tracks_event_cardReaderSoftwareUpdateTapped() {
+    func test_startCardReaderUpdate_viewModel_logs_tracks_event_cardReaderSoftwareUpdateTapped() throws {
         // Given
 
         // When
@@ -190,13 +194,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateTapped.rawValue))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            WooAnalyticsEvent.InPersonPayments.unknownGatewayID
-        )
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String, WooAnalyticsEvent.InPersonPayments.unknownGatewayID)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.countryCode] as? String, "US")
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
+                       MockCardReader.bbposChipper2XBT().readerType.model)
     }
 
-    func test_card_reader_update_starts_viewModel_logs_tracks_event_cardReaderSoftwareUpdateStarted() {
+    func test_starting_card_reader_update_logs_cardReaderSoftwareUpdate_event_after_setting_candidateCardReader() throws {
         // Given
         // .available not sent
 
@@ -205,16 +210,15 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateStarted.rawValue))
-        XCTAssert(analyticsProvider.receivedProperties.contains(where: {
-            $0["software_update_type"] as? String == "Required"
-        }))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            WooAnalyticsEvent.InPersonPayments.unknownGatewayID
-        )
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String, WooAnalyticsEvent.InPersonPayments.unknownGatewayID)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.countryCode] as? String, "US")
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
+                       MockCardReader.bbposChipper2XBT().readerType.model)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.softwareUpdateType] as? String, "Required")
     }
 
-    func test_optional_card_reader_update_starts_viewModel_logs_tracks_event_cardReaderSoftwareUpdateStarted_with_optional() {
+    func test_optional_card_reader_update_starts_viewModel_logs_cardReaderSoftwareUpdateStarted_event_with_optional_update_type() throws {
         // Given
         mockStoresManager.simulateOptionalUpdateAvailable()
 
@@ -223,16 +227,15 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateStarted.rawValue))
-        XCTAssert(analyticsProvider.receivedProperties.contains(where: {
-            $0["software_update_type"] as? String == "Optional"
-        }))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            WooAnalyticsEvent.InPersonPayments.unknownGatewayID
-        )
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String, WooAnalyticsEvent.InPersonPayments.unknownGatewayID)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.countryCode] as? String, "US")
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
+                       MockCardReader.bbposChipper2XBT().readerType.model)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.softwareUpdateType] as? String, "Optional")
     }
 
-    func test_when_store_sends_update_complete_viewModel_logs_tracks_event_cardReaderSoftwareUpdateSuccess() {
+    func test_when_store_sends_update_complete_viewModel_logs_tracks_event_cardReaderSoftwareUpdateSuccess() throws {
         // Given
 
         // When
@@ -240,13 +243,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateSuccess.rawValue))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            WooAnalyticsEvent.InPersonPayments.unknownGatewayID
-        )
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String, WooAnalyticsEvent.InPersonPayments.unknownGatewayID)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.countryCode] as? String, "US")
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
+                       MockCardReader.bbposChipper2XBT().readerType.model)
     }
 
-    func test_when_store_sends_update_failed_viewModel_logs_tracks_event_cardReaderSoftwareUpdateFailed() {
+    func test_when_store_sends_update_failed_viewModel_logs_tracks_event_cardReaderSoftwareUpdateFailed() throws {
         // Given
         // .available not sent
 
@@ -256,21 +260,18 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         mockStoresManager.simulateFailedUpdate(error: expectedError)
 
         // Then
-        let expectedErrorDescription = "Unable to update card reader software - the reader battery is too low"
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateFailed.rawValue))
-        XCTAssert(analyticsProvider.receivedProperties.contains(where: {
-            $0["software_update_type"] as? String == "Required"
-        }))
-        XCTAssert(analyticsProvider.receivedProperties.contains(where: {
-            $0[MockAnalyticsProvider.WooAnalyticsKeys.errorKeyDescription] as? String == expectedErrorDescription
-        }))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            WooAnalyticsEvent.InPersonPayments.unknownGatewayID
-        )
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String, WooAnalyticsEvent.InPersonPayments.unknownGatewayID)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.countryCode] as? String, "US")
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
+                       MockCardReader.bbposChipper2XBT().readerType.model)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.softwareUpdateType] as? String, "Required")
+        let expectedErrorDescription = "Unable to update card reader software - the reader battery is too low"
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.errorDescription] as? String, expectedErrorDescription)
     }
 
-    func test_when_user_cancels_update_viewModel_logs_tracks_event_cardReaderSoftwareUpdateCancelTapped() {
+    func test_when_user_cancels_update_viewModel_logs_tracks_event_cardReaderSoftwareUpdateCancelTapped() throws {
         // Given
         mockStoresManager.simulateCancelableUpdate(onCancel: {})
 
@@ -279,13 +280,14 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateCancelTapped.rawValue))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            WooAnalyticsEvent.InPersonPayments.unknownGatewayID
-        )
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String, WooAnalyticsEvent.InPersonPayments.unknownGatewayID)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.countryCode] as? String, "US")
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
+                       MockCardReader.bbposChipper2XBT().readerType.model)
     }
 
-    func test_when_update_is_successfully_canceled_viewModel_logs_tracks_event_cardReaderSoftwareUpdateCanceled() {
+    func test_when_update_is_successfully_canceled_viewModel_logs_tracks_event_cardReaderSoftwareUpdateCanceled() throws {
         // Given
         let expectation = self.expectation(description: #function)
 
@@ -299,10 +301,11 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: Constants.expectationTimeout)
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateCanceled.rawValue))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            WooAnalyticsEvent.InPersonPayments.unknownGatewayID
-        )
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String, WooAnalyticsEvent.InPersonPayments.unknownGatewayID)
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.countryCode] as? String, "US")
+        XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
+                       MockCardReader.bbposChipper2XBT().readerType.model)
     }
 
     func test_when_update_is_successfully_canceled_viewModel_does_not_log_tracks_event_cardReaderSoftwareUpdateFailed() {
@@ -319,6 +322,19 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: Constants.expectationTimeout)
         XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateFailed.rawValue))
+    }
+
+    func test_starting_card_reader_update_does_not_log_cardReaderSoftwareUpdateStarted_event_without_candidateCardReader() throws {
+        // Given
+        // .available not sent.
+        analyticsTracker.setCandidateReader(nil)
+
+        // When
+        mockStoresManager.simulateUpdateStarted()
+        viewModel.cancelCardReaderUpdate?()
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderSoftwareUpdateStarted.rawValue))
     }
 
     func test_when_update_reaches_100_percent_viewModel_does_not_provide_cancel_handler_so_cancel_button_is_not_shown() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
@@ -24,7 +24,9 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
             XCTAssertTrue(shouldShow == .isTrue)
             expectation.fulfill()
         }, knownReaderProvider: mockKnownReaderProvider,
-                                                     configuration: TestConstants.mockConfiguration)
+                                                     configuration: TestConstants.mockConfiguration,
+                                                     cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
+                                                                                                 stores: mockStoresManager))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
@@ -45,7 +47,9 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
             XCTAssertTrue(shouldShow == .isFalse)
             expectation.fulfill()
         }, knownReaderProvider: mockKnownReaderProvider,
-                                                     configuration: TestConstants.mockConfiguration)
+                                                     configuration: TestConstants.mockConfiguration,
+                                                     cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
+                                                                                                 stores: mockStoresManager))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5984 
Fixes #6215 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR aimed to add `card_reader_model` parameter to all software update events. During testing, I learned that there are two entry points to trigger software updates - from Settings > IPP during card connection and also in the connected reader screen, plus order details. However, some of the software update events are currently logged only within `CardReaderSettingsConnectedViewModel` in the connected reader screen, and that's why some software update events aren't logged from order details as in https://github.com/woocommerce/woocommerce-ios/issues/6215.

I went down the path to fix the logging issue by adding `CardReaderConnectionAnalyticsTracker` as the centralized place to log events related to card reader connection and software updates. This tracker is initialized individually in order details and IPP settings, and the software update state subscription is only active when a candidate reader is set to avoid multiple subscriptions logging the same events at the same time. Please feel free to suggest anything about this refactoring!

There are 6 software update events updated in this PR:
- `card_reader_software_update_tapped`
- `card_reader_software_update_started`
- `card_reader_software_update_failed`
- `card_reader_software_update_success`
- `card_reader_software_update_cancel_tapped`
- `card_reader_software_update_canceled`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to test as many events as possible, I tested all events on my end.

For each event, there should be a new `card_reader_model` property that shows the card reader model that is being updated. It is easier to test in a simulator with simulated card reader enabled, and `Terminal.shared.simulatorConfiguration.availableReaderUpdate = .required`.

- `card_reader_software_update_tapped`: this is triggered from IPP settings > Manage Card Reader with a connected reader and it's harder to test this case since software update is complete during the connection process. I tested this by [manually enabling "Update Reader Software" CTA](https://github.com/woocommerce/woocommerce-ios/blob/667504644115ef4b635952a20d2f17b888eeb805/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift#L201) in the connected reader screen and tapping it
- `card_reader_software_update_started`
- `card_reader_software_update_failed`: this can be tested by turning off Wifi in the middle of the software update
- `card_reader_software_update_success`
- `card_reader_software_update_cancel_tapped`
- `card_reader_software_update_canceled`

I tested scenarios with multiple `CardConnectionController` instances around with required software update in the simulated card reader:
- Go to Settings > In-Person Payments > Manage Card Reader and wait for the card connection modal
- Cancel the software update while it's in progress --> `card_reader_software_update_started`, `card_reader_software_update_cancel_tapped`, and `card_reader_software_update_canceled` should be logged with the card reader model property
- Go to the orders tab
- Tap on an order that is eligible for IPP
- Tap "Collect Payment" CTA and wait for the software update to start
- Cancel the software update while it's in progress  --> only one set of `card_reader_software_update_started`, `card_reader_software_update_cancel_tapped`, and `card_reader_software_update_canceled` should be logged with the card reader model property

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->