### PR TITLE
Products list: pin filter bar outside of the products list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 
 - [*] Product name field in product form - Remove scroll behaviour and increase field height to fully display long product names. [https://github.com/woocommerce/woocommerce-ios/pull/6681]
+- [*] Filter toolbar in Products list tab - Filter toolbar is pinned outside of the products list. [https://github.com/woocommerce/woocommerce-ios/pull/6698]
 
 9.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -42,7 +42,7 @@ final class ProductsViewController: UIViewController {
 
     /// Top toolbar that shows the sort and filter CTAs.
     ///
-    @IBOutlet weak var toolbar: ToolbarView!
+    @IBOutlet private weak var toolbar: ToolbarView!
 
     // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
     private let hiddenScrollView = UIScrollView()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -32,7 +32,7 @@ final class ProductsViewController: UIViewController {
     /// Top stack view that is shown above the table view as the table header view.
     ///
     private lazy var topStackView: UIStackView = {
-        let subviews = [topBannerContainerView, toolbar]
+        let subviews = [topBannerContainerView]
         let stackView = UIStackView(arrangedSubviews: subviews)
         stackView.axis = .vertical
         stackView.spacing = Constants.headerViewSpacing
@@ -42,9 +42,10 @@ final class ProductsViewController: UIViewController {
 
     /// Top toolbar that shows the sort and filter CTAs.
     ///
-    private lazy var toolbar: UIView = {
-        return createToolbar()
-    }()
+    @IBOutlet weak var toolbar: ToolbarView!
+
+    // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
+    private let hiddenScrollView = UIScrollView()
 
     /// The filter CTA in the top toolbar.
     private lazy var filterButton: UIButton = UIButton(frame: .zero)
@@ -162,7 +163,8 @@ final class ProductsViewController: UIViewController {
         configureNavigationBar()
         configureMainView()
         configureTableView()
-        configureToolBarView()
+        configureHiddenScrollView()
+        configureToolbar()
         configureSyncingCoordinator()
         registerTableViewCells()
 
@@ -364,13 +366,24 @@ private extension ProductsViewController {
         stateCoordinator.transitionToResultsUpdatedState(hasData: !isEmpty)
     }
 
-    /// Configure toolbar view by number of products
-    ///
-    func configureToolBarView() {
-        showOrHideToolBar()
+    private func configureHiddenScrollView() {
+        // Configure large title using the `hiddenScrollView` trick.
+        hiddenScrollView.configureForLargeTitleWorkaround()
+        // Adds the "hidden" scroll view to the root of the UIViewController for large title workaround.
+        view.addSubview(hiddenScrollView)
+        view.sendSubviewToBack(hiddenScrollView)
+        hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
     }
 
-    func createToolbar() -> ToolbarView {
+    /// Configure toolbar view by number of products
+    ///
+    private func configureToolbar() {
+        setupToolbar()
+        showOrHideToolbar()
+    }
+
+    private func setupToolbar() {
         let sortTitle = NSLocalizedString("Sort by", comment: "Title of the toolbar button to sort products in different ways.")
         let sortButton = UIButton(frame: .zero)
         sortButton.setTitle(sortTitle, for: .normal)
@@ -385,11 +398,8 @@ private extension ProductsViewController {
             $0.contentEdgeInsets = Constants.toolbarButtonInsets
         }
 
-        let toolbar = ToolbarView()
         toolbar.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
         toolbar.setSubviews(leftViews: [sortButton], rightViews: [filterButton])
-
-        return toolbar
     }
 
     /// Setup: Sync'ing Coordinator
@@ -409,7 +419,7 @@ private extension ProductsViewController {
     /// If there is 0 products, toolbar will be hidden
     /// if there is 1 or more products, toolbar will be visible
     ///
-    func showOrHideToolBar() {
+    func showOrHideToolbar() {
         toolbar.isHidden = filters.numberOfActiveFilters == 0 ? isEmpty : false
     }
 }
@@ -538,7 +548,7 @@ private extension ProductsViewController {
     /// Manages view components and reload tableview
     ///
     func reloadTableAndView() {
-        showOrHideToolBar()
+        showOrHideToolbar()
         addOrRemoveOverlay()
         tableView.reloadData()
     }
@@ -625,6 +635,10 @@ extension ProductsViewController: UITableViewDelegate {
         // the actual value. AKA no flicker!
         //
         estimatedRowHeights[indexPath] = cell.frame.height
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        hiddenScrollView.updateFromScrollViewDidScrollEventForLargeTitleWorkaround(scrollView)
     }
 }
 
@@ -965,7 +979,7 @@ private extension ProductsViewController {
             ensureFooterSpinnerIsStopped()
             removePlaceholderProducts()
             showTopBannerViewIfNeeded()
-            showOrHideToolBar()
+            showOrHideToolbar()
         case .results:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
@@ -21,30 +21,41 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="1mE-SE-uK9">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="tDW-j0-dUT">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="orders-table-view"/>
-                    </userDefinedRuntimeAttributes>
-                </tableView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eA-hc-k15" userLabel="Filter Bar" customClass="ToolbarView" customModule="WooCommerce" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="44" width="414" height="0.0"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eA-hc-k15" userLabel="Filter Bar" customClass="ToolbarView" customModule="WooCommerce" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" id="sEi-OR-bvb"/>
+                            </constraints>
+                        </view>
+                        <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="1mE-SE-uK9">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="orders-table-view"/>
+                            </userDefinedRuntimeAttributes>
+                        </tableView>
+                    </subviews>
                     <constraints>
-                        <constraint firstAttribute="height" id="sEi-OR-bvb"/>
+                        <constraint firstItem="9eA-hc-k15" firstAttribute="leading" secondItem="tDW-j0-dUT" secondAttribute="leading" id="2Md-DN-FrJ"/>
+                        <constraint firstItem="1mE-SE-uK9" firstAttribute="top" secondItem="9eA-hc-k15" secondAttribute="bottom" id="CRj-o0-2WZ"/>
+                        <constraint firstAttribute="trailing" secondItem="9eA-hc-k15" secondAttribute="trailing" id="Qcx-pF-i9M"/>
+                        <constraint firstItem="1mE-SE-uK9" firstAttribute="trailing" secondItem="9eA-hc-k15" secondAttribute="trailing" id="g0z-q4-rFD"/>
+                        <constraint firstItem="1mE-SE-uK9" firstAttribute="leading" secondItem="9eA-hc-k15" secondAttribute="leading" id="i2H-MX-SoN"/>
+                        <constraint firstItem="9eA-hc-k15" firstAttribute="top" secondItem="tDW-j0-dUT" secondAttribute="top" id="ilw-mJ-v1G"/>
+                        <constraint firstAttribute="bottom" secondItem="1mE-SE-uK9" secondAttribute="bottom" id="jCv-iK-SJb"/>
                     </constraints>
-                </view>
+                </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="9eA-hc-k15" secondAttribute="trailing" id="7Oz-dR-GwR"/>
-                <constraint firstItem="1mE-SE-uK9" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="8hS-PH-Szg"/>
-                <constraint firstItem="1mE-SE-uK9" firstAttribute="top" secondItem="9eA-hc-k15" secondAttribute="bottom" id="CKX-Om-8xR"/>
-                <constraint firstItem="9eA-hc-k15" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="EMu-rn-qlD"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="1mE-SE-uK9" secondAttribute="bottom" id="Xci-eH-29p"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="1mE-SE-uK9" secondAttribute="trailing" id="h1p-cR-5re"/>
-                <constraint firstItem="9eA-hc-k15" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="w8G-wM-Nhh"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="tDW-j0-dUT" secondAttribute="trailing" id="3MC-6D-nnm"/>
+                <constraint firstItem="tDW-j0-dUT" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9UK-Qy-FXd"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="tDW-j0-dUT" secondAttribute="bottom" id="AQF-qF-3wt"/>
+                <constraint firstItem="tDW-j0-dUT" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="KSv-iL-NFv"/>
             </constraints>
             <point key="canvasLocation" x="100.00000000000001" y="48.883928571428569"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
@@ -25,14 +25,14 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eA-hc-k15" userLabel="Filter Bar" customClass="ToolbarView" customModule="WooCommerce" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="height" id="sEi-OR-bvb"/>
+                                <constraint firstAttribute="height" constant="50" id="sEi-OR-bvb"/>
                             </constraints>
                         </view>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="1mE-SE-uK9">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                            <rect key="frame" x="0.0" y="50" width="414" height="768"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="orders-table-view"/>
                             </userDefinedRuntimeAttributes>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductsViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
                 <outlet property="tableView" destination="1mE-SE-uK9" id="ogX-nu-l5x"/>
+                <outlet property="toolbar" destination="9eA-hc-k15" id="V2c-iT-WpM"/>
                 <outlet property="view" destination="iN0-l3-epB" id="Jh9-wF-LZg"/>
             </connections>
         </placeholder>
@@ -26,16 +27,26 @@
                         <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="orders-table-view"/>
                     </userDefinedRuntimeAttributes>
                 </tableView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eA-hc-k15" userLabel="Filter Bar" customClass="ToolbarView" customModule="WooCommerce" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="44" width="414" height="0.0"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" id="sEi-OR-bvb"/>
+                    </constraints>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="9eA-hc-k15" secondAttribute="trailing" id="7Oz-dR-GwR"/>
                 <constraint firstItem="1mE-SE-uK9" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="8hS-PH-Szg"/>
+                <constraint firstItem="1mE-SE-uK9" firstAttribute="top" secondItem="9eA-hc-k15" secondAttribute="bottom" id="CKX-Om-8xR"/>
+                <constraint firstItem="9eA-hc-k15" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="EMu-rn-qlD"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="1mE-SE-uK9" secondAttribute="bottom" id="Xci-eH-29p"/>
-                <constraint firstItem="1mE-SE-uK9" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="ZjI-Dc-KKp"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="1mE-SE-uK9" secondAttribute="trailing" id="h1p-cR-5re"/>
+                <constraint firstItem="9eA-hc-k15" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="w8G-wM-Nhh"/>
             </constraints>
-            <point key="canvasLocation" x="101" y="49"/>
+            <point key="canvasLocation" x="100.00000000000001" y="48.883928571428569"/>
         </view>
     </objects>
     <resources>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
@@ -25,14 +25,14 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eA-hc-k15" userLabel="Filter Bar" customClass="ToolbarView" customModule="WooCommerce" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="50" id="sEi-OR-bvb"/>
+                                <constraint firstAttribute="height" id="sEi-OR-bvb"/>
                             </constraints>
                         </view>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="1mE-SE-uK9">
-                            <rect key="frame" x="0.0" y="50" width="414" height="768"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="orders-table-view"/>
                             </userDefinedRuntimeAttributes>

--- a/WooCommerce/Classes/ViewRelated/Toolbar/ToolbarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Toolbar/ToolbarView.swift
@@ -18,8 +18,8 @@ final class ToolbarView: UIView {
         pinSubviewToAllEdges(stackView)
     }
 
-    required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    required convenience init(coder: NSCoder) {
+        self.init()
     }
 
     func setSubviews(leftViews: [UIView], rightViews: [UIView]) {

--- a/WooCommerce/Classes/ViewRelated/Toolbar/ToolbarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Toolbar/ToolbarView.swift
@@ -12,14 +12,18 @@ final class ToolbarView: UIView {
 
     init() {
         super.init(frame: .zero)
-        translatesAutoresizingMaskIntoConstraints = false
-
-        addSubview(stackView)
-        pinSubviewToAllEdges(stackView)
+        setup()
     }
 
-    required convenience init(coder: NSCoder) {
-        self.init()
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+        pinSubviewToAllEdges(stackView)
     }
 
     func setSubviews(leftViews: [UIView], rightViews: [UIView]) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6694 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we align the design of the Products tab to the Orders one, where the filter toolbar is pinned outside of the table view. This will also contribute to the resolution of p91TBi-810-p2, where the ghosting animation shouldn't cover the filter toolbar.
Furthermore, we replicate the behavior of the orders to trick the navigation large title mechanism, which follows the table view scrolling and breaks the design as explained in p91TBi-45c-p2. To solve that, we add an invisible scroll view behind the view so the navigation bar ignores the table view scrolling down.

### Changes
- Remove the toolbar from the table view header
- Pin it on top with the help of Interface Builder
- Add a hidden scroll view to trick the navigation bar with a large title
- Allow initialization of `ToolbarView` from Interface Builder by implementing `init(coder: NSCoder)
`
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open the app
2. Go to the products tab
3. Scroll up:
3a. The filter toolbar should remain fixed
3b. The navigation bar should collapse as in orders
4. Scroll down:
4a.  Navigation bar and toolbar should remain fixed

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![toolbar-pinned-products-list](https://user-images.githubusercontent.com/1864060/164723728-bb11a9f6-0c84-4991-92e9-eea7b59c28c7.gif)


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->