### PR TITLE
Share Payment Links on existing orders

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -294,7 +294,7 @@ public extension OrdersRemote {
         private static let commonOrderFieldValues = [
             "id", "parent_id", "number", "status", "currency", "customer_id", "customer_note", "date_created_gmt", "date_modified_gmt", "date_paid_gmt",
             "discount_total", "discount_tax", "shipping_total", "shipping_tax", "total", "total_tax", "payment_method", "payment_method_title",
-            "billing", "coupon_lines", "shipping_lines", "refunds", "fee_lines", "order_key", "tax_lines", "meta_data"
+            "payment_url", "billing", "coupon_lines", "shipping_lines", "refunds", "fee_lines", "order_key", "tax_lines", "meta_data"
         ]
         // Use with caution. Any fields in here will be overwritten with empty values by
         // `Order+ReadOnlyConvertible.swift: Order.update(with:)` when the list of orders is fetched.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 9.0
 -----
 
+- [*] Share payment links from the order details screen. [https://github.com/woocommerce/woocommerce-ios/pull/6609]
 - [internal] Reviews lists on Products and Menu tabs are refactored to avoid duplicated code. Please quickly smoke test them to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6553]
 
 8.9

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -149,7 +149,7 @@ final class OrderDetailsViewModel {
     /// Conditions copied from:
     /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1520-L1523
     ///
-    var needsPayment: Bool {
+    private var needsPayment: Bool {
         guard let total = Double(order.total) else {
             return false
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -138,6 +138,31 @@ final class OrderDetailsViewModel {
 
     private var receipt: CardPresentReceiptParameters? = nil
 
+    /// Defines if the actions menu item should be shown.
+    /// Currently the only action should be to share a payment link.
+    ///
+    var shouldShowActionsMenuItem: Bool {
+        needsPayment && paymentLink != nil
+    }
+
+    /// This check is temporary, we are working on knowing if an order needs payment directly from the API.
+    /// Conditions copied from:
+    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1520-L1523
+    ///
+    var needsPayment: Bool {
+        guard let total = Double(order.total) else {
+            return false
+        }
+        return total > .zero && (order.status == .pending || order.status == .failed)
+    }
+
+    /// Returns the order payment link.
+    /// Should exists on `6.4+` stores.
+    ///
+    var paymentLink: URL? {
+        return order.paymentURL
+    }
+
     /// Helpers
     ///
     func lookUpOrderStatus(for order: Order) -> OrderStatus? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -64,7 +64,7 @@ final class OrderDetailsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureNavigationBarTitle()
+        configureNavigationBar()
         configureTopLoaderView()
         configureTableView()
         registerTableViewCells()
@@ -126,9 +126,18 @@ private extension OrderDetailsViewController {
 
     /// Setup: Navigation
     ///
-    func configureNavigationBarTitle() {
+    func configureNavigationBar() {
+        // Title
         let titleFormat = NSLocalizedString("Order #%1$@", comment: "Order number title. Parameters: %1$@ - order number")
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
+
+        // Actions menu
+        if viewModel.shouldShowActionsMenuItem {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(image: .moreImage,
+                                                                style: .plain,
+                                                                target: self,
+                                                                action: #selector(presentActionMenuSheet(_:)))
+        }
     }
 
     /// Setup: EntityListener
@@ -292,6 +301,29 @@ private extension OrderDetailsViewController {
             NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
             self?.refreshControl.endRefreshing()
         }
+    }
+
+    /// Actions Menu Sheet.
+    ///
+    @objc func presentActionMenuSheet(_ sender: UIBarButtonItem) {
+        let sheetTitle = "#" + viewModel.order.number
+        guard let paymentLink = viewModel.paymentLink else {
+            return DDLogError("⛔️ No payment link for order: \(sheetTitle)")
+        }
+
+        // Configure share sheet
+        let actionSheet = UIAlertController(title: nil, message: sheetTitle, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+        actionSheet.addCancelActionWithTitle(Localization.ActionsMenu.cancelAction)
+        actionSheet.addDefaultActionWithTitle(Localization.ActionsMenu.paymentLink) { [weak self] _ in
+            guard let self = self else { return }
+            SharingHelper.shareURL(url: paymentLink, title: nil, from: self.view, in: self)
+        }
+
+        // Handle sheet presentation
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.barButtonItem = sender
+        present(actionSheet, animated: true)
     }
 }
 
@@ -940,6 +972,11 @@ private extension OrderDetailsViewController {
         enum Payments {
             static let backToOrder = NSLocalizedString("Back to Order",
                                                        comment: "Button to dismiss modal overlay and go back to the order after a sucessful payment")
+        }
+
+        enum ActionsMenu {
+            static let cancelAction = NSLocalizedString("Cancel", comment: "Cancel the main more actions menu sheet.")
+            static let paymentLink = NSLocalizedString("Share Payment Link", comment: "Title to share an order payment link.")
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -90,4 +90,63 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(siteID, order.siteID)
         XCTAssertEqual(orderID, order.orderID)
     }
+
+    func test_should_show_actions_menu_is_false_if_there_is_no_payment_link() {
+        // Given
+        let order = Order.fake().copy(status: .pending, total: "10.0", paymentURL: nil)
+
+        // When
+        let viewModel = OrderDetailsViewModel(order: order)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowActionsMenuItem)
+    }
+
+    func test_should_show_actions_menu_is_false_if_there_is_payment_link_but_total_is_zero() {
+        // Given
+        let paymentURL = URL(string: "http://www.automattic.com")
+        let order = Order.fake().copy(status: .pending, total: "0.0", paymentURL: paymentURL)
+
+        // When
+        let viewModel = OrderDetailsViewModel(order: order)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowActionsMenuItem)
+    }
+
+    func test_should_show_actions_menu_is_false_if_there_is_payment_link_total_is_not_zero_but_status_is_not_pending_or_failed() {
+        // Given
+        let paymentURL = URL(string: "http://www.automattic.com")
+        let order = Order.fake().copy(status: .completed, total: "0.0", paymentURL: paymentURL)
+
+        // When
+        let viewModel = OrderDetailsViewModel(order: order)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowActionsMenuItem)
+    }
+
+    func test_should_show_actions_menu_is_true_if_there_is_payment_link_total_is_not_zero_and_status_is_pending() {
+        // Given
+        let paymentURL = URL(string: "http://www.automattic.com")
+        let order = Order.fake().copy(status: .pending, total: "10.0", paymentURL: paymentURL)
+
+        // When
+        let viewModel = OrderDetailsViewModel(order: order)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowActionsMenuItem)
+    }
+
+    func test_should_show_actions_menu_is_true_if_there_is_payment_link_total_is_not_zero_and_status_is_failed() {
+        // Given
+        let paymentURL = URL(string: "http://www.automattic.com")
+        let order = Order.fake().copy(status: .failed, total: "10.0", paymentURL: paymentURL)
+
+        // When
+        let viewModel = OrderDetailsViewModel(order: order)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowActionsMenuItem)
+    }
 }


### PR DESCRIPTION
Closes: #6101 

# Why

Now that we have access to the `paymentURL` directly from there `Order` Entity.  This PR adds the ability to share it from the order details screen.

Note:  According to core, the payment link [should only be visible](https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php#L250-L256) for orders that have a total value greater than `zero` and with a `payment valid` status. 

```php
if ( $order->needs_payment() ) {
    printf(
        '<a href="%s">%s</a>',
        esc_url( $order->get_checkout_payment_url() ),
        __( 'Customer payment page &rarr;', 'woocommerce' )
    );
}
```

```php
public function needs_payment() {
    $valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $this );
    return apply_filters( 'woocommerce_order_needs_payment', ( $this->has_status( $valid_order_statuses ) && $this->get_total() > 0 ), $this, $valid_order_statuses );
}
```


I'm copying the conditions from `needs_payment` locally, but on the apps, we can't know if a custom status is a `payment valid` status. 

For that reason, I will be speaking to core in order to include the `needs_payment` field on the order response. p91TBi-8af-p2

In the meantime, only `pending` & `failed` are considered to be `payment valid` statuses.

# How

- Update `OrdersRemote` to include the `payment_url` fields on the Orders response.

- Update `OrderDetailsViewModel` with the `paymentLink`, `needsPayment`, and `shouldShowActionsMenuItem` computer properties.

- Update `OrderDetailsViewController` to share the payment link when the view model dictates to.

# Demo

### Sharing a payment link on a `v6.4` store.

https://user-images.githubusercontent.com/562080/162526058-0a300bcf-c430-4018-9667-8d4cdee7346f.MP4

### Orders with non-valid-payments statutes on a`v6.4` store.

https://user-images.githubusercontent.com/562080/162526181-39398513-bbec-4bbb-a4d9-88dc9bfd85ea.MP4

### Orders on a`v6.3` store.

https://user-images.githubusercontent.com/562080/162526354-20914e01-e07e-44d8-a2a1-df7fb711a751.MP4

# Testing Steps

A.
- Set your store version to `6.4.0-rc.1`
- Navigate to a `pending` or `failed` order with a positive total value.
- See that you can share the payment link by tapping the "More Actions" button at the top right of the screen.

B.
- Set your store version to `6.4.0-rc.1`
- Navigate to a `complete`, `onHold`, or `processing` order with a positive total value.
- See that you can **NOT** share the payment link.

C.
- Set your store version to `6.3.1`
- Navigate to a `pending` or `failed` order with a positive total value.
- See that you can **NOT** share the payment link.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
