### PR TITLE
IPP: support card present refunds for Interac

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -563,7 +563,7 @@ extension StripeCardReaderService {
                 }
                 promise(.success(()))
             })
-            //TODO: handle timeout?
+            //TODO: 5983 - handle timeout when called from retry after refund failure
         }.eraseToAnyPublisher()
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -7,11 +7,7 @@ import PassKit
 /// 3. Refund payment in-person with a card reader.
 /// Steps 1 and 2 are the same as the payments flow in `PaymentCaptureOrchestrator`.
 final class CardPresentRefundOrchestrator {
-    private let personNameComponentsFormatter = PersonNameComponentsFormatter()
-
-    private let celebration = PaymentCaptureCelebration()
     private let stores: StoresManager
-
     private var walletSuppressionRequestToken: PKSuppressionRequestToken?
 
     init(stores: StoresManager) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -59,7 +59,7 @@ final class CardPresentRefundOrchestrator {
     /// Cancels the current refund.
     /// - Parameter onCompletion: called when the cancellation completes.
     func cancelRefund(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = CardPresentPaymentAction.cancelRefund() { [weak self] result in
+        let action = CardPresentPaymentAction.cancelRefund { [weak self] result in
             self?.allowPassPresentation()
             onCompletion(result)
         }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -1,0 +1,121 @@
+import Yosemite
+import PassKit
+
+/// Orchestrates the sequence of actions required to refund in-person that is required for certain payment methods:
+/// 1. Check if there is a card reader connected
+/// 2. Launch the reader discovering and pairing UI if there is no reader connected
+/// 3. Refund payment in-person with a card reader.
+/// Steps 1 and 2 are the same as the payments flow in `PaymentCaptureOrchestrator`.
+final class CardPresentRefundOrchestrator {
+    private let personNameComponentsFormatter = PersonNameComponentsFormatter()
+
+    private let celebration = PaymentCaptureCelebration()
+    private let stores: StoresManager
+
+    private var walletSuppressionRequestToken: PKSuppressionRequestToken?
+
+    init(stores: StoresManager) {
+        self.stores = stores
+    }
+
+    /// Refunds a payment for an order in-person, which is required for certain payment methods like Interac in Canada.
+    /// - Parameters:
+    ///   - amount: the amount to refund in Decimal.
+    ///   - charge: details about how the order was charged to verify refund.
+    ///   - paymentGatewayAccount: payment gateway (e.g. WCPay or Stripe extension).
+    ///   - onWaitingForInput: called when the card reader is waiting for card input.
+    ///   - onProcessingMessage: called when the refund is processing.
+    ///   - onDisplayMessage: called when the card reader sends a message to display to the user.
+    ///   - onCompletion: called when the refund completes.
+    func refund(amount: Decimal,
+                charge: WCPayCharge,
+                paymentGatewayAccount: PaymentGatewayAccount,
+                onWaitingForInput: @escaping () -> Void,
+                onProcessingMessage: @escaping () -> Void,
+                onDisplayMessage: @escaping (String) -> Void,
+                onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        /// Sets the state of `CardPresentPaymentStore`.
+        let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
+        stores.dispatch(setAccount)
+
+        /// Briefly suppresses pass (wallet) presentation so that the merchant doesn't attempt to pay for the buyer's order when the
+        /// reader begins to collect payment.
+        suppressPassPresentation()
+
+        /// Refunds payment in-person with a card reader.
+        let refundParameters = RefundParameters(chargeId: charge.id, amount: amount, currency: charge.currency)
+        let refundAction = CardPresentPaymentAction.refundPayment(parameters: refundParameters,
+                                                                  onCardReaderMessage: { event in
+            switch event {
+            case .waitingForInput:
+                onWaitingForInput()
+            case .displayMessage(let message):
+                onDisplayMessage(message)
+            default:
+                break
+            }
+        }, onCompletion: { result in
+            onCompletion(result)
+        })
+        stores.dispatch(refundAction)
+    }
+
+    /// Cancels the current refund.
+    /// - Parameter onCompletion: called when the cancellation completes.
+    func cancelRefund(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let action = CardPresentPaymentAction.cancelRefund() { [weak self] result in
+            self?.allowPassPresentation()
+            onCompletion(result)
+        }
+        stores.dispatch(action)
+    }
+}
+
+// MARK: - Apple wallet suppression
+
+private extension CardPresentRefundOrchestrator {
+    /// Suppresses wallet presentation. This requires a special entitlement from Apple:
+    /// `com.apple.developer.passkit.pass-presentation-suppression`
+    /// See Woo-*.entitlements in WooCommerce/Resources
+    func suppressPassPresentation() {
+        /// iPads don't support NFC passes. Attempting to call `requestAutomaticPassPresentationSuppression` on them will
+        /// return 0 `notSupported`
+        ///
+        guard !UIDevice.isPad() else {
+            return
+        }
+
+        guard !PKPassLibrary.isSuppressingAutomaticPassPresentation() else {
+            return
+        }
+
+        walletSuppressionRequestToken = PKPassLibrary.requestAutomaticPassPresentationSuppression() { result in
+            guard result == .success else {
+                DDLogWarn("Automatic pass presentation suppression request failed. Reason: \(result.rawValue)")
+
+                let logProperties: [String: Any] = ["PKAutomaticPassPresentationSuppressionResult": result.rawValue]
+                ServiceLocator.crashLogging.logMessage(
+                    "Automatic pass presentation suppression request failed",
+                    properties: logProperties,
+                    level: .warning
+                )
+                return
+            }
+        }
+    }
+
+    /// Restores wallet presentation.
+    func allowPassPresentation() {
+        /// iPads don't have passes (wallets) to present
+        ///
+        guard !UIDevice.isPad() else {
+            return
+        }
+
+        guard let walletSuppressionRequestToken = walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
+            return
+        }
+
+        PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: walletSuppressionRequestToken)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -69,13 +69,15 @@ extension RefundConfirmationViewController {
     /// Submits the refund and dismisses the flow upon successful completion.
     ///
     func submitRefund() {
-        onRefundCreationAction?()
-        viewModel.submit { [weak self] result in
+        viewModel.submit(rootViewController: self,
+                         showInProgressUI: { [weak self] in
+            self?.onRefundCreationAction?()
+        }, onCompletion: { [weak self] result in
             if let error = result.failure {
                 self?.displayNotice(with: error)
             }
             self?.onRefundCompletion?(result.failure)
-        }
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -48,6 +48,10 @@ final class RefundConfirmationViewModel {
         )
     ]
 
+    /// Retains the use-case so it can perform all of its async tasks.
+    ///
+    private var submissionUseCase: RefundSubmissionProtocol?
+
     private let analytics: Analytics
 
     init(details: Details,
@@ -62,37 +66,59 @@ final class RefundConfirmationViewModel {
 
     /// Submit the refund.
     ///
-    func submit(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        // Create refund object
+    /// - Parameters:
+    ///   - rootViewController: view controller used to present in-person refund alerts if needed.
+    ///   - showInProgressUI: called when in-progress UI should be shown during refund submission. In-person refund submission does not show in-progress UI.
+    ///   - onCompletion: called when the refund submission completes.
+    func submit(rootViewController: UIViewController,
+                showInProgressUI: @escaping (() -> Void),
+                onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        // TODO: 6601 - remove Interac workaround when the API support is shipped.
+        let isInterac: Bool = {
+            switch details.charge?.paymentMethodDetails {
+            case .some(.interacPresent):
+                return true
+            default:
+                return false
+            }
+        }()
+        let automaticallyRefundsPayment = isInterac && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.canadaInPersonPayments) ?
+        false: gatewaySupportsAutomaticRefunds()
+
+        // Creates refund object.
         let shippingLine = details.refundsShipping ? details.order.shippingLines.first : nil
         let fees = details.refundsFees ? details.order.fees : []
         let useCase = RefundCreationUseCase(amount: details.amount,
                                             reason: reasonForRefundCellViewModel.value,
-                                            automaticallyRefundsPayment: gatewaySupportsAutomaticRefunds(),
+                                            automaticallyRefundsPayment: automaticallyRefundsPayment,
                                             items: details.items,
                                             shippingLine: shippingLine,
                                             fees: fees,
                                             currencyFormatter: currencyFormatter)
         let refund = useCase.createRefund()
 
-        // Submit it
-        let action = RefundAction.createRefund(siteID: details.order.siteID, orderID: details.order.orderID, refund: refund) { [weak self] _, error  in
+        // Submits refund.
+        let submissionUseCase = RefundSubmissionUseCase(siteID: details.order.siteID,
+                                                        details: details,
+                                                        rootViewController: rootViewController,
+                                                        currencyFormatter: currencyFormatter)
+        self.submissionUseCase = submissionUseCase
+        submissionUseCase.submitRefund(refund,
+                                       details: details,
+                                       showInProgressUI: showInProgressUI,
+                                       onCompletion: { [weak self] result in
             guard let self = self else { return }
-            if let error = error {
-                DDLogError("Error creating refund: \(refund)\nWith Error: \(error)")
-                self.trackCreateRefundRequestFailed(error: error)
-                return onCompletion(.failure(error))
-            }
 
-            // We don't care if the "update order" fails. We return .success() as the refund creation already succeeded.
-            self.updateOrder { _ in
-                onCompletion(.success(()))
+            switch result {
+            case .success:
+                // We don't care if the "update order" fails. We return .success() as the refund creation already succeeded.
+                self.updateOrder { _ in
+                    onCompletion(.success(()))
+                }
+            default:
+                onCompletion(result)
             }
-            self.trackCreateRefundRequestSuccess()
-        }
-
-        actionProcessor.dispatch(action)
-        trackCreateRefundRequest()
+        })
     }
 
     /// Updates the order associated with the refund to reflect the latest refund status.
@@ -191,28 +217,6 @@ extension RefundConfirmationViewModel {
     ///
     func trackSummaryButtonTapped() {
         analytics.track(event: WooAnalyticsEvent.IssueRefund.summaryButtonTapped(orderID: details.order.orderID))
-    }
-
-    /// Tracks when the create refund request is made.
-    ///
-    private func trackCreateRefundRequest() {
-        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefund(orderID: details.order.orderID,
-                                                                          fullyRefunded: details.amount == details.order.total,
-                                                                          method: .items,
-                                                                          gateway: details.order.paymentMethodID,
-                                                                          amount: details.amount))
-    }
-
-    /// Tracks when the create refund request succeeds.
-    ///
-    private func trackCreateRefundRequestSuccess() {
-        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefundSuccess(orderID: details.order.orderID))
-    }
-
-    /// Tracks when the create refund request fails.
-    ///
-    private func trackCreateRefundRequestFailed(error: Error) {
-        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefundFailed(orderID: details.order.orderID, error: error))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -99,14 +99,15 @@ final class RefundConfirmationViewModel {
 
         // Submits refund.
         let submissionUseCase = RefundSubmissionUseCase(siteID: details.order.siteID,
-                                                        details: details,
+                                                        details: .init(order: details.order,
+                                                                       charge: details.charge,
+                                                                       amount: details.amount),
                                                         rootViewController: rootViewController,
                                                         currencyFormatter: currencyFormatter,
                                                         stores: actionProcessor,
                                                         analytics: analytics)
         self.submissionUseCase = submissionUseCase
         submissionUseCase.submitRefund(refund,
-                                       details: details,
                                        showInProgressUI: showInProgressUI,
                                        onCompletion: { [weak self] result in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -101,7 +101,9 @@ final class RefundConfirmationViewModel {
         let submissionUseCase = RefundSubmissionUseCase(siteID: details.order.siteID,
                                                         details: details,
                                                         rootViewController: rootViewController,
-                                                        currencyFormatter: currencyFormatter)
+                                                        currencyFormatter: currencyFormatter,
+                                                        stores: actionProcessor,
+                                                        analytics: analytics)
         self.submissionUseCase = submissionUseCase
         submissionUseCase.submitRefund(refund,
                                        details: details,

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -252,7 +252,7 @@ private extension RefundSubmissionUseCase {
     /// Logs the failure reason, cancels the current refund, and offers retry if possible.
     func handleRefundFailureAndRetryRefund(_ error: Error, refundAmount: Decimal, charge: WCPayCharge, onCompletion: @escaping (Result<Void, Error>) -> ()) {
         // TODO: 5984 - tracks in-person refund error
-        DDLogError("Failed to collect payment: \(error.localizedDescription)")
+        DDLogError("Failed to refund: \(error.localizedDescription)")
         // Informs about the error.
         alerts?.error(error: error) { [weak self] in
             // Cancels current payment.

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -1,0 +1,357 @@
+import Foundation
+import Combine
+import Yosemite
+import MessageUI
+import protocol Storage.StorageManagerType
+
+/// Protocol to abstract the `CollectOrderPaymentUseCase`.
+/// Currently only used to facilitate unit tests.
+///
+protocol RefundSubmissionProtocol {
+    /// Starts the refund submission flow.
+    ///
+    /// - Parameter refund: the refund to submit.
+    /// - Parameter details: details about the refund.
+    /// - Parameter showInProgressUI: called when the in-progress UI should be shown during refund submission.
+    /// - Parameter onCompletion: called when the refund completes.
+    func submitRefund(_ refund: Refund, details: RefundDetails, showInProgressUI: @escaping (() -> Void), onCompletion: @escaping (Result<Void, Error>) -> Void)
+}
+
+// TODO: rename or create a new struct with necessary info
+typealias RefundDetails = RefundConfirmationViewModel.Details
+
+/// Use case to submit a refund for an order.
+/// If in-person refund is required for the payment method (e.g. Interac in Canada), orchestrates reader connection, refund, UI alerts,
+/// submit refund to the site, and analytics.
+/// Otherwise, it submits the refund to the site directly with analytics.
+final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
+    /// Store's ID.
+    private let siteID: Int64
+
+    /// Refund details.
+    private let details: RefundDetails
+
+    /// Order of the refund.
+    private var order: Order {
+        details.order
+    }
+
+    /// Currency formatted needed for decimal calculations.
+    let currencyFormatter: CurrencyFormatter
+
+    /// Formatted amount to collect.
+    private let formattedAmount: String
+
+    /// Stores manager.
+    private let stores: StoresManager
+
+    /// Storage manager for fetching payment gateway accounts.
+    private let storageManager: StorageManagerType
+
+    /// Analytics manager.
+    private let analytics: Analytics
+
+    /// View controller used to present alerts.
+    private var rootViewController: UIViewController
+
+    /// Stores the card reader listener subscription while trying to connect to one.
+    private var readerSubscription: AnyCancellable?
+
+    /// Stores the connected card reader for analytics.
+    private var connectedReader: CardReader?
+
+    /// Closure to inform when the full flow has been completed, after receipt management.
+    /// Needed to be saved as an instance variable because it needs to be referenced from the `MailComposer` delegate.
+    private var onCompleted: (() -> ())?
+
+    /// Alert manager to inform merchants about reader & card actions.
+    private var alerts: OrderDetailsPaymentAlerts?
+
+    /// In-person refund orchestrator.
+    private lazy var refundOrchestrator = CardPresentRefundOrchestrator(stores: stores)
+
+    /// Controller to connect a card reader for in-person refund.
+    private lazy var connectionController = CardReaderConnectionController(forSiteID: siteID,
+                                                                           knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
+                                                                           alertsProvider: CardReaderSettingsAlerts(),
+                                                                           configuration: configurationLoader.configuration)
+
+    /// IPP Configuration loader.
+    private lazy var configurationLoader = CardPresentConfigurationLoader(stores: stores)
+
+    /// PaymentGatewayAccount Results Controller.
+    private lazy var paymentGatewayAccountResultsController: ResultsController<StoragePaymentGatewayAccount> = {
+        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        return ResultsController<StoragePaymentGatewayAccount>(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
+    /// Payment Gateway Accounts for the site (i.e. that can be used to refund)
+    private var paymentGatewayAccounts: [PaymentGatewayAccount] {
+        paymentGatewayAccountResultsController.fetchedObjects
+    }
+
+    init(siteID: Int64,
+         details: RefundDetails,
+         rootViewController: UIViewController,
+         currencyFormatter: CurrencyFormatter,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.details = details
+        self.formattedAmount = {
+            let currencyCode = currencySettings.currencyCode
+            let unit = currencySettings.symbol(from: currencyCode)
+            return currencyFormatter.formatAmount(details.amount, with: unit) ?? ""
+        }()
+        self.rootViewController = rootViewController
+        self.currencyFormatter = currencyFormatter
+        self.stores = stores
+        self.storageManager = storageManager
+        self.analytics = analytics
+    }
+
+    /// Starts the refund submission flow.
+    ///
+    /// If in-person refund is required:
+    /// 1. Connect to a reader
+    /// 2. Refund with a card reader
+    ///   - If successful: submit the refund to the site
+    ///   - If failure: allow the customer to retry
+    ///
+    /// Otherwise, if in-person refund is not required, the refund is submitted directly to the site.
+    ///
+    /// - Parameters:
+    ///   - refund: the refund to submit.
+    ///   - details: details about the refund.
+    ///   - showInProgressUI: called when the in-progress UI should be shown during refund submission.
+    ///   - onCompletion: called when the refund completes.
+    func submitRefund(_ refund: Refund,
+                      details: RefundDetails,
+                      showInProgressUI: @escaping (() -> Void),
+                      onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        if let charge = details.charge, shouldRefundWithCardReader(details: details) {
+            guard let refundAmount = currencyFormatter.convertToDecimal(from: details.amount) else {
+                DDLogError("Error: attempted to refund an order without a valid amount.")
+                return
+            }
+            observeConnectedReadersForAnalytics()
+            connectReader { [weak self] in
+                self?.attemptRefund(refundAmount: refundAmount as Decimal, charge: charge, onCompletion: { [weak self] result in
+                    guard let self = self else { return }
+                    self.submitRefundToSite(refund: refund) { result in
+                        onCompletion(result)
+                    }
+                })
+            }
+        } else {
+            showInProgressUI()
+            submitRefundToSite(refund: refund, onCompletion: onCompletion)
+        }
+    }
+}
+
+// MARK: Private functions
+private extension RefundSubmissionUseCase {
+    /// Determines if in-person refund is required. Currently, only Interac payment method requires in-person refunds.
+    /// - Parameter details: details about the refund.
+    /// - Returns: whether the refund should be in-person with a card reader.
+    func shouldRefundWithCardReader(details: RefundDetails) -> Bool {
+        let isInterac: Bool = {
+            switch details.charge?.paymentMethodDetails {
+            case .some(.interacPresent):
+                return true
+            default:
+                return false
+            }
+        }()
+        return isInterac
+    }
+
+    /// Attempts to connect to a reader.
+    /// Finishes immediately if a reader is already connected.
+    func connectReader(onCompletion: @escaping () -> ()) {
+        // `checkCardReaderConnected` action will return a publisher that:
+        // - Sends one value if there is no reader connected.
+        // - Completes when a reader is connected.
+        let readerConnected = CardPresentPaymentAction.checkCardReaderConnected { [weak self] connectPublisher in
+            guard let self = self else { return }
+            self.readerSubscription = connectPublisher
+                .sink(receiveCompletion: { [weak self] _ in
+                    // Dismisses the current connection alert before notifying the completion.
+                    // If no presented controller is found(because the reader was already connected), just notify the completion.
+                    if let connectionController = self?.rootViewController.presentedViewController {
+                        connectionController.dismiss(animated: true) {
+                            onCompletion()
+                        }
+                    } else {
+                        onCompletion()
+                    }
+
+                    // Nil the subscription since we are done with the connection.
+                    self?.readerSubscription = nil
+
+                }, receiveValue: { [weak self] _ in
+                    guard let self = self else { return }
+
+                    // Attempts reader connection
+                    self.connectionController.searchAndConnect(from: self.rootViewController) { _ in }
+                })
+        }
+        stores.dispatch(readerConnected)
+    }
+
+    /// Attempts to refund with a card reader when it is connected.
+    ///
+    /// - Parameters:
+    ///   - refundAmount: the amount to refund.
+    ///   - charge: the charge of the order for the refund to match the payment method.
+    ///   - onCompletion: called when the in-person refund completes.
+    func attemptRefund(refundAmount: Decimal, charge: WCPayCharge, onCompletion: @escaping (Result<Void, Error>) -> ()) {
+        // Fetches payment gateway accounts, at least one is required for in-person refunds.
+        try? paymentGatewayAccountResultsController.performFetch()
+        guard let paymentGatewayAccount = paymentGatewayAccounts.first else {
+            onCompletion(.failure(RefundSubmissionError.unknownPaymentGatewayAccount))
+            return
+        }
+
+        // Instantiates the alerts coordinator.
+        let alerts = OrderDetailsPaymentAlerts(presentingController: rootViewController,
+                                               paymentGatewayAccountID: paymentGatewayAccount.gatewayID,
+                                               countryCode: configurationLoader.configuration.countryCode,
+                                               cardReaderModel: connectedReader?.readerType.model ?? "")
+        self.alerts = alerts
+
+        // Shows reader ready alert.
+        alerts.readerIsReady(title: Localization.collectPaymentTitle(username: order.billingAddress?.firstName), amount: formattedAmount)
+
+        // Starts refund process.
+        refundOrchestrator.refund(amount: refundAmount,
+                                  charge: charge,
+                                  paymentGatewayAccount: paymentGatewayAccount,
+                                  onWaitingForInput: { [weak self] in
+            // Requests card input.
+            self?.alerts?.tapOrInsertCard(onCancel: {
+                self?.cancelRefund()
+            })
+        }, onProcessingMessage: { [weak self] in
+            // Shows waiting message.
+            self?.alerts?.processingPayment()
+        }, onDisplayMessage: { [weak self] message in
+            // Shows reader messages (e.g. Remove Card).
+            self?.alerts?.displayReaderMessage(message: message)
+        }, onCompletion: { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success:
+                onCompletion(.success(()))
+            case .failure(let error):
+                self.handleRefundFailureAndRetryRefund(error, refundAmount: refundAmount, charge: charge, onCompletion: onCompletion)
+            }
+        })
+    }
+
+    /// Logs the failure reason, cancels the current refund, and offers retry if possible.
+    func handleRefundFailureAndRetryRefund(_ error: Error, refundAmount: Decimal, charge: WCPayCharge, onCompletion: @escaping (Result<Void, Error>) -> ()) {
+        // TODO: 5984 - tracks in-person refund error
+        DDLogError("Failed to collect payment: \(error.localizedDescription)")
+        // Informs about the error.
+        alerts?.error(error: error) { [weak self] in
+            // Cancels current payment.
+            self?.refundOrchestrator.cancelRefund { [weak self] result in
+                guard let self = self else { return }
+
+                switch result {
+                case .success:
+                    // Retries refund.
+                    self.attemptRefund(refundAmount: refundAmount, charge: charge, onCompletion: onCompletion)
+                case .failure(let cancelError):
+                    // Informs that payment can't be retried.
+                    self.alerts?.nonRetryableError(from: self.rootViewController, error: cancelError)
+                    onCompletion(.failure(error))
+                }
+            }
+        }
+    }
+
+    /// Cancels refund and records analytics.
+    func cancelRefund() {
+        refundOrchestrator.cancelRefund { _ in
+            // TODO: 5984 - tracks in-person refund cancellation
+        }
+    }
+
+    /// Submits the refund to the site.
+    /// - Parameters:
+    ///   - refund: the refund to submit.
+    ///   - onCompletion: called when the submission completes.
+    func submitRefundToSite(refund: Refund, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let action = RefundAction.createRefund(siteID: details.order.siteID, orderID: details.order.orderID, refund: refund) { [weak self] _, error  in
+            guard let self = self else { return }
+            if let error = error {
+                DDLogError("Error creating refund: \(refund)\nWith Error: \(error)")
+                self.trackCreateRefundRequestFailed(error: error)
+                return onCompletion(.failure(error))
+            }
+            onCompletion(.success(()))
+            self.trackCreateRefundRequestSuccess()
+        }
+        stores.dispatch(action)
+        trackCreateRefundRequest()
+    }
+}
+
+// MARK: - Analytics
+private extension RefundSubmissionUseCase {
+    /// Tracks when the create refund request is made.
+    func trackCreateRefundRequest() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefund(orderID: details.order.orderID,
+                                                                          fullyRefunded: details.amount == details.order.total,
+                                                                          method: .items,
+                                                                          gateway: details.order.paymentMethodID,
+                                                                          amount: details.amount))
+    }
+
+    /// Tracks when the create refund request succeeds.
+    func trackCreateRefundRequestSuccess() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefundSuccess(orderID: details.order.orderID))
+    }
+
+    /// Tracks when the create refund request fails.
+    func trackCreateRefundRequestFailed(error: Error) {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefundFailed(orderID: details.order.orderID, error: error))
+    }
+}
+
+// MARK: Connected Card Readers
+private extension RefundSubmissionUseCase {
+    func observeConnectedReadersForAnalytics() {
+        let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
+            self?.connectedReader = readers.first
+        }
+        stores.dispatch(action)
+    }
+}
+
+// MARK: Definitions
+private extension RefundSubmissionUseCase {
+    /// Mailing a receipt failed but the SDK didn't return a more specific error
+    ///
+    enum RefundSubmissionError: Error {
+        case unknownPaymentGatewayAccount
+    }
+
+    enum Localization {
+        private static let collectPaymentWithoutName = NSLocalizedString("Refund payment",
+                                                                         comment: "Alert title when starting the in-person refund flow without a user name.")
+        private static let collectPaymentWithName = NSLocalizedString("Refund payment from %1$@",
+                                                                      comment: "Alert title when starting the in-person refund flow with a user name.")
+        static func collectPaymentTitle(username: String?) -> String {
+            guard let username = username, username.isNotEmpty else {
+                return collectPaymentWithoutName
+            }
+            return .localizedStringWithFormat(collectPaymentWithName, username)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -231,7 +231,7 @@ private extension RefundSubmissionUseCase {
         self.alerts = alerts
 
         // Shows reader ready alert.
-        alerts.readerIsReady(title: Localization.collectPaymentTitle(username: order.billingAddress?.firstName), amount: formattedAmount)
+        alerts.readerIsReady(title: Localization.refundPaymentTitle(username: order.billingAddress?.firstName), amount: formattedAmount)
 
         // Starts refund process.
         cardPresentRefundOrchestrator.refund(amount: refundAmount,
@@ -351,15 +351,15 @@ private extension RefundSubmissionUseCase {
     }
 
     enum Localization {
-        private static let collectPaymentWithoutName = NSLocalizedString("Refund payment",
-                                                                         comment: "Alert title when starting the in-person refund flow without a user name.")
-        private static let collectPaymentWithName = NSLocalizedString("Refund payment from %1$@",
-                                                                      comment: "Alert title when starting the in-person refund flow with a user name.")
-        static func collectPaymentTitle(username: String?) -> String {
+        private static let refundPaymentWithoutName = NSLocalizedString("Refund payment",
+                                                                        comment: "Alert title when starting the in-person refund flow without a user name.")
+        private static let refundPaymentWithName = NSLocalizedString("Refund payment from %1$@",
+                                                                     comment: "Alert title when starting the in-person refund flow with a user name.")
+        static func refundPaymentTitle(username: String?) -> String {
             guard let username = username, username.isNotEmpty else {
-                return collectPaymentWithoutName
+                return refundPaymentWithoutName
             }
-            return .localizedStringWithFormat(collectPaymentWithName, username)
+            return .localizedStringWithFormat(refundPaymentWithName, username)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -3,8 +3,8 @@ import Combine
 import Yosemite
 import protocol Storage.StorageManagerType
 
-/// Protocol to abstract the `CollectOrderPaymentUseCase`.
-/// Currently only used to facilitate unit tests.
+/// Protocol to abstract the `RefundSubmissionUseCase`.
+/// TODO: 5983 - Use this to facilitate unit tests.
 ///
 protocol RefundSubmissionProtocol {
     /// Starts the refund submission flow.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -336,6 +336,8 @@
 		02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2923B5BB1C00F880B1 /* ImageService.swift */; };
 		02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */; };
 		02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */; };
+		02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1853A27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift */; };
+		02C1853D27FF153A00ABD764 /* CardPresentRefundOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1853C27FF153A00ABD764 /* CardPresentRefundOrchestrator.swift */; };
 		02C2756824F4E77F00286C04 /* ProductShippingSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2756724F4E77F00286C04 /* ProductShippingSettingsViewModel.swift */; };
 		02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2756C24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift */; };
 		02C2756F24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2756E24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift */; };
@@ -2036,6 +2038,8 @@
 		02C0CD2923B5BB1C00F880B1 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageService.swift; sourceTree = "<group>"; };
 		02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageServiceTests.swift; sourceTree = "<group>"; };
+		02C1853A27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundSubmissionUseCase.swift; sourceTree = "<group>"; };
+		02C1853C27FF153A00ABD764 /* CardPresentRefundOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentRefundOrchestrator.swift; sourceTree = "<group>"; };
 		02C2756724F4E77F00286C04 /* ProductShippingSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingSettingsViewModel.swift; sourceTree = "<group>"; };
 		02C2756C24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		02C2756E24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductShippingSettingsViewModel+ProductVariationTests.swift"; sourceTree = "<group>"; };
@@ -4219,6 +4223,14 @@
 				02EA6BF92435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift */,
 			);
 			path = ImageService;
+			sourceTree = "<group>";
+		};
+		02C1853927FED8BE00ABD764 /* Refund */ = {
+			isa = PBXGroup;
+			children = (
+				02C1853A27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift */,
+			);
+			path = Refund;
 			sourceTree = "<group>";
 		};
 		02C2756924F4EE6F00286C04 /* Edit Price */ = {
@@ -6817,6 +6829,7 @@
 				CEE006022077D0F80079161F /* Cells */,
 				268FD44827580A92008FDF9B /* Collect Payments */,
 				CE35F1092343E482007B2A6B /* Order Details */,
+				02C1853927FED8BE00ABD764 /* Refund */,
 				2678897A270E6E3C00BD249E /* Simple Payments */,
 				CCFC50532743BBBF001E505F /* Order Creation */,
 				0206483923FA4160008441BB /* OrdersRootViewController.swift */,
@@ -7473,6 +7486,7 @@
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 				D8752EF6265E60F4008ACC80 /* PaymentCaptureCelebration.swift */,
 				03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */,
+				02C1853C27FF153A00ABD764 /* CardPresentRefundOrchestrator.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -8937,6 +8951,7 @@
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				D8610D762570AE1F00A5DF27 /* NotWPErrorViewModel.swift in Sources */,
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,
+				02C1853D27FF153A00ABD764 /* CardPresentRefundOrchestrator.swift in Sources */,
 				AEC95D432774D07B001571F5 /* CreateOrderAddressFormViewModel.swift in Sources */,
 				024DF31B23742E1C006658FE /* FormatBarItemViewProperties.swift in Sources */,
 				26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */,
@@ -9293,6 +9308,7 @@
 				0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
+				02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */,
 				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,
 				4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -183,7 +183,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
         let result = waitFor { promise in
-            viewModel.submit { result in
+            viewModel.submit(rootViewController: .init(),
+                             showInProgressUI: {}) { result in
                 promise(result)
             }
         }
@@ -224,7 +225,9 @@ final class RefundConfirmationViewModelTests: XCTestCase {
 
             // Submit refund
             let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
-            viewModel.submit(onCompletion: { _ in })
+            viewModel.submit(rootViewController: .init(),
+                             showInProgressUI: {},
+                             onCompletion: { _ in })
         }
 
         // Then
@@ -252,7 +255,9 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                     promise(refund)
                 }
             }
-            viewModel.submit(onCompletion: { _ in })
+            viewModel.submit(rootViewController: .init(),
+                             showInProgressUI: {},
+                             onCompletion: { _ in })
         }
 
 
@@ -282,7 +287,9 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                     promise(refund)
                 }
             }
-            viewModel.submit(onCompletion: { _ in })
+            viewModel.submit(rootViewController: .init(),
+                             showInProgressUI: {},
+                             onCompletion: { _ in })
         }
 
         // Then
@@ -319,7 +326,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
         let result = waitFor { promise in
-            viewModel.submit { result in
+            viewModel.submit(rootViewController: .init(),
+                             showInProgressUI: {}) { result in
                 promise(result)
             }
         }
@@ -363,7 +371,9 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let viewModel = RefundConfirmationViewModel(details: details, analytics: analytics)
 
         // When
-        viewModel.submit(onCompletion: { _ in })
+        viewModel.submit(rootViewController: .init(),
+                         showInProgressUI: {},
+                         onCompletion: { _ in })
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.refundCreate.rawValue)
@@ -388,7 +398,9 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let viewModel = RefundConfirmationViewModel(details: details, analytics: analytics)
 
         // When
-        viewModel.submit(onCompletion: { _ in })
+        viewModel.submit(rootViewController: .init(),
+                         showInProgressUI: {},
+                         onCompletion: { _ in })
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.refundCreate.rawValue)
@@ -423,7 +435,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher, analytics: analytics)
         let result = waitFor { promise in
-            viewModel.submit { result in
+            viewModel.submit(rootViewController: .init(),
+                             showInProgressUI: {}) { result in
                 promise(result)
             }
         }
@@ -462,7 +475,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher, analytics: analytics)
         waitForExpectation { exp in
-            viewModel.submit { _ in
+            viewModel.submit(rootViewController: .init(),
+                             showInProgressUI: {}) { result in
                 exp.fulfill()
             }
         }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -60,10 +60,10 @@ public enum CardPresentPaymentAction: Action {
 
     /// Refund payment of an order, client side. Only for use on Interac payments
     ///
-    case refundPayment(parameters: RefundParameters)
+    case refundPayment(parameters: RefundParameters, onCardReaderMessage: (CardReaderEvent) -> Void, onCompletion: ((Result<Void, Error>) -> Void)?)
 
     /// Cancels a refund, if one is in progress
-    case cancelRefund
+    case cancelRefund(onCompletion: ((Result<Void, Error>) -> Void)?)
 
     /// Check the state of available software updates.
     case observeCardReaderUpdateState(onCompletion: (AnyPublisher<CardReaderSoftwareUpdateState, Never>) -> Void)

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -28,6 +28,9 @@ public final class CardPresentPaymentStore: Store {
     /// We need to be able to cancel the process of collecting a payment.
     private var paymentCancellable: AnyCancellable? = nil
 
+    /// We need to be able to cancel the process of refunding a payment.
+    private var refundCancellable: AnyCancellable? = nil
+
     public init(
         dispatcher: Dispatcher,
         storageManager: StorageManagerType,
@@ -89,10 +92,10 @@ public final class CardPresentPaymentStore: Store {
                            onCompletion: completion)
         case .cancelPayment(let completion):
             cancelPayment(onCompletion: completion)
-        case .refundPayment(let parameters):
-            refundPayment(parameters: parameters)
-        case .cancelRefund:
-            cancelRefund()
+        case .refundPayment(let parameters, let onCardReaderMessage, let completion):
+            refundPayment(parameters: parameters, onCardReaderMessage: onCardReaderMessage, onCompletion: completion)
+        case .cancelRefund(let completion):
+            cancelRefund(onCompletion: completion)
         case .observeCardReaderUpdateState(onCompletion: let completion):
             observeCardReaderUpdateState(onCompletion: completion)
         case .startCardReaderUpdate:
@@ -241,32 +244,44 @@ private extension CardPresentPaymentStore {
         }))
     }
 
-    func refundPayment(parameters: RefundParameters) {
-        cardReaderService.refundPayment(parameters: parameters)
-            .sink { error in
+    func refundPayment(parameters: RefundParameters, onCardReaderMessage: @escaping (CardReaderEvent) -> Void, onCompletion: ((Result<Void, Error>) -> Void)?) {
+        // Observes status events fired by the card reader.
+        let readerEventsSubscription = cardReaderService.readerEvents.sink { event in
+            onCardReaderMessage(event)
+        }
+
+        refundCancellable = cardReaderService.refundPayment(parameters: parameters)
+            .sink { [weak readerEventsSubscription] error in
+                readerEventsSubscription?.cancel()
                 switch error {
                 case .failure(let error):
                     DDLogError("⛔️ Error during client-side refund: \(error.localizedDescription)")
+                    onCompletion?(.failure(error))
                 case .finished:
                     break
                 }
             } receiveValue: { status in
                 DDLogInfo("💳 Refund Success: \(status)")
+                onCompletion?(.success(()))
             }
-            .store(in: &cancellables)
     }
 
-    func cancelRefund() {
+    func cancelRefund(onCompletion: ((Result<Void, Error>) -> Void)?) {
+        refundCancellable?.cancel()
+        refundCancellable = nil
+
         cardReaderService.cancelRefund()
             .sink { error in
                 switch error {
                 case .failure(let error):
                     DDLogError("⛔️ Error cancelling client-side refund: \(error.localizedDescription)")
+                    onCompletion?(.failure(error))
                 case .finished:
                     break
                 }
             } receiveValue: {
                 DDLogInfo("🍁 Refund cancelled successfully!")
+                onCompletion?(.success(()))
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #5983 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For our IPP launch in Canada, we want to support Interac as one of the biggest payment providers in Canada. Normally, a refund can be issued via the API but Interac requires refunds to be made in person. This PR implemented the main flow for the refund for Interac, with a few follow-up tasks (subtasks of #5983) since this PR is already larger than I hoped (apology for the size! 🙇🏻‍♀️ ):
- Add unit tests for refund use case and orchestrator
- Look into why there is no "Remove card" and "Processing" messages from the reader service
- Update copy from payments to refunds
- Handle refund payment cancellation: `CardPresentModalReaderIsReady.didTapSecondaryButton` currently calls `CardPresentPaymentAction.cancelPayment` by default
- Retrying a failed in-person refund currently does not work, somehow `StripeCardReaderService.cancelRefund` never invokes the completion block 🤔 

### Major changes

- Created `CardPresentRefundOrchestrator` that orchestrates the lower-level actions needed for refunding in person
- Created `RefundSubmissionUseCase` (with a protocol `RefundSubmissionProtocol`) to encapsulate all the logic for submitting a refund whether it is in-person or not. It first checks whether in-person refund is required (Interac only so far), and initiates card reader connection and the following card-present refund after a reader is connected using `CardPresentRefundOrchestrator`. Both cases (in-person or not) submit the refund to the site in the end, with the difference that in-person flow does not show in-progress UI because card reader alerts UI is shown
- Updated `RefundConfirmationViewModel` and `RefundConfirmationViewController` accordingly

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please note the following:
- There are still a few pending tasks as mentioned above. If you encounter an issue, please check the pending tasks and make a comment if you don't see it logged!
- Since the API support is in-progress, the refund is currently submitted as "manual" (not to the original payment gateway) as a workaround

Prerequisites: the store is in Canada and eligible for IPP (setup instructions PdfdoF-D-p2)

#### In-person refund

- Go to the orders tab
- Create an order and pay it with Interac using a physical card reader, if you don't have one already
- Go to the order above
- Tap "Issue Refund" and select the refund amount to confirm --> the card reader connection alerts should appear
- Connect to WisePad 3 reader if you haven't
- Insert the Interac test card and enter pin number --> a success notice is shown with the updated order, and the refund should go through in wp-admin

#### Online refund

- Switch to another non-Canada store
- Go to the orders tab
- Create an order that is refundable, if you don't have one alrady
- Go to the order above
- Tap "Issue Refund" and select the refund amount to confirm --> a fullscreen in-progress UI should appear, and a success notice is shown with the updated order. The refund should also go through in wp-admin

### Screencast
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1945542/162394282-a9c4505d-364f-45c8-a770-da9aaf18daee.MP4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->