### PR TITLE
Product form - Remove scroll behaviour and increase field height to fully display long product names.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 9.1
 -----
 
+- [*] Product name field in product form - Remove scroll behaviour and increase field height to fully display long product names. [https://github.com/woocommerce/woocommerce-ios/pull/6681]
 
 9.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -149,6 +149,7 @@ private extension ProductFormTableViewDataSource {
                                                                    productStatus: productStatus,
                                                                    placeholder: placeholder,
                                                                    textViewMinimumHeight: 10.0,
+                                                                   isScrollEnabled: false,
                                                                    onNameChange: { [weak self] (newName) in self?.onNameChange?(newName) },
                                                                    style: .headline)
         cell.configure(with: cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,13 +19,13 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UC5-pp-RCE">
-                        <rect key="frame" x="16" y="3" width="288" height="25"/>
+                        <rect key="frame" x="16" y="8" width="288" height="28"/>
                         <subviews>
                             <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="A6r-Hf-px7" userLabel="Product Status Label Holder">
-                                <rect key="frame" x="0.0" y="0.0" width="51.5" height="25"/>
+                                <rect key="frame" x="0.0" y="0.0" width="51.5" height="28"/>
                                 <subviews>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ls-Wz-Lz4">
-                                        <rect key="frame" x="8" y="0.0" width="35.5" height="25"/>
+                                        <rect key="frame" x="8" y="0.0" width="35.5" height="28"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -39,7 +40,7 @@
                                 </constraints>
                             </view>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="gvh-NZ-8It" customClass="EnhancedTextView" customModule="WooCommerce" customModuleProvider="target">
-                                <rect key="frame" x="56.5" y="0.0" width="231.5" height="25"/>
+                                <rect key="frame" x="56.5" y="0.0" width="231.5" height="28"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -49,10 +50,10 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="UC5-pp-RCE" firstAttribute="top" secondItem="0sv-hP-tpf" secondAttribute="top" constant="3" id="8Wf-g3-eXM"/>
+                    <constraint firstItem="UC5-pp-RCE" firstAttribute="top" secondItem="0sv-hP-tpf" secondAttribute="top" constant="8" id="8Wf-g3-eXM"/>
                     <constraint firstItem="UC5-pp-RCE" firstAttribute="leading" secondItem="0sv-hP-tpf" secondAttribute="leading" constant="16" id="GgM-C5-CHt"/>
                     <constraint firstAttribute="trailing" secondItem="UC5-pp-RCE" secondAttribute="trailing" constant="16" id="Sjf-TQ-4xv"/>
-                    <constraint firstAttribute="bottom" secondItem="UC5-pp-RCE" secondAttribute="bottom" constant="16" id="ZhY-zm-fhU"/>
+                    <constraint firstAttribute="bottom" secondItem="UC5-pp-RCE" secondAttribute="bottom" constant="8" id="ZhY-zm-fhU"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="SEn-yL-fY3"/>


### PR DESCRIPTION
Closes: #6566 

### Description

While viewing `Product Details`, if a product has a long name, the name field does not expand to show all the lines. Instead, it becomes scrollable. In contrast, Android shows all the lines of the product name by increasing the height of the field/label.

The above-described problem was reported in #6566. 

This PR aims to fix that problem by removing the scroll behaviour from the product name field. This makes the field grow according to the length of the product name.

### Testing instructions

1. Navigate to the Products tab
1. Select a product with a long title or select the "+" button to create one.
1. Notice that the title row displays the full product name on the product form. (In multiple lines if needed)

### Screenshots
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/524475/164407219-b668734e-bb7f-46ab-b105-022e99594458.png"> | <img src="https://user-images.githubusercontent.com/524475/164407304-945e4980-b6ef-4705-a268-c4d432386ffa.png"> |

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/524475/164407469-6c002e36-b25f-4850-b1d5-5a9178b0b09f.png"> | <img src="https://user-images.githubusercontent.com/524475/164407515-2499e7f1-0696-4a44-9037-5677208470e7.png">  |

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.