### PR TITLE
[Mobile Payments] Handle exceptional cases for setting the receipt email

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		55CD4BB4273E617C007686D3 /* ReceiptRendererTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CD4BB3273E617C007686D3 /* ReceiptRendererTest.swift */; };
 		5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */; };
 		8FFAA245E257B9EB98E2FCBD /* Pods_SampleReceiptPrinter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */; };
+		B9C4AB2327FDE133007008B8 /* Email.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2227FDE133007008B8 /* Email.swift */; };
 		C5D2CB7D21CEE28FEBF18BF6 /* Pods_Hardware.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9F0AC202B287C1221EA2C99 /* Pods_Hardware.framework */; platformFilter = ios; };
 		D80409A625FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80409A525FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift */; };
 		D80B4652260E19590092EDC0 /* PaymentIntentParametersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80B4651260E19590092EDC0 /* PaymentIntentParametersTests.swift */; };
@@ -156,6 +157,7 @@
 		9726331F55A9621F2F887E13 /* Pods-Hardware.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.release.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.release.xcconfig"; sourceTree = "<group>"; };
 		AE60F16D43C20AD4523A61A5 /* Pods-SampleReceiptPrinter.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleReceiptPrinter.debug.xcconfig"; path = "Target Support Files/Pods-SampleReceiptPrinter/Pods-SampleReceiptPrinter.debug.xcconfig"; sourceTree = "<group>"; };
 		B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HardwareTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9C4AB2227FDE133007008B8 /* Email.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Email.swift; sourceTree = "<group>"; };
 		C61D1642BE09D1A1AD6AA9FA /* Pods-HardwareTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HardwareTests.release.xcconfig"; path = "Target Support Files/Pods-HardwareTests/Pods-HardwareTests.release.xcconfig"; sourceTree = "<group>"; };
 		C810BBAD03E7D4ECFD29D7AC /* Pods-SampleReceiptPrinter.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleReceiptPrinter.release-alpha.xcconfig"; path = "Target Support Files/Pods-SampleReceiptPrinter/Pods-SampleReceiptPrinter.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		D80409A525FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentIntentParameters+Stripe.swift"; sourceTree = "<group>"; };
@@ -426,6 +428,7 @@
 				D845BDC1262D98C400A3E40F /* CardBrand.swift */,
 				D845BDD9262DAADB00A3E40F /* PaymentMethod.swift */,
 				317975BF274EB1F9004357B1 /* DeclineReason.swift */,
+				B9C4AB2227FDE133007008B8 /* Email.swift */,
 			);
 			path = CardReader;
 			sourceTree = "<group>";
@@ -768,6 +771,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9C4AB2327FDE133007008B8 /* Email.swift in Sources */,
 				D845BE59262ED84000A3E40F /* AirPrintReceiptPrinterService.swift in Sources */,
 				317975C2274EBC1F004357B1 /* DeclineReason+Stripe.swift in Sources */,
 				D845BDB8262D97B300A3E40F /* ReceiptDetails.swift in Sources */,

--- a/Hardware/Hardware/CardReader/Email.swift
+++ b/Hardware/Hardware/CardReader/Email.swift
@@ -1,0 +1,31 @@
+/// A property wrapper to validate that a property is a valid email
+/// Property Wrappers can not throw, so
+/// what this wrapper does is return a nil when trying to set an invalid
+/// email address as a value of a property of type String.
+/// The reason to do this is add an extra layer of validation before passing
+/// an instance of PaymentIntentParameters to the Stripe Terminal SDK
+/// https://emailregex.com
+@propertyWrapper
+public struct Email<Value: StringProtocol> {
+    var value: Value?
+
+    public init(wrappedValue value: Value?) {
+        self.value = value
+    }
+
+    public var wrappedValue: Value? {
+        get {
+            return validate(email: value) ? value : nil
+        }
+        set {
+            value = newValue
+        }
+    }
+    private func validate(email: Value?) -> Bool {
+        guard let email = email else { return false }
+        // https://emailregex.com
+        let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailPred = NSPredicate(format: "SELF MATCHES %@", emailRegEx)
+        return emailPred.evaluate(with: email)
+    }
+}

