### PR TITLE
Hub Menu: Add accessibility label to Settings button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -178,6 +178,7 @@ struct HubMenu: View {
                             }
                         }
                     }
+                    .accessibilityLabel(Localization.settings)
                     .accessibilityIdentifier("dashboard-settings-button")
                     Spacer()
                 }
@@ -206,6 +207,7 @@ struct HubMenu: View {
     private enum Localization {
         static let switchStore = NSLocalizedString("Switch store",
                                                    comment: "Switch store option in the hub menu")
+        static let settings = NSLocalizedString("Settings", comment: "Settings button in the hub menu")
     }
 }
 


### PR DESCRIPTION
Closes: #6595

## Description

Adds an accessibility label to the Settings (cog icon) button in the Hub menu.

## Testing

1. If testing on a device, enable VoiceOver. If testing in a simulator, open the Accessibility Inspector.
2. In the app, go to the Menu tab.
3. Check that the Settings button has the label "Settings".

## Screenshots

Before|After
-|-
![Settings button before](https://user-images.githubusercontent.com/8658164/163228500-243690e6-cf41-459a-b7f1-89a22899eba0.PNG)|![Settings button after](https://user-images.githubusercontent.com/8658164/163228513-22e8f24d-39d4-485f-a12e-02810d448ea6.PNG)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
