### PR TITLE
Fix merge issue in `trunk`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -64,10 +64,14 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     private lazy var cardPresentRefundOrchestrator = CardPresentRefundOrchestrator(stores: stores)
 
     /// Controller to connect a card reader for in-person refund.
-    private lazy var cardReaderConnectionController = CardReaderConnectionController(forSiteID: siteID,
-                                                                                     knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
-                                                                                     alertsProvider: CardReaderSettingsAlerts(),
-                                                                                     configuration: cardPresentConfigurationLoader.configuration)
+    private lazy var cardReaderConnectionController =
+    CardReaderConnectionController(forSiteID: siteID,
+                                   knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
+                                   alertsProvider: CardReaderSettingsAlerts(),
+                                   configuration: cardPresentConfigurationLoader.configuration,
+                                   analyticsTracker: .init(configuration: cardPresentConfigurationLoader.configuration,
+                                                           stores: stores,
+                                                           analytics: analytics))
 
     /// IPP Configuration loader.
     private lazy var cardPresentConfigurationLoader = CardPresentConfigurationLoader(stores: stores)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In a previous PR https://github.com/woocommerce/woocommerce-ios/pull/6584, I added a new parameter `analyticsTracker` to the initializer of `CardReaderConnectionController`. However, in the latest IPP PR https://github.com/woocommerce/woocommerce-ios/pull/6602, I started the work on `trunk` before the first PR was merged and missed the update in the new class `RefundSubmissionUseCase` in the PR 🤦🏻‍♀️ This PR fixed this issue by passing the `analyticsTracker` dependency to `CardReaderConnectionController` in `RefundSubmissionUseCase`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please feel free to try building the app to make sure the build succeeds!


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
