### PR TITLE
In-person refund: receive/display card reader messages, update copy in alerts, handle cancel action

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -2,10 +2,6 @@ import UIKit
 
 /// Modal presented on error
 final class CardPresentModalError: CardPresentPaymentsModalViewModel {
-
-    /// The error returned by the stack
-    private let error: Error
-
     /// A closure to execute when the primary button is tapped
     private let primaryAction: () -> Void
 
@@ -24,9 +20,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
     let auxiliaryButtonTitle: String? = nil
 
-    var bottomTitle: String? {
-        error.localizedDescription
-    }
+    let bottomTitle: String?
 
     let bottomSubtitle: String? = nil
 
@@ -37,9 +31,9 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
         return topTitle + bottomTitle
     }
 
-    init(error: Error, transactionType: CardPresentTransactionType, primaryAction: @escaping () -> Void) {
-        self.error = error
+    init(errorDescription: String?, transactionType: CardPresentTransactionType, primaryAction: @escaping () -> Void) {
         self.topTitle = Localization.paymentFailed(transactionType: transactionType)
+        self.bottomTitle = errorDescription
         self.primaryButtonTitle = Localization.tryAgain(transactionType: transactionType)
         self.secondaryButtonTitle = Localization.noThanks(transactionType: transactionType)
         self.primaryAction = primaryAction

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -12,15 +12,15 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
     let actionsMode: PaymentsModalActionsMode = .twoAction
 
-    let topTitle: String = Localization.paymentFailed
+    let topTitle: String
 
     var topSubtitle: String? = nil
 
     let image: UIImage = .paymentErrorImage
 
-    let primaryButtonTitle: String? = Localization.tryAgain
+    let primaryButtonTitle: String?
 
-    let secondaryButtonTitle: String? = Localization.noThanks
+    let secondaryButtonTitle: String?
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -37,8 +37,11 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
         return topTitle + bottomTitle
     }
 
-    init(error: Error, primaryAction: @escaping () -> Void) {
+    init(error: Error, transactionType: CardPresentTransactionType, primaryAction: @escaping () -> Void) {
         self.error = error
+        self.topTitle = Localization.paymentFailed(transactionType: transactionType)
+        self.primaryButtonTitle = Localization.tryAgain(transactionType: transactionType)
+        self.secondaryButtonTitle = Localization.noThanks(transactionType: transactionType)
         self.primaryAction = primaryAction
     }
 
@@ -55,19 +58,49 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
 private extension CardPresentModalError {
     enum Localization {
-        static let paymentFailed = NSLocalizedString(
-            "Payment failed",
-            comment: "Error message. Presented to users after a collecting a payment fails"
-        )
+        static func paymentFailed(transactionType: CardPresentTransactionType) -> String {
+            switch transactionType {
+            case .collectPayment:
+                return NSLocalizedString(
+                    "Payment failed",
+                    comment: "Error message. Presented to users after collecting a payment fails"
+                )
+            case .refund:
+                return NSLocalizedString(
+                    "Refund failed",
+                    comment: "Error message. Presented to users after an in-person refund fails"
+                )
+            }
+        }
 
-        static let tryAgain = NSLocalizedString(
-            "Try Collecting Again",
-            comment: "Button to try to collect a payment again. Presented to users after a collecting a payment fails"
-        )
+        static func tryAgain(transactionType: CardPresentTransactionType) -> String {
+            switch transactionType {
+            case .collectPayment:
+                return NSLocalizedString(
+                    "Try Collecting Again",
+                    comment: "Button to try to collect a payment again. Presented to users after collecting a payment fails"
+                )
+            case .refund:
+                return NSLocalizedString(
+                    "Try Again",
+                    comment: "Button to try to refund a payment again. Presented to users after refunding a payment fails"
+                )
+            }
+        }
 
-        static let noThanks = NSLocalizedString(
-            "Back to Order",
-            comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails"
-        )
+        static func noThanks(transactionType: CardPresentTransactionType) -> String {
+            switch transactionType {
+            case .collectPayment:
+                return NSLocalizedString(
+                    "Back to Order",
+                    comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails"
+                )
+            case .refund:
+                return NSLocalizedString(
+                    "Close",
+                    comment: "Button to dismiss modal overlay. Presented to users after refunding a payment fails"
+                )
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProcessing.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProcessing.swift
@@ -29,17 +29,17 @@ final class CardPresentModalProcessing: CardPresentPaymentsModalViewModel {
 
     let auxiliaryButtonTitle: String? = nil
 
-    let bottomTitle: String? = Localization.processingPayment
+    let bottomTitle: String?
 
     let bottomSubtitle: String? = nil
 
-    var accessibilityLabel: String? {
-        return Localization.processingPaymentAccessibilityLabel
-    }
+    let accessibilityLabel: String?
 
-    init(name: String, amount: String) {
+    init(name: String, amount: String, transactionType: CardPresentTransactionType) {
         self.name = name
         self.amount = amount
+        self.bottomTitle = Localization.processingPayment(transactionType: transactionType)
+        self.accessibilityLabel = Localization.processingPaymentAccessibilityLabel(transactionType: transactionType)
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -57,14 +57,34 @@ final class CardPresentModalProcessing: CardPresentPaymentsModalViewModel {
 
 private extension CardPresentModalProcessing {
     enum Localization {
-        static let processingPayment = NSLocalizedString(
-            "Processing payment...",
-            comment: "Indicates that a payment is being processed"
-        )
+        static func processingPayment(transactionType: CardPresentTransactionType) -> String {
+            switch transactionType {
+            case .collectPayment:
+                return NSLocalizedString(
+                    "Processing payment...",
+                    comment: "Indicates that a payment is being processed"
+                )
+            case .refund:
+                return NSLocalizedString(
+                    "Processing refund",
+                    comment: "Indicates that an in-person refund is being processed"
+                )
+            }
+        }
 
-        static let processingPaymentAccessibilityLabel = NSLocalizedString(
-            "Processing payment",
-            comment: "VoiceOver accessibility label. Indicates that a payment is being processed"
-        )
+        static func processingPaymentAccessibilityLabel(transactionType: CardPresentTransactionType) -> String {
+            switch transactionType {
+            case .collectPayment:
+                return NSLocalizedString(
+                    "Processing payment",
+                    comment: "VoiceOver accessibility label. Indicates that a payment is being processed"
+                )
+            case .refund:
+                return NSLocalizedString(
+                    "Refunding payment",
+                    comment: "VoiceOver accessibility label. Indicates that an in-person refund is being processed"
+                )
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -41,23 +41,15 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
         return topTitle + bottomTitle
     }
 
-    private let paymentGatewayAccountID: String?
-    private let countryCode: String
-    private let cardReaderModel: String
-    private let analytics: Analytics
+    /// Closure to execute when cancel button is tapped
+    private let cancelAction: () -> Void
 
     init(name: String,
          amount: String,
-         paymentGatewayAccountID: String?,
-         countryCode: String,
-         cardReaderModel: String,
-         analytics: Analytics = ServiceLocator.analytics) {
+         cancelAction: @escaping () -> Void) {
         self.name = name
         self.amount = amount
-        self.paymentGatewayAccountID = paymentGatewayAccountID
-        self.countryCode = countryCode
-        self.cardReaderModel = cardReaderModel
-        self.analytics = analytics
+        self.cancelAction = cancelAction
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -65,15 +57,7 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        analytics.track(event: WooAnalyticsEvent.InPersonPayments
-                                        .collectPaymentCanceled(forGatewayID: paymentGatewayAccountID,
-                                                                countryCode: countryCode,
-                                                                cardReaderModel: cardReaderModel))
-
-        let action = CardPresentPaymentAction.cancelPayment(onCompletion: nil)
-
-        ServiceLocator.stores.dispatch(action)
-
+        cancelAction()
         viewController?.dismiss(animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -31,7 +31,7 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
 
     let bottomTitle: String? = Localization.readerIsReady
 
-    let bottomSubtitle: String? = Localization.tapInsertOrSwipe
+    let bottomSubtitle: String?
 
     var accessibilityLabel: String? {
         guard let bottomTitle = bottomTitle else {
@@ -46,9 +46,11 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
 
     init(name: String,
          amount: String,
+         transactionType: CardPresentTransactionType,
          cancelAction: @escaping () -> Void) {
         self.name = name
         self.amount = amount
+        self.bottomSubtitle = Localization.tapInsertOrSwipe(transactionType: transactionType)
         self.cancelAction = cancelAction
     }
 
@@ -70,17 +72,27 @@ private extension CardPresentModalReaderIsReady {
     enum Localization {
         static let readerIsReady = NSLocalizedString(
             "Reader is ready",
-            comment: "Indicates the status of a card reader. Presented to users when payment collection starts"
+            comment: "Indicates the status of a card reader. Presented to users when in-person payment collection or refund starts"
         )
 
-        static let tapInsertOrSwipe = NSLocalizedString(
-            "Tap, insert or swipe to pay",
-            comment: "Indicates the action expected from a user. Presented to users when payment collection starts"
-        )
+        static func tapInsertOrSwipe(transactionType: CardPresentTransactionType) -> String {
+            switch transactionType {
+            case .collectPayment:
+                return NSLocalizedString(
+                    "Tap, insert or swipe to pay",
+                    comment: "Indicates the action expected from a user. Presented to users when payment collection starts"
+                )
+            case .refund:
+                return NSLocalizedString(
+                    "Tap, insert or swipe to refund",
+                    comment: "Indicates the action expected from a user. Presented to users when in-person refund starts"
+                )
+            }
+        }
 
         static let cancel = NSLocalizedString(
             "Cancel",
-            comment: "Button to cancel a payment"
+            comment: "Button to cancel an in-person payment or refund"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
@@ -34,15 +34,15 @@ final class CardPresentModalTapCard: CardPresentPaymentsModalViewModel {
 
     let bottomTitle: String? = Localization.readerIsReady
 
-    let bottomSubtitle: String? = Localization.tapInsertOrSwipe
+    let bottomSubtitle: String?
 
-    var accessibilityLabel: String? {
-        return Localization.readerIsReady + Localization.tapInsertOrSwipe
-    }
+    let accessibilityLabel: String?
 
-    init(name: String, amount: String, onCancel: @escaping () -> Void) {
+    init(name: String, amount: String, transactionType: CardPresentTransactionType, onCancel: @escaping () -> Void) {
         self.name = name
         self.amount = amount
+        self.bottomSubtitle = Localization.tapInsertOrSwipe(transactionType: transactionType)
+        self.accessibilityLabel = Localization.readerIsReady + Localization.tapInsertOrSwipe(transactionType: transactionType)
         self.onCancel = onCancel
     }
 
@@ -68,10 +68,20 @@ private extension CardPresentModalTapCard {
             comment: "Indicates the status of a card reader. Presented to users when payment collection starts"
         )
 
-        static let tapInsertOrSwipe = NSLocalizedString(
-            "Tap, insert or swipe to pay",
-            comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
-        )
+        static func tapInsertOrSwipe(transactionType: CardPresentTransactionType) -> String {
+            switch transactionType {
+            case .collectPayment:
+                return NSLocalizedString(
+                    "Tap, insert or swipe to pay",
+                    comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
+                )
+            case .refund:
+                return NSLocalizedString(
+                    "Tap, insert or swipe to refund",
+                    comment: "Label asking users to present a card. Presented to users when an in-person refund is going to be executed"
+                )
+            }
+        }
 
         static let cancel = NSLocalizedString(
             "Cancel",

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -49,6 +49,14 @@ protocol CardPresentPaymentsModalViewModel {
     func didTapAuxiliaryButton(in viewController: UIViewController?)
 }
 
+/// The type of card-present transaction.
+enum CardPresentTransactionType {
+    /// To collect payment.
+    case collectPayment
+
+    /// To issue a refund.
+    case refund
+}
 
 /// Represents the different visual modes of the modal view's textfields
 enum PaymentsModalTextMode {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -30,10 +30,6 @@ final class CardPresentRefundOrchestrator {
                 onProcessingMessage: @escaping () -> Void,
                 onDisplayMessage: @escaping (String) -> Void,
                 onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        /// Sets the state of `CardPresentPaymentStore`.
-        let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
-        stores.dispatch(setAccount)
-
         /// Briefly suppresses pass (wallet) presentation so that the merchant doesn't attempt to pay for the buyer's order when the
         /// reader begins to collect payment.
         suppressPassPresentation()

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -47,6 +47,7 @@ final class CardPresentRefundOrchestrator {
                 break
             }
         }, onCompletion: { result in
+            onProcessingMessage()
             onCompletion(result)
         })
         stores.dispatch(refundAction)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -95,11 +95,12 @@ private extension OrderDetailsPaymentAlerts {
     func readerIsReady(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalReaderIsReady(name: name,
                                       amount: amount,
+                                      transactionType: transactionType,
                                       cancelAction: onCancel)
     }
 
     func tapOrInsert(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalTapCard(name: name, amount: amount, onCancel: onCancel)
+        CardPresentModalTapCard(name: name, amount: amount, transactionType: transactionType, onCancel: onCancel)
     }
 
     func displayMessage(message: String) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -1,6 +1,8 @@
 import MessageUI
 import UIKit
 import WordPressUI
+import enum Hardware.CardReaderServiceError
+import enum Hardware.UnderlyingError
 
 /// A layer of indirection between OrderDetailsViewController and the modal alerts
 /// presented to provide user-facing feedback about the progress
@@ -126,7 +128,28 @@ private extension OrderDetailsPaymentAlerts {
     }
 
     func errorViewModel(error: Error, tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalError(error: error, transactionType: transactionType, primaryAction: tryAgain)
+        let errorDescription: String?
+        if let error = error as? CardReaderServiceError {
+            switch error {
+            case .connection(let underlyingError),
+                    .discovery(let underlyingError),
+                    .disconnection(let underlyingError),
+                    .intentCreation(let underlyingError),
+                    .paymentMethodCollection(let underlyingError),
+                    .paymentCapture(let underlyingError),
+                    .paymentCancellation(let underlyingError),
+                    .refundCreation(let underlyingError),
+                    .refundPayment(let underlyingError),
+                    .refundCancellation(let underlyingError),
+                    .softwareUpdate(let underlyingError, _):
+                errorDescription = Localization.errorDescription(underlyingError: underlyingError, transactionType: transactionType)
+            default:
+                errorDescription = error.errorDescription
+            }
+        } else {
+            errorDescription = error.localizedDescription
+        }
+        return CardPresentModalError(errorDescription: errorDescription, transactionType: transactionType, primaryAction: tryAgain)
     }
 
     func retryableErrorViewModel(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
@@ -135,5 +158,64 @@ private extension OrderDetailsPaymentAlerts {
 
     func nonRetryableErrorViewModel(amount: String, error: Error) -> CardPresentPaymentsModalViewModel {
         CardPresentModalNonRetryableError(amount: amount, error: error)
+    }
+}
+
+private extension OrderDetailsPaymentAlerts {
+    enum Localization {
+        static func errorDescription(underlyingError: UnderlyingError, transactionType: CardPresentTransactionType) -> String? {
+            switch underlyingError {
+            case .unsupportedReaderVersion:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString(
+                        "The card reader software is out-of-date - please update the card reader software before attempting to process payments",
+                        comment: "Error message when the card reader software is too far out of date to process payments."
+                    )
+                case .refund:
+                    return NSLocalizedString(
+                        "The card reader software is out-of-date - please update the card reader software before attempting to process refunds",
+                        comment: "Error message when the card reader software is too far out of date to process in-person refunds."
+                    )
+                }
+            case .paymentDeclinedByCardReader:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString("The card was declined by the card reader - please try another means of payment",
+                                             comment: "Error message when the card reader itself declines the card.")
+                case .refund:
+                    return NSLocalizedString("The card was declined by the card reader - please try another means of refund",
+                                             comment: "Error message when the card reader itself declines the card.")
+                }
+            case .processorAPIError:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString(
+                        "The payment can not be processed by the payment processor.",
+                        comment: "Error message when the payment can not be processed (i.e. order amount is below the minimum amount allowed.)"
+                    )
+                case .refund:
+                    return NSLocalizedString(
+                        "The refund can not be processed by the payment processor.",
+                        comment: "Error message when the in-person refund can not be processed (i.e. order amount is below the minimum amount allowed.)"
+                    )
+                }
+            case .internalServiceError:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString(
+                        "Sorry, this payment couldn’t be processed",
+                        comment: "Error message when the card reader service experiences an unexpected internal service error."
+                    )
+                case .refund:
+                    return NSLocalizedString(
+                        "Sorry, this refund couldn’t be processed",
+                        comment: "Error message when the card reader service experiences an unexpected internal service error."
+                    )
+                }
+            default:
+                return underlyingError.errorDescription
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -25,20 +25,11 @@ final class OrderDetailsPaymentAlerts {
     private var amount: String = ""
 
     private let transactionType: CardPresentTransactionType
-    private let paymentGatewayAccountID: String?
-    private let countryCode: String
-    private let cardReaderModel: String
 
     init(transactionType: CardPresentTransactionType,
-         presentingController: UIViewController,
-         paymentGatewayAccountID: String?,
-         countryCode: String,
-         cardReaderModel: String) {
+         presentingController: UIViewController) {
         self.transactionType = transactionType
         self.presentingController = presentingController
-        self.paymentGatewayAccountID = paymentGatewayAccountID
-        self.countryCode = countryCode
-        self.cardReaderModel = cardReaderModel
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -15,7 +15,7 @@ final class OrderDetailsPaymentAlerts {
         if let controller = _modalController {
             return controller
         } else {
-            let controller = CardPresentPaymentsModalViewController(viewModel: readerIsReady())
+            let controller = CardPresentPaymentsModalViewController(viewModel: readerIsReady(onCancel: {}))
             _modalController = controller
             return controller
         }
@@ -24,11 +24,17 @@ final class OrderDetailsPaymentAlerts {
     private var name: String = ""
     private var amount: String = ""
 
+    private let transactionType: CardPresentTransactionType
     private let paymentGatewayAccountID: String?
     private let countryCode: String
     private let cardReaderModel: String
 
-    init(presentingController: UIViewController, paymentGatewayAccountID: String?, countryCode: String, cardReaderModel: String) {
+    init(transactionType: CardPresentTransactionType,
+         presentingController: UIViewController,
+         paymentGatewayAccountID: String?,
+         countryCode: String,
+         cardReaderModel: String) {
+        self.transactionType = transactionType
         self.presentingController = presentingController
         self.paymentGatewayAccountID = paymentGatewayAccountID
         self.countryCode = countryCode
@@ -45,13 +51,13 @@ final class OrderDetailsPaymentAlerts {
         }
     }
 
-    func readerIsReady(title: String, amount: String) {
+    func readerIsReady(title: String, amount: String, onCancel: @escaping () -> Void) {
         self.name = title
         self.amount = amount
 
         // Initial presentation of the modal view controller. We need to provide
         // a customer name and an amount.
-        let viewModel = readerIsReady()
+        let viewModel = readerIsReady(onCancel: onCancel)
         presentViewModel(viewModel: viewModel)
     }
 
@@ -95,12 +101,10 @@ final class OrderDetailsPaymentAlerts {
 }
 
 private extension OrderDetailsPaymentAlerts {
-    func readerIsReady() -> CardPresentPaymentsModalViewModel {
+    func readerIsReady(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalReaderIsReady(name: name,
                                       amount: amount,
-                                      paymentGatewayAccountID: paymentGatewayAccountID,
-                                      countryCode: countryCode,
-                                      cardReaderModel: cardReaderModel)
+                                      cancelAction: onCancel)
     }
 
     func tapOrInsert(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
@@ -112,7 +116,7 @@ private extension OrderDetailsPaymentAlerts {
     }
 
     func processing() -> CardPresentPaymentsModalViewModel {
-        CardPresentModalProcessing(name: name, amount: amount)
+        CardPresentModalProcessing(name: name, amount: amount, transactionType: transactionType)
     }
 
     func successViewModel(printReceipt: @escaping () -> Void,
@@ -130,7 +134,7 @@ private extension OrderDetailsPaymentAlerts {
     }
 
     func errorViewModel(error: Error, tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalError(error: error, primaryAction: tryAgain)
+        CardPresentModalError(error: error, transactionType: transactionType, primaryAction: tryAgain)
     }
 
     func retryableErrorViewModel(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -19,14 +19,6 @@ final class CardReaderSettingsConnectedViewController: UIViewController, CardRea
     ///
     private var sections = [Section]()
 
-    /// Card Present Payments alerts
-    private lazy var paymentAlerts: OrderDetailsPaymentAlerts = {
-        OrderDetailsPaymentAlerts(presentingController: self,
-                                  paymentGatewayAccountID: viewModel?.dataSource.cardPresentPaymentGatewayID(),
-                                  countryCode: CardPresentConfigurationLoader().configuration.countryCode,
-                                  cardReaderModel: viewModel?.connectedReaderModel ?? "")
-    }()
-
     private let settingsAlerts = CardReaderSettingsAlerts()
 
     /// Accept our viewmodel

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -63,7 +63,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 
     /// Alert manager to inform merchants about reader & card actions.
     ///
-    private lazy var alerts = OrderDetailsPaymentAlerts(presentingController: rootViewController,
+    private lazy var alerts = OrderDetailsPaymentAlerts(transactionType: .collectPayment,
+                                                        presentingController: rootViewController,
                                                         paymentGatewayAccountID: paymentGatewayAccount.gatewayID,
                                                         countryCode: configurationLoader.configuration.countryCode,
                                                         cardReaderModel: connectedReader?.readerType.model ?? "")
@@ -182,7 +183,11 @@ private extension CollectOrderPaymentUseCase {
                                                                                        cardReaderModel: connectedReader?.readerType.model ?? ""))
 
         // Show reader ready alert
-        alerts.readerIsReady(title: Localization.collectPaymentTitle(username: order.billingAddress?.firstName), amount: formattedAmount)
+        alerts.readerIsReady(title: Localization.collectPaymentTitle(username: order.billingAddress?.firstName),
+                             amount: formattedAmount,
+                             onCancel: { [weak self] in
+            self?.cancelPayment()
+        })
 
         // Start collect payment process
         paymentOrchestrator.collectPayment(

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -64,10 +64,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     /// Alert manager to inform merchants about reader & card actions.
     ///
     private lazy var alerts = OrderDetailsPaymentAlerts(transactionType: .collectPayment,
-                                                        presentingController: rootViewController,
-                                                        paymentGatewayAccountID: paymentGatewayAccount.gatewayID,
-                                                        countryCode: configurationLoader.configuration.countryCode,
-                                                        cardReaderModel: connectedReader?.readerType.model ?? "")
+                                                        presentingController: rootViewController)
 
     /// IPP payments collector.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -229,10 +229,7 @@ private extension RefundSubmissionUseCase {
 
         // Instantiates the alerts coordinator.
         let alerts = OrderDetailsPaymentAlerts(transactionType: .refund,
-                                               presentingController: rootViewController,
-                                               paymentGatewayAccountID: paymentGatewayAccount.gatewayID,
-                                               countryCode: cardPresentConfigurationLoader.configuration.countryCode,
-                                               cardReaderModel: connectedReader?.readerType.model ?? "")
+                                               presentingController: rootViewController)
         self.alerts = alerts
 
         // Shows reader ready alert.

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -136,8 +136,13 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
             connectReader { [weak self] in
                 self?.attemptCardPresentRefund(refundAmount: refundAmount as Decimal, charge: charge, onCompletion: { [weak self] result in
                     guard let self = self else { return }
-                    self.submitRefundToSite(refund: refund) { result in
-                        onCompletion(result)
+                    switch result {
+                    case .success:
+                        self.submitRefundToSite(refund: refund) { result in
+                            onCompletion(result)
+                        }
+                    case .failure(let error):
+                        onCompletion(.failure(error))
                     }
                 })
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -228,14 +228,19 @@ private extension RefundSubmissionUseCase {
         }
 
         // Instantiates the alerts coordinator.
-        let alerts = OrderDetailsPaymentAlerts(presentingController: rootViewController,
+        let alerts = OrderDetailsPaymentAlerts(transactionType: .refund,
+                                               presentingController: rootViewController,
                                                paymentGatewayAccountID: paymentGatewayAccount.gatewayID,
                                                countryCode: cardPresentConfigurationLoader.configuration.countryCode,
                                                cardReaderModel: connectedReader?.readerType.model ?? "")
         self.alerts = alerts
 
         // Shows reader ready alert.
-        alerts.readerIsReady(title: Localization.refundPaymentTitle(username: order.billingAddress?.firstName), amount: formattedAmount)
+        alerts.readerIsReady(title: Localization.refundPaymentTitle(username: order.billingAddress?.firstName),
+                             amount: formattedAmount,
+                             onCancel: { [weak self] in
+            self?.cancelRefund()
+        })
 
         // Starts refund process.
         cardPresentRefundOrchestrator.refund(amount: refundAmount,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -8,7 +8,9 @@ final class CardPresentModalErrorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalError(error: Expectations.error, transactionType: .collectPayment, primaryAction: closures.primaryAction())
+        viewModel = CardPresentModalError(errorDescription: Expectations.error.localizedDescription,
+                                          transactionType: .collectPayment,
+                                          primaryAction: closures.primaryAction())
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -8,7 +8,7 @@ final class CardPresentModalErrorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalError(error: Expectations.error, primaryAction: closures.primaryAction())
+        viewModel = CardPresentModalError(error: Expectations.error, transactionType: .collectPayment, primaryAction: closures.primaryAction())
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalProcessingTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalProcessingTests.swift
@@ -6,7 +6,7 @@ final class CardPresentModalProcessingTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        viewModel = CardPresentModalProcessing(name: Expectations.name, amount: Expectations.amount)
+        viewModel = CardPresentModalProcessing(name: Expectations.name, amount: Expectations.amount, transactionType: .collectPayment)
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
@@ -10,6 +10,7 @@ final class CardPresentModalReaderIsReadyTests: XCTestCase {
         super.setUp()
         viewModel = CardPresentModalReaderIsReady(name: Expectations.name,
                                                   amount: Expectations.amount,
+                                                  transactionType: .collectPayment,
                                                   cancelAction: {})
     }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
@@ -49,7 +49,6 @@ final class CardPresentModalReaderIsReadyTests: XCTestCase {
     func test_bottom_subTitle_is_not_nil() {
         XCTAssertNotNil(viewModel.bottomSubtitle)
     }
-
 }
 
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
@@ -6,25 +6,15 @@ import TestKit
 final class CardPresentModalReaderIsReadyTests: XCTestCase {
     private var viewModel: CardPresentModalReaderIsReady!
 
-    private var analyticsProvider: MockAnalyticsProvider!
-    private var analytics: WooAnalytics!
-
     override func setUp() {
         super.setUp()
-        analyticsProvider = MockAnalyticsProvider()
-        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         viewModel = CardPresentModalReaderIsReady(name: Expectations.name,
                                                   amount: Expectations.amount,
-                                                  paymentGatewayAccountID: Expectations.paymentGatewayAccountID,
-                                                  countryCode: Expectations.countryCode,
-                                                  cardReaderModel: Expectations.cardReaderModel,
-                                                  analytics: analytics)
+                                                  cancelAction: {})
     }
 
     override func tearDown() {
         viewModel = nil
-        analytics = nil
-        analyticsProvider = nil
         super.tearDown()
     }
 
@@ -60,43 +50,6 @@ final class CardPresentModalReaderIsReadyTests: XCTestCase {
         XCTAssertNotNil(viewModel.bottomSubtitle)
     }
 
-    func test_secondary_button_dispatched_cancel_action() throws {
-        let storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        storesManager.reset()
-
-        ServiceLocator.setStores(storesManager)
-
-        assertEmpty(storesManager.receivedActions)
-
-        viewModel.didTapSecondaryButton(in: nil)
-
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-
-        let action = try XCTUnwrap(storesManager.receivedActions.first as? CardPresentPaymentAction)
-        switch action {
-        case .cancelPayment(onCompletion: _):
-            XCTAssertTrue(true)
-        default:
-            XCTFail("Primary button failed to dispatch .cancelPayment action")
-        }
-    }
-
-    func test_tapping_secondary_button_tracks_cancel_event() throws {
-        // Given
-        assertEmpty(analyticsProvider.receivedEvents)
-
-        // When
-        viewModel.didTapSecondaryButton(in: nil)
-
-        // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
-        XCTAssertEqual(analyticsProvider.receivedEvents.first, "card_present_collect_payment_canceled")
-
-        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(firstPropertiesBatch["card_reader_model"] as? String, Expectations.cardReaderModel)
-        XCTAssertEqual(firstPropertiesBatch["country"] as? String, Expectations.countryCode)
-        XCTAssertEqual(firstPropertiesBatch["plugin_slug"] as? String, Expectations.paymentGatewayAccountID)
-    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
@@ -13,6 +13,7 @@ final class CardPresentModalTapCardTests: XCTestCase {
         viewModel = CardPresentModalTapCard(
             name: Expectations.name,
             amount: Expectations.amount,
+            transactionType: .collectPayment,
             onCancel: closures.onCancel()
         )
     }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -251,8 +251,8 @@ private extension CardPresentPaymentStore {
         }
 
         refundCancellable = cardReaderService.refundPayment(parameters: parameters)
-            .sink { [weak readerEventsSubscription] error in
-                readerEventsSubscription?.cancel()
+            .sink { error in
+                readerEventsSubscription.cancel()
                 switch error {
                 case .failure(let error):
                     DDLogError("⛔️ Error during client-side refund: \(error.localizedDescription)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #5983 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR addressed some of the issues from the main refund flow:

- Look into why there are no "Remove card" and "Processing" messages from the reader service: this was fixed in `CardPresentPaymentStore` by not weaking the reader events subscription. `onProcessingMessage` was added to the end of card-present refund flow for the processing message to be shown before submitting to the site
- Update copy from payments to refunds: this was implemented by introducing a new enum `CardPresentTransactionType` for us to differentiate between payments and refunds in `OrderDetailsPaymentAlerts` and its view models (please feel free to suggest other naming!)
- Handle refund payment cancellation: previously, `CardPresentModalReaderIsReady.didTapSecondaryButton` was called to dispatch `CardPresentPaymentAction.cancelPayment` for IPP. However, this doesn't work for refunds anymore and I moved the cancellation logic from the `CardPresentModalReaderIsReady` view to its caller by passing a `cancelAction` closure. It's a good practice letting views be pure views without the heavy logic anyway, and we don't have to pass a few  dependenceies for analytics anymore. On the other hand, there were test cases on this cancellation logic in the view `CardPresentModalReaderIsReadyTests` and I am going to add back these tests separately by adding unit tests for `CollectOrderPaymentUseCase`

Other changes:
- I removed `CardPresentPaymentAction.use(paymentGatewayAccount:)` when submitting a refund since the payment gateway account isn't needed for refunds
- Removed unused code in `CardReaderSettingsConnectedViewController`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites: the store is in Canada and eligible for IPP (setup instructions PdfdoF-D-p2)

#### Error case

- Go to the orders tab
- Create an order and pay it with Interac using a physical card reader, if you don't have one already
- Go to the order above
- Tap "Issue Refund" and select the refund amount to confirm --> the card reader connection alerts should appear
- Connect to WisePad 3 reader if you haven't
- When the reader is ready for in-person refund, tap "Cancel" in the alert --> the app dismisses the alert, and the reader should show a "cancelled" message as well
- Tap "Refund" again, then insert a non-Interac card (like the Stripe M2 test card) --> after the reader shows an erro message, the app should also show an error message in the alert followed by an alert with "Try Again" and "Close" CTAs (there is an issue with "Try Again" as a followup subtask)
- Tap "Close" to dismiss the alert

#### Success case

- Tap "Refund" again, then insert the Interac test card and enter the pin number --> after the reader shows a success message and it's ready to remove the card, the app should also show "Remove card" in the alert message followed by "Processing refund" before the refund is successfully submitted to the site


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

ready state | failure
-- | --
![IMG_3443](https://user-images.githubusercontent.com/1945542/162974575-804425c6-c6e0-4d99-88b3-e1d5fda7d73e.PNG) | ![IMG_3444](https://user-images.githubusercontent.com/1945542/162974595-c1b2b32e-2c10-446a-a5c4-1089f1ffe2b2.PNG)



https://user-images.githubusercontent.com/1945542/162974865-fd08efbb-8fa0-4732-8f12-f21643c599c3.MP4





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
