### PR TITLE
Remove direct link to the .ipa of Installable Build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -457,12 +457,21 @@ platform :ios do
       dsym_path: './build/WooCommerce.app.dSYM.zip'
     )
 
+    UI.message("Successfully built and uploaded installable build `#{build_number}` to App Center.")
+
     return if ENV['BUILDKITE_PULL_REQUEST'].nil?
 
-    UI.message("Successfully built and uploaded installable build `#{build_number}` to App Center.")
     install_url = 'https://install.appcenter.ms/orgs/automattic/apps/WooCommerce-Installable-Builds'
+    qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
 
-    comment_body = "You can test the changes on this Pull Request by downloading it from App Center <a href='#{install_url}'>here</a> with build number: <code>#{build_number}</code>. If you need access to this, you can ask a maintainer to add you."
+    comment_body = <<~COMMENT_BODY
+      You can test the changes from this Pull Request by:<ul>
+        <li><a href='#{install_url}'>Clicking here</a> or scanning the QR code below to access App Center</li>
+        <li>Then installing the build number <code>#{build_number}</code> on your iPhone</li>
+      </ul>
+      <img src='#{qr_code_url}' width='150' height='150' /><br />
+      If you need access to App Center, please ask a maintainer to add you.
+    COMMENT_BODY
 
     comment_on_pr(
       project: 'woocommerce/woocommerce-ios',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -469,7 +469,7 @@ platform :ios do
         <li><a href='#{install_url}'>Clicking here</a> or scanning the QR code below to access App Center</li>
         <li>Then installing the build number <code>#{build_number}</code> on your iPhone</li>
       </ul>
-      <img src='#{qr_code_url}' width='150' height='150' /><br />
+      <img src='#{qr_code_url}' width='150' height='150' />
       If you need access to App Center, please ask a maintainer to add you.
     COMMENT_BODY
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -459,11 +459,10 @@ platform :ios do
 
     return if ENV['BUILDKITE_PULL_REQUEST'].nil?
 
-    download_url = Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]
-    UI.message("Successfully built and uploaded installable build here: #{download_url}")
+    UI.message("Successfully built and uploaded installable build `#{build_number}` to App Center.")
     install_url = 'https://install.appcenter.ms/orgs/automattic/apps/WooCommerce-Installable-Builds'
 
-    comment_body = "You can test the changes on this Pull Request by downloading it from AppCenter <a href='#{install_url}'>here</a> with build number: <code>#{build_number}</code>. IPA is available <a href='#{download_url}'>here</a>. If you need access to this, you can ask a maintainer to add you."
+    comment_body = "You can test the changes on this Pull Request by downloading it from AppCenter <a href='#{install_url}'>here</a> with build number: <code>#{build_number}</code>. If you need access to this, you can ask a maintainer to add you."
 
     comment_on_pr(
       project: 'woocommerce/woocommerce-ios',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,7 @@ SCREENSHOT_DEVICES = [
 # Fastlane mutates these internally, see
 # https://github.com/fastlane/fastlane/blob/b817148d4967ab6e38b8f1a8b81d1b3e60d6e645/match/lib/match/runner.rb#L84-L86
 MAIN_BUNDLE_IDENTIFIERS = %w[com.automattic.woocommerce]        # Registered in our main account, for development and AppStore
-ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce] # Registered in our Enterprise account, for AppCenter / Installable Builds
+ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce] # Registered in our Enterprise account, for App Center / Installable Builds
 # rubocop:enable Style/MutableConstant
 
 # Use this instead of getting values from ENV directly
@@ -462,7 +462,7 @@ platform :ios do
     UI.message("Successfully built and uploaded installable build `#{build_number}` to App Center.")
     install_url = 'https://install.appcenter.ms/orgs/automattic/apps/WooCommerce-Installable-Builds'
 
-    comment_body = "You can test the changes on this Pull Request by downloading it from AppCenter <a href='#{install_url}'>here</a> with build number: <code>#{build_number}</code>. If you need access to this, you can ask a maintainer to add you."
+    comment_body = "You can test the changes on this Pull Request by downloading it from App Center <a href='#{install_url}'>here</a> with build number: <code>#{build_number}</code>. If you need access to this, you can ask a maintainer to add you."
 
     comment_on_pr(
       project: 'woocommerce/woocommerce-ios',


### PR DESCRIPTION
Addresses pdnsEh-gZ-p2 

## What

 - Removes the direct link to download IPA, only leaving the option to install Installable Builds via App Center.
 - Takes the occasion to reword the PR comment and add QR Code for installing the build, inspired by how we did it in WPiOS

## To Test

Verify that the comment posted by our bot once the "Installable Build" have been built does not contain any direct link to the unrestricted `.ipa` anymore.