### PR TITLE
Coupons: Update product selector view buttons

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -11,7 +11,7 @@ final class ProductListSelectorViewController: UIViewController {
     private var productIDs: [Int64] = [] {
         didSet {
             if productIDs != oldValue {
-                // TODO: update bottom button
+                updateActionButton(productIDs: productIDs)
                 updateNavigationRightBarButtonItem(productIDs: productIDs)
             }
         }
@@ -124,6 +124,13 @@ private extension ProductListSelectorViewController {
         } else {
             navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
         }
+    }
+
+    func updateActionButton(productIDs: [Int64]) {
+        let itemCount = String.pluralize(productIDs.count, singular: Localization.singleProduct, plural: Localization.multipleProducts)
+        let format = isExclusion ? Localization.exclusionActionTitle : Localization.selectionActionTitle
+        let title = String.localizedStringWithFormat(format, itemCount)
+        // TODO: set button title or hide the button
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -51,7 +51,7 @@ final class ProductListSelectorViewController: UIViewController {
         let buttonContainer = UIView(frame: .zero)
         buttonContainer.translatesAutoresizingMaskIntoConstraints = false
         buttonContainer.addSubview(doneButton)
-        buttonContainer.pinSubviewToSafeArea(doneButton, insets: .init(top: 16, left: 16, bottom: 0, right: 16))
+        buttonContainer.pinSubviewToSafeArea(doneButton, insets: Constants.doneButtonInsets)
         return buttonContainer
     }()
 
@@ -187,6 +187,10 @@ private extension ProductListSelectorViewController {
 // MARK: - Constants
 //
 private extension ProductListSelectorViewController {
+    enum Constants {
+        static let doneButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 0, right: 16)
+    }
+
     enum Localization {
         static let noResultsPlaceholder = NSLocalizedString("No products yet",
                                                                 comment: "Placeholder text when there are no products on the product list selector")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -11,7 +11,7 @@ final class ProductListSelectorViewController: UIViewController {
     private var productIDs: [Int64] = [] {
         didSet {
             if productIDs != oldValue {
-                updateNavigationTitle(productIDs: productIDs)
+                // TODO: update bottom button
                 updateNavigationRightBarButtonItem(productIDs: productIDs)
             }
         }
@@ -125,19 +125,6 @@ private extension ProductListSelectorViewController {
             navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
         }
     }
-
-    func updateNavigationTitle(productIDs: [Int64]) {
-        let title: String
-        switch productIDs.count {
-        case 0:
-            title = Localization.titleWithoutSelectedProducts
-        case 1:
-            title = Localization.titleWithOneSelectedProduct
-        default:
-            title = String.localizedStringWithFormat(Localization.titleWithMultipleSelectedProductsFormat, productIDs.count)
-        }
-        navigationItem.title = title
-    }
 }
 
 // MARK: - UI configurations
@@ -148,7 +135,7 @@ private extension ProductListSelectorViewController {
     }
 
     func configureNavigation() {
-        updateNavigationTitle(productIDs: productIDs)
+        navigationItem.title = isExclusion ? Localization.exclusionTitle : Localization.selectionTitle
         updateNavigationRightBarButtonItem(productIDs: productIDs)
     }
 
@@ -176,12 +163,7 @@ private extension ProductListSelectorViewController {
     enum Localization {
         static let noResultsPlaceholder = NSLocalizedString("No products yet",
                                                                 comment: "Placeholder text when there are no products on the product list selector")
-        static let titleWithoutSelectedProducts = NSLocalizedString("Add Products", comment: "Navigation bar title for selecting multiple products.")
-        static let titleWithOneSelectedProduct =
-            NSLocalizedString("1 Product Selected",
-                              comment: "Navigation bar title for selecting multiple products when one product has been selected.")
-        static let titleWithMultipleSelectedProductsFormat =
-            NSLocalizedString("%ld Products Selected",
-                              comment: "Navigation bar title for selecting multiple products when more multiple products have been selected.")
+        static let selectionTitle = NSLocalizedString("Select products", comment: "Title for the Select Products screen")
+        static let exclusionTitle = NSLocalizedString("Exclude products", comment: "Title of the Exclude Products screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -12,7 +12,6 @@ final class ProductListSelectorViewController: UIViewController {
         didSet {
             if productIDs != oldValue {
                 updateDoneButton(productIDs: productIDs)
-                updateNavigationRightBarButtonItem(productIDs: productIDs)
             }
         }
     }
@@ -141,13 +140,6 @@ extension ProductListSelectorViewController {
 
 // MARK: - UI updates
 private extension ProductListSelectorViewController {
-    func updateNavigationRightBarButtonItem(productIDs: [Int64]) {
-        if productIDs.isEmpty {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(searchButtonTapped))
-        } else {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
-        }
-    }
 
     func updateDoneButton(productIDs: [Int64]) {
         let itemCount = String.pluralize(productIDs.count, singular: Localization.singleProduct, plural: Localization.multipleProducts)
@@ -167,7 +159,7 @@ private extension ProductListSelectorViewController {
 
     func configureNavigation() {
         navigationItem.title = isExclusion ? Localization.exclusionTitle : Localization.selectionTitle
-        updateNavigationRightBarButtonItem(productIDs: productIDs)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(searchButtonTapped))
     }
 
     func configureContentStackView() {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -55,6 +55,37 @@ final class ProductListSelectorViewController: UIViewController {
         return buttonContainer
     }()
 
+    private lazy var topBarContainer: UIView = {
+        let container = UIView(frame: .zero)
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let selectAllButton = UIButton()
+        selectAllButton.setTitle(Localization.selectAll, for: .normal)
+        selectAllButton.translatesAutoresizingMaskIntoConstraints = false
+        selectAllButton.addTarget(self, action: #selector(selectAllProducts), for: .touchUpInside)
+        selectAllButton.applyLinkButtonStyle()
+        selectAllButton.contentEdgeInsets = .zero
+        container.addSubview(selectAllButton)
+
+        let filterButton = UIButton()
+        filterButton.setTitle(Localization.filter, for: .normal)
+        filterButton.translatesAutoresizingMaskIntoConstraints = false
+        filterButton.addTarget(self, action: #selector(filterProducts), for: .touchUpInside)
+        filterButton.applyLinkButtonStyle()
+        filterButton.contentEdgeInsets = .zero
+        container.addSubview(filterButton)
+
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(equalToConstant: Constants.topBarHeight),
+            selectAllButton.leadingAnchor.constraint(equalTo: container.safeLeadingAnchor, constant: Constants.topBarMargin),
+            selectAllButton.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            container.safeTrailingAnchor.constraint(equalTo: filterButton.trailingAnchor, constant: Constants.topBarMargin),
+            filterButton.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+
+        return container
+    }()
+
     // Completion callback
     //
     typealias Completion = (_ selectedProductIDs: [Int64]) -> Void
@@ -83,6 +114,14 @@ final class ProductListSelectorViewController: UIViewController {
 
 // MARK: - Actions
 private extension ProductListSelectorViewController {
+    @objc func selectAllProducts() {
+        // TODO
+    }
+
+    @objc func filterProducts() {
+        // TODO
+    }
+
     @objc func doneButtonTapped() {
         completeUpdating()
     }
@@ -163,8 +202,9 @@ private extension ProductListSelectorViewController {
     }
 
     func configureContentStackView() {
-        observeSelectedProductIDs(observableProductIDs: dataSource.productIDs)
+        contentStackView.addArrangedSubview(topBarContainer)
 
+        observeSelectedProductIDs(observableProductIDs: dataSource.productIDs)
         addChild(paginatedListSelector)
         paginatedListSelector.view.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.addArrangedSubview(paginatedListSelector.view)
@@ -174,7 +214,12 @@ private extension ProductListSelectorViewController {
         doneButtonContainer.isHidden = true // Hide the button initially since no product is selected yet.
 
         view.addSubview(contentStackView)
-        view.pinSubviewToAllEdges(contentStackView)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
+            view.safeTopAnchor.constraint(equalTo: contentStackView.safeTopAnchor),
+            view.safeBottomAnchor.constraint(equalTo: contentStackView.safeBottomAnchor)
+        ])
     }
 
     func observeSelectedProductIDs(observableProductIDs: AnyPublisher<[Int64], Never>) {
@@ -189,6 +234,8 @@ private extension ProductListSelectorViewController {
 private extension ProductListSelectorViewController {
     enum Constants {
         static let doneButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 0, right: 16)
+        static let topBarMargin: CGFloat = 16
+        static let topBarHeight: CGFloat = 46
     }
 
     enum Localization {
@@ -208,5 +255,7 @@ private extension ProductListSelectorViewController {
         )
         static let singleProduct = NSLocalizedString("%1$d Product", comment: "Count of one product")
         static let multipleProducts = NSLocalizedString("%1$d Products", comment: "Count of several products, reads like: 2 Products")
+        static let selectAll = NSLocalizedString("Select All", comment: "Button to select all products on the product list selector")
+        static let filter = NSLocalizedString("Filter", comment: "Button to filter products on the product list selector")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -4,6 +4,9 @@ import Yosemite
 
 /// Displays a paginated list of products where the user can select.
 final class ProductListSelectorViewController: UIViewController {
+    /// Whether the view is for selecting or excluding products
+    private let isExclusion: Bool
+
     private let excludedProductIDs: [Int64]
     private var productIDs: [Int64] = [] {
         didSet {
@@ -35,9 +38,10 @@ final class ProductListSelectorViewController: UIViewController {
     typealias Completion = (_ selectedProductIDs: [Int64]) -> Void
     private let onCompletion: Completion
 
-    init(excludedProductIDs: [Int64], siteID: Int64, onCompletion: @escaping Completion) {
+    init(excludedProductIDs: [Int64], siteID: Int64, isExclusion: Bool = false, onCompletion: @escaping Completion) {
         self.excludedProductIDs = excludedProductIDs
         self.siteID = siteID
+        self.isExclusion = isExclusion
         self.onCompletion = onCompletion
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -18,6 +18,7 @@ final class ProductListSelectorViewController: UIViewController {
 
     private let siteID: Int64
     private var selectedProductIDsSubscription: AnyCancellable?
+    private var filters: FilterProductListViewModel.Filters = FilterProductListViewModel.Filters()
 
     private lazy var dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: excludedProductIDs)
 
@@ -70,7 +71,7 @@ final class ProductListSelectorViewController: UIViewController {
         let filterButton = UIButton()
         filterButton.setTitle(Localization.filter, for: .normal)
         filterButton.translatesAutoresizingMaskIntoConstraints = false
-        filterButton.addTarget(self, action: #selector(filterProducts), for: .touchUpInside)
+        filterButton.addTarget(self, action: #selector(showFilter), for: .touchUpInside)
         filterButton.applyLinkButtonStyle()
         filterButton.contentEdgeInsets = .zero
         container.addSubview(filterButton)
@@ -118,8 +119,17 @@ private extension ProductListSelectorViewController {
         // TODO
     }
 
-    @objc func filterProducts() {
-        // TODO
+    @objc func showFilter() {
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: siteID)
+        let filterProductListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in
+            ServiceLocator.analytics.track(.productFilterListShowProductsButtonTapped, withProperties: ["filters": filters.analyticsDescription])
+            self?.filters = filters
+        }, onClearAction: {
+            ServiceLocator.analytics.track(.productFilterListClearMenuButtonTapped)
+        }, onDismissAction: {
+            ServiceLocator.analytics.track(.productFilterListDismissButtonTapped)
+        })
+        present(filterProductListViewController, animated: true, completion: nil)
     }
 
     @objc func doneButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -165,5 +165,17 @@ private extension ProductListSelectorViewController {
                                                                 comment: "Placeholder text when there are no products on the product list selector")
         static let selectionTitle = NSLocalizedString("Select products", comment: "Title for the Select Products screen")
         static let exclusionTitle = NSLocalizedString("Exclude products", comment: "Title of the Exclude Products screen")
+        static let selectionActionTitle = NSLocalizedString(
+            "Select %1$@",
+            comment: "Title of the action button on the Select Products screen" +
+            "Reads like: Select 1 Product"
+        )
+        static let exclusionActionTitle = NSLocalizedString(
+            "Exclude %1$@",
+            comment: "Title of the action button on the Exclude Products screen" +
+            "Reads like: Exclude 1 Product"
+        )
+        static let singleProduct = NSLocalizedString("%1$d Product", comment: "Count of one product")
+        static let multipleProducts = NSLocalizedString("%1$d Products", comment: "Count of several products, reads like: 2 Products")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6489
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds some adjustments to the buttons in the product selector view:
- Update the title of the view based on whether the view is for selecting or excluding products.
- Remove the Done button from the navigation bar and add one for completing the selection at the bottom.
- Add a banner on top of the product list with 2 buttons: Select All and Filter. The Select All button is not doing anything at the moment, and the Filter button only shows the filter screen and hasn't handled any filter updates yet.

In the next PR, we'll need to duplicate the current selector data source and add updates to that.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Since the product selector screen hasn't got an entry point from the coupons flow, let's test the linked product flow instead.
With the `couponEdit` feature flag on:
- Navigate to the Products tab > select a Product > Add more details > Linked products > Add Products > Add Products.
- Notice that the title of the view now stays the same no matter how many products are selected.
- Notice that there's a bar at the top with 2 buttons: Select All and Filter.
- Select one or more products on the list. Notice that when there's at least one product selected, a button shows up at the bottom with a title indicating the number of products selected. Tapping this button completes the selection and dismisses the view.

With the `couponEdit` feature flag on: repeat the first step above and notice that the product selector view stay the same as before.


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/162405981-0b6f43ea-d506-4e91-b9d8-bb7ead2866e8.png" width=320 />  | <img src="https://user-images.githubusercontent.com/5533851/162405625-6a6c6b62-2c6c-4bda-892c-d23f7e887e26.png" width=320 /> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
