### PR TITLE
Order Creation: Make `+ Add ...` rows tappable on full width

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -217,9 +217,9 @@ private struct PlusButton: View {
             } icon: {
                 Image(uiImage: .plusImage)
             }
-            Spacer()
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
         .foregroundColor(Color(foregroundColor))
         .background(Color(.clear))
     }


### PR DESCRIPTION
Closes: #6614

## Description

While selecting any `+ Add (...)` button on the New Order screen during order creation, only the text was tappable. This PR makes the full row (including the empty space to the right) tappable.

## Changes

* Adds the `.contentShape(Rectangle())` modifier to the `PlusButton` button style.
* Also updated this button style to set the `.leading` alignment in the `.frame` modifier, instead of using a `Spacer` view. This doesn't change the behavior.

## Testing

* Go to the Orders tab and create a new order.
* On the New Order screen, tap each `+ Add ...` button and confirm it responds no matter where on the row you tap (including in the empty space to the right of the button text).

## Screenshots

<img src="https://user-images.githubusercontent.com/8658164/164053169-c561bc74-b9b2-4a22-94d1-96e1b1c531b7.png" width="300px">


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
