### PR TITLE
Order Creation: Add proposed order creation UI test coverage to docs

### DIFF
--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -25,6 +25,13 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] Update order status
     - [ ] Issue refund
     - [ ] Add shipping details
+    - Create a new order:
+       - [x] With a selected order status
+       - [ ] With a product
+       - [ ] With customer details
+       - [ ] With shipping
+       - [ ] With a fee
+       - [ ] With a customer note
 4. [Products](../WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift)
     - [x] Products list and single product screens load
     - [ ] Add new product - Simple physical product


### PR DESCRIPTION
Related: #6524

## Description

Updates the UI tests documentation to include order creation in the proposed/planned UI test coverage.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
