### PR TITLE
`BulkUpdateViewModel` - Fix flaky unit test

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -158,7 +158,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1,
+                                            productID: 1,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager,
+                                            currencySettings: CurrencySettings())
 
         // When
         viewModel.syncVariations()


### PR DESCRIPTION
Closes: #6533

### Description
`test_sale_price_description_when_all_products_have_same_price()` unit test from `BulkUpdateViewModelTests` fails when we run the tests on a device/simulator which has an account logged in with a site that uses a different currency other than the dollar.

This PR aims to fix the above issue by injecting an instance of `CurrencySettings` to make `BulkUpdateViewModel` always output in dollars (`$`).

### Testing instructions
1. Login with an account & site that uses a different currency other than the dollar. (`$`)
1. Run unit tests.
1. Observe that all tests are successful.

### Screenshots
NA

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
