### PR TITLE
Add drag and drop support in Product image screen to change the order of product images

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 
 - [internal] Reviews lists on Products and Menu tabs are refactored to avoid duplicated code. Please quickly smoke test them to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6553]
+- [**] Now it's possible to change the order of the product images. [https://github.com/woocommerce/woocommerce-ios/pull/6620]
 
 8.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -206,6 +206,18 @@ final class ProductImageActionHandler {
     func resetProductImages(to product: ProductFormDataModel) {
         allStatuses = (productImageStatuses: product.imageStatuses, error: nil)
     }
+
+    /// Updates the product images with the given ones.
+    ///
+    func updateProductImageStatusesAfterReordering(_ productImageStatuses: [ProductImageStatus]) {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            self.allStatuses = (productImageStatuses: productImageStatuses, error: nil)
+        }
+    }
 }
 
 private extension ProductImageActionHandler {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -204,7 +204,13 @@ final class ProductImageActionHandler {
     /// Resets the product images to the ones from the given Product.
     ///
     func resetProductImages(to product: ProductFormDataModel) {
-        allStatuses = (productImageStatuses: product.imageStatuses, error: nil)
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            self.allStatuses = (productImageStatuses: product.imageStatuses, error: nil)
+        }
     }
 
     /// Updates the product images with the given ones.

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageStatus.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageStatus.swift
@@ -52,4 +52,16 @@ extension ProductImageStatus {
             return ProductImageCollectionViewCell.self
         }
     }
