### PR TITLE
HF: Fix sharing helper presentation on iPad

### DIFF
--- a/WooCommerce/Classes/Tools/SharingHelper.swift
+++ b/WooCommerce/Classes/Tools/SharingHelper.swift
@@ -47,6 +47,28 @@ class SharingHelper {
         viewController.present(avc, animated: true)
     }
 
+    /// Share a URL using the iOS share sheet.
+    ///
+    /// - Parameters:
+    ///   - url: URL you want to share.
+    ///   - title: Optional descriptive title for the url.
+    ///   - item: Item that the share action sheet should be displayed from.
+    ///   - viewController: VC presenting the share VC (UIActivityViewController).
+    ///
+    static func shareURL(url: URL,
+                         title: String? = nil,
+                         from item: UIBarButtonItem,
+                         in viewController: UIViewController,
+                         onCompletion: Completion? = nil) {
+        guard let avc = createActivityVC(title: title, url: url, onCompletion: onCompletion) else {
+            return
+        }
+
+        let popoverController = avc.popoverPresentationController
+        popoverController?.barButtonItem = item
+        viewController.present(avc, animated: true)
+    }
+
     /// List all activity types.
     /// UIActivity.ActivityType is not CaseIterable. :sadface:
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -318,7 +318,7 @@ private extension OrderDetailsViewController {
         actionSheet.addDefaultActionWithTitle(Localization.ActionsMenu.paymentLink) { [weak self] _ in
             guard let self = self else { return }
 
-            SharingHelper.shareURL(url: paymentLink, title: nil, from: self.view, in: self) { _, completed, _, _ in
+            SharingHelper.shareURL(url: paymentLink, title: nil, from: sender, in: self) { _, completed, _, _ in
                 if completed {
                     ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailPaymentLinkShared())
                 }


### PR DESCRIPTION
# Why

@kidinov noticed that the sharing sheet when sharing a payment link from the order details screen did not work correctly on iPad.

This PR fixes that by assigning the specific button item as a source view for the share sheet.

# Screenshots

Before | After | iPhone
---- | ---- | ---
![before](https://user-images.githubusercontent.com/562080/165185525-479a328d-4841-4cf1-824c-e042960a1b56.PNG) | ![after](https://user-images.githubusercontent.com/562080/165185512-4cd602be-26b6-4ce3-9912-5d00ada03db4.PNG) |  <img width="435" alt="Screen Shot 2022-04-25 at 5 25 15 PM" src="https://user-images.githubusercontent.com/562080/165185593-d57a91c4-5554-4aef-820c-bba43e128604.png">

# Testing Steps

- Go to a pending order with a positive value amount.
- Tap on the right bar button item to share the a payment link
- See that the share sheet appears correctly.


