### PR TITLE
Products: Add dynamic type support to product tags field

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -131,6 +131,7 @@ private extension ProductTagsViewController {
         textView.autocorrectionType = .yes
         textView.autocapitalizationType = .none
         textView.font = .body
+        textView.adjustsFontForContentSizeCategory = true
         textView.textColor = .text
         textView.isScrollEnabled = false
         // Padding already provided by readable margins


### PR DESCRIPTION
Closes: #6598

## Description

Adds support for dynamic type to the text view used to add tags to a product.

## Testing

1. Go to the Products tab.
2. Select or add a product.
3. Edit the product tags (you can select "Add more details" > "Tags" if the product doesn't have any tags yet).
4. While on the Tags screen, increase the device font size and confirm the text resizes accordingly, including the text in the input text field.

## Screenshots

Before|After
-|-
![Tags-LargeFont-Before](https://user-images.githubusercontent.com/8658164/163244430-a81c0c0f-446f-4b0f-a4d6-96ee43272e1e.PNG)|![Tags-LargeFont-After](https://user-images.githubusercontent.com/8658164/163244443-789d8797-43ba-449a-9114-c9f4e5350001.PNG)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
