### PR TITLE
Simple Payments: Update order entity to decode payment URL

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -337,6 +337,7 @@ extension Order {
             totalTax: .fake(),
             paymentMethodID: .fake(),
             paymentMethodTitle: .fake(),
+            paymentURL: .fake(),
             chargeID: .fake(),
             items: .fake(),
             billingAddress: .fake(),

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -257,6 +257,7 @@ extension Order {
         totalTax: CopiableProp<String> = .copy,
         paymentMethodID: CopiableProp<String> = .copy,
         paymentMethodTitle: CopiableProp<String> = .copy,
+        paymentURL: NullableCopiableProp<URL> = .copy,
         chargeID: NullableCopiableProp<String> = .copy,
         items: CopiableProp<[OrderItem]> = .copy,
         billingAddress: NullableCopiableProp<Address> = .copy,
@@ -287,6 +288,7 @@ extension Order {
         let totalTax = totalTax ?? self.totalTax
         let paymentMethodID = paymentMethodID ?? self.paymentMethodID
         let paymentMethodTitle = paymentMethodTitle ?? self.paymentMethodTitle
+        let paymentURL = paymentURL ?? self.paymentURL
         let chargeID = chargeID ?? self.chargeID
         let items = items ?? self.items
         let billingAddress = billingAddress ?? self.billingAddress
@@ -318,6 +320,7 @@ extension Order {
             totalTax: totalTax,
             paymentMethodID: paymentMethodID,
             paymentMethodTitle: paymentMethodTitle,
+            paymentURL: paymentURL,
             chargeID: chargeID,
             items: items,
             billingAddress: billingAddress,

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -31,6 +31,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
     public let totalTax: String
     public let paymentMethodID: String
     public let paymentMethodTitle: String
+    public let paymentURL: URL?
     public let chargeID: String?
 
     public let items: [OrderItem]
@@ -64,6 +65,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                 totalTax: String,
                 paymentMethodID: String,
                 paymentMethodTitle: String,
+                paymentURL: URL?,
                 chargeID: String?,
                 items: [OrderItem]?,
                 billingAddress: Address?,
@@ -97,6 +99,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         self.totalTax = totalTax
         self.paymentMethodID = paymentMethodID
         self.paymentMethodTitle = paymentMethodTitle
+        self.paymentURL = paymentURL
         self.chargeID = chargeID
 
         self.items = items ?? []
@@ -142,6 +145,9 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         let totalTax = try container.decode(String.self, forKey: .totalTax)
         let paymentMethodID = try container.decode(String.self, forKey: .paymentMethodID)
         let paymentMethodTitle = try container.decode(String.self, forKey: .paymentMethodTitle)
+
+        // "payment_url" is only available on stores stores with version >= 8.4.
+        let paymentURL = try container.decodeIfPresent(URL.self, forKey: .paymentURL)
 
         let allOrderMetaData = try? container.decode([OrderMetaData].self, forKey: .metadata)
         var chargeID: String? = nil
@@ -192,6 +198,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   totalTax: totalTax,
                   paymentMethodID: paymentMethodID,
                   paymentMethodTitle: paymentMethodTitle,
+                  paymentURL: paymentURL,
                   chargeID: chargeID,
                   items: items,
                   billingAddress: billingAddress,
@@ -224,6 +231,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   totalTax: "",
                   paymentMethodID: "",
                   paymentMethodTitle: "",
+                  paymentURL: nil,
                   chargeID: nil,
                   items: [],
                   billingAddress: nil,
@@ -264,6 +272,7 @@ internal extension Order {
         case totalTax           = "total_tax"
         case paymentMethodID    = "payment_method"
         case paymentMethodTitle = "payment_method_title"
+        case paymentURL         = "payment_url"
 
         case items              = "line_items"
         case shippingAddress    = "shipping"
@@ -301,6 +310,7 @@ extension Order: Equatable {
             lhs.totalTax == rhs.totalTax &&
             lhs.paymentMethodID == rhs.paymentMethodID &&
             lhs.paymentMethodTitle == rhs.paymentMethodTitle &&
+            lhs.paymentURL == rhs.paymentURL &&
             lhs.billingAddress == rhs.billingAddress &&
             lhs.shippingAddress == rhs.shippingAddress &&
             lhs.shippingLines.count == rhs.shippingLines.count &&

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -146,7 +146,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         let paymentMethodID = try container.decode(String.self, forKey: .paymentMethodID)
         let paymentMethodTitle = try container.decode(String.self, forKey: .paymentMethodTitle)
 
-        // "payment_url" is only available on stores stores with version >= 8.4.
+        // "payment_url" is only available on stores stores with version >= 6.4
         let paymentURL = try container.decodeIfPresent(URL.self, forKey: .paymentURL)
 
         let allOrderMetaData = try? container.decode([OrderMetaData].self, forKey: .metadata)

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -40,6 +40,7 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(order.shippingTax, "0.00")
         XCTAssertEqual(order.total, "31.20")
         XCTAssertEqual(order.totalTax, "1.20")
+        XCTAssertEqual(order.paymentURL, URL(string: "http://www.automattic.com"))
     }
 
     /// Verifies that all of the Order Address fields are parsed correctly.

--- a/Networking/NetworkingTests/Responses/order.json
+++ b/Networking/NetworkingTests/Responses/order.json
@@ -100,6 +100,7 @@
         ],
         "payment_method": "stripe",
         "payment_method_title": "Credit Card (Stripe)",
+        "payment_url": "http://www.automattic.com",
         "date_paid_gmt": "2018-04-03T23:05:14",
         "date_completed_gmt": null,
         "line_items": [

--- a/Networking/NetworkingTests/Responses/orders-load-all.json
+++ b/Networking/NetworkingTests/Responses/orders-load-all.json
@@ -101,6 +101,7 @@
              ],
              "payment_method": "stripe",
              "payment_method_title": "Credit Card (Stripe)",
+             "payment_url": "http://www.automattic.com",
              "date_paid_gmt": "2018-04-03T23:05:14",
              "date_completed_gmt": null,
              "line_items": [
@@ -246,6 +247,7 @@
              },
              "payment_method": "stripe",
              "payment_method_title": "Credit Card (Stripe)",
+             "payment_url": "http://www.automattic.com",
              "date_paid_gmt": "2018-04-03T20:54:23",
              "date_completed_gmt": null,
              "line_items": [
@@ -314,6 +316,7 @@
              },
              "payment_method": "stripe",
              "payment_method_title": "Credit Card (Stripe)",
+             "payment_url": "http://www.automattic.com",
              "date_paid_gmt": "2018-04-03T20:52:41",
              "date_completed_gmt": null,
              "line_items": [
@@ -395,6 +398,7 @@
                  },
                  "payment_method": "stripe",
                  "payment_method_title": "Credit Card (Stripe)",
+                 "payment_url": "http://www.automattic.com",
                  "transaction_id": "ch_1FOr46J71fgCH5kvqxjdQyqZ",
                  "date_paid": "2019-10-01T19:31:19",
                  "date_paid_gmt": "2019-10-01T19:31:19",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -391,6 +391,7 @@ struct EditAddressForm_Previews: PreviewProvider {
                                    totalTax: "1.20",
                                    paymentMethodID: "stripe",
                                    paymentMethodTitle: "Credit Card (Stripe)",
+                                   paymentURL: nil,
                                    chargeID: nil,
                                    items: [],
                                    billingAddress: sampleAddress,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -461,6 +461,7 @@ extension ShippingLabelPackagesFormViewModel {
                      totalTax: "1.20",
                      paymentMethodID: "stripe",
                      paymentMethodTitle: "Credit Card (Stripe)",
+                     paymentURL: nil,
                      chargeID: nil,
                      items: sampleItems(),
                      billingAddress: sampleAddress(),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -26,6 +26,7 @@ enum ShippingLabelSampleData {
                      totalTax: "1.20",
                      paymentMethodID: "stripe",
                      paymentMethodTitle: "Credit Card (Stripe)",
+                     paymentURL: nil,
                      chargeID: nil,
                      items: sampleItems(),
                      billingAddress: sampleAddress(),

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -230,6 +230,7 @@ extension MockObjectGraph {
             totalTax: "0",
             paymentMethodID: "0",
             paymentMethodTitle: "MasterCard",
+            paymentURL: nil,
             chargeID: nil,
             items: items,
             billingAddress: customer.billingAddress,

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -32,6 +32,7 @@ extension Storage.Order: ReadOnlyConvertible {
         totalTax = order.totalTax
         paymentMethodID = order.paymentMethodID
         paymentMethodTitle = order.paymentMethodTitle
+        paymentURL = order.paymentURL as NSURL?
         chargeID = order.chargeID
 
         if let billingAddress = order.billingAddress {
@@ -93,6 +94,7 @@ extension Storage.Order: ReadOnlyConvertible {
                      totalTax: totalTax ?? "",
                      paymentMethodID: paymentMethodID ?? "",
                      paymentMethodTitle: paymentMethodTitle ?? "",
+                     paymentURL: paymentURL as URL?,
                      chargeID: chargeID,
                      items: orderItems,
                      billingAddress: createReadOnlyBillingAddress(),

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -28,6 +28,7 @@ public enum OrderFactory {
               totalTax: "",
               paymentMethodID: "",
               paymentMethodTitle: "",
+              paymentURL: nil,
               chargeID: nil,
               items: [],
               billingAddress: nil,

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -933,6 +933,7 @@ private extension OrderStoreTests {
                                  totalTax: "1.20",
                                  paymentMethodID: "stripe",
                                  paymentMethodTitle: "Credit Card (Stripe)",
+                                 paymentURL: URL(string: "http://www.automattic.com"),
                                  items: sampleItems(),
                                  billingAddress: sampleAddress(),
                                  shippingAddress: sampleAddress(),


### PR DESCRIPTION
part of #6087 

# Why

Previously, we were building orders payment links inside the app, but this proved to not be reliable as the merchants can change different parts of that URL in their store settings.

As of WC 6.4 stores will start delivering the payment_url field inside the order entity.

This PR takes care of updating the Order(networking) entity so we can safely decode the `payment_url`.

# Testing Steps

- Make sure the migration unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