--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -24,6 +24,10 @@ public struct PaymentIntentParameters {
     @StatementDescriptor
     public private(set) var statementDescription: String?
 
+    /// Email address that the receipt for the resulting payment will be sent to.
+    @Email
+    public private(set) var receiptEmail: String?
+
     /// Set of key-value pairs that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     public let metadata: [AnyHashable: Any]?
@@ -38,12 +42,14 @@ public struct PaymentIntentParameters {
                 currency: String,
                 receiptDescription: String? = nil,
                 statementDescription: String? = nil,
+                receiptEmail: String? = nil,
                 paymentMethodTypes: [String] = [],
                 metadata: [AnyHashable: Any]? = nil) {
         self.amount = amount
         self.currency = currency
         self.receiptDescription = receiptDescription
         self.statementDescription = statementDescription
+        self.receiptEmail = receiptEmail
         self.paymentMethodTypes = paymentMethodTypes
         self.metadata = metadata
     }

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -32,6 +32,7 @@ extension Hardware.PaymentIntentParameters {
             returnValue.statementDescriptor = descriptor
         }
 
+        returnValue.receiptEmail = receiptEmail
         returnValue.metadata = metadata
 
         return returnValue

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -2,6 +2,18 @@ import XCTest
 @testable import Hardware
 
 final class PaymentIntentParametersTests: XCTestCase {
+    func test_validEmail_is_saved() {
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "validemail@validdomain.us", paymentMethodTypes: ["card_present"])
+
+        XCTAssertNotNil(params.receiptEmail)
+    }
+
+    func test_not_validEmail_is_ignored() {
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "woocommerce", paymentMethodTypes: ["card_present"])
+
+        XCTAssertNil(params.receiptEmail)
+    }
+
     func test_currency_is_lowercased() {
         let params = PaymentIntentParameters(amount: 100, currency: "USD", paymentMethodTypes: ["card_present"])
 

--- a/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
@@ -6,7 +6,17 @@ import Storage
 /// It extracts the information from the provided `StorageManagerType`, but please notice that it does not
 /// take care of syncing the data, so it should be done beforehand.
 ///
-struct PaymentsPluginsDataProvider {
+protocol PaymentsPluginsDataProviderProtocol {
+    func getWCPayPlugin() -> Yosemite.SystemPlugin?
+    func getStripePlugin() -> Yosemite.SystemPlugin?
+    func bothPluginsInstalledAndActive(wcPay: Yosemite.SystemPlugin?, stripe: Yosemite.SystemPlugin?) -> Bool
+    func wcPayInstalledAndActive(wcPay: Yosemite.SystemPlugin?) -> Bool
+    func stripeInstalledAndActive(stripe: Yosemite.SystemPlugin?) -> Bool
+    func isWCPayVersionSupported(plugin: Yosemite.SystemPlugin) -> Bool
+    func isStripeVersionSupported(plugin: Yosemite.SystemPlugin) -> Bool
+}
+
+struct PaymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol {
     let storageManager: StorageManagerType
     let stores: StoresManager
 

--- a/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
@@ -6,7 +6,7 @@ import Storage
 /// It extracts the information from the provided `StorageManagerType`, but please notice that it does not
 /// take care of syncing the data, so it should be done beforehand.
 ///
-protocol PaymentsPluginsDataProviderProtocol {
+protocol CardPresentPluginsDataProviderProtocol {
     func getWCPayPlugin() -> Yosemite.SystemPlugin?
     func getStripePlugin() -> Yosemite.SystemPlugin?
     func bothPluginsInstalledAndActive(wcPay: Yosemite.SystemPlugin?, stripe: Yosemite.SystemPlugin?) -> Bool
@@ -16,7 +16,7 @@ protocol PaymentsPluginsDataProviderProtocol {
     func isStripeVersionSupported(plugin: Yosemite.SystemPlugin) -> Bool
 }
 
-struct PaymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol {
+struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
     let storageManager: StorageManagerType
     let stores: StoresManager
 

--- a/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
@@ -17,8 +17,8 @@ protocol CardPresentPluginsDataProviderProtocol {
 }
 
 struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
-    let storageManager: StorageManagerType
-    let stores: StoresManager
+    private let storageManager: StorageManagerType
+    private let stores: StoresManager
 
     init(
         storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -28,7 +28,7 @@ struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
         self.stores = stores
     }
 
-    var siteID: Int64? {
+    private var siteID: Int64? {
         stores.sessionManager.defaultStoreID
     }
 

--- a/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
@@ -2,7 +2,7 @@ import Yosemite
 import Foundation
 import Storage
 
-/// This helper struct provides data and helper methods related to the Payments Plugins (WCPay, Stripe).
+/// Provides data and helper methods related to the Payments Plugins (WCPay, Stripe).
 /// It extracts the information from the provided `StorageManagerType`, but please notice that it does not
 /// take care of syncing the data, so it should be done beforehand.
 ///

--- a/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/PaymentsPluginsDataProvider.swift
@@ -2,16 +2,24 @@ import Yosemite
 import Foundation
 import Storage
 
-struct PaymentsPluginsInfoProvider {
+/// This helper struct provides data and helper methods related to the Payments Plugins (WCPay, Stripe).
+/// It extracts the information from the provided `StorageManagerType`, but please notice that it does not
+/// take care of syncing the data, so it should be done beforehand.
+///
+struct PaymentsPluginsDataProvider {
     let storageManager: StorageManagerType
-    let siteID: Int64?
+    let stores: StoresManager
 
     init(
         storageManager: StorageManagerType = ServiceLocator.storageManager,
-        siteID: Int64?
+        stores: StoresManager = ServiceLocator.stores
     ) {
         self.storageManager = storageManager
-        self.siteID = siteID
+        self.stores = stores
+    }
+
+    var siteID: Int64? {
+        stores.sessionManager.defaultStoreID
     }
 
     func getWCPayPlugin() -> Yosemite.SystemPlugin? {
@@ -57,7 +65,6 @@ struct PaymentsPluginsInfoProvider {
 
         return stripe.active
     }
-
 
     func isWCPayVersionSupported(plugin: Yosemite.SystemPlugin) -> Bool {
         VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: CardPresentPaymentsPlugins.wcPay.minimumSupportedPluginVersion)

--- a/WooCommerce/Classes/Tools/PaymentsPluginsInfoProvider.swift
+++ b/WooCommerce/Classes/Tools/PaymentsPluginsInfoProvider.swift
@@ -1,0 +1,69 @@
+import Yosemite
+import Foundation
+import Storage
+
+struct PaymentsPluginsInfoProvider {
+    let storageManager: StorageManagerType
+    let siteID: Int64?
+
+    init(
+        storageManager: StorageManagerType = ServiceLocator.storageManager,
+        siteID: Int64?
+    ) {
+        self.storageManager = storageManager
+        self.siteID = siteID
+    }
+
+    func getWCPayPlugin() -> Yosemite.SystemPlugin? {
+        guard let siteID = siteID else {
+            return nil
+        }
+        return storageManager.viewStorage
+            .loadSystemPlugin(siteID: siteID, name: CardPresentPaymentsPlugins.wcPay.pluginName)?
+            .toReadOnly()
+    }
+
+    func getStripePlugin() -> Yosemite.SystemPlugin? {
+        guard let siteID = siteID else {
+            return nil
+        }
+        return storageManager.viewStorage
+            .loadSystemPlugin(siteID: siteID, name: CardPresentPaymentsPlugins.stripe.pluginName)?
+            .toReadOnly()
+    }
+
+    func bothPluginsInstalledAndActive(wcPay: Yosemite.SystemPlugin?, stripe: Yosemite.SystemPlugin?) -> Bool {
+        guard let wcPay = wcPay, let stripe = stripe else {
+            return false
+        }
+
+        return wcPay.active && stripe.active
+    }
+
+    func wcPayInstalledAndActive(wcPay: Yosemite.SystemPlugin?) -> Bool {
+        // If the WCPay plugin is not installed, immediately return false
+        guard let wcPay = wcPay else {
+            return false
+        }
+
+        return wcPay.active
+    }
+
+    func stripeInstalledAndActive(stripe: Yosemite.SystemPlugin?) -> Bool {
+        // If the Stripe plugin is not installed, immediately return false
+        guard let stripe = stripe else {
+            return false
+        }
+
+        return stripe.active
+    }
+
+
+    func isWCPayVersionSupported(plugin: Yosemite.SystemPlugin) -> Bool {
+        VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: CardPresentPaymentsPlugins.wcPay.minimumSupportedPluginVersion)
+    }
+
+    func isStripeVersionSupported(plugin: Yosemite.SystemPlugin) -> Bool {
+        VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: CardPresentPaymentsPlugins.stripe.minimumSupportedPluginVersion)
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -229,6 +229,7 @@ private extension PaymentCaptureOrchestrator {
                                  currency: order.currency,
                                  receiptDescription: receiptDescription(orderNumber: order.number),
                                  statementDescription: statementDescriptor,
+                                 receiptEmail: order.billingAddress?.email,
                                  paymentMethodTypes: paymentMethodTypes,
                                  metadata: metadata)
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -233,7 +233,7 @@ private extension PaymentCaptureOrchestrator {
                                  currency: order.currency,
                                  receiptDescription: receiptDescription(orderNumber: order.number),
                                  statementDescription: statementDescriptor,
-                                 receiptEmail: receiptEmail(from: order),
+                                 receiptEmail: provideReceiptEmailIfNecessary(from: order),
                                  paymentMethodTypes: paymentMethodTypes,
                                  metadata: metadata)
     }
@@ -253,7 +253,9 @@ private extension PaymentCaptureOrchestrator {
             })
     }
 
-    private func receiptEmail(from order: Order) -> String? {
+    /// We do not need to set the receipt email if WCPay is installed and active
+    /// and its version is higher or equal than 4.0.0, as it does itself in that case.
+    private func provideReceiptEmailIfNecessary(from order: Order) -> String? {
         let paymentsPluginsDataProvider = PaymentsPluginsDataProvider()
 
         let wcPay = paymentsPluginsDataProvider.getWCPayPlugin()
@@ -273,7 +275,9 @@ private extension PaymentCaptureOrchestrator {
     }
 
     private func wcPayPluginSendsReceiptEmail(version: String) -> Bool {
-        return VersionHelpers.compare(version, Constants.minimumWCPayPluginVersionThatSendsReceiptEmail) == .orderedAscending
+        let comparisonResult = VersionHelpers.compare(version, Constants.minimumWCPayPluginVersionThatSendsReceiptEmail)
+
+        return comparisonResult == .orderedDescending || comparisonResult == .orderedSame
     }
 
     func receiptDescription(orderNumber: String) -> String? {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Yosemite
+
+/// Determines the email to be set (if any) on a payment receipt depending on the current payment plugins (WCPay, Stripe) configuration
+/// 
+struct PaymentReceiptEmailParameterDeterminer {
+
+    /// We do not need to set the receipt email if WCPay is installed and active
+    /// and its version is higher or equal than 4.0.0, as it does it itself in that case.
+    ///
+    /// - Parameters:
+    ///   - order: the order associated with the payment
+    ///   - onCompletion: closure invoked with the result of the inquiry, containg the email (if any) or error
+    ///
+    func receiptEmail(from order: Order, onCompletion: @escaping ((Result<String?, Error>) -> Void)) {
+        synchronizePlugins(from: order.siteID) { result in
+            switch result {
+            case .success():
+                onCompletion(Result.success(receiptEmail(from: order)))
+            case let .failure(error):
+                onCompletion(Result.failure(error))
+            }
+        }
+    }
+
+    private func receiptEmail(from order: Order) -> String? {
+        let paymentsPluginsDataProvider = PaymentsPluginsDataProvider()
+
+        let wcPay = paymentsPluginsDataProvider.getWCPayPlugin()
+        let stripe = paymentsPluginsDataProvider.getStripePlugin()
+
+        guard !paymentsPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) else {
+            // This case should not happen, shall we fatal error here?
+            return nil
+        }
+
+        guard let wcPay = wcPay,
+              paymentsPluginsDataProvider.wcPayInstalledAndActive(wcPay: wcPay) else {
+            return order.billingAddress?.email
+        }
+
+        return wcPayPluginSendsReceiptEmail(version: wcPay.version) ? nil : order.billingAddress?.email
+    }
+
+    private func synchronizePlugins(from siteID: Int64, onCompletion: @escaping ((Result<Void, Error>) -> Void)) {
+        let systemPluginsAction = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { result in
+            if case let .failure(error) = result {
+                DDLogError("[PaymentCaptureOrchestrator] Error syncing system plugins: \(error)")
+                onCompletion(Result.failure(error))
+            } else {
+                onCompletion(Result.success(()))
+            }
+        }
+
+        ServiceLocator.stores.dispatch(systemPluginsAction)
+    }
+
+    private func wcPayPluginSendsReceiptEmail(version: String) -> Bool {
+        let comparisonResult = VersionHelpers.compare(version, Constants.minimumWCPayPluginVersionThatSendsReceiptEmail)
+
+        return comparisonResult == .orderedDescending || comparisonResult == .orderedSame
+    }
+}
+
+private extension PaymentReceiptEmailParameterDeterminer {
+    enum Constants {
+        static let minimumWCPayPluginVersionThatSendsReceiptEmail = "4.0.0"
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -51,7 +51,7 @@ struct PaymentReceiptEmailParameterDeterminer {
     private func synchronizePlugins(from siteID: Int64, onCompletion: @escaping ((Result<Void, Error>) -> Void)) {
         let systemPluginsAction = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { result in
             if case let .failure(error) = result {
-                DDLogError("[PaymentCaptureOrchestrator] Error syncing system plugins: \(error)")
+                DDLogError("[PaymentReceiptEmailParameterDeterminer] Error syncing system plugins: \(error)")
                 onCompletion(Result.failure(error))
             } else {
                 onCompletion(Result.success(()))

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -36,7 +36,6 @@ struct PaymentReceiptEmailParameterDeterminer {
         let stripe = paymentsPluginsDataProvider.getStripePlugin()
 
         guard !paymentsPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) else {
-            // This case should not happen, shall we fatal error here?
             return nil
         }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -18,7 +18,7 @@ struct PaymentReceiptEmailParameterDeterminer {
     ///
     /// - Parameters:
     ///   - order: the order associated with the payment
-    ///   - onCompletion: closure invoked with the result of the inquiry, containg the email (if any) or error
+    ///   - onCompletion: closure invoked with the result of the inquiry, containing the email (if any) or error
     ///
     func receiptEmail(from order: Order, onCompletion: @escaping ((Result<String?, Error>) -> Void)) {
         synchronizePlugins(from: order.siteID) { result in

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -4,6 +4,14 @@ import Yosemite
 /// Determines the email to be set (if any) on a payment receipt depending on the current payment plugins (WCPay, Stripe) configuration
 /// 
 struct PaymentReceiptEmailParameterDeterminer {
+    private let paymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol
+    private let stores: StoresManager
+
+    init(paymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol = PaymentsPluginsDataProvider(),
+         stores: StoresManager = ServiceLocator.stores) {
+        self.paymentsPluginsDataProvider = paymentsPluginsDataProvider
+        self.stores = stores
+    }
 
     /// We do not need to set the receipt email if WCPay is installed and active
     /// and its version is higher or equal than 4.0.0, as it does it itself in that case.
@@ -24,8 +32,6 @@ struct PaymentReceiptEmailParameterDeterminer {
     }
 
     private func receiptEmail(from order: Order) -> String? {
-        let paymentsPluginsDataProvider = PaymentsPluginsDataProvider()
-
         let wcPay = paymentsPluginsDataProvider.getWCPayPlugin()
         let stripe = paymentsPluginsDataProvider.getStripePlugin()
 
@@ -52,7 +58,7 @@ struct PaymentReceiptEmailParameterDeterminer {
             }
         }
 
-        ServiceLocator.stores.dispatch(systemPluginsAction)
+        stores.dispatch(systemPluginsAction)
     }
 
     private func wcPayPluginSendsReceiptEmail(version: String) -> Bool {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -4,12 +4,12 @@ import Yosemite
 /// Determines the email to be set (if any) on a payment receipt depending on the current payment plugins (WCPay, Stripe) configuration
 /// 
 struct PaymentReceiptEmailParameterDeterminer {
-    private let paymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol
+    private let cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol
     private let stores: StoresManager
 
-    init(paymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol = PaymentsPluginsDataProvider(),
+    init(cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol = CardPresentPluginsDataProvider(),
          stores: StoresManager = ServiceLocator.stores) {
-        self.paymentsPluginsDataProvider = paymentsPluginsDataProvider
+        self.cardPresentPluginsDataProvider = cardPresentPluginsDataProvider
         self.stores = stores
     }
 
@@ -32,15 +32,15 @@ struct PaymentReceiptEmailParameterDeterminer {
     }
 
     private func receiptEmail(from order: Order) -> String? {
-        let wcPay = paymentsPluginsDataProvider.getWCPayPlugin()
-        let stripe = paymentsPluginsDataProvider.getStripePlugin()
+        let wcPay = cardPresentPluginsDataProvider.getWCPayPlugin()
+        let stripe = cardPresentPluginsDataProvider.getStripePlugin()
 
-        guard !paymentsPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) else {
+        guard !cardPresentPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) else {
             return nil
         }
 
         guard let wcPay = wcPay,
-              paymentsPluginsDataProvider.wcPayInstalledAndActive(wcPay: wcPay) else {
+              cardPresentPluginsDataProvider.wcPayInstalledAndActive(wcPay: wcPay) else {
             return order.billingAddress?.email
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -31,7 +31,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     let storageManager: StorageManagerType
     let stores: StoresManager
     let configurationLoader: CardPresentConfigurationLoader
-    private let paymentsPluginsInfoProvider: PaymentsPluginsInfoProvider
+    private let paymentsPluginsDataProvider: PaymentsPluginsDataProvider
 
     @Published var state: CardPresentPaymentOnboardingState = .loading
 
@@ -46,7 +46,8 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         self.storageManager = storageManager
         self.stores = stores
         self.configurationLoader = .init(stores: stores)
-        self.paymentsPluginsInfoProvider = .init(storageManager: storageManager, siteID: stores.sessionManager.defaultStoreID)
+        self.paymentsPluginsDataProvider = .init(storageManager: storageManager, stores: stores)
+
 
         // At the time of writing, actions are dispatched and processed synchronously, so the completion blocks for
         // loadStripeInPersonPaymentsSwitchState and loadCanadaInPersonPaymentsSwitchState should have been called already.
@@ -71,12 +72,12 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
             return
         }
 
-        let wcPayPlugin = paymentsPluginsInfoProvider.getWCPayPlugin()
-        let stripePlugin = paymentsPluginsInfoProvider.getStripePlugin()
+        let wcPayPlugin = paymentsPluginsDataProvider.getWCPayPlugin()
+        let stripePlugin = paymentsPluginsDataProvider.getStripePlugin()
 
         /// If both plugins are active, don't bother initializing the backend nor fetching
         /// accounts. Fall through to updateState so the end user can fix the problem.
-        guard !paymentsPluginsInfoProvider.bothPluginsInstalledAndActive(wcPay: wcPayPlugin, stripe: stripePlugin) else {
+        guard !paymentsPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPayPlugin, stripe: stripePlugin) else {
             self.updateState()
             return
         }
@@ -145,8 +146,8 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         let configuration = configurationLoader.configuration
 
-        let wcPay = paymentsPluginsInfoProvider.getWCPayPlugin()
-        let stripe = paymentsPluginsInfoProvider.getStripePlugin()
+        let wcPay = paymentsPluginsDataProvider.getWCPayPlugin()
+        let stripe = paymentsPluginsDataProvider.getStripePlugin()
         let isStripeSupported = configuration.paymentGateways.contains(StripeAccount.gatewayID)
 
         // If isSupportedCountry is false, IPP is not supported in the country through any
@@ -160,7 +161,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             // If we only support WCPay, we don't want to ask users to set up WCPay if they already
             // have Stripe. In that case, we can tell them that IPP is not supported for Stripe in
             // their country yet.
-            if paymentsPluginsInfoProvider.stripeInstalledAndActive(stripe: stripe) {
+            if paymentsPluginsDataProvider.stripeInstalledAndActive(stripe: stripe) {
                 return .countryNotSupportedStripe(plugin: .stripe, countryCode: countryCode)
             } else {
                 return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -169,13 +170,13 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // If both the Stripe plugin and WCPay are installed and activated, the user needs
         // to deactivate one: pdfdoF-fW-p2#comment-683
-        if paymentsPluginsInfoProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
+        if paymentsPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
             return .selectPlugin
         }
 
         // If only the Stripe extension is installed, skip to checking Stripe activation and version
         if let stripe = stripe,
-           paymentsPluginsInfoProvider.wcPayInstalledAndActive(wcPay: wcPay) == false {
+           paymentsPluginsDataProvider.wcPayInstalledAndActive(wcPay: wcPay) == false {
             return stripeGatewayOnlyOnboardingState(plugin: stripe)
         } else {
             return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -187,7 +188,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         guard let plugin = plugin else {
             return .pluginNotInstalled
         }
-        guard paymentsPluginsInfoProvider.isWCPayVersionSupported(plugin: plugin) else {
+        guard paymentsPluginsDataProvider.isWCPayVersionSupported(plugin: plugin) else {
             return .pluginUnsupportedVersion(plugin: .wcPay)
         }
         guard plugin.active else {
@@ -199,7 +200,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func stripeGatewayOnlyOnboardingState(plugin: SystemPlugin) -> CardPresentPaymentOnboardingState {
-        guard paymentsPluginsInfoProvider.isStripeVersionSupported(plugin: plugin) else {
+        guard paymentsPluginsDataProvider.isStripeVersionSupported(plugin: plugin) else {
             return .pluginUnsupportedVersion(plugin: .stripe)
         }
         guard plugin.active else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -31,7 +31,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     let storageManager: StorageManagerType
     let stores: StoresManager
     let configurationLoader: CardPresentConfigurationLoader
-    private let paymentsPluginsDataProvider: PaymentsPluginsDataProvider
+    private let cardPresentPluginsDataProvider: CardPresentPluginsDataProvider
 
     @Published var state: CardPresentPaymentOnboardingState = .loading
 
@@ -46,7 +46,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         self.storageManager = storageManager
         self.stores = stores
         self.configurationLoader = .init(stores: stores)
-        self.paymentsPluginsDataProvider = .init(storageManager: storageManager, stores: stores)
+        self.cardPresentPluginsDataProvider = .init(storageManager: storageManager, stores: stores)
 
 
         // At the time of writing, actions are dispatched and processed synchronously, so the completion blocks for
@@ -72,12 +72,12 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
             return
         }
 
-        let wcPayPlugin = paymentsPluginsDataProvider.getWCPayPlugin()
-        let stripePlugin = paymentsPluginsDataProvider.getStripePlugin()
+        let wcPayPlugin = cardPresentPluginsDataProvider.getWCPayPlugin()
+        let stripePlugin = cardPresentPluginsDataProvider.getStripePlugin()
 
         /// If both plugins are active, don't bother initializing the backend nor fetching
         /// accounts. Fall through to updateState so the end user can fix the problem.
-        guard !paymentsPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPayPlugin, stripe: stripePlugin) else {
+        guard !cardPresentPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPayPlugin, stripe: stripePlugin) else {
             self.updateState()
             return
         }
@@ -146,8 +146,8 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         let configuration = configurationLoader.configuration
 
-        let wcPay = paymentsPluginsDataProvider.getWCPayPlugin()
-        let stripe = paymentsPluginsDataProvider.getStripePlugin()
+        let wcPay = cardPresentPluginsDataProvider.getWCPayPlugin()
+        let stripe = cardPresentPluginsDataProvider.getStripePlugin()
         let isStripeSupported = configuration.paymentGateways.contains(StripeAccount.gatewayID)
 
         // If isSupportedCountry is false, IPP is not supported in the country through any
@@ -161,7 +161,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             // If we only support WCPay, we don't want to ask users to set up WCPay if they already
             // have Stripe. In that case, we can tell them that IPP is not supported for Stripe in
             // their country yet.
-            if paymentsPluginsDataProvider.stripeInstalledAndActive(stripe: stripe) {
+            if cardPresentPluginsDataProvider.stripeInstalledAndActive(stripe: stripe) {
                 return .countryNotSupportedStripe(plugin: .stripe, countryCode: countryCode)
             } else {
                 return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -170,13 +170,13 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // If both the Stripe plugin and WCPay are installed and activated, the user needs
         // to deactivate one: pdfdoF-fW-p2#comment-683
-        if paymentsPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
+        if cardPresentPluginsDataProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
             return .selectPlugin
         }
 
         // If only the Stripe extension is installed, skip to checking Stripe activation and version
         if let stripe = stripe,
-           paymentsPluginsDataProvider.wcPayInstalledAndActive(wcPay: wcPay) == false {
+           cardPresentPluginsDataProvider.wcPayInstalledAndActive(wcPay: wcPay) == false {
             return stripeGatewayOnlyOnboardingState(plugin: stripe)
         } else {
             return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -188,7 +188,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         guard let plugin = plugin else {
             return .pluginNotInstalled
         }
-        guard paymentsPluginsDataProvider.isWCPayVersionSupported(plugin: plugin) else {
+        guard cardPresentPluginsDataProvider.isWCPayVersionSupported(plugin: plugin) else {
             return .pluginUnsupportedVersion(plugin: .wcPay)
         }
         guard plugin.active else {
@@ -200,7 +200,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func stripeGatewayOnlyOnboardingState(plugin: SystemPlugin) -> CardPresentPaymentOnboardingState {
-        guard paymentsPluginsDataProvider.isStripeVersionSupported(plugin: plugin) else {
+        guard cardPresentPluginsDataProvider.isStripeVersionSupported(plugin: plugin) else {
             return .pluginUnsupportedVersion(plugin: .stripe)
         }
         guard plugin.active else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -31,6 +31,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     let storageManager: StorageManagerType
     let stores: StoresManager
     let configurationLoader: CardPresentConfigurationLoader
+    private let paymentsPluginsInfoProvider: PaymentsPluginsInfoProvider
 
     @Published var state: CardPresentPaymentOnboardingState = .loading
 
@@ -45,6 +46,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         self.storageManager = storageManager
         self.stores = stores
         self.configurationLoader = .init(stores: stores)
+        self.paymentsPluginsInfoProvider = .init(storageManager: storageManager, siteID: stores.sessionManager.defaultStoreID)
 
         // At the time of writing, actions are dispatched and processed synchronously, so the completion blocks for
         // loadStripeInPersonPaymentsSwitchState and loadCanadaInPersonPaymentsSwitchState should have been called already.
@@ -69,12 +71,12 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
             return
         }
 
-        let wcPayPlugin = getWCPayPlugin()
-        let stripePlugin = getStripePlugin()
+        let wcPayPlugin = paymentsPluginsInfoProvider.getWCPayPlugin()
+        let stripePlugin = paymentsPluginsInfoProvider.getStripePlugin()
 
         /// If both plugins are active, don't bother initializing the backend nor fetching
         /// accounts. Fall through to updateState so the end user can fix the problem.
-        guard !bothPluginsInstalledAndActive(wcPay: wcPayPlugin, stripe: stripePlugin) else {
+        guard !paymentsPluginsInfoProvider.bothPluginsInstalledAndActive(wcPay: wcPayPlugin, stripe: stripePlugin) else {
             self.updateState()
             return
         }
@@ -143,8 +145,8 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         let configuration = configurationLoader.configuration
 
-        let wcPay = getWCPayPlugin()
-        let stripe = getStripePlugin()
+        let wcPay = paymentsPluginsInfoProvider.getWCPayPlugin()
+        let stripe = paymentsPluginsInfoProvider.getStripePlugin()
         let isStripeSupported = configuration.paymentGateways.contains(StripeAccount.gatewayID)
 
         // If isSupportedCountry is false, IPP is not supported in the country through any
@@ -158,7 +160,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             // If we only support WCPay, we don't want to ask users to set up WCPay if they already
             // have Stripe. In that case, we can tell them that IPP is not supported for Stripe in
             // their country yet.
-            if stripeInstalledAndActive(stripe: stripe) {
+            if paymentsPluginsInfoProvider.stripeInstalledAndActive(stripe: stripe) {
                 return .countryNotSupportedStripe(plugin: .stripe, countryCode: countryCode)
             } else {
                 return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -167,13 +169,13 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // If both the Stripe plugin and WCPay are installed and activated, the user needs
         // to deactivate one: pdfdoF-fW-p2#comment-683
-        if bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
+        if paymentsPluginsInfoProvider.bothPluginsInstalledAndActive(wcPay: wcPay, stripe: stripe) {
             return .selectPlugin
         }
 
         // If only the Stripe extension is installed, skip to checking Stripe activation and version
         if let stripe = stripe,
-            wcPayInstalledAndActive(wcPay: wcPay) == false {
+           paymentsPluginsInfoProvider.wcPayInstalledAndActive(wcPay: wcPay) == false {
             return stripeGatewayOnlyOnboardingState(plugin: stripe)
         } else {
             return wcPayOnlyOnboardingState(plugin: wcPay)
@@ -185,7 +187,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         guard let plugin = plugin else {
             return .pluginNotInstalled
         }
-        guard isWCPayVersionSupported(plugin: plugin) else {
+        guard paymentsPluginsInfoProvider.isWCPayVersionSupported(plugin: plugin) else {
             return .pluginUnsupportedVersion(plugin: .wcPay)
         }
         guard plugin.active else {
@@ -197,7 +199,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func stripeGatewayOnlyOnboardingState(plugin: SystemPlugin) -> CardPresentPaymentOnboardingState {
-        guard isStripeVersionSupported(plugin: plugin) else {
+        guard paymentsPluginsInfoProvider.isStripeVersionSupported(plugin: plugin) else {
             return .pluginUnsupportedVersion(plugin: .stripe)
         }
         guard plugin.active else {
@@ -254,59 +256,6 @@ private extension CardPresentPaymentsOnboardingUseCase {
         let storeCountryCode = storeAddress.countryCode
 
         return storeCountryCode.nonEmptyString()
-    }
-
-    func getWCPayPlugin() -> SystemPlugin? {
-        guard let siteID = siteID else {
-            return nil
-        }
-        return storageManager.viewStorage
-            .loadSystemPlugin(siteID: siteID, name: CardPresentPaymentsPlugins.wcPay.pluginName)?
-            .toReadOnly()
-    }
-
-    func getStripePlugin() -> SystemPlugin? {
-        guard let siteID = siteID else {
-            return nil
-        }
-        return storageManager.viewStorage
-            .loadSystemPlugin(siteID: siteID, name: CardPresentPaymentsPlugins.stripe.pluginName)?
-            .toReadOnly()
-    }
-
-    func bothPluginsInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin?) -> Bool {
-        guard let wcPay = wcPay, let stripe = stripe else {
-            return false
-        }
-
-        return wcPay.active && stripe.active
-    }
-
-    func wcPayInstalledAndActive(wcPay: SystemPlugin?) -> Bool {
-        // If the WCPay plugin is not installed, immediately return false
-        guard let wcPay = wcPay else {
-            return false
-        }
-
-        return wcPay.active
-    }
-
-    func stripeInstalledAndActive(stripe: SystemPlugin?) -> Bool {
-        // If the Stripe plugin is not installed, immediately return false
-        guard let stripe = stripe else {
-            return false
-        }
-
-        return stripe.active
-    }
-
-
-    func isWCPayVersionSupported(plugin: SystemPlugin) -> Bool {
-        VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: CardPresentPaymentsPlugins.wcPay.minimumSupportedPluginVersion)
-    }
-
-    func isStripeVersionSupported(plugin: SystemPlugin) -> Bool {
-        VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: CardPresentPaymentsPlugins.stripe.minimumSupportedPluginVersion)
     }
 
     // Note: This counts on synchronizeStoreCountryAndPlugins having been called to get

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1195,6 +1195,7 @@
 		B6E851F7276331110041D1BA /* RefundFeesDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
+		B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift */; };
 		BAA34C202787494300846F3C /* ReviewsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */; };
 		BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE4F8422734325C00871344 /* SettingsViewModel.swift */; };
 		BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */; };
@@ -2884,6 +2885,7 @@
 		B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundFeesDetailsTableViewCell.xib; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
+		B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsPluginsInfoProvider.swift; sourceTree = "<group>"; };
 		BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewsViewControllerTests.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAE4F8422734325C00871344 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
@@ -6036,6 +6038,7 @@
 				31579027273EE2B1008CA3AF /* VersionHelpers.swift */,
 				267066042773DAE6008E1F68 /* PaymentLinkBuilder.swift */,
 				174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */,
+				B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -9286,6 +9289,7 @@
 				025C006B2550DE4700FAC222 /* BarcodeScannerViewController.swift in Sources */,
 				09885C8727C6947A00910A62 /* ProductPriceSettingsValidator.swift in Sources */,
 				A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */,
+				B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift in Sources */,
 				D8915DC12372C8AC00F63762 /* ColorStudio.swift in Sources */,
 				F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */,
 				D8C2A28B231931D100F503E9 /* ReviewViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1197,6 +1197,8 @@
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */; };
 		B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */; };
+		B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */; };
+		B9C4AB2B28003481007008B8 /* MockPaymentsPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2A28003481007008B8 /* MockPaymentsPluginsDataProvider.swift */; };
 		BAA34C202787494300846F3C /* ReviewsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */; };
 		BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE4F8422734325C00871344 /* SettingsViewModel.swift */; };
 		BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */; };
@@ -2888,6 +2890,8 @@
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsPluginsDataProvider.swift; sourceTree = "<group>"; };
 		B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminer.swift; sourceTree = "<group>"; };
+		B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminerTests.swift; sourceTree = "<group>"; };
+		B9C4AB2A28003481007008B8 /* MockPaymentsPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentsPluginsDataProvider.swift; sourceTree = "<group>"; };
 		BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewsViewControllerTests.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAE4F8422734325C00871344 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
@@ -5622,6 +5626,7 @@
 				FE3E427626A8545B00C596CE /* MockRoleEligibilityUseCase.swift */,
 				02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */,
 				02CE43082769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift */,
+				B9C4AB2A28003481007008B8 /* MockPaymentsPluginsDataProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7337,6 +7342,7 @@
 				E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */,
 				3190D61C26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift */,
 				31AD0B1226E95998000B6391 /* CardPresentModalConnectingFailedTests.swift */,
+				B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -9775,6 +9781,7 @@
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockAnalyticsProvider.swift in Sources */,
+				B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */,
 				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,
 				573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */,
 				77423F17251CF77E0016A083 /* ProductDownloadListViewModelTests.swift in Sources */,
@@ -9816,6 +9823,7 @@
 				CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */,
 				4520A1612722D495001FA573 /* FilterOrderListViewModelTests.swift in Sources */,
 				02E4AF7126FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift in Sources */,
+				B9C4AB2B28003481007008B8 /* MockPaymentsPluginsDataProvider.swift in Sources */,
 				57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1195,7 +1195,7 @@
 		B6E851F7276331110041D1BA /* RefundFeesDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
-		B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift */; };
+		B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */; };
 		BAA34C202787494300846F3C /* ReviewsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */; };
 		BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE4F8422734325C00871344 /* SettingsViewModel.swift */; };
 		BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */; };
@@ -2885,7 +2885,7 @@
 		B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundFeesDetailsTableViewCell.xib; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
-		B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsPluginsInfoProvider.swift; sourceTree = "<group>"; };
+		B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsPluginsDataProvider.swift; sourceTree = "<group>"; };
 		BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewsViewControllerTests.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAE4F8422734325C00871344 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
@@ -6038,7 +6038,7 @@
 				31579027273EE2B1008CA3AF /* VersionHelpers.swift */,
 				267066042773DAE6008E1F68 /* PaymentLinkBuilder.swift */,
 				174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */,
-				B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift */,
+				B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -9289,7 +9289,7 @@
 				025C006B2550DE4700FAC222 /* BarcodeScannerViewController.swift in Sources */,
 				09885C8727C6947A00910A62 /* ProductPriceSettingsValidator.swift in Sources */,
 				A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */,
-				B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsInfoProvider.swift in Sources */,
+				B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift in Sources */,
 				D8915DC12372C8AC00F63762 /* ColorStudio.swift in Sources */,
 				F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */,
 				D8C2A28B231931D100F503E9 /* ReviewViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1196,6 +1196,7 @@
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */; };
+		B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */; };
 		BAA34C202787494300846F3C /* ReviewsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */; };
 		BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE4F8422734325C00871344 /* SettingsViewModel.swift */; };
 		BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */; };
@@ -2886,6 +2887,7 @@
 		B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundFeesDetailsTableViewCell.xib; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsPluginsDataProvider.swift; sourceTree = "<group>"; };
+		B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminer.swift; sourceTree = "<group>"; };
 		BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewsViewControllerTests.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAE4F8422734325C00871344 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
@@ -7441,6 +7443,7 @@
 				D8815B122638686200EDAD62 /* CardPresentModalError.swift */,
 				D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */,
 				D85806282642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift */,
+				B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */,
 				D82BB3A926454F3300A82741 /* CardPresentModalProcessing.swift */,
 				311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */,
 				31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */,
@@ -8539,6 +8542,7 @@
 				31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */,
 				02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */,
 				E11228BE2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift in Sources */,
+				B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */,
 				5739D2D426274D580020E737 /* NoSecureConnectionErrorViewModel.swift in Sources */,
 				7459A6C621B0680300F83A78 /* RequirementsChecker.swift in Sources */,
 				CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentsPluginsDataProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentsPluginsDataProvider.swift
@@ -3,7 +3,7 @@ import Foundation
 import Yosemite
 @testable import WooCommerce
 
-final class MockPaymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol {
+final class MockCardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
     private let wcPayPlugin: SystemPlugin?
     private let stripePlugin: SystemPlugin?
     private let bothPluginsInstalledAndActive: Bool

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentsPluginsDataProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentsPluginsDataProvider.swift
@@ -1,0 +1,59 @@
+
+import Foundation
+import Yosemite
+@testable import WooCommerce
+
+final class MockPaymentsPluginsDataProvider: PaymentsPluginsDataProviderProtocol {
+    private let wcPayPlugin: SystemPlugin?
+    private let stripePlugin: SystemPlugin?
+    private let bothPluginsInstalledAndActive: Bool
+    private let wcPayInstalledAndActive: Bool
+    private let stripeInstalledAndActive: Bool
+    private let isWCPayVersionSupported: Bool
+    private let isStripeVersionSupported: Bool
+
+    init(wcPayPlugin: SystemPlugin? = nil,
+         stripePlugin: SystemPlugin? = nil,
+         bothPluginsInstalledAndActive: Bool = false,
+         wcPayInstalledAndActive: Bool = false,
+         stripeInstalledAndActive: Bool = false,
+         isWCPayVersionSupported: Bool = false,
+         isStripeVersionSupported: Bool = false) {
+        self.wcPayPlugin = wcPayPlugin
+        self.stripePlugin = stripePlugin
+        self.bothPluginsInstalledAndActive = bothPluginsInstalledAndActive
+        self.wcPayInstalledAndActive = wcPayInstalledAndActive
+        self.stripeInstalledAndActive = stripeInstalledAndActive
+        self.isWCPayVersionSupported = isWCPayVersionSupported
+        self.isStripeVersionSupported = isStripeVersionSupported
+    }
+
+
+    func getWCPayPlugin() -> SystemPlugin? {
+        wcPayPlugin
+    }
+
+    func getStripePlugin() -> SystemPlugin? {
+        stripePlugin
+    }
+
+    func bothPluginsInstalledAndActive(wcPay: SystemPlugin?, stripe: SystemPlugin?) -> Bool {
+        bothPluginsInstalledAndActive
+    }
+
+    func wcPayInstalledAndActive(wcPay: SystemPlugin?) -> Bool {
+        wcPayInstalledAndActive
+    }
+
+    func stripeInstalledAndActive(stripe: SystemPlugin?) -> Bool {
+        stripeInstalledAndActive
+    }
+
+    func isWCPayVersionSupported(plugin: SystemPlugin) -> Bool {
+        isWCPayVersionSupported
+    }
+
+    func isStripeVersionSupported(plugin: SystemPlugin) -> Bool {
+        isStripeVersionSupported
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import TestKit
+@testable import WooCommerce
+@testable import Yosemite
+
+final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+
+        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            guard case let .synchronizeSystemPlugins(_, onCompletion) = action else {
+                return
+            }
+
+            onCompletion(.success(()))
+        }
+    }
+
+    override func tearDown() {
+        stores = nil
+    }
+
+    func test_when_only_WCPay_is_active_and_version_is_higher_than_minimum_that_sends_email_then_returns_nil() {
+        let order = Order.fake()
+        let wcPayPlugin = SystemPlugin.fake().copy(version: "4.3.4")
+        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(wcPayPlugin: wcPayPlugin,
+                                                                      bothPluginsInstalledAndActive: false,
+                                                                      wcPayInstalledAndActive: true)
+        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+
+        let result: Result<String?, Error> = waitFor { promise in
+            sut.receiptEmail(from: order) { result in
+                promise(result)
+            }
+        }
+
+        guard case let .success(email) = result else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNil(email)
+    }
+
+    func test_when_only_WCPay_is_active_and_version_is_equal_than_minimum_that_sends_email_then_returns_nil() {
+        let wcPayPlugin = SystemPlugin.fake().copy(version: "4.0.0")
+        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(wcPayPlugin: wcPayPlugin,
+                                                                      bothPluginsInstalledAndActive: false,
+                                                                      wcPayInstalledAndActive: true)
+        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+
+        let result: Result<String?, Error> = waitFor { promise in
+            sut.receiptEmail(from: Order.fake()) { result in
+                promise(result)
+            }
+        }
+
+        guard case let .success(email) = result else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNil(email)
+    }
+
+    func test_when_only_WCPay_is_active_and_version_is_lower_than_minimum_that_sends_email_then_returns_order_email() {
+        let receiptEmail = "test@test.com"
+        let billingAddress = Address.fake().copy(email: receiptEmail)
+        let wcPayPlugin = SystemPlugin.fake().copy(version: "3.9.9")
+        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(wcPayPlugin: wcPayPlugin,
+                                                                      bothPluginsInstalledAndActive: false,
+                                                                      wcPayInstalledAndActive: true)
+        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+
+        let result: Result<String?, Error> = waitFor { promise in
+            sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in
+                promise(result)
+            }
+        }
+
+        guard case let .success(returnedEmail) = result else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(returnedEmail, receiptEmail)
+    }
+
+    func test_when_WCPay_and_Stripe_are_both_installed_and_active_then_returns_nil() {
+        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(bothPluginsInstalledAndActive: false)
+        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+
+        let result: Result<String?, Error> = waitFor { promise in
+            sut.receiptEmail(from: Order.fake()) { result in
+                promise(result)
+            }
+        }
+
+        guard case let .success(email) = result else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNil(email)
+    }
+
+    func test_when_WCPay_is_not_active_then_returns_email() {
+        let receiptEmail = "test@test.com"
+        let billingAddress = Address.fake().copy(email: receiptEmail)
+        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(bothPluginsInstalledAndActive: false, wcPayInstalledAndActive: false)
+        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+
+        let result: Result<String?, Error> = waitFor { promise in
+            sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in
+                promise(result)
+            }
+        }
+
+        guard case let .success(returnedEmail) = result else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(returnedEmail, receiptEmail)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
@@ -51,6 +51,8 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
 
     func test_when_only_WCPay_is_active_and_version_is_equal_to_minimum_that_sends_email_then_returns_nil() {
         // Given
+        let receiptEmail = "test@test.com"
+        let billingAddress = Address.fake().copy(email: receiptEmail)
         let wcPayPlugin = SystemPlugin.fake().copy(version: "4.0.0")
         let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(wcPayPlugin: wcPayPlugin,
                                                                       bothPluginsInstalledAndActive: false,
@@ -59,7 +61,7 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
 
         // When
         let result: Result<String?, Error> = waitFor { promise in
-            sut.receiptEmail(from: Order.fake()) { result in
+            sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in
                 promise(result)
             }
         }
@@ -101,12 +103,14 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
 
     func test_when_WCPay_and_Stripe_are_both_installed_and_active_then_returns_nil() {
         // Given
-        let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(bothPluginsInstalledAndActive: false)
+        let receiptEmail = "test@test.com"
+        let billingAddress = Address.fake().copy(email: receiptEmail)
+        let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(bothPluginsInstalledAndActive: true)
         let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
         // When
         let result: Result<String?, Error> = waitFor { promise in
-            sut.receiptEmail(from: Order.fake()) { result in
+            sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in
                 promise(result)
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
@@ -49,7 +49,7 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
         XCTAssertNil(email)
     }
 
-    func test_when_only_WCPay_is_active_and_version_is_equal_than_minimum_that_sends_email_then_returns_nil() {
+    func test_when_only_WCPay_is_active_and_version_is_equal_to_minimum_that_sends_email_then_returns_nil() {
         // Given
         let wcPayPlugin = SystemPlugin.fake().copy(version: "4.0.0")
         let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(wcPayPlugin: wcPayPlugin,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
@@ -21,6 +21,7 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
 
     override func tearDown() {
         stores = nil
+        super.tearDown()
     }
 
     func test_when_only_WCPay_is_active_and_version_is_higher_than_minimum_that_sends_email_then_returns_nil() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
@@ -26,10 +26,10 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     func test_when_only_WCPay_is_active_and_version_is_higher_than_minimum_that_sends_email_then_returns_nil() {
         let order = Order.fake()
         let wcPayPlugin = SystemPlugin.fake().copy(version: "4.3.4")
-        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(wcPayPlugin: wcPayPlugin,
+        let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(wcPayPlugin: wcPayPlugin,
                                                                       bothPluginsInstalledAndActive: false,
                                                                       wcPayInstalledAndActive: true)
-        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+        let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: order) { result in
@@ -47,10 +47,10 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
 
     func test_when_only_WCPay_is_active_and_version_is_equal_than_minimum_that_sends_email_then_returns_nil() {
         let wcPayPlugin = SystemPlugin.fake().copy(version: "4.0.0")
-        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(wcPayPlugin: wcPayPlugin,
+        let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(wcPayPlugin: wcPayPlugin,
                                                                       bothPluginsInstalledAndActive: false,
                                                                       wcPayInstalledAndActive: true)
-        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+        let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake()) { result in
@@ -70,10 +70,10 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
         let receiptEmail = "test@test.com"
         let billingAddress = Address.fake().copy(email: receiptEmail)
         let wcPayPlugin = SystemPlugin.fake().copy(version: "3.9.9")
-        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(wcPayPlugin: wcPayPlugin,
+        let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(wcPayPlugin: wcPayPlugin,
                                                                       bothPluginsInstalledAndActive: false,
                                                                       wcPayInstalledAndActive: true)
-        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+        let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in
@@ -90,8 +90,8 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     }
 
     func test_when_WCPay_and_Stripe_are_both_installed_and_active_then_returns_nil() {
-        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(bothPluginsInstalledAndActive: false)
-        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+        let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(bothPluginsInstalledAndActive: false)
+        let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake()) { result in
@@ -110,8 +110,8 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     func test_when_WCPay_is_not_active_then_returns_email() {
         let receiptEmail = "test@test.com"
         let billingAddress = Address.fake().copy(email: receiptEmail)
-        let paymentsPluginsDataProvider = MockPaymentsPluginsDataProvider(bothPluginsInstalledAndActive: false, wcPayInstalledAndActive: false)
-        let sut = PaymentReceiptEmailParameterDeterminer(paymentsPluginsDataProvider: paymentsPluginsDataProvider, stores: stores)
+        let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(bothPluginsInstalledAndActive: false, wcPayInstalledAndActive: false)
+        let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminerTests.swift
@@ -25,6 +25,7 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     }
 
     func test_when_only_WCPay_is_active_and_version_is_higher_than_minimum_that_sends_email_then_returns_nil() {
+        // Given
         let order = Order.fake()
         let wcPayPlugin = SystemPlugin.fake().copy(version: "4.3.4")
         let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(wcPayPlugin: wcPayPlugin,
@@ -32,12 +33,14 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
                                                                       wcPayInstalledAndActive: true)
         let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
+        // When
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: order) { result in
                 promise(result)
             }
         }
 
+        // Then
         guard case let .success(email) = result else {
             XCTFail()
             return
@@ -47,18 +50,21 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     }
 
     func test_when_only_WCPay_is_active_and_version_is_equal_than_minimum_that_sends_email_then_returns_nil() {
+        // Given
         let wcPayPlugin = SystemPlugin.fake().copy(version: "4.0.0")
         let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(wcPayPlugin: wcPayPlugin,
                                                                       bothPluginsInstalledAndActive: false,
                                                                       wcPayInstalledAndActive: true)
         let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
+        // When
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake()) { result in
                 promise(result)
             }
         }
 
+        // Then
         guard case let .success(email) = result else {
             XCTFail()
             return
@@ -68,6 +74,7 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     }
 
     func test_when_only_WCPay_is_active_and_version_is_lower_than_minimum_that_sends_email_then_returns_order_email() {
+        // Given
         let receiptEmail = "test@test.com"
         let billingAddress = Address.fake().copy(email: receiptEmail)
         let wcPayPlugin = SystemPlugin.fake().copy(version: "3.9.9")
@@ -76,12 +83,14 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
                                                                       wcPayInstalledAndActive: true)
         let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
+        // When
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in
                 promise(result)
             }
         }
 
+        // Then
         guard case let .success(returnedEmail) = result else {
             XCTFail()
             return
@@ -91,15 +100,18 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     }
 
     func test_when_WCPay_and_Stripe_are_both_installed_and_active_then_returns_nil() {
+        // Given
         let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(bothPluginsInstalledAndActive: false)
         let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
+        // When
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake()) { result in
                 promise(result)
             }
         }
 
+        // Then
         guard case let .success(email) = result else {
             XCTFail()
             return
@@ -109,17 +121,20 @@ final class PaymentReceiptEmailParameterDeterminerTests: XCTestCase {
     }
 
     func test_when_WCPay_is_not_active_then_returns_email() {
+        // Given
         let receiptEmail = "test@test.com"
         let billingAddress = Address.fake().copy(email: receiptEmail)
         let cardPresentPluginsDataProvider = MockCardPresentPluginsDataProvider(bothPluginsInstalledAndActive: false, wcPayInstalledAndActive: false)
         let sut = PaymentReceiptEmailParameterDeterminer(cardPresentPluginsDataProvider: cardPresentPluginsDataProvider, stores: stores)
 
+        // When
         let result: Result<String?, Error> = waitFor { promise in
             sut.receiptEmail(from: Order.fake().copy(billingAddress: billingAddress)) { result in
                 promise(result)
             }
         }
 
+        // Then
         guard case let .success(returnedEmail) = result else {
             XCTFail()
             return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6570
<!-- Id number of the GitHub issue this PR addresses. -->

Sorry for the larger PR, it got bloated after restoring the previous code and adding unit tests. I can split it into smaller PRs if that's better. The logic is however very straightforward.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As pointed [here](https://github.com/woocommerce/woocommerce-ios/issues/6570) , we removed the email receipt setting for all the cases in [this PR](https://github.com/woocommerce/woocommerce-ios/pull/6547). This however is not valid for some exceptional cases where we do have to set the email:

- WCPay plugin version is lower than 4.0.0
- WCPay is not active but Stripe is

If both WCPay and Stripe and installed and active, we do not send the receipt email.

With this PR we handle these cases.

### Changes
- Extract payments plugin information provider into its own class and use it in `CardPresentPaymentsOnboardingUseCase` and `PaymentCaptureOrchestrator` to avoid duplicated code
- Restore `Email` property wrapper, properties, and unit tests
- Implement new logic in `PaymentReceiptEmailParameterDeterminer`
- Use it in `PaymentCaptureOrchestrator`
- Unit tests

~~As you can see, I used `async/await` and throwable errors in `PaymentCaptureOrchestrator`. With it, we make the code simpler and more readable, as it could get very convoluted with nested completion callbacks. It is however only used and isolated in `PaymentCaptureOrchestrator` for this specific case, so it should not cause any undesired side effects in other scenarios.~~ As @jaclync pointed out, It is not possible until we update the Xcode version in our CI to Xcode 13.2

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Prerequisites
- In order to test it, you have to have a Local Delivery (cash on delivery) order still processing. You can trigger that on your site before testing this flow in the app.
- Please make sure that you are able to test payments (more info [here](PdfdoF-D-p2)

#### Only WCPay installed, version lower than 4.0.0
Make sure that you have WooCommerce Payments plugin installed and active, but not Stripe.
1. Open App
2. Go to orders
3. Open processing order
4. Tap on Collect Payment
5. Proceed with payment with the reader and test card
6. Email information is set

#### WCPay installed, version 4.0.0 or higher
This version is not released yet (please correct me if I am wrong). The case is unit tested however in `PaymentReceiptEmailParameterDeterminerTests`: It should not set the email parameter

#### Only Stripe
Make sure that you have the Stripe plugin installed and active, but not WooCommerce Payments.
1. Open App
2. Go to orders
3. Open processing order
4. Tap on Collect Payment
5. Proceed with payment with the reader and test card
6. Email information is sent

#### Both plugins installed and active
Make sure that you have WooCommerce Payments and Stripe plugin installed and active, but not WooCommerce Payments.
1. Open App
2. Go to orders
3. Open processing order
4. Tap on Collect Payment
5. Proceed with payment with the reader and test card
6. Email information is not sent

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->