### PR TITLE
Update UI test coverage documentation formatting

### DIFF
--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -6,7 +6,7 @@ WooCommerce for iOS has UI acceptance tests for critical user flows through the 
 
 The following flows are covered/planned to be covered by UI tests. Tests that are covered will be checked.
 
-1. [Login](../WooCommerce/WooCommerceUITests/Tests/LoginTests.swift):
+1. [Login](../WooCommerce/WooCommerceUITests/Tests/LoginTests.swift)
     - [x] Log in with Store Address
     - [x] Log in with email/password
     - [x] Invalid password
@@ -17,21 +17,23 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] Stats Today, This Week, This Month, This Year load
     - [ ] Tap chart on stats
 3. [Orders](../WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift)
-    - [x] Orders list and single order screens load
-    - [x] Dismissal of order creation flow when tapping the Close button
-    - [ ] View product on single order screen
-    - [ ] Add customer note
-    - [ ] Add order note
-    - [ ] Update order status
-    - [ ] Issue refund
-    - [ ] Add shipping details
-    - Create a new order:
-       - [x] With a selected order status
-       - [ ] With a product
-       - [ ] With customer details
-       - [ ] With shipping
-       - [ ] With a fee
-       - [ ] With a customer note
+   - [x] Orders list loads
+   - [ ] Single Order Screen:
+     - [x] Single order screen loads
+     - [x] Dismissal of order creation flow when tapping the Close button
+     - [ ] View product on single order screen
+     - [ ] Add customer note
+     - [ ] Add order note
+     - [ ] Update order status
+     - [ ] Issue refund
+     - [ ] Add shipping details
+   - [ ] Create a new order:
+     - [x] With a selected order status
+     - [ ] With a product
+     - [ ] With customer details
+     - [ ] With shipping
+     - [ ] With a fee
+     - [ ] With a customer note
 4. [Products](../WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift)
     - [x] Products list and single product screens load
     - [ ] Add new product - Simple physical product

--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -20,7 +20,6 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
    - [x] Orders list loads
    - [ ] Single Order Screen:
      - [x] Single order screen loads
-     - [x] Dismissal of order creation flow when tapping the Close button
      - [ ] View product on single order screen
      - [ ] Add customer note
      - [ ] Add order note
@@ -34,6 +33,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
      - [ ] With shipping
      - [ ] With a fee
      - [ ] With a customer note
+   - [x] Order Creation flow can be dismissed
 4. [Products](../WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift)
     - [x] Products list and single product screens load
     - [ ] Add new product - Simple physical product


### PR DESCRIPTION
Related: #6524
Followup to https://github.com/woocommerce/woocommerce-ios/pull/6668

## Description

Updates the UI tests documentation formatting to indent items under Single Order Screen and New Order

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
