### PR TITLE
Allow Apple pass presentation only after the in-person refund flow

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -55,10 +55,6 @@ final class CardPresentRefundOrchestrator {
         stores.dispatch(refundAction)
     }
 
-    deinit {
-        allowPassPresentation()
-    }
-
     /// Cancels the current refund.
     /// - Parameter onCompletion: called when the cancellation completes.
     func cancelRefund(onCompletion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -46,7 +46,9 @@ final class CardPresentRefundOrchestrator {
             default:
                 break
             }
-        }, onCompletion: { result in
+        }, onCompletion: { [weak self] result in
+            guard let self = self else { return }
+            self.allowPassPresentation()
             onProcessingMessage()
             onCompletion(result)
         })
@@ -60,8 +62,7 @@ final class CardPresentRefundOrchestrator {
     /// Cancels the current refund.
     /// - Parameter onCompletion: called when the cancellation completes.
     func cancelRefund(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = CardPresentPaymentAction.cancelRefund { [weak self] result in
-            self?.allowPassPresentation()
+        let action = CardPresentPaymentAction.cancelRefund { result in
             onCompletion(result)
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -60,7 +60,8 @@ final class CardPresentRefundOrchestrator {
     /// Cancels the current refund.
     /// - Parameter onCompletion: called when the cancellation completes.
     func cancelRefund(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = CardPresentPaymentAction.cancelRefund { result in
+        let action = CardPresentPaymentAction.cancelRefund { [weak self] result in
+            self?.allowPassPresentation()
             onCompletion(result)
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -53,11 +53,14 @@ final class CardPresentRefundOrchestrator {
         stores.dispatch(refundAction)
     }
 
+    deinit {
+        allowPassPresentation()
+    }
+
     /// Cancels the current refund.
     /// - Parameter onCompletion: called when the cancellation completes.
     func cancelRefund(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = CardPresentPaymentAction.cancelRefund { [weak self] result in
-            self?.allowPassPresentation()
+        let action = CardPresentPaymentAction.cancelRefund { result in
             onCompletion(result)
         }
         stores.dispatch(action)
@@ -75,10 +78,6 @@ private extension CardPresentRefundOrchestrator {
         /// return 0 `notSupported`
         ///
         guard !UIDevice.isPad() else {
-            return
-        }
-
-        guard !PKPassLibrary.isSuppressingAutomaticPassPresentation() else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -123,6 +123,7 @@ final class RefundConfirmationViewModel {
             default:
                 onCompletion(result)
             }
+            self.submissionUseCase = nil
         })
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6656 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#### Some background about Apple pass presentation

If an iOS device has Apple Wallet set up with Apple pay, because the card reader also supports tap to pay an Apple pass is presented when the device is near a card reader when the reader is ready for payment. However, it doesn't make sense in our use case because the merchant most likely isn't paying with their own Apple Pay 😅. We currently suppress Apple pass presentation during the in-person payment and refund flow and re-enable it at the end of the flow.

After we implemented retry after an in-person refund failure in https://github.com/woocommerce/woocommerce-ios/pull/6654, we noticed that the Apple pass was presented right after tapping to retry (screencast in https://github.com/woocommerce/woocommerce-ios/pull/6654#pullrequestreview-943116440). This is because `CardPresentRefundOrchestrator.cancelRefund` calls `allowPassPresentation` when we cancel the refund as the first step of retry. Even though we call `CardPresentRefundOrchestrator.refund` right after to suppress the pass presentation, it might be a bug or unexpected behavior in `PassKit` that `PKPassLibrary.isSuppressingAutomaticPassPresentation()` still returns `true` after `allowPassPresentation` is called before so that the suppression is not called again.

This PR fixes this by:
- Only call `allowPassPresentation` in `CardPresentRefundOrchestrator.deinit` - this requires the refund use case to be deinitialized in `RefundConfirmationViewModel`
- In case there are unexpected retain cycles that cause `CardPresentRefundOrchestrator.deinit` to not be called, we also want to always request pass presentation suppression by removing the check on the current suppression state


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Make an order for a product, with shipping cost ending in .01, and a fee ending in .99 so that we can take payment (the exact amount matters as we'll be refunding the shipping cost later and amounts that end in .01 allow us to test the refund failure case from [Stripe doc](https://stripe.com/docs/terminal/references/testing#interac-test-card). However, there are other ways to trigger a refund failure and please feel free to fail the refund any other ways 😄 )
1. Take IPP payment with an interac card
1. Refund the shipping only
1. Observe that the refund fails
1. Tap "Try again" on the error alert --> the refund should be retried, and Apple pass modal shouldn't be presented as in `trunk`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
