### PR TITLE
[Mobile Payments] Experiment with flat fee on all IPP transactions when PaymentIntent is created

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -24,6 +24,9 @@ extension Hardware.PaymentIntentParameters {
         let returnValue = StripeTerminal.PaymentIntentParameters(amount: amountForStripe, currency: currency, paymentMethodTypes: paymentMethodTypes)
         returnValue.stripeDescription = receiptDescription
 
+        let applicationFeeForStripe = NSDecimalNumber(decimal: amountInSmallestUnit * 0.1)
+        returnValue.applicationFeeAmount = applicationFeeForStripe
+
         /// Stripe allows the credit card statement descriptor to be nil, but not an empty string
         /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)statementDescriptor
         returnValue.statementDescriptor = nil


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds a 10% flat rate fee, which gets overwritten on the WCPay Server when the payment is captured, with the correct rate for the payment method used.

**10% is only used for example and testing purposes** to make the effect clear when viewing transactions in Stripe's dashboard, it's not a fee we're intending to use.

This is a potential very simple resolution for #6708, where only Interac payments will have fees from the app.

We could still scope this to CA only, to reduce risk, but it would add a bit of complexity in the app.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N/A

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

