### PR TITLE
Updated Order banner text

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTopBannerFactory.swift
@@ -25,9 +25,9 @@ struct OrdersTopBannerFactory {
 
 private extension OrdersTopBannerFactory {
     enum Localization {
-        static let title = NSLocalizedString("Create orders and take payments!", comment: "Title of the banner notice in the Orders tab")
+        static let title = NSLocalizedString("Create orders & take payments!", comment: "Title of the banner notice in the Orders tab")
         static let infoText = NSLocalizedString("We've been working on making it possible to create orders and take payments from your device! " +
-                                                "You can try these features out by tapping on the \"+\" icon",
+                                                "You can try these features out by tapping on the \"+\" button",
                                                 comment: "Content of the banner notice in the Orders tab")
         static let dismiss = NSLocalizedString("Dismiss", comment: "The title of the button to dismiss the Orders top banner")
         static let giveFeedback = NSLocalizedString("Give feedback", comment: "Title of the button to give feedback about the Orders features")

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1189,7 +1189,7 @@
 "Create order" = "Create order";
 
 /* Title of the banner notice in the Orders tab */
-"Create orders & take payments!" = "Create orders & take payments!";
+"Create orders and take payments!" = "Create orders and take payments!";
 
 /* Title of the view for creating a coupon with percentage discount. */
 "Create percentage discount" = "Create percentage discount";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/* Variation ID. Parameters: %1$@ - Product variation ID */
+/* Variation ID. Parameters: %1$@ - Product variation ID */
 "#%1$@" = "#%1$@";
 
 /* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
@@ -1189,7 +1189,7 @@
 "Create order" = "Create order";
 
 /* Title of the banner notice in the Orders tab */
-"Create orders and take payments!" = "Create orders and take payments!";
+"Create orders & take payments!" = "Create orders & take payments!";
 
 /* Title of the view for creating a coupon with percentage discount. */
 "Create percentage discount" = "Create percentage discount";


### PR DESCRIPTION
Updated Order banner text from 'and' to '&', 'icon' to 'button'

<!-- Remember about a good descriptive title. -->

Closes: #6666
<!-- Id number of the GitHub issue this PR addresses. -->

### Changed Order banner text from 'and' to '&'.  Changed the text 'icon' to 'button' in the OrdersTopBannerFactory struct
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
