### PR TITLE
Update localization comment to match template.

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -137,7 +137,9 @@ final class OrderPaymentDetailsViewModel {
         )
 
         let template = NSLocalizedString("%@ via %@",
-                                         comment: "It reads: \"<date> via <refund method type> – View details\". The text `View details` is a link.")
+                                         comment: "Label for a refund on an order, which reads \"<date> via <refund method type>\", " +
+                                         "e.g. \"25 Apr 2022 via WooCommerce In-Person Payments\". " +
+                                         "Shown in a cell with a title \"Refunded\" for context")
         let refundText = String.localizedStringWithFormat(template, dateCreated, refundType)
 
         return refundText


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The template string for the Refund row subtitle which had the “– View Details” suffix mentioned in the previous localization comment was updated in 0375958 to remove that suffix.

The suffix was still there in the localization comment, which would cause confusion for translators. This updates the comment to avoid confusion.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
None

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
