### PR TITLE
Coupons: Update product selection list cells UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/LegacyProductListMultiSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/LegacyProductListMultiSelectorDataSource.swift
@@ -1,0 +1,98 @@
+import Combine
+import Yosemite
+
+/// Enables the user to select multiple products from a paginated list.
+/// This uses the old design for the product list selector,
+/// and should be removed once updates for `ProductListMultiSelectorDataSource` are complete.
+final class LegacyProductListMultiSelectorDataSource: PaginatedListSelectorDataSource {
+    typealias StorageModel = StorageProduct
+
+    // Observable list of the latest product IDs
+    var productIDs: AnyPublisher<[Int64], Never> {
+        productIDsSubject.eraseToAnyPublisher()
+    }
+    private let productIDsSubject: PassthroughSubject<[Int64], Never> = PassthroughSubject<[Int64], Never>()
+
+    // Not used: since multiple products can be selected in this use case, the single selected product is not used.
+    var selected: Product?
+
+    private let siteID: Int64
+    private let excludedProductIDs: [Int64]
+    private var selectedProductIDs: [Int64] = [] {
+        didSet {
+            if selectedProductIDs != oldValue {
+                productIDsSubject.send(selectedProductIDs)
+            }
+        }
+    }
+    private let imageService: ImageService
+
+    init(siteID: Int64, excludedProductIDs: [Int64], imageService: ImageService = ServiceLocator.imageService) {
+        self.siteID = siteID
+        self.excludedProductIDs = excludedProductIDs
+        self.imageService = imageService
+    }
+
+    func createResultsController() -> ResultsController<StorageProduct> {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld AND NOT(productID IN %@)", siteID, excludedProductIDs)
+        return ResultsController<StorageProduct>(storageManager: storageManager,
+                                                 matching: predicate,
+                                                 sortOrder: .nameAscending)
+    }
+
+    func handleSelectedChange(selected: Product) {
+        if isProductSelected(selected) {
+            selectedProductIDs.removeAll { $0 == selected.productID }
+        } else {
+            selectedProductIDs.append(selected.productID)
+        }
+    }
+
+    func isSelected(model: Product) -> Bool {
+        return isProductSelected(model)
+    }
+
+    func configureCell(cell: ProductsTabProductTableViewCell, model: Product) {
+        cell.selectionStyle = .default
+
+        let viewModel = ProductsTabProductViewModel(product: model, isSelected: isSelected(model: model))
+        cell.update(viewModel: viewModel, imageService: imageService)
+    }
+
+    func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Result<Bool, Error>) -> Void)?) {
+        let action = ProductAction
+            .synchronizeProducts(siteID: siteID,
+                                 pageNumber: pageNumber,
+                                 pageSize: pageSize,
+                                 stockStatus: nil,
+                                 productStatus: nil,
+                                 productType: nil,
+                                 productCategory: nil,
+                                 sortOrder: .nameAscending,
+                                 excludedProductIDs: excludedProductIDs,
+                                 shouldDeleteStoredProductsOnFirstPage: false) { result in
+                                    switch result {
+                                    case .failure(let error):
+                                        DDLogError("⛔️ Error synchronizing products on product list selector: \(error)")
+                                        onCompletion?(.failure(error))
+                                    case .success(let hasNextPage):
+                                        onCompletion?(.success(hasNextPage))
+                                    }
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+}
+
+extension LegacyProductListMultiSelectorDataSource {
+    /// Called when it receives events from adding a list of products (e.g. from search UI).
+    func addProducts(_ productIDs: [Int64]) {
+        selectedProductIDs = (selectedProductIDs + productIDs).removingDuplicates()
+    }
+}
+
+private extension LegacyProductListMultiSelectorDataSource {
+    func isProductSelected(_ product: Product) -> Bool {
+        return selectedProductIDs.contains(product.productID)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/LegacyProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/LegacyProductListSelectorViewController.swift
@@ -19,10 +19,10 @@ final class LegacyProductListSelectorViewController: UIViewController {
     private let siteID: Int64
     private var selectedProductIDsSubscription: AnyCancellable?
 
-    private lazy var dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: excludedProductIDs)
+    private lazy var dataSource = LegacyProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: excludedProductIDs)
 
     private lazy var paginatedListSelector: PaginatedListSelectorViewController
-        <ProductListMultiSelectorDataSource, Product, StorageProduct, ProductsTabProductTableViewCell> = {
+        <LegacyProductListMultiSelectorDataSource, Product, StorageProduct, ProductsTabProductTableViewCell> = {
             let viewProperties = PaginatedListSelectorViewProperties(navigationBarTitle: nil,
                                                                      noResultsPlaceholderText: Localization.noResultsPlaceholder,
                                                                      noResultsPlaceholderImage: .emptyProductsImage,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListMultiSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListMultiSelectorDataSource.swift
@@ -56,6 +56,7 @@ final class ProductListMultiSelectorDataSource: PaginatedListSelectorDataSource 
 
         let viewModel = ProductsTabProductViewModel(product: model, isSelected: isSelected(model: model))
         cell.update(viewModel: viewModel, imageService: imageService)
+        cell.accessoryType = model.variations.isNotEmpty ? .disclosureIndicator : .none
     }
 
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Result<Bool, Error>) -> Void)?) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListMultiSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListMultiSelectorDataSource.swift
@@ -51,7 +51,7 @@ final class ProductListMultiSelectorDataSource: PaginatedListSelectorDataSource 
         return isProductSelected(model)
     }
 
-    func configureCell(cell: ProductsTabProductTableViewCell, model: Product) {
+    func configureCell(cell: ProductListSelectorTableViewCell, model: Product) {
         cell.selectionStyle = .default
 
         let viewModel = ProductsTabProductViewModel(product: model, isSelected: isSelected(model: model))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorTableViewCell.swift
@@ -29,6 +29,13 @@ final class ProductListSelectorTableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureBackground()
+        configureSubviews()
+        configureNameLabel()
+        configureDetailsLabel()
+        configureSkuLabel()
+        configureProductImageView()
+        configureCircleImageView()
 
     }
 
@@ -36,4 +43,115 @@ final class ProductListSelectorTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+}
+
+extension ProductListSelectorTableViewCell {
+    func update(viewModel: ProductsTabProductViewModel, imageService: ImageService) {
+        nameLabel.text = viewModel.createNameLabel()
+        detailsLabel.attributedText = viewModel.detailsAttributedString
+        accessibilityIdentifier = viewModel.createNameLabel()
+
+        productImageView.contentMode = .center
+        if let productURLString = viewModel.imageUrl {
+            imageService.downloadAndCacheImageForImageView(productImageView,
+                                                           with: productURLString,
+                                                           placeholder: .productsTabProductCellPlaceholderImage,
+                                                           progressBlock: nil) { [weak self] (image, error) in
+                                                            let success = image != nil && error == nil
+                                                            if success {
+                                                                self?.productImageView.contentMode = .scaleAspectFill
+                                                            }
+            }
+        }
+
+        // Selected state.
+        let isSelected = viewModel.isSelected
+        if isSelected {
+            circleImageView.image = UIImage.checkCircleImage.applyTintColor(.primary)
+        } else {
+            circleImageView.image = UIImage.checkEmptyCircleImage
+        }
+    }
+}
+
+// MARK: - View configuration
+//
+private extension ProductListSelectorTableViewCell {
+    func configureSubviews() {
+        let contentStackView = createContentStackView()
+        let stackView = UIStackView(arrangedSubviews: [circleImageView, productImageView, contentStackView])
+        stackView.axis = .horizontal
+        stackView.spacing = 16
+        stackView.alignment = .center
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stackView)
+        contentView.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
+    }
+
+    func createContentStackView() -> UIView {
+        let contentStackView = UIStackView(arrangedSubviews: [nameLabel, detailsLabel, skuLabel])
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.axis = .vertical
+        contentStackView.spacing = 4
+        return contentStackView
+    }
+
+    func configureBackground() {
+        backgroundColor = .listForeground
+
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = .listBackground
+    }
+
+    func configureNameLabel() {
+        nameLabel.applyBodyStyle()
+        nameLabel.numberOfLines = 0
+    }
+
+    func configureDetailsLabel() {
+        detailsLabel.numberOfLines = 0
+        detailsLabel.applySubheadlineStyle()
+    }
+
+    func configureSkuLabel() {
+        skuLabel.numberOfLines = 0
+        skuLabel.applySubheadlineStyle()
+    }
+
+    func configureProductImageView() {
+        productImageView.backgroundColor = Colors.imageBackgroundColor
+        productImageView.tintColor = Colors.imagePlaceholderTintColor
+        productImageView.layer.cornerRadius = Constants.productImageCornerRadius
+        productImageView.clipsToBounds = true
+
+        NSLayoutConstraint.activate([
+            productImageView.widthAnchor.constraint(equalToConstant: Constants.productImageSize),
+            productImageView.heightAnchor.constraint(equalToConstant: Constants.productImageSize),
+        ])
+    }
+
+    func configureCircleImageView() {
+        NSLayoutConstraint.activate([
+            circleImageView.widthAnchor.constraint(equalToConstant: Constants.circleImageSize),
+            circleImageView.heightAnchor.constraint(equalToConstant: Constants.circleImageSize),
+        ])
+    }
+}
+
+// MARK: - Constants
+//
+private extension ProductListSelectorTableViewCell {
+    enum Constants {
+        static let productImageCornerRadius: CGFloat = 4.0
+        static let productImageSize: CGFloat = 48
+        static let circleImageSize: CGFloat = 24
+    }
+
+    enum Colors {
+        static let imageBorderColor = UIColor.border
+        static let imagePlaceholderTintColor = UIColor.systemColor(.systemGray2)
+        static let imageBackgroundColor = UIColor.listForeground
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorTableViewCell.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+final class ProductListSelectorTableViewCell: UITableViewCell {
+
+    private lazy var circleImageView: UIImageView = {
+        let image = UIImageView(frame: .zero)
+        return image
+    }()
+
+    private lazy var productImageView: UIImageView = {
+        let image = UIImageView(frame: .zero)
+        return image
+    }()
+
+    private lazy var nameLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        return label
+    }()
+
+    private lazy var detailsLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        return label
+    }()
+
+    private lazy var skuLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorTableViewCell.swift
@@ -48,7 +48,8 @@ final class ProductListSelectorTableViewCell: UITableViewCell {
 extension ProductListSelectorTableViewCell {
     func update(viewModel: ProductsTabProductViewModel, imageService: ImageService) {
         nameLabel.text = viewModel.createNameLabel()
-        detailsLabel.attributedText = viewModel.detailsAttributedString
+        detailsLabel.text = viewModel.detailsString
+        skuLabel.text = viewModel.skuString
         accessibilityIdentifier = viewModel.createNameLabel()
 
         productImageView.contentMode = .center
@@ -93,7 +94,6 @@ private extension ProductListSelectorTableViewCell {
         let contentStackView = UIStackView(arrangedSubviews: [nameLabel, detailsLabel, skuLabel])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
-        contentStackView.spacing = 4
         return contentStackView
     }
 
@@ -113,11 +113,13 @@ private extension ProductListSelectorTableViewCell {
     func configureDetailsLabel() {
         detailsLabel.numberOfLines = 0
         detailsLabel.applySubheadlineStyle()
+        detailsLabel.textColor = .secondaryLabel
     }
 
     func configureSkuLabel() {
         skuLabel.numberOfLines = 0
         skuLabel.applySubheadlineStyle()
+        skuLabel.textColor = .secondaryLabel
     }
 
     func configureProductImageView() {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductListSelector/ProductListSelectorViewController.swift
@@ -23,7 +23,7 @@ final class ProductListSelectorViewController: UIViewController {
     private lazy var dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: excludedProductIDs)
 
     private lazy var paginatedListSelector: PaginatedListSelectorViewController
-        <ProductListMultiSelectorDataSource, Product, StorageProduct, ProductsTabProductTableViewCell> = {
+        <ProductListMultiSelectorDataSource, Product, StorageProduct, ProductListSelectorTableViewCell> = {
             let viewProperties = PaginatedListSelectorViewProperties(navigationBarTitle: nil,
                                                                      noResultsPlaceholderText: Localization.noResultsPlaceholder,
                                                                      noResultsPlaceholderImage: .emptyProductsImage,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
@@ -11,6 +11,8 @@ extension ProductsTabProductViewModel {
         imageService = ServiceLocator.imageService
         isSelected = false
         isDraggable = false
+        detailsString = productVariationModel.createDetailsString(currencySettings: currencySettings)
+        skuString = productVariationModel.createSKUString()
     }
 }
 
@@ -66,6 +68,26 @@ private extension EditableProductVariationModel {
     func createPriceText(currency: String, currencySettings: CurrencySettings) -> String {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         return currencyFormatter.formatAmount(productVariation.price, with: currency) ?? ""
+    }
+
+    func createDetailsString(currencySettings: CurrencySettings) -> String {
+        let currencyCode = currencySettings.currencyCode
+        let currency = currencySettings.symbol(from: currencyCode)
+        let stockText = createStockText()
+        let priceText = createPriceText(currency: currency, currencySettings: currencySettings)
+
+        return [stockText, priceText]
+            .compactMap({ $0 })
+            .joined(separator: " • ")
+    }
+
+    func createSKUString() -> String? {
+        if let sku = sku, sku.isNotEmpty {
+            let format = NSLocalizedString("SKU: %1$@", comment: "SKU number for a product, reads like: SKU: 32425")
+            return String.localizedStringWithFormat(format, sku)
+        } else {
+            return nil
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1512,6 +1512,7 @@
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE001322279A793A00EB0350 /* CouponWooTests.swift */; };
 		DE0C96A22806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0C96A12806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift */; };
+		DE0C96A42806A192003B28EE /* ProductListSelectorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0C96A32806A192003B28EE /* ProductListSelectorTableViewCell.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -3222,6 +3223,7 @@
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE001322279A793A00EB0350 /* CouponWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponWooTests.swift; sourceTree = "<group>"; };
 		DE0C96A12806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyProductListMultiSelectorDataSource.swift; sourceTree = "<group>"; };
+		DE0C96A32806A192003B28EE /* ProductListSelectorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorTableViewCell.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -7687,6 +7689,7 @@
 			isa = PBXGroup;
 			children = (
 				DEE4BBCB27FED9EF0002C818 /* ProductListSelectorViewController.swift */,
+				DE0C96A32806A192003B28EE /* ProductListSelectorTableViewCell.swift */,
 				021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */,
 				0273707F24C0094500167204 /* ProductListMultiSelectorDataSource.swift */,
 				023D1DD024AB2D05002B03A3 /* LegacyProductListSelectorViewController.swift */,
@@ -8683,6 +8686,7 @@
 				B5A8F8AD20B88D9900D211DE /* LoginPrologueViewController.swift in Sources */,
 				B5D1AFC620BC7B7300DB0E8C /* StorePickerViewController.swift in Sources */,
 				02DD81FB242CAA400060E50B /* WordPressMediaLibraryPickerDataSource.swift in Sources */,
+				DE0C96A42806A192003B28EE /* ProductListSelectorTableViewCell.swift in Sources */,
 				0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */,
 				31579028273EE2B1008CA3AF /* VersionHelpers.swift in Sources */,
 				CCD2F51C26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1511,6 +1511,7 @@
 		D8F01DD325DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE001322279A793A00EB0350 /* CouponWooTests.swift */; };
+		DE0C96A22806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0C96A12806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -3220,6 +3221,7 @@
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE001322279A793A00EB0350 /* CouponWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponWooTests.swift; sourceTree = "<group>"; };
+		DE0C96A12806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyProductListMultiSelectorDataSource.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -7686,8 +7688,9 @@
 			children = (
 				DEE4BBCB27FED9EF0002C818 /* ProductListSelectorViewController.swift */,
 				021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */,
-				023D1DD024AB2D05002B03A3 /* LegacyProductListSelectorViewController.swift */,
 				0273707F24C0094500167204 /* ProductListMultiSelectorDataSource.swift */,
+				023D1DD024AB2D05002B03A3 /* LegacyProductListSelectorViewController.swift */,
+				DE0C96A12806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift */,
 			);
 			path = ProductListSelector;
 			sourceTree = "<group>";
@@ -8861,6 +8864,7 @@
 				2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				02AB407C27827C9100929CF3 /* ChartPlaceholderView.swift in Sources */,
+				DE0C96A22806A057003B28EE /* LegacyProductListMultiSelectorDataSource.swift in Sources */,
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,
 				CC254F3226C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift in Sources */,
 				0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -93,16 +93,42 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         XCTAssertTrue(detailsText.contains(expectedStockDetail))
     }
 
+    func test_skuString_is_not_nil_when_product_has_sku() throws {
+        // Given
+        let product = productMock(sku: "1324")
+
+        // When
+        let viewModel = ProductsTabProductViewModel(product: product)
+
+        // Then
+        let expectedSKU = String.localizedStringWithFormat(NSLocalizedString("SKU: %1$@", comment: ""), try XCTUnwrap(product.sku))
+        XCTAssertEqual(viewModel.skuString, expectedSKU)
+    }
+
+    func test_detailsString_contains_product_price_if_price_is_not_empty() {
+        // Given
+        let product = productMock(price: "10.00")
+
+        // When
+        let viewModel = ProductsTabProductViewModel(product: product)
+
+        // Then
+        XCTAssertTrue(viewModel.detailsString.contains(product.price))
+    }
 }
 
 extension ProductsTabProductViewModelTests {
     func productMock(name: String = "Hogsmeade",
+                     price: String = "",
                      stockQuantity: Decimal? = nil,
                      stockStatus: ProductStockStatus = .inStock,
                      variations: [Int64] = [],
-                     images: [ProductImage] = []) -> Product {
+                     images: [ProductImage] = [],
+                     sku: String? = nil) -> Product {
 
         return Product.fake().copy(name: name,
+                                   sku: sku,
+                                   price: price,
                                    stockQuantity: stockQuantity,
                                    stockStatusKey: stockStatus.rawValue,
                                    images: images,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6489 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the look of the cells on the new product selection screen. Changes include:
- Duplicate `ProductListMultiSelectorDataSource` for the new update.
- Add a new cell type `ProductListSelectorTableViewCell` to be used in the new data source.
- Update `ProductsTabProductViewModel` with new fields to be used in `ProductListSelectorTableViewCell`. I found that this option is better than creating a new view model since we want to reuse most of the logic in the existing view model. Let me know if there's a better solution, thanks!

In the next PR, I'll handle the navigation to the product variation selector when selecting a variable product.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Since the product selector screen hasn't got an entry point from the coupons flow, let's test the linked product flow instead.
With the `couponEdit` feature flag on:

- Navigate to the Products tab > select a Product > Add more details > Linked products > Add Products > Add Products.
- Notice that the UI for the cells on the product selection screen match the new design.

With the couponEdit feature flag on: repeat the first step above and notice that the product selector view stay the same as before.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/163153125-547812ad-5fba-4e2a-988d-01359b76057c.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
