### PR TITLE
[Mobile Payments] Remove prompt to `Remove card` when starting refund

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -481,13 +481,7 @@ private extension StripeCardReaderService {
 // MARK: - Refunds
 extension StripeCardReaderService {
     public func refundPayment(parameters: RefundParameters) -> AnyPublisher<String, Error> {
-        if isChipCardInserted {
-            sendReaderEvent(CardReaderEvent.make(displayMessage: .removeCard))
-        }
-        return waitForInsertedCardToBeRemoved()
-            .flatMap {
-                self.createRefundParameters(parameters: parameters)
-            }
+        return createRefundParameters(parameters: parameters)
             .flatMap { refundParameters in
                 self.refund(refundParameters)
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6461
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Based on the payment flow, client-side refunds were implemented with a requirement to remove the card if one were inserted at the start of the refund transaction. This had not been checked as a requirement.

This PR removes the prompt to remove the card, if one is present, at the start of the client-side refund flow.

The refund flow works well even when the customer puts their card in too early. A new transaction won’t be permitted by the reader if it’s not taken out after the last one, so there’s low risk that the refund will be done to a previous customer’s card.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Using a store set up for In-person payments in Canada, add an order or simple payment 
2. Take payment with an Interac card inserted, removing the card when prompted at the end of the flow
3. Insert the same card again
4. Refund the transaction
5. Observe that the refund continues without prompting you to remove your card until the end.


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
