### PR TITLE
Order Creation: Allow shipping with zero amount

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
@@ -52,7 +52,7 @@ class ShippingLineDetailsViewModel: ObservableObject {
     /// Returns true when there are no valid pending changes.
     ///
     var shouldDisableDoneButton: Bool {
-        guard let amountDecimal = priceFieldFormatter.amountDecimal, amountDecimal != .zero else {
+        guard let amountDecimal = priceFieldFormatter.amountDecimal, amountDecimal >= .zero else {
             return true
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
@@ -21,7 +21,7 @@ class ShippingLineDetailsViewModel: ObservableObject {
 
     /// Placeholder for amount text field
     ///
-    let amountPlaceholder: String
+    let amountPlaceholder: String = "0"
 
     /// Stores the amount entered by the merchant.
     ///
@@ -36,7 +36,7 @@ class ShippingLineDetailsViewModel: ObservableObject {
     ///
     @Published var methodTitle: String
 
-    private let initialAmount: Decimal
+    private let initialAmount: Decimal?
     private let initialMethodTitle: String
 
     /// Returns true when existing shipping line is edited.
@@ -52,7 +52,7 @@ class ShippingLineDetailsViewModel: ObservableObject {
     /// Returns true when there are no valid pending changes.
     ///
     var shouldDisableDoneButton: Bool {
-        guard let amountDecimal = priceFieldFormatter.amountDecimal, amountDecimal >= .zero else {
+        guard let amountDecimal = priceFieldFormatter.amountDecimal else {
             return true
         }
 
@@ -71,7 +71,6 @@ class ShippingLineDetailsViewModel: ObservableObject {
         self.priceFieldFormatter = .init(locale: locale, storeCurrencySettings: storeCurrencySettings, allowNegativeNumber: true)
         self.currencySymbol = storeCurrencySettings.symbol(from: storeCurrencySettings.currencyCode)
         self.currencyPosition = storeCurrencySettings.currencyPosition
-        self.amountPlaceholder = priceFieldFormatter.formatAmount("0")
 
         self.isExistingShippingLine = isExistingShippingLine
         self.initialMethodTitle = initialMethodTitle
@@ -81,10 +80,10 @@ class ShippingLineDetailsViewModel: ObservableObject {
         if let initialAmount = currencyFormatter.convertToDecimal(from: shippingTotal) {
             self.initialAmount = initialAmount as Decimal
         } else {
-            self.initialAmount = .zero
+            self.initialAmount = nil
         }
 
-        if initialAmount != .zero, let formattedInputAmount = currencyFormatter.formatAmount(initialAmount) {
+        if let initialAmount = initialAmount, let formattedInputAmount = currencyFormatter.formatAmount(initialAmount) {
             self.amount = priceFieldFormatter.formatAmount(formattedInputAmount)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
@@ -158,9 +158,9 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
         // When
         viewModel.amount = "$11.30"
         viewModel.methodTitle = "Flat Rate"
+        viewModel.saveData()
 
         // Then
-        viewModel.saveData()
         XCTAssertEqual(savedShippingLine?.total, "11.30")
         XCTAssertEqual(savedShippingLine?.methodTitle, "Flat Rate")
     }
@@ -180,11 +180,32 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
         // When
         viewModel.amount = "-11.30"
         viewModel.methodTitle = "Flat Rate"
+        viewModel.saveData()
 
         // Then
-        viewModel.saveData()
         XCTAssertEqual(savedShippingLine?.total, "-11.30")
         XCTAssertEqual(savedShippingLine?.methodTitle, "Flat Rate")
+    }
+
+    func test_view_model_allows_saving_zero_amount_and_creates_correct_shippping_line() {
+        // Given
+        var savedShippingLine: ShippingLine?
+        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { newShippingLine in
+            savedShippingLine = newShippingLine
+        })
+
+        // When
+        viewModel.amount = "0"
+        viewModel.saveData()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisableDoneButton)
+        XCTAssertEqual(savedShippingLine?.total, "0")
     }
 
     func test_view_model_creates_shippping_line_with_placeholder_for_method_title() {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6649.

## Description

This PR updates Shipping Line Details screen to allow creating shipping line with zero amount.

## Changes
- Updates done button logic in `ShippingLineDetailsViewModel` to allow zero amount.

## Testing

1. Go to the Orders tab and create a new order.
2. Select "Add Shipping"
3. Keep zero amount for shipping price but enter custom shipping method name.
4. Tap "Done" to save shipping line and "Create" to create the order.
5. On order details confirm that there is zero value for shipping amount and custom title for shipping method.

## Screenshots

order creation|order details
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/163398571-212834c4-f85f-4f51-a1c2-732ed418b734.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/163398584-7d899605-72c8-44e7-9338-c0cbe1deef9b.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
