### PR TITLE
L10n Improvements – Mini preparatory refactor

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -124,7 +124,7 @@ platform :ios do
   desc 'Creates a new release branch from the current trunk'
   lane :complete_code_freeze do |options|
     ios_completecodefreeze_prechecks(options)
-    ios_localize_project
+    update_localization
     version = ios_get_app_version
     trigger_beta_build(branch_to_build: "release/#{version}")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,6 +12,7 @@ PROJECT_ENV_FILE_PATH = File.join(SECRETS_DIR, 'project.env')
 
 # Constants
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
+RESOURCES_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'Resources')
 FASTLANE_DIR = __dir__
 DERIVED_DATA_DIR = File.join(FASTLANE_DIR, 'DerivedData')
 SCREENSHOTS_DIR =  File.join(FASTLANE_DIR, 'screenshots')
@@ -101,7 +102,7 @@ platform :ios do
     extract_release_notes_for_version(
       version: new_version,
       release_notes_file_path: 'RELEASE-NOTES.txt',
-      extracted_notes_file_path: File.join('WooCommerce', 'Resources', 'release_notes.txt')
+      extracted_notes_file_path: File.join(RESOURCES_FOLDER, 'release_notes.txt')
     )
     ios_update_release_notes(new_version: new_version)
     setbranchprotection(repository: GHHELPER_REPO, branch: "release/#{new_version}")
@@ -147,7 +148,7 @@ platform :ios do
     source_metadata_folder = File.join(project_root, 'fastlane', 'appstoreres', 'metadata', 'source')
 
     files = {
-      whats_new: File.join(project_root, 'WooCommerce', 'Resources', 'release_notes.txt'),
+      whats_new: File.join(RESOURCES_FOLDER, 'release_notes.txt'),
       app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
       app_store_desc: File.join(source_metadata_folder, 'description.txt'),
       app_store_keywords: File.join(source_metadata_folder, 'keywords.txt'),
@@ -160,7 +161,7 @@ platform :ios do
     }
 
     ios_update_metadata_source(
-      po_file_path: File.join(project_root, 'WooCommerce', 'Resources', 'AppStoreStrings.pot'),
+      po_file_path: File.join(RESOURCES_FOLDER, 'AppStoreStrings.pot'),
       source_files: files,
       release_version: options[:version]
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -144,8 +144,7 @@ platform :ios do
   #####################################################################################
   desc 'Updates the AppStoreStrings.pot file with the latest data'
   lane :update_appstore_strings do |options|
-    project_root = File.dirname(File.expand_path(__dir__))
-    source_metadata_folder = File.join(project_root, 'fastlane', 'appstoreres', 'metadata', 'source')
+    source_metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'appstoreres', 'metadata', 'source')
 
     files = {
       whats_new: File.join(RESOURCES_FOLDER, 'release_notes.txt'),


### PR DESCRIPTION
### Description

I started working on replacing `ios_localize_project` with `ios_generate_strings_file_from_code`, but I struggled to get to a good diff for the `.strings` file to verify the changes are correct.

While I try to sort that out, here's some tidying I've done along the way.

### Testing instructions
 
N.A. – This is a super small DRY refactor. Reading the code should be enough. (_Last famous words... If I broke something, we'll notice when testing the upcoming changes)

### Screenshots

N.A.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
