### PR TITLE
[Mobile Payments] Allow retries of failed interac refunds

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -518,10 +518,12 @@ extension StripeCardReaderService {
         return Future() { [weak self] promise in
             self?.refundCancellable = Terminal.shared.collectRefundPaymentMethod(parameters) { collectError in
                 if let error = collectError {
+                    self?.refundCancellable = nil
                     promise(.failure(CardReaderServiceError.refundPayment(underlyingError: UnderlyingError(with: error))))
                 } else {
                     // Process refund
                     Terminal.shared.processRefund { processedRefund, processError in
+                        self?.refundCancellable = nil
                         if let error = processError {
                             promise(.failure(CardReaderServiceError.refundPayment(underlyingError: UnderlyingError(with: error))))
                         } else if let refund = processedRefund {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6643 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When an interac refund fails, we show an error with a “Try again” button.

When the user taps that, we attempt to cancel the Interac refund “intent” using the `refundCancelable` that Stripe Terminal gives us in response to `SCPTerminal.collectRefundPaymentMethod()`

When there’s been a failure or error in the refund, the `refundCancelable` that Stripe gave us ends up in an unexpected situation: it’s not `completed`, but it also doesn’t call back the completion handler when we call `cancel`. This meant that our previous “Try again” handler did not start the new refund attempt.

Cancelling a refund after Stripe have called the completion handler from `processRefund`, or given us an error from `collectRefundPaymentMethod`, shouldn’t be required: those calls from Stripe have already told us that the original refund attempt is complete (even if failed), so we can’t cancel it anyway.

This change sets the `refundCancelable` to nil when Stripe have told us that the refund is complete, resulting in a `noRefundInProgress` error being returned to the `handleRefundFailureAndRetryRefund` handler. We don’t need to worry about this error or whether the cancellation was successful: in either case, we should try the refund again.

This change does not address that some refund errors should not be retriable: that will follow in future work.

N.B. the creation of `alerts` in `RefundSubmissionUseCase` is moved to `init`, because doing it in the refund retry attempt (for a second time) results in an error when we try to present the view controller container modally again without dismissing the one with the error in it. Moving the creation avoids the need to dismiss, and that keeps the visual flow consistent.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. Make an order for a product, with shipping cost ending in .01, and a fee ending in .99 so that we can take payment
2. Take IPP payment with an interac card
3. Refund the shipping only
4. Observe that the refund fails
5. Tap "Try again" on the error alert
6. Observe that the refund is retried



### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/163441454-f35c40fe-a04c-42c9-88ce-98e2c0eefde3.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
