### PR TITLE
Screenshots: Update UI test and Fastlane for generating app screenshots

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -68,6 +68,7 @@ struct HubMenu: View {
                                 showingCoupons = true
                             }
                         })
+                            .accessibilityIdentifier(menu.accessibilityIdentifier)
                     }
                     .background(Color(.listForeground))
                     .cornerRadius(Constants.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -67,8 +67,7 @@ struct HubMenu: View {
                                 ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: "coupons"])
                                 showingCoupons = true
                             }
-                        })
-                            .accessibilityIdentifier(menu.accessibilityIdentifier)
+                        }).accessibilityIdentifier(menu.accessibilityIdentifier)
                     }
                     .background(Color(.listForeground))
                     .cornerRadius(Constants.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -176,6 +176,21 @@ extension HubMenuViewModel {
                 return .primary
             }
         }
+
+        var accessibilityIdentifier: String {
+            switch self {
+            case .woocommerceAdmin:
+                return "menu-woocommerce-admin"
+            case .viewStore:
+                return "menu-view-store"
+            case .inbox:
+                return "menu-inbox"
+            case .coupons:
+                return "menu-coupons"
+            case .reviews:
+                return "menu-reviews"
+            }
+        }
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -56,6 +56,7 @@ private extension FilteredOrdersHeaderBar {
 
         filterButton.setTitle(title, for: .normal)
         filterButton.contentEdgeInsets = .zero
+        filterButton.accessibilityIdentifier = "orders-filter-button"
     }
 
     enum Localization {

--- a/WooCommerce/UITestsFoundation/Screens/Menu/MenuScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Menu/MenuScreen.swift
@@ -6,13 +6,23 @@ public final class MenuScreen: ScreenObject {
         (try? MenuScreen().isLoaded) ?? false
     }
 
+    private let reviewsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["menu-reviews"]
+    }
+
+    private let viewStoreButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["menu-view-store"]
+    }
+
+    /// Button to open the Reviews section
+    ///
+    private var reviewsButton: XCUIElement { reviewsButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
-                // swiftlint:disable next opening_brace
-                { $0.staticTexts["Reviews"] },
-                { $0.staticTexts["View Store"] }
-                // swiftlint:enable next opening_brace
+                reviewsButtonGetter,
+                viewStoreButtonGetter
             ],
             app: app
         )
@@ -20,7 +30,7 @@ public final class MenuScreen: ScreenObject {
 
     @discardableResult
     public func goToReviewsScreen() throws -> ReviewsScreen {
-        app.staticTexts["Reviews"].tap()
+        reviewsButton.tap()
         return try ReviewsScreen()
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -11,7 +11,7 @@ public final class OrdersScreen: ScreenObject {
     }
 
     private let filterButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Filter"]
+        $0.buttons["orders-filter-button"]
     }
 
     private let createButtonGetter: (XCUIApplication) -> XCUIElement = {

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -165,7 +165,7 @@ open class Snapshot: NSObject {
             }
 
             let screenshot = XCUIScreen.main.screenshot()
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
             #else
             let image = screenshot.image
@@ -193,16 +193,20 @@ open class Snapshot: NSObject {
     }
 
     class func fixLandscapeOrientation(image: UIImage) -> UIImage {
-        if #available(iOS 10.0, *) {
-            let format = UIGraphicsImageRendererFormat()
-            format.scale = image.scale
-            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-            return renderer.image { context in
-                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-            }
-        } else {
+        #if os(watchOS)
             return image
-        }
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
     }
 
     class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
@@ -302,4 +306,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.25]
+// SnapshotHelperVersion [1.28]

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -25,7 +25,12 @@ struct MockAppSettingsActionHandler: MockActionHandler {
             onCompletion(.failure(AppSettingsStoreErrors.noEligibilityErrorInfo))
         case .loadJetpackBenefitsBannerVisibility(_, _, let onCompletion):
             onCompletion(false)
-        case .resetEligibilityErrorInfo, .setTelemetryAvailability, .loadOrdersSettings, .upsertProductsSettings:
+        case .resetEligibilityErrorInfo,
+                .setTelemetryAvailability,
+                .loadOrdersSettings,
+                .upsertProductsSettings,
+                .loadCanadaInPersonPaymentsSwitchState,
+                .loadCouponManagementFeatureSwitchState:
             break
         default: unimplementedAction(action: action)
         }

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -126,7 +126,7 @@ public class MockStoresManager: StoresManager {
             announcementsActionHandler.handle(action: action)
         case let action as ReceiptAction:
             receiptActionHandler.handle(action: action)
-        case _ as CardPresentPaymentAction:
+        case _ as CardPresentPaymentAction, _ as SystemStatusAction:
             break
         default:
             fatalError("Unable to handle action: \(action.identifier) \(String(describing: action))")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -551,7 +551,7 @@ platform :ios do
     xcversion(version: '~> 12.0')
 
     scan(
-      workspace: File.join(FASTLANE_DIR, '../WooCommerce.xcworkspace'),
+      workspace: 'WooCommerce.xcworkspace',
       scheme: 'WooCommerceScreenshots',
       build_for_testing: true,
       derived_data_path: DERIVED_DATA_DIR


### PR DESCRIPTION
## Description

Our App Store screenshots are out of date, and we'd like to be able to update them with our screenshot UI test. This PR ensures the screenshot test passes and the screenshots can be generated with Fastlane.

Internal ref: p1650555775375329-slack-CGPNUU63E

Note: I tried using the `generate screenshots` tag to use our GitHub action to generate the screenshots in CI. However, the [build step](https://github.com/woocommerce/woocommerce-ios/runs/6131181868?check_suite_focus=true) for that action is currently failing with an SPM dependency error. I'm skipping investigating that to prioritize at least generating the screenshots locally.

## Changes

Screenshot test fixes:

* Adds support for new actions in `MockAppSettingsActionHandler` and `MockStoresManager`. (These actions need to be handled, but specific behavior for these actions isn't required for the screenshots, so their cases are simply handled with a `break`.)
* Adds accessibility identifiers used in UI test screen objects. These replace static texts that only work when the device is set to English.

Fastlane fixes:

* Updates the location of the workspace (`WooCommerce.xcworkspace`) for the `build_screenshots` lane.
* Updates the `SnapshotHelper` file used by Fastlane for taking screenshots; this is an automated update generated by running `bundle exec fastlane snapshot update`.

## Testing

Prerequisite: Set the `splitViewInOrdersTab` feature flag to `false` in `DefaultFeatureFlagService`. (This is a WIP feature and should not be included in the screenshots; it also is not compatible with the screenshot test on iPad yet.)

Screenshot test:

* Set your simulator's device language to something other than English. (This is not required but does confirm that the tests can pass in other languages.)
* In Xcode, select the `WooCommerceScreenshots` target.
* Run the test in that target (a single UI test `testScreenshots()`) and confirm it passes.

Fastlane:

* Note: You may need to adjust the Xcode and iOS simulator versions in `fastlane/Fastfile` to test the fastlane action, based on what you have available locally.
* Run `bundle exec fastlane build_screenshots` and confirm the app builds. (You can also try running `bundle exec fastlane screenshots` to go through the complete screenshot generation process, although keep in mind it takes quite a long time to complete.)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.