### PR TITLE
Order Creation: Update fee line button title to "Add Fee"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -78,7 +78,7 @@ struct OrderPaymentSection: View {
                 shouldShowFeeLineDetails = true
             }
         } else {
-            Button(Localization.addFees) {
+            Button(Localization.addFee) {
                 shouldShowFeeLineDetails = true
             }
             .buttonStyle(PlusButtonStyle())
@@ -95,7 +95,7 @@ private extension OrderPaymentSection {
         static let orderTotal = NSLocalizedString("Order Total", comment: "Label for the the row showing the total cost of the order")
         static let addShipping = NSLocalizedString("Add Shipping", comment: "Title text of the button that adds shipping line when creating a new order")
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
-        static let addFees = NSLocalizedString("Add Fees", comment: "Title text of the button that adds fees when creating a new order")
+        static let addFee = NSLocalizedString("Add Fee", comment: "Title text of the button that adds a fee when creating a new order")
         static let feesTotal = NSLocalizedString("Fees", comment: "Label for the row showing the cost of fees in the order")
         static let taxesTotal = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
     }


### PR DESCRIPTION
Closes: #6648

## Description/Changes

This updates the fee line button in order creation to say "Add Fee" (instead of "Add Fees"), matching Android and aligning with the behavior, since you can only add one fee to a new order at this point.

## Testing

1. Go to the Orders tab.
2. Tap the + icon and create a new order.
3. Confirm the Payment section has the expected "Add Fee" button.

## Screenshots

<img src="https://user-images.githubusercontent.com/8658164/163426438-7fc24c90-0036-465d-8fb3-c67029ce6024.png" width="300px">


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
