### PR TITLE
Update card reader purchase URL

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -132,7 +132,7 @@ private extension InPersonPaymentsMenuViewController {
 //
 extension InPersonPaymentsMenuViewController {
     func orderCardReaderWasPressed() {
-        WebviewHelper.launch(configurationLoader.configuration.purchaseCardReaderUrl(for: plugin), with: self)
+        WebviewHelper.launch(configurationLoader.configuration.purchaseCardReaderUrl(), with: self)
     }
 
     func manageCardReaderWasPressed() {
@@ -147,7 +147,7 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func bbposChipper2XBTManualWasPressed() {
-            WebviewHelper.launch(Constants.bbposChipper2XBTManualURL, with: self)
+        WebviewHelper.launch(Constants.bbposChipper2XBTManualURL, with: self)
     }
 
     func stripeM2ManualWasPressed() {

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -59,26 +59,14 @@ public struct CardPresentPaymentsConfiguration {
         paymentMethods.isEmpty == false && currencies.isEmpty == false && paymentGateways.isEmpty == false && supportedReaders.isEmpty == false
     }
 
-    /// Given a two character country code and the active plugin, returns a URL
-    /// where the merchant can purchase a card reader
+    /// Given a two character country code, returns a URL where the merchant can purchase a card reader.
     ///
-    public func purchaseCardReaderUrl(for plugin: CardPresentPaymentsPlugins) -> URL {
-        if case .stripe = plugin {
-            return Constants.stripeReaderPurchaseUrl
-        }
-
-        // TODO when https://woocommerce.com/products/hardware/US and
-        // https://woocommerce.com/products/hardware/CA are live, return the
-        // following instead
-        // URL(string: Constants.purchaseReaderForCountryUrlBase + self.countryCode) ?? Constants.fallbackInPersonPaymentsUrl
-
-        return Constants.purchaseM2ReaderUrl
+    public func purchaseCardReaderUrl() -> URL {
+        URL(string: Constants.purchaseReaderForCountryUrlBase + countryCode) ?? Constants.fallbackInPersonPaymentsUrl
     }
 }
 
 private enum Constants {
-    static let purchaseM2ReaderUrl = URL(string: "https://woocommerce.com/products/m2-card-reader/")!
     static let fallbackInPersonPaymentsUrl = URL(string: "https://woocommerce.com/in-person-payments/")!
     static let purchaseReaderForCountryUrlBase = "https://woocommerce.com/products/hardware/"
-    static let stripeReaderPurchaseUrl = URL(string: "https://stripe.com/terminal/stripe-reader")!
 }

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -10,8 +10,7 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [.USD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl().absoluteString, Constants.PurchaseURL.us)
     }
 
     func test_configuration_for_US_with_Canada_disabled() throws {
@@ -20,8 +19,7 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [.USD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl().absoluteString, Constants.PurchaseURL.us)
     }
 
     // MARK: - Canada Tests
@@ -31,15 +29,13 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.currencies, [.CAD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl().absoluteString, Constants.PurchaseURL.ca)
     }
 
     func test_configuration_for_Canada_with_Canada_disabled() {
         let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: false)
         XCTAssertFalse(configuration.isSupportedCountry)
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .wcPay).absoluteString, Constants.PurchaseURL.wcpay)
-        XCTAssertEqual(configuration.purchaseCardReaderUrl(for: .stripe).absoluteString, Constants.PurchaseURL.stripe)
+        XCTAssertEqual(configuration.purchaseCardReaderUrl().absoluteString, Constants.PurchaseURL.ca)
     }
 
     private enum Constants {
@@ -50,18 +46,10 @@ class CardPresentConfigurationTests: XCTestCase {
         }
 
         enum PurchaseURL {
-            /// This is the older URL format for ordering card  readers for WCPay stores
+            /// The URL format directs users to a country specific page
             ///
-            static let wcpay = "https://woocommerce.com/products/m2-card-reader/"
-
-            /// The new URL format (behind feature flag at the moment) directs users to a country specific page
-            ///
-            static let wcpayUS = "https://woocommerce.com/products/hardware/US"
-            static let wcpayCA = "https://woocommerce.com/products/hardware/CA"
-
-            /// Merchants using the Stripe extension should order their readers from Stripe directly
-            ///
-            static let stripe = "https://stripe.com/terminal/stripe-reader"
+            static let us = "https://woocommerce.com/products/hardware/US"
+            static let ca = "https://woocommerce.com/products/hardware/CA"
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6330 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Now that the [hardware URL for US stores](https://woocommerce.com/products/hardware/US) has been set up, we are going to follow the same URL patterns when we launch in other countries. This PR updated the card reader purchase URL to be `https://woocommerce.com/products/hardware/` appended by the country code from card-present configuration.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: having a store in the US and Canada eligible for IPP

- Switch to a US store that is eligible for IPP
- Go to the menu tab
- Tap the settings icon
- Tap on "In-Person Payments"
- Tap on "Order card reader" --> it should open `https://woocommerce.com/products/hardware/US` with a CTA to buy a Stripe M2 reader after scrolling
- Switch to a CA store that is eligible for IPP and repeat the steps above --> it should open `https://woocommerce.com/products/hardware/CA` which currently redirects to woocommerce.com

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

The US link looks like:

<img src="https://user-images.githubusercontent.com/1945542/164153526-2918b6f8-345a-44f8-86c2-3dd99bf52b24.png" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
