### PR TITLE
Analytics: Payment Link on existing orders 

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -452,6 +452,10 @@ extension WooAnalyticsEvent {
         static func orderDetailEditFlowCanceled(subject: Subject) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderDetailEditFlowCanceled, properties: [Subject.key: subject.rawValue])
         }
+
+        static func orderDetailPaymentLinkShared() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailPaymentLinkShared, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -203,6 +203,7 @@ public enum WooAnalyticsStat: String {
     case orderDetailEditFlowCompleted = "order_detail_edit_flow_completed"
     case orderDetailEditFlowCanceled = "order_detail_edit_flow_canceled"
     case orderDetailEditFlowFailed = "order_detail_edit_flow_failed"
+    case orderDetailPaymentLinkShared = "order_detail_payment_link_shared"
 
     // MARK: Order Data/Action Events
     //

--- a/WooCommerce/Classes/Tools/SharingHelper.swift
+++ b/WooCommerce/Classes/Tools/SharingHelper.swift
@@ -7,6 +7,8 @@ import WordPressUI
 ///
 class SharingHelper {
 
+    typealias Completion = (UIActivity.ActivityType?, Bool, [Any]?, Error?) -> Void
+
     /// Private: NO-OP
     ///
     private init() { }
@@ -20,8 +22,12 @@ class SharingHelper {
     ///   - anchorView: View that the share popover should be displayed from (needed for iPad support)
     ///   - viewController: VC presenting the share VC (UIActivityViewController)
     ///
-    static func shareURL(url: URL, title: String? = nil, from anchorView: UIView, in viewController: UIViewController) {
-        guard let avc = createActivityVC(title: title, url: url) else {
+    static func shareURL(url: URL,
+                         title: String? = nil,
+                         from anchorView: UIView,
+                         in viewController: UIViewController,
+                         onCompletion: Completion? = nil) {
+        guard let avc = createActivityVC(title: title, url: url, onCompletion: onCompletion) else {
             return
         }
 
@@ -69,7 +75,7 @@ class SharingHelper {
 //
 private extension SharingHelper {
 
-    static func createActivityVC(title: String? = nil, url: URL? = nil) -> UIActivityViewController? {
+    static func createActivityVC(title: String? = nil, url: URL? = nil, onCompletion: Completion?) -> UIActivityViewController? {
         guard title != nil || url != nil else {
             DDLogWarn("⚠ Cannot create sharing activity — both title AND URL are nil.")
             return nil
@@ -84,6 +90,8 @@ private extension SharingHelper {
             items.append(url)
         }
 
-        return UIActivityViewController(activityItems: items, applicationActivities: nil)
+        let activityController = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        activityController.completionWithItemsHandler = onCompletion
+        return activityController
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -318,8 +318,11 @@ private extension OrderDetailsViewController {
         actionSheet.addDefaultActionWithTitle(Localization.ActionsMenu.paymentLink) { [weak self] _ in
             guard let self = self else { return }
 
-            SharingHelper.shareURL(url: paymentLink, title: nil, from: self.view, in: self)
-            ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailPaymentLinkShared())
+            SharingHelper.shareURL(url: paymentLink, title: nil, from: self.view, in: self) { _, completed, _, _ in
+                if completed {
+                    ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailPaymentLinkShared())
+                }
+            }
         }
 
         // Handle sheet presentation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -317,7 +317,9 @@ private extension OrderDetailsViewController {
         actionSheet.addCancelActionWithTitle(Localization.ActionsMenu.cancelAction)
         actionSheet.addDefaultActionWithTitle(Localization.ActionsMenu.paymentLink) { [weak self] _ in
             guard let self = self else { return }
+
             SharingHelper.shareURL(url: paymentLink, title: nil, from: self.view, in: self)
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailPaymentLinkShared())
         }
 
         // Handle sheet presentation


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: # https://github.com/woocommerce/woocommerce-ios/issues/6101

# Why

This PR adds the `woocommerceios_order_detail_payment_link_shared` event after a payment link from an existing order is shared.

- [Event Registration](https://mc.a8c.com/tracks/events/event.php?eventname=woocommerceios_order_detail_payment_link_shared#)

# How

- Update `SharingHelper` to provide a completion block.
- Fire the event after the link was shared successfully.

# Testing Steps

- Set your store version to `6.4.0-rc.1`
- Navigate to a pending or failed order with a positive total value.
- Share the payment link by tapping the "More Actions" button at the top right of the screen.
- See the event being tacked in the console

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
