### PR TITLE
Accessibility: Add accessibility label for the X close button

### DIFF
--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -30,6 +30,7 @@ extension UIViewController {
         }
         else {
             navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: target, action: action)
+            navigationItem.leftBarButtonItem?.accessibilityLabel = Localization.close
         }
     }
 
@@ -43,5 +44,12 @@ private extension UIViewController {
     ///
     @objc func dismissVC() {
         dismiss(animated: true, completion: nil)
+    }
+}
+
+// MARK: Constants
+private extension UIViewController {
+    enum Localization {
+        static let close = NSLocalizedString("Close", comment: "Accessibility label for the close button")
     }
 }


### PR DESCRIPTION
Closes: #6596

## Description

Adds a "Close" accessibility label for the "X" close button, which is used in various places in the app such as the feedback survey modal.

## Changes

In our `UIViewController` extension `addCloseNavigationBarButton()`, sets the "Close" accessibility label on the left navigation bar button when the button is set as the "X" image (when there isn't a label provided for the button).

## Testing

1. If testing on a device, enable VoiceOver. If testing in a simulator, open the Accessibility Inspector.
2. In the app, go to the Menu tab.
3. Open the app settings (the cog icon in the top right).
4. Select "Send Feedback."
5. Confirm the close button (the "X" icon in the top left) has the label "Close."

## Screenshots

Before|After
-|-
![Close button before](https://user-images.githubusercontent.com/8658164/163237101-1c554809-27ca-45fc-89ca-33c1e1174062.PNG)|![Close button after](https://user-images.githubusercontent.com/8658164/163237110-0fce2011-21e8-4bce-a9a5-b16d620ac6a2.PNG)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