+
+    /// A string that uniquely identifies a `ProductImageStatus` during
+    /// dragging.
+    ///
+    var dragItemIdentifier: String {
+        switch self {
+        case .uploading(let asset):
+            return asset.identifier()
+        case .remote(let image):
+            return "\(image.imageID)"
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -135,13 +135,33 @@ extension ProductImagesCollectionViewController {
     }
 }
 
-/// Drag support
+/// Drag & Drop support
 ///
-extension ProductImagesCollectionViewController: UICollectionViewDragDelegate {
+extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
         let item = productImageStatuses[indexPath.row]
         let dragItem = dragItem(for: item)
         return [dragItem]
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        dropSessionDidUpdate session: UIDropSession,
+                        withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
+        // Dropping photos from external apps is not allowed yet.
+        guard session.localDragSession != nil else {
+            return UICollectionViewDropProposal(operation: .forbidden)
+        }
+        return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
+        guard let destinationIndexPath = coordinator.destinationIndexPath else {
+            return
+        }
+
+        coordinator.items.forEach { dropItem in
+            print("Drop item \(dropItem) at \(destinationIndexPath)")
+        }
     }
 
     private func dragItem(for productImageStatus: ProductImageStatus) -> UIDragItem {
@@ -155,7 +175,9 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate {
 private extension ProductImagesCollectionViewController {
     func configureCollectionView() {
         collectionView.backgroundColor = .basicBackground
+
         collectionView.dragDelegate = self
+        collectionView.dropDelegate = self
 
         registerCollectionViewCells()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -13,18 +13,18 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
     private let isDeletionEnabled: Bool
     private let productUIImageLoader: ProductUIImageLoader
     private let onDeletion: ProductImagesGalleryViewController.Deletion
-    private let reorderHandler: ReorderingHandler
+    private let onReordering: ReorderingHandler
 
     init(imageStatuses: [ProductImageStatus],
          isDeletionEnabled: Bool,
          productUIImageLoader: ProductUIImageLoader,
          onDeletion: @escaping ProductImagesGalleryViewController.Deletion,
-         reorderHandler: @escaping ReorderingHandler) {
+         onReordering: @escaping ReorderingHandler) {
         self.productImageStatuses = imageStatuses
         self.isDeletionEnabled = isDeletionEnabled
         self.productUIImageLoader = productUIImageLoader
         self.onDeletion = onDeletion
-        self.reorderHandler = reorderHandler
+        self.onReordering = onReordering
         let columnLayout = ColumnFlowLayout(
             cellsPerRow: 2,
             minimumInteritemSpacing: 16,
@@ -220,7 +220,7 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
         })
 
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
-        reorderHandler(productImageStatuses)
+        onReordering(productImageStatuses)
     }
 
     /// Reloads collection view only if there is any pending upload.

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -224,6 +224,8 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
     }
 
     /// Reloads collection view only if there is any pending upload.
+    /// This makes sure that cells for pending uploads are reloaded properly 
+    /// to remove their overlays after uploading is done. 
     ///
     private func reloadCollectionViewIfNeeded() {
         if productImageStatuses.hasPendingUpload {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -6,20 +6,25 @@ import Yosemite
 ///
 final class ProductImagesCollectionViewController: UICollectionViewController {
 
+    typealias ReorderingHandler = (_ productImageStatuses: [ProductImageStatus]) -> Void
+
     private var productImageStatuses: [ProductImageStatus]
 
     private let isDeletionEnabled: Bool
     private let productUIImageLoader: ProductUIImageLoader
     private let onDeletion: ProductImagesGalleryViewController.Deletion
+    private let onReorder: ReorderingHandler
 
     init(imageStatuses: [ProductImageStatus],
          isDeletionEnabled: Bool,
          productUIImageLoader: ProductUIImageLoader,
-         onDeletion: @escaping ProductImagesGalleryViewController.Deletion) {
+         onDeletion: @escaping ProductImagesGalleryViewController.Deletion,
+         onReorder: @escaping ReorderingHandler) {
         self.productImageStatuses = imageStatuses
         self.isDeletionEnabled = isDeletionEnabled
         self.productUIImageLoader = productUIImageLoader
         self.onDeletion = onDeletion
+        self.onReorder = onReorder
         let columnLayout = ColumnFlowLayout(
             cellsPerRow: 2,
             minimumInteritemSpacing: 16,
@@ -195,6 +200,7 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
         })
 
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
+        onReorder(productImageStatuses)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -160,13 +160,41 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
         }
 
         coordinator.items.forEach { dropItem in
-            print("Drop item \(dropItem) at \(destinationIndexPath)")
+            reorder(dropItem, to: destinationIndexPath, with: coordinator)
         }
     }
 
+    /// Returns a `UIDragItem` from a given product image.
+    ///
     private func dragItem(for productImageStatus: ProductImageStatus) -> UIDragItem {
         let itemProvider = NSItemProvider(object: NSString(string: productImageStatus.dragItemIdentifier))
         return UIDragItem(itemProvider: itemProvider)
+    }
+
+    /// Removes the product image at the given source index and inserts it
+    /// at the given destination index.
+    ///
+    private func moveProductImageStatus(from sourceIndex: Int, to destinationIndex: Int) {
+        let imageStatus = productImageStatuses[sourceIndex]
+        productImageStatuses.remove(at: sourceIndex)
+        productImageStatuses.insert(imageStatus, at: destinationIndex)
+    }
+
+    /// Moves an item (`ProductImageStatus`) in the collection view from one index path to another index path.
+    ///
+    private func reorder(_ item: UICollectionViewDropItem, to destinationIndexPath: IndexPath, with coordinator: UICollectionViewDropCoordinator) {
+        guard let sourceIndexPath = item.sourceIndexPath else {
+            return
+        }
+
+        moveProductImageStatus(from: sourceIndexPath.item, to: destinationIndexPath.item)
+
+        collectionView.performBatchUpdates({
+            collectionView.deleteItems(at: [sourceIndexPath])
+            collectionView.insertItems(at: [destinationIndexPath])
+        })
+
+        coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -135,11 +135,27 @@ extension ProductImagesCollectionViewController {
     }
 }
 
+/// Drag support
+///
+extension ProductImagesCollectionViewController: UICollectionViewDragDelegate {
+    func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        let item = productImageStatuses[indexPath.row]
+        let dragItem = dragItem(for: item)
+        return [dragItem]
+    }
+
+    private func dragItem(for productImageStatus: ProductImageStatus) -> UIDragItem {
+        let itemProvider = NSItemProvider(object: NSString(string: productImageStatus.dragItemIdentifier))
+        return UIDragItem(itemProvider: itemProvider)
+    }
+}
+
 /// View configuration
 ///
 private extension ProductImagesCollectionViewController {
     func configureCollectionView() {
         collectionView.backgroundColor = .basicBackground
+        collectionView.dragDelegate = self
 
         registerCollectionViewCells()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -145,7 +145,9 @@ extension ProductImagesCollectionViewController {
 ///
 extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-        let item = productImageStatuses[indexPath.row]
+        guard let item = productImageStatuses[safe: indexPath.row] else {
+            return []
+        }
         let dragItem = dragItem(for: item)
         return [dragItem]
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -210,10 +210,22 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
         collectionView.performBatchUpdates({
             collectionView.deleteItems(at: [sourceIndexPath])
             collectionView.insertItems(at: [destinationIndexPath])
+        }, completion: { [weak self] _ in
+            // [Workaround] Reload the collection view if there are more than
+            // one type of cells, for example, when there are any pending upload.
+            self?.reloadCollectionViewIfNeeded()
         })
 
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
         onReorder(productImageStatuses)
+    }
+
+    /// Reloads collection view only if there is any pending upload.
+    ///
+    private func reloadCollectionViewIfNeeded() {
+        if productImageStatuses.hasPendingUpload {
+            collectionView.reloadData()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -36,11 +36,7 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        collectionView.backgroundColor = .basicBackground
-
-        collectionView.register(ProductImageCollectionViewCell.loadNib(), forCellWithReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier)
-        collectionView.register(InProgressProductImageCollectionViewCell.loadNib(),
-                                forCellWithReuseIdentifier: InProgressProductImageCollectionViewCell.reuseIdentifier)
+        configureCollectionView()
 
         collectionView.reloadData()
     }
@@ -136,5 +132,22 @@ extension ProductImagesCollectionViewController {
                                                                                         self?.onDeletion(productImage)
         }
         navigationController?.show(productImagesGalleryViewController, sender: self)
+    }
+}
+
+/// View configuration
+///
+private extension ProductImagesCollectionViewController {
+    func configureCollectionView() {
+        collectionView.backgroundColor = .basicBackground
+
+        registerCollectionViewCells()
+    }
+
+    func registerCollectionViewCells() {
+        collectionView.register(ProductImageCollectionViewCell.loadNib(),
+                                forCellWithReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier)
+        collectionView.register(InProgressProductImageCollectionViewCell.loadNib(),
+                                forCellWithReuseIdentifier: InProgressProductImageCollectionViewCell.reuseIdentifier)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -150,13 +150,14 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
         return [dragItem]
     }
 
+    func collectionView(_ collectionView: UICollectionView, dragSessionIsRestrictedToDraggingApplication session: UIDragSession) -> Bool {
+        // Dropping photos from external apps is not allowed yet.
+        return false
+    }
+
     func collectionView(_ collectionView: UICollectionView,
                         dropSessionDidUpdate session: UIDropSession,
                         withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
-        // Dropping photos from external apps is not allowed yet.
-        guard session.localDragSession != nil else {
-            return UICollectionViewDropProposal(operation: .forbidden)
-        }
         return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -152,7 +152,7 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
 
     func collectionView(_ collectionView: UICollectionView, dragSessionIsRestrictedToDraggingApplication session: UIDragSession) -> Bool {
         // Dropping photos from external apps is not allowed yet.
-        return false
+        return true
     }
 
     func collectionView(_ collectionView: UICollectionView,

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -50,6 +50,7 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
         self.productImageStatuses = productImageStatuses
 
         collectionView.reloadData()
+        updateDragAndDropSupport()
     }
 }
 
@@ -167,6 +168,18 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
         coordinator.items.forEach { dropItem in
             reorder(dropItem, to: destinationIndexPath, with: coordinator)
         }
+    }
+
+    /// Indicates whether the collection view supports moving items.
+    ///
+    private var isReorderingEnabled: Bool {
+        productImageStatuses.containsMoreThanOne
+    }
+
+    /// Enables/disables collection view drag interaction.
+    ///
+    private func updateDragAndDropSupport() {
+        collectionView.dragInteractionEnabled = isReorderingEnabled
     }
 
     /// Returns a `UIDragItem` from a given product image.

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -13,18 +13,18 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
     private let isDeletionEnabled: Bool
     private let productUIImageLoader: ProductUIImageLoader
     private let onDeletion: ProductImagesGalleryViewController.Deletion
-    private let onReorder: ReorderingHandler
+    private let reorderHandler: ReorderingHandler
 
     init(imageStatuses: [ProductImageStatus],
          isDeletionEnabled: Bool,
          productUIImageLoader: ProductUIImageLoader,
          onDeletion: @escaping ProductImagesGalleryViewController.Deletion,
-         onReorder: @escaping ReorderingHandler) {
+         reorderHandler: @escaping ReorderingHandler) {
         self.productImageStatuses = imageStatuses
         self.isDeletionEnabled = isDeletionEnabled
         self.productUIImageLoader = productUIImageLoader
         self.onDeletion = onDeletion
-        self.onReorder = onReorder
+        self.reorderHandler = reorderHandler
         let columnLayout = ColumnFlowLayout(
             cellsPerRow: 2,
             minimumInteritemSpacing: 16,
@@ -217,7 +217,7 @@ extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, U
         })
 
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
-        onReorder(productImageStatuses)
+        reorderHandler(productImageStatuses)
     }
 
     /// Reloads collection view only if there is any pending upload.

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -239,9 +239,21 @@ private extension ProductImagesViewController {
         productImageActionHandler.deleteProductImage(productImage)
     }
 
-    func handleProductImageStatusesReordering(_ productImageStatuses: [ProductImageStatus]) {
-        hasMovedAnyImages = true
+    func handleProductImageStatusesReordering(_ reorderedProductImageStatuses: [ProductImageStatus]) {
+        // We have to validate if the order of the product images has been changed.
+        // The user can make some changes but the list may end up with the old order.
+        hasMovedAnyImages = validateIfAnyImagesHasMovedAfterReordering(reorderedProductImageStatuses)
+
         productImageActionHandler.updateProductImageStatusesAfterReordering(productImageStatuses)
+    }
+
+    /// Check if the given product images are in the same order as the original ones.
+    ///
+    func validateIfAnyImagesHasMovedAfterReordering(_ reorderedItems: [ProductImageStatus]) -> Bool {
+        let zippedProductImages = zip(reorderedItems, self.productImageStatuses)
+        return zippedProductImages.contains(where: { reordered, original -> Bool in
+            reordered.dragItemIdentifier != original.dragItemIdentifier
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -144,10 +144,10 @@ private extension ProductImagesViewController {
     /// there is no help text to show.
     ///
     func getAppropiateHelpText() -> String? {
-        if !(allowsMultipleImages || product.productType != .variable) {
-            return Localization.variableProductHelperText
-        } else if productImageStatuses.containsMoreThanOne {
+        if productImageStatuses.containsMoreThanOne {
             return Localization.dragAndDropHelperText
+        } else if !(allowsMultipleImages || product.productType != .variable) {
+            return Localization.variableProductHelperText
         }
 
         return nil

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -146,7 +146,7 @@ private extension ProductImagesViewController {
     func getAppropiateHelpText() -> String? {
         if productImageStatuses.containsMoreThanOne {
             return Localization.dragAndDropHelperText
-        } else if !(allowsMultipleImages || product.productType != .variable) {
+        } else if !allowsMultipleImages && product.productType == .variable {
             return Localization.variableProductHelperText
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -240,20 +240,8 @@ private extension ProductImagesViewController {
     }
 
     func handleProductImageStatusesReordering(_ reorderedProductImageStatuses: [ProductImageStatus]) {
-        // We have to validate if the order of the product images has been changed.
-        // The user can make some changes but the list may end up with the old order.
-        hasMovedAnyImages = validateIfAnyImagesHasMovedAfterReordering(reorderedProductImageStatuses)
-
+        hasMovedAnyImages = true
         productImageActionHandler.updateProductImageStatusesAfterReordering(reorderedProductImageStatuses)
-    }
-
-    /// Check if the given product images are in the same order as the original ones.
-    ///
-    func validateIfAnyImagesHasMovedAfterReordering(_ reorderedItems: [ProductImageStatus]) -> Bool {
-        let zippedProductImages = zip(reorderedItems, self.product.imageStatuses)
-        return zippedProductImages.contains(where: { reordered, original -> Bool in
-            reordered.dragItemIdentifier != original.dragItemIdentifier
-        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -48,8 +48,8 @@ final class ProductImagesViewController: UIViewController {
             productUIImageLoader: productUIImageLoader,
             onDeletion: { [weak self] productImage in
                 self?.onDeletion(productImage: productImage)
-            }, onReorder: { _ in
-                print("Products reordered!")
+            }, onReorder: { [weak self] productImageStatuses in
+                self?.handleProductImageStatusesReordering(productImageStatuses)
             })
         return viewController
     }()
@@ -210,6 +210,10 @@ private extension ProductImagesViewController {
     func onDeletion(productImage: ProductImage) {
         hasDeletedAnyImages = true
         productImageActionHandler.deleteProductImage(productImage)
+    }
+
+    func handleProductImageStatusesReordering(_ productImageStatuses: [ProductImageStatus]) {
+        productImageActionHandler.updateProductImageStatusesAfterReordering(productImageStatuses)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -49,7 +49,7 @@ final class ProductImagesViewController: UIViewController {
             onDeletion: { [weak self] productImage in
                 self?.onDeletion(productImage: productImage)
             },
-            reorderHandler: { [weak self] productImageStatuses in
+            onReordering: { [weak self] productImageStatuses in
                 self?.handleProductImageStatusesReordering(productImageStatuses)
             })
         return viewController

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -48,7 +48,8 @@ final class ProductImagesViewController: UIViewController {
             productUIImageLoader: productUIImageLoader,
             onDeletion: { [weak self] productImage in
                 self?.onDeletion(productImage: productImage)
-            }, onReorder: { [weak self] productImageStatuses in
+            },
+            reorderHandler: { [weak self] productImageStatuses in
                 self?.handleProductImageStatusesReordering(productImageStatuses)
             })
         return viewController

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -244,7 +244,7 @@ private extension ProductImagesViewController {
         // The user can make some changes but the list may end up with the old order.
         hasMovedAnyImages = validateIfAnyImagesHasMovedAfterReordering(reorderedProductImageStatuses)
 
-        productImageActionHandler.updateProductImageStatusesAfterReordering(productImageStatuses)
+        productImageActionHandler.updateProductImageStatusesAfterReordering(reorderedProductImageStatuses)
     }
 
     /// Check if the given product images are in the same order as the original ones.

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -67,6 +67,7 @@ final class ProductImagesViewController: UIViewController {
     }()
 
     private var hasDeletedAnyImages: Bool = false
+    private var hasMovedAnyImages: Bool = false
 
     private let onCompletion: Completion
 
@@ -213,6 +214,7 @@ private extension ProductImagesViewController {
     }
 
     func handleProductImageStatusesReordering(_ productImageStatuses: [ProductImageStatus]) {
+        hasMovedAnyImages = true
         productImageActionHandler.updateProductImageStatusesAfterReordering(productImageStatuses)
     }
 }
@@ -244,7 +246,7 @@ extension ProductImagesViewController {
     }
 
     private func hasOutstandingChanges() -> Bool {
-        return hasDeletedAnyImages
+        return hasDeletedAnyImages || hasMovedAnyImages
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -131,9 +131,25 @@ private extension ProductImagesViewController {
     }
 
     func configureHelperViews() {
-        helperContainerView.isHidden = allowsMultipleImages || product.productType != .variable
         helperLabel.applySecondaryFootnoteStyle()
-        helperLabel.text = Localization.variableProductHelperText
+        updateHelperViews()
+    }
+
+    var shouldShowHelperViews: Bool {
+        return getAppropiateHelpText() != nil
+    }
+
+    /// Returns the appropiate localizable help text or `nil` when
+    /// there is no help text to show.
+    ///
+    func getAppropiateHelpText() -> String? {
+        if !(allowsMultipleImages || product.productType != .variable) {
+            return Localization.variableProductHelperText
+        } else if productImageStatuses.containsMoreThanOne {
+            return Localization.dragAndDropHelperText
+        }
+
+        return nil
     }
 
     func configureImagesContainerView() {
@@ -159,6 +175,7 @@ private extension ProductImagesViewController {
                 self.displayErrorAlert(error: error)
             }
 
+            self.updateHelperViews()
             self.updateAddButtonTitle(numberOfImages: productImageStatuses.count)
 
             self.imagesViewController.updateProductImageStatuses(productImageStatuses)
@@ -177,6 +194,14 @@ private extension ProductImagesViewController {
             title = numberOfImages == 0 ? Localization.addPhoto: Localization.replacePhoto
         }
         addButton.setTitle(title, for: .normal)
+    }
+
+    /// Shows/Hides the helper container view and update the helper label
+    /// with the appropiate localizable text.
+    ///
+    func updateHelperViews() {
+        helperContainerView.isHidden = !shouldShowHelperViews
+        helperLabel.text = getAppropiateHelpText()
     }
 }
 
@@ -332,5 +357,7 @@ private extension ProductImagesViewController {
         static let replacePhoto = NSLocalizedString("Replace Photo", comment: "Action to replace one photo on the Product images screen")
         static let variableProductHelperText = NSLocalizedString("Only one photo can be displayed by variation",
                                                                  comment: "Helper text above photo list in Product images screen")
+        static let dragAndDropHelperText = NSLocalizedString("Drag and drop to re-order photos",
+                                                             comment: "Drag and drop helper text above photo list in Product images screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -42,12 +42,15 @@ final class ProductImagesViewController: UIViewController {
     // Child view controller.
     private lazy var imagesViewController: ProductImagesCollectionViewController = {
         let isDeletionEnabled = product.isImageDeletionEnabled()
-        let viewController = ProductImagesCollectionViewController(imageStatuses: productImageStatuses,
-                                                                   isDeletionEnabled: isDeletionEnabled,
-                                                                   productUIImageLoader: productUIImageLoader,
-                                                                   onDeletion: { [weak self] productImage in
-                                                                    self?.onDeletion(productImage: productImage)
-        })
+        let viewController = ProductImagesCollectionViewController(
+            imageStatuses: productImageStatuses,
+            isDeletionEnabled: isDeletionEnabled,
+            productUIImageLoader: productUIImageLoader,
+            onDeletion: { [weak self] productImage in
+                self?.onDeletion(productImage: productImage)
+            }, onReorder: { _ in
+                print("Products reordered!")
+            })
         return viewController
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -250,7 +250,7 @@ private extension ProductImagesViewController {
     /// Check if the given product images are in the same order as the original ones.
     ///
     func validateIfAnyImagesHasMovedAfterReordering(_ reorderedItems: [ProductImageStatus]) -> Bool {
-        let zippedProductImages = zip(reorderedItems, self.productImageStatuses)
+        let zippedProductImages = zip(reorderedItems, self.product.imageStatuses)
         return zippedProductImages.contains(where: { reordered, original -> Bool in
             reordered.dragItemIdentifier != original.dragItemIdentifier
         })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageActionHandlerTests.swift
@@ -239,7 +239,7 @@ final class ProductImageActionHandlerTests: XCTestCase {
 
     // MARK: - `updateProductImageStatusesAfterReordering
 
-    func testUpdatingProductImageStatusesAfterReordering() {
+    func test_productImageStatuses_are_updated_correctly_after_reordering() {
         // Given
         let mockProduct = Product.fake().copy(images: [])
         let model = EditableProductModel(product: mockProduct)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageStatus+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageStatus+HelpersTests.swift
@@ -63,7 +63,7 @@ final class ProductImageStatus_HelpersTests: XCTestCase {
         XCTAssertEqual(obtainedIdentifier, expectedIdentifier)
     }
 
-    func testDragItemIdentifierForUploadingAsset() {
+    func test_dragItemIdentifier_is_correct_for_uploading_asset() {
         // Given
         let asset = PHAsset()
         let status = ProductImageStatus.uploading(asset: asset)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageStatus+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageStatus+HelpersTests.swift
@@ -50,7 +50,7 @@ final class ProductImageStatus_HelpersTests: XCTestCase {
 
     // MARK: - `dragItemIdentifier`
 
-    func testDragItemIdentifierForRemoteImage() {
+    func test_dragItemIdentifier_is_correct_for_remote_image() {
         // Given
         let productImage = ProductImage(imageID: 17, dateCreated: Date(), dateModified: Date(), src: "", name: nil, alt: nil)
         let status = ProductImageStatus.remote(image: productImage)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageStatus+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageStatus+HelpersTests.swift
@@ -47,4 +47,32 @@ final class ProductImageStatus_HelpersTests: XCTestCase {
         ]
         XCTAssertTrue(statuses.hasPendingUpload)
     }
+
+    // MARK: - `dragItemIdentifier`
+
+    func testDragItemIdentifierForRemoteImage() {
+        // Given
+        let productImage = ProductImage(imageID: 17, dateCreated: Date(), dateModified: Date(), src: "", name: nil, alt: nil)
+        let status = ProductImageStatus.remote(image: productImage)
+        let expectedIdentifier = "\(17)"
+
+        // When
+        let obtainedIdentifier = status.dragItemIdentifier
+
+        // Then
+        XCTAssertEqual(obtainedIdentifier, expectedIdentifier)
+    }
+
+    func testDragItemIdentifierForUploadingAsset() {
+        // Given
+        let asset = PHAsset()
+        let status = ProductImageStatus.uploading(asset: asset)
+        let expectedIdentifier = asset.identifier()
+
+        // When
+        let obtainedIdentifier = status.dragItemIdentifier
+
+        // Then
+        XCTAssertEqual(obtainedIdentifier, expectedIdentifier)
+    }
 }


### PR DESCRIPTION
Closes: #3106

### Description

This PR updates the product images screen by adding support for drag and drop images. This means that merchants can change the order of images on the product image screen.

|**>1 photo (Drag and drop enabled)**|**1 photo (Drag and drop disabled)**|
|--|--|
|<img width="250px" src="https://user-images.githubusercontent.com/1409041/162748506-2367ad27-f8cf-4ea0-a9f3-a3ddc7de41ba.png"/>|<img width="250px" src="https://user-images.githubusercontent.com/1409041/162748533-2832b0bd-5440-470a-8024-88b5f3866aa6.png"/>|

**Solution**

As I explained in the issue, there are two ways to "move" the items. One is by using, like table views, the [delegate methods](https://developer.apple.com/documentation/uikit/uicollectionviewdatasource/1618015-collectionview) that allow users to move cells (**Approach One**), and the other one is by using the protocols `UICollectionViewDragDelegate` and `UICollectionViewDropDelegate` (**Approach Two**). 

First, I thought of using **Approach One**, because it was easier to implement. However, the final solution uses **Approach Two** 😅. I'd like to write a **P2** post to explain why I decided to change my initial approach, the experiments I did, the articles and docs I read, etc. But, to summarize, the UX is much, much better, for example, the elements are highlighted when dragging starts and the drop action is animated. Also, it's more powerful because we prepared the code for interesting new features, such as dragging and dropping photos from external applications with little effort. Finally, the implementation was easier than I thought 🙂 

So I implemented [the drag and drop feature](https://github.com/Juanpe/woocommerce-ios/blob/0fe0e72f39c63c3b87cfaef67f1a6e2b8620d323/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift#L146) following this [WWDC session](https://developer.apple.com/videos/play/wwdc2017/223/) and [the official documentation](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/supporting_drag_and_drop_in_collection_views). When the drop finishes, we [notify the change via callback](https://github.com/Juanpe/woocommerce-ios/blob/0fe0e72f39c63c3b87cfaef67f1a6e2b8620d323/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift#L221) and forward the event to the `ProductImagesActionHandler` to [update the current states of the product images in a thread safe way](https://github.com/Juanpe/woocommerce-ios/blob/0fe0e72f39c63c3b87cfaef67f1a6e2b8620d323/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift#L212).

As for the help text I used the [current](https://github.com/woocommerce/woocommerce-ios/pull/4061), which is used to explain that the variations only have one photo. I used the same one because both have the same design specs and will never be visible at the same time.

**Workaround**

I've encountered a `problem` when moving an image and there is at least one pending upload. Since we are using the `performBatchUpdates` method to handle collection view modifications, not all cells are reloaded and it seems that if there is more than one cell type in a section, the visible cells result in a strange state. Then, when the image is uploaded and the collection is reloaded, a random cell is seen with a white alpha layer, i.e., it is not properly reloaded. 

Here is a video showing the problem:

https://user-images.githubusercontent.com/1409041/162842598-d30c1cbc-16b9-4485-a2dc-9eaea3316025.mp4

One solution could be to disable the drag and drop function when there is any pending upload. But now, we allow navigating to an image detail screen or deleting one when there is any pending upload, so I think this feature should not depend on this scenario. 

I found out that if we [reload the collection view when the batch update block completes](https://github.com/Juanpe/woocommerce-ios/blob/0fe0e72f39c63c3b87cfaef67f1a6e2b8620d323/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift#L217), the problem is solved. So, considering this as an edge case and that a product could have up to 20 photos, maybe? performance is not affected if we reload the collection view only when there is any pending upload.

Here is a video showing the fixed problem:

https://user-images.githubusercontent.com/1409041/162843558-51780cb1-979f-435d-8b69-e51bb23e63cb.mp4


### Testing instructions

#### Scenario 1️⃣: Change the order of an image in the Product images screen.

1. Go to the products tab. 
2. Select a product with more than one image.
3. Tap on a photo.
4. Drag an image (long press).
5. Drop to a different position.
6. The images should be reordered. 

**Demo** 

https://user-images.githubusercontent.com/1409041/162750440-3155bc78-5b02-47af-b070-2a8e6f2df97f.mp4

#### Scenario 2️⃣: Drag and drop is not allowed if a product only has an image.

1. Go to the products tab. 
2. Select a product with one image.
3. Tap on the photo. 
4. Drag an image (long press).
5. Nothing happens.

**Demo** 

https://user-images.githubusercontent.com/1409041/162750717-f4d258b1-00ca-4555-9be5-2a23a99a5f8b.mp4

#### Scenario 3️⃣: Change the order of an image in the Product images screen when there is a pending upload.

1. Go to the products tab. 
2. Select a product with one or more than one images.
3. Tap on a photo.
4. Add a new photo.
5. Tap on a photo again.
6. Drag an image (long press).
7. Drop to a different position.
8. The images should be reordered. 

**Demo** 

https://user-images.githubusercontent.com/1409041/162751224-735f08df-aae3-40df-b8ee-f32425caa68f.mp4


#### Scenario 4️⃣: Change the order of an image in the Product images screen when there are multiple pending uploads.

1. Go to the products tab. 
2. Select a product with one or more than one images.
3. Tap on a photo.
4. Add a couple of photos.
5. Tap on a photo again.
6. Drag an image (long press).
7. Drop to a different position.
8. The images should be reordered. 

**Demo** 

https://user-images.githubusercontent.com/1409041/162751427-2181b933-6cde-4386-8504-ab7096a20126.mp4


#### Scenario 5️⃣: Change the order of an image in the Product images screen and save.

1. Go to the products tab. 
2. Select a product with one or more than one images.
3. Tap on a photo.
6. Drag an image (long press).
7. Drop to a different position.
8. Tap on "Save" button.  
9. Changes should be persisted and sent to the backend.

**Demo**

https://user-images.githubusercontent.com/1409041/162752190-4281577b-d1b0-44d0-8070-87e5375c77fe.mp4

#### Scenario 6️⃣: Drag and drop help text disappear after deleting a photo and leaving only one.

1. Go to the products tab. 
2. Select a product with one or more than one images.
3. Tap on a photo. 
4. Delete a photo (Tap on it). 
5. Go back to the Product images screen.
6. Drag and drop help text should disappear. 

**Demo**

https://user-images.githubusercontent.com/1409041/162753502-962f11cc-e61d-44e7-9008-e7dbcdc8f4d8.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
