### PR TITLE
Order creation: dismiss orders banner permanently

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -16,4 +16,8 @@ public enum FeedbackType: String, Codable {
     /// Identifier for the coupon management feedback survey
     ///
     case couponManagement
+
+    /// Identifier for the orders creation release feedback
+    ///
+    case ordersCreation
 }

--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -17,7 +17,7 @@ public enum FeedbackType: String, Codable {
     ///
     case couponManagement
 
-    /// Identifier for the orders creation release feedback
+    /// Identifier for the orders creation feedback survey
     ///
     case ordersCreation
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -659,7 +659,7 @@ private extension OrderListViewController {
         topBannerView = OrdersTopBannerFactory.createOrdersBanner(onTopButtonPressed: { [weak self] in
             self?.tableView.updateHeaderHeight()
         }, onDismissButtonPressed: { [weak self] in
-            self?.viewModel.hideOrdersBanners = true
+            self?.viewModel.dismissOrdersBanner()
         }, onGiveFeedbackButtonPressed: { [weak self] in
             let surveyNavigation = SurveyCoordinatingController(survey: .orderCreation)
             self?.present(surveyNavigation, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -137,7 +137,7 @@ final class OrderListViewModel {
             self?.hideOrdersBanners = true
         }
 
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 
     /// Starts the snapshotsProvider, logging any errors.
@@ -159,8 +159,8 @@ final class OrderListViewModel {
                 ServiceLocator.crashLogging.logError(error)
             }
         }
-        
-        ServiceLocator.stores.dispatch(action)
+
+        stores.dispatch(action)
     }
 
     @objc private func handleAppDeactivation() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -126,6 +126,19 @@ final class OrderListViewModel {
         bindTopBannerState()
     }
 
+    func dismissOrdersBanner() {
+        let action = AppSettingsAction.updateFeedbackStatus(type: .ordersCreation,
+                                               status: .dismissed) { [weak self] result in
+            if let error = result.failure {
+                ServiceLocator.crashLogging.logError(error)
+            }
+
+            self?.hideOrdersBanners = true
+        }
+
+        ServiceLocator.stores.dispatch(action)
+    }
+
     /// Starts the snapshotsProvider, logging any errors.
     private func startReceivingSnapshots() {
         do {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -86,9 +86,9 @@ final class OrderListViewModel {
     @Published private(set) var topBanner: TopBanner = .none
 
     /// If true, no orders banner will be shown as the user has told us that they are not interested in this information.
-    /// Resets with every session.
+    /// It is persisted through app sessions.
     ///
-    @Published var hideOrdersBanners: Bool = false
+    @Published var hideOrdersBanners: Bool = true
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -124,6 +124,7 @@ final class OrderListViewModel {
 
         observeForegroundRemoteNotifications()
         bindTopBannerState()
+        loadOrdersBannerVisibility()
     }
 
     func dismissOrdersBanner() {
@@ -146,6 +147,20 @@ final class OrderListViewModel {
         } catch {
             ServiceLocator.crashLogging.logError(error)
         }
+    }
+
+    private func loadOrdersBannerVisibility() {
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .ordersCreation) { [weak self] result in
+            switch result {
+            case .success(let visible):
+                self?.hideOrdersBanners = !visible
+            case.failure(let error):
+                self?.hideOrdersBanners = true
+                ServiceLocator.crashLogging.logError(error)
+            }
+        }
+        
+        ServiceLocator.stores.dispatch(action)
     }
 
     @objc private func handleAppDeactivation() {

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,12 +37,8 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .productsVariations:
-            return shouldProductsFeedbackBeVisible()
-        case .shippingLabelsRelease3:
-            return shouldShippingLabelsRelease3FeedbackBeVisible()
-        case .couponManagement:
-            return shouldCouponManagementFeedbackBeVisible()
+        case .productsVariations, .shippingLabelsRelease3, .couponManagement, .ordersCreation:
+            return settings.feedbackStatus(of: feedbackType) == .pending
         }
     }
 
@@ -66,24 +62,6 @@ struct InAppFeedbackCardVisibilityUseCase {
         }
 
         return true
-    }
-
-    /// Returns whether the products feedback request should be displayed
-    ///
-    private func shouldProductsFeedbackBeVisible() -> Bool {
-        return settings.feedbackStatus(of: feedbackType) == .pending
-    }
-
-    /// Returns whether the shippingLabelsRelease3 feedback request should be displayed
-    ///
-    private func shouldShippingLabelsRelease3FeedbackBeVisible() -> Bool {
-        return settings.feedbackStatus(of: feedbackType) == .pending
-    }
-
-    /// Returns whether the couponManagement feedback request should be displayed
-    ///
-    private func shouldCouponManagementFeedbackBeVisible() -> Bool {
-        return settings.feedbackStatus(of: feedbackType) == .pending
     }
 
     /// Returns the total number of days between `from` and `to`.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6701
<!-- Id number of the GitHub issue this PR addresses. -->

### Note
The PR belongs to an issue of the project [WooMobile -> Eagle](https://github.com/orgs/woocommerce/projects/30#card-81032619). Unfortunately, it seems like I don't have permission to set that project on the project field for this PR, please feel free to add it if appropriate.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As explained in the [original issue](https://github.com/woocommerce/woocommerce-ios/issues/6701) the fact that a user dismisses the orders creation feedback banner is not persisted, thus showing it again after restarting the app. This is not the intended behavior; as described in p91TBi-3dX-p2 the banner should be hidden permanently.
With this PR we store that information when dismissed, and load it when showing the orders. Furthermore, we do not show this banner by default, to avoid a glitch if the banner was already dismissed (show banner - load feedback visibility - visibility is false - hide banner).

### Changes
- Add a new feedback type for orders creation
- Trigger feedback status action when the banner is dismissed in orders
- Load orders creation feedback information from storage
- Unit tests
- Small refactor: collapse visibility helper functions into one method and case to avoid duplicated code

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open the app
2. Go to orders
3. Expand the "Create Orders and take payments!" banner
4. Tap on Dismiss
5. Restart the app
6. Go to orders
7. "Create Orders and take payments!" banner should be hidden

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Dimiss banner action:
![dismiss-banner-action](https://user-images.githubusercontent.com/1864060/165091831-2b87474a-e41f-4cdc-b407-625eabfa7cfa.gif)

The banner should be hidden when we restart the app:
<img src="https://user-images.githubusercontent.com/1864060/165092064-7a9ec086-9705-42c5-9c31-79b4e6a539e7.png" width=375>

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->