### PR TITLE
Accessibility: Improve VoiceOver accessibility for top banner button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Share payment links from the order details screen. [https://github.com/woocommerce/woocommerce-ios/pull/6609]
 - [internal] Reviews lists on Products and Menu tabs are refactored to avoid duplicated code. Please quickly smoke test them to make sure that everything still works as before. [https://github.com/woocommerce/woocommerce-ios/pull/6553]
 - [**] Now it's possible to change the order of the product images. [https://github.com/woocommerce/woocommerce-ios/pull/6620]
+- [*] Improved accessibility for the error banner and info banner displayed in Orders and Products. [https://github.com/woocommerce/woocommerce-ios/pull/6633]
 
 8.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -44,6 +44,12 @@ final class TopBannerView: UIView {
         return stackView
     }()
 
+    private let titleStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        return stackView
+    }()
+
     // StackView to hold the action buttons. Needed to change the axis on larger accessibility traits
     private let buttonsStackView = UIStackView()
 
@@ -126,6 +132,7 @@ private extension TopBannerView {
             dismissButton.setImage(UIImage.gridicon(.cross, size: CGSize(width: 24, height: 24)), for: .normal)
             dismissButton.tintColor = .textSubtle
             dismissButton.addTarget(self, action: #selector(onDismissButtonTapped), for: .touchUpInside)
+            titleStackView.accessibilityHint = Localization.dismissHint
 
         case .none:
             break
@@ -162,9 +169,12 @@ private extension TopBannerView {
 
     func createInformationStackView(with viewModel: TopBannerViewModel) -> UIStackView {
         let topActionButton = topButton(for: viewModel.topButton)
-        let titleStackView = UIStackView(arrangedSubviews: [titleLabel, topActionButton].compactMap { $0 })
-        titleStackView.axis = .horizontal
+        titleStackView.addArrangedSubviews([titleLabel, topActionButton].compactMap { $0 })
         titleStackView.spacing = 16
+        titleStackView.isAccessibilityElement = true
+        titleStackView.accessibilityTraits = .button
+        titleStackView.accessibilityLabel = viewModel.title
+        titleStackView.accessibilityIdentifier = topActionButton?.accessibilityIdentifier
 
         // titleStackView will hidden if there is no title
         titleStackView.isHidden = viewModel.title == nil || viewModel.title?.isEmpty == true
@@ -287,8 +297,22 @@ private extension TopBannerView {
         if isActionEnabled {
             actionStackView.isHidden = !isExpanded
         }
+        titleStackView.accessibilityHint = isExpanded ? Localization.collapseHint : Localization.expandHint
+        titleStackView.accessibilityValue = isExpanded ? Localization.expanded : Localization.collapsed
 
         let accessibleView = isExpanded ? infoLabel : nil
         UIAccessibility.post(notification: .layoutChanged, argument: accessibleView)
+    }
+}
+
+// MARK: Constants
+//
+private extension TopBannerView {
+    enum Localization {
+        static let expanded = NSLocalizedString("Expanded", comment: "Accessibility value when a banner is expanded")
+        static let collapsed = NSLocalizedString("Collapsed", comment: "Accessibility value when a banner is collapsed")
+        static let expandHint = NSLocalizedString("Double-tap for more information", comment: "Accessibility hint to expand a banner")
+        static let collapseHint = NSLocalizedString("Double-tap to collapse", comment: "Accessibility hint to collapse a banner")
+        static let dismissHint = NSLocalizedString("Double-tap to dismiss", comment: "Accessibility hint to dismiss a banner")
     }
 }


### PR DESCRIPTION
Closes: #6593

## Description

The top banner previously read the banner title and button separately, with no label for the button.

Now, the title and button are combined into a single accessibility element with a label, value, and hint:

* The label is the banner title.
* The hint depends on the button type: one hint for a dismiss button, one of two possible hints for the chevron button depending on whether the banner is expanded or collapsed.
* If the button is a chevron, there is an accessibility value depending on the banner state (expanded/collapsed).

## Changes

* Adds a `titleStackView` constant and makes that an accessibility element (instead of separate elements for its subviews).
* Sets the accessibility label for `titleStackView` as the title (from the view model).
* Sets the accessibility identifier for `titleStackView` as the button's accessibility identifier (for UI tests).
* Sets the accessibility hint and value for `titleStackView` when configuring the button. This makes sure the hint and value depend on the button type and are updated when the button is updated (i.e. when the banner is expanded/collapsed).

## Testing

1. If testing on a device, enable VoiceOver. If testing in a simulator, open the Accessibility Inspector.
2. In the app, go to a tab with the top banner (e.g. Orders or Products).
3. Check that the collapsed top banner has a single accessibility element, for example on the Orders tab: "Create orders an take payments!, Collapsed, Button, Double-tap for more information"
4. Expand the banner and confirm the value/hint change.

## Screenshots

Before|After
-|-
![IMG_9307](https://user-images.githubusercontent.com/8658164/163222639-c3d848c0-de7b-425e-bec5-2fa644f434a3.PNG)|![IMG_9301](https://user-images.githubusercontent.com/8658164/163222645-36664d49-04b9-45f2-9b7e-4a063b425f5a.PNG)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
