### PR TITLE
[Mobile Payments] Remove "Manual refund" workaround for interac refunds.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -73,24 +73,12 @@ final class RefundConfirmationViewModel {
     func submit(rootViewController: UIViewController,
                 showInProgressUI: @escaping (() -> Void),
                 onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        // TODO: 6601 - remove Interac workaround when the API support is shipped.
-        let isInterac: Bool = {
-            switch details.charge?.paymentMethodDetails {
-            case .some(.interacPresent):
-                return true
-            default:
-                return false
-            }
-        }()
-        let automaticallyRefundsPayment = isInterac && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.canadaInPersonPayments) ?
-        false: gatewaySupportsAutomaticRefunds()
-
         // Creates refund object.
         let shippingLine = details.refundsShipping ? details.order.shippingLines.first : nil
         let fees = details.refundsFees ? details.order.fees : []
         let useCase = RefundCreationUseCase(amount: details.amount,
                                             reason: reasonForRefundCellViewModel.value,
-                                            automaticallyRefundsPayment: automaticallyRefundsPayment,
+                                            automaticallyRefundsPayment: gatewaySupportsAutomaticRefunds(),
                                             items: details.items,
                                             shippingLine: shippingLine,
                                             fees: fees,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6703 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We used a temporary workaround for Interac refunds during development, flagging them as "manual refunds" to the WCPay API, so that WCPay would not attempt to refund the money to the customer's card. The refund to the card is done entirely within the app and Stripe SDK.

Changes to the WCPay API made this unnecessary, so this removes the workaround. We submit Interac refunds to the API as normal, and the API records them but doesn't attempt to action them. This API fix was released in WCPay 4.0.0.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. With a Canadian store, add a Simple Payment transaction
2. Take payment using an interac card 
3. Go to the order, and refund the payment
4. When the refund is complete, refresh the order, and note that it shows it's refunded via WooCommerce Payments.

N.B. There's an issue where all refunds initially are shown on Order Details as "via manual refund". This is not related to the Moose on the Loose work or this ticket, but I've raised a new issue for that bug. #6704

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
