### PR TITLE
Remove stats API workaround for stale data

### DIFF
--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -21,14 +21,10 @@ public final class OrderStatsRemoteV4: Remote {
                                completion: @escaping (Result<OrderStatsV4, Error>) -> Void) {
         let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
 
-        // Workaround for #1183: random number between 31-100 for `num_page` param.
-        // Replace `randomQuantity` with `quantity` in `num_page` param when API issue is fixed.
-        let randomQuantity = arc4random_uniform(70) + 31
-
         let parameters = [ParameterKeys.interval: unit.rawValue,
                           ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
                           ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
-                          ParameterKeys.quantity: String(randomQuantity)]
+                          ParameterKeys.quantity: String(quantity)]
 
         let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.orderStatsPath, parameters: parameters)
         let mapper = OrderStatsV4Mapper(siteID: siteID, granularity: unit)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #1183
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Before WC Admin version 0.20.0 about 2 years ago, there was an issue in the stats API where the data stay the same for the same request URL for a long time. That's why we put in a workaround to set `per_page` parameter to a random number so that the request URL is different every time to refresh the data. This issue was fixed in WC Admin version 0.20.0, but it took a while for stores to adopt the newer version. Two years later, I checked the WC Admin version data as of Jan 2022 and saw that only ~6% of the stores are using WC Admin version lower than version 0.20.0 with the fix. This PR then deletes this API workaround.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Create an order either on the website or in the app, make sure the order is paid (orders with pending payment status don't seem to be counted in the stats)
- After a bit, pull down to refresh the stats in the My store tab --> the stats data should now include the newly created order. sometimes it took a minute or two for me to see the updated data


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
