### PR TITLE
In-person refunds: ensure payment gateway account is available before fetching refund charge

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -107,7 +107,9 @@ final class IssueRefundViewModel {
     /// PaymentGatewayAccount Results Controller.
     private lazy var paymentGatewayAccountResultsController: ResultsController<StoragePaymentGatewayAccount> = {
         let predicate = NSPredicate(format: "siteID = %ld", state.order.siteID)
-        return ResultsController<StoragePaymentGatewayAccount>(storageManager: storage, matching: predicate, sortedBy: [])
+        let resultsController = ResultsController<StoragePaymentGatewayAccount>(storageManager: storage, matching: predicate, sortedBy: [])
+        try? resultsController.performFetch()
+        return resultsController
     }()
 
     /// Payment Gateway Accounts for the site (i.e. that can be used to refund)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -478,7 +478,7 @@ extension IssueRefundViewModel {
     /// Calculates whether there are pending changes to commit
     ///
     private func calculatePendingChangesState() -> Bool {
-        state.refundQuantityStore.count() > 0 || state.shouldRefundShipping || state.shouldRefundFees
+        (state.refundQuantityStore.count() > 0 || state.shouldRefundShipping || state.shouldRefundFees) && state.fetchChargeError == nil
     }
 
     /// Calculates whether the "select all" button should be visible or not.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -478,7 +478,11 @@ extension IssueRefundViewModel {
     /// Calculates whether there are pending changes to commit
     ///
     private func calculatePendingChangesState() -> Bool {
-        (state.refundQuantityStore.count() > 0 || state.shouldRefundShipping || state.shouldRefundFees) && state.fetchChargeError == nil
+        guard state.fetchChargeError == nil else {
+            return false
+        }
+
+        return state.refundQuantityStore.count() > 0 || state.shouldRefundShipping || state.shouldRefundFees
     }
 
     /// Calculates whether the "select all" button should be visible or not.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -107,6 +107,7 @@ final class RefundConfirmationViewModel {
                                                                                           presentingController: rootViewController),
                                                         currencyFormatter: currencyFormatter,
                                                         cardPresentConfiguration: CardPresentConfigurationLoader(stores: actionProcessor).configuration,
+                                                        paymentGatewayAccount: details.paymentGatewayAccount,
                                                         stores: actionProcessor,
                                                         analytics: analytics)
         self.submissionUseCase = submissionUseCase
@@ -171,6 +172,10 @@ extension RefundConfirmationViewModel {
         /// Payment gateway used with the order
         ///
         let paymentGateway: PaymentGateway?
+
+        /// Payment gateway account of the site (e.g. WCPay or Stripe extension)
+        ///
+        let paymentGatewayAccount: PaymentGatewayAccount?
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -98,16 +98,15 @@ final class RefundConfirmationViewModel {
         let refund = useCase.createRefund()
 
         // Submits refund.
-        let submissionUseCase = RefundSubmissionUseCase(siteID: details.order.siteID,
-                                                        details: .init(order: details.order,
+        let submissionUseCase = RefundSubmissionUseCase(details: .init(order: details.order,
                                                                        charge: details.charge,
-                                                                       amount: details.amount),
+                                                                       amount: details.amount,
+                                                                       paymentGatewayAccount: details.paymentGatewayAccount),
                                                         rootViewController: rootViewController,
                                                         alerts: OrderDetailsPaymentAlerts(transactionType: .refund,
                                                                                           presentingController: rootViewController),
                                                         currencyFormatter: currencyFormatter,
                                                         cardPresentConfiguration: CardPresentConfigurationLoader(stores: actionProcessor).configuration,
-                                                        paymentGatewayAccount: details.paymentGatewayAccount,
                                                         stores: actionProcessor,
                                                         analytics: analytics)
         self.submissionUseCase = submissionUseCase

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -21,9 +21,6 @@ protocol RefundSubmissionProtocol {
 /// submit refund to the site, and analytics.
 /// Otherwise, it submits the refund to the site directly with analytics.
 final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
-    /// Store's ID.
-    private let siteID: Int64
-
     /// Refund details.
     private let details: Details
 
@@ -61,7 +58,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
 
     /// Controller to connect a card reader for in-person refund.
     private lazy var cardReaderConnectionController =
-    CardReaderConnectionController(forSiteID: siteID,
+    CardReaderConnectionController(forSiteID: order.siteID,
                                    knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
                                    alertsProvider: CardReaderSettingsAlerts(),
                                    configuration: cardPresentConfiguration,
@@ -72,20 +69,14 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     /// IPP Configuration.
     private let cardPresentConfiguration: CardPresentPaymentsConfiguration
 
-    /// Payment Gateway Account for the site (i.e. that can be used to refund).
-    private let paymentGatewayAccount: PaymentGatewayAccount?
-
-    init(siteID: Int64,
-         details: Details,
+    init(details: Details,
          rootViewController: UIViewController,
          alerts: OrderDetailsPaymentAlertsProtocol,
          currencyFormatter: CurrencyFormatter,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          cardPresentConfiguration: CardPresentPaymentsConfiguration,
-         paymentGatewayAccount: PaymentGatewayAccount?,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
-        self.siteID = siteID
         self.details = details
         self.formattedAmount = {
             let currencyCode = currencySettings.currencyCode
@@ -96,7 +87,6 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
         self.alerts = alerts
         self.currencyFormatter = currencyFormatter
         self.cardPresentConfiguration = cardPresentConfiguration
-        self.paymentGatewayAccount = paymentGatewayAccount
         self.stores = stores
         self.analytics = analytics
     }
@@ -124,7 +114,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
                 return onCompletion(.failure(RefundSubmissionError.invalidRefundAmount))
             }
 
-            guard let paymentGatewayAccount = paymentGatewayAccount else {
+            guard let paymentGatewayAccount = details.paymentGatewayAccount else {
                 return onCompletion(.failure(RefundSubmissionError.unknownPaymentGatewayAccount))
             }
 
@@ -169,6 +159,9 @@ extension RefundSubmissionUseCase {
 
         /// Total amount to refund.
         let amount: String
+
+        /// Payment Gateway Account for the site (i.e. that can be used to refund).
+        let paymentGatewayAccount: PaymentGatewayAccount?
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Combine
 import Yosemite
-import protocol Storage.StorageManagerType
 
 /// Protocol to abstract the `RefundSubmissionUseCase`.
 /// TODO: 5983 - Use this to facilitate unit tests.
@@ -42,9 +41,6 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     /// Stores manager.
     private let stores: StoresManager
 
-    /// Storage manager for fetching payment gateway accounts.
-    private let storageManager: StorageManagerType
-
     /// Analytics manager.
     private let analytics: Analytics
 
@@ -76,16 +72,8 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     /// IPP Configuration.
     private let cardPresentConfiguration: CardPresentPaymentsConfiguration
 
-    /// PaymentGatewayAccount Results Controller.
-    private lazy var paymentGatewayAccountResultsController: ResultsController<StoragePaymentGatewayAccount> = {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
-        return ResultsController<StoragePaymentGatewayAccount>(storageManager: storageManager, matching: predicate, sortedBy: [])
-    }()
-
-    /// Payment Gateway Accounts for the site (i.e. that can be used to refund)
-    private var paymentGatewayAccounts: [PaymentGatewayAccount] {
-        paymentGatewayAccountResultsController.fetchedObjects
-    }
+    /// Payment Gateway Account for the site (i.e. that can be used to refund).
+    private let paymentGatewayAccount: PaymentGatewayAccount?
 
     init(siteID: Int64,
          details: Details,
@@ -94,8 +82,8 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
          currencyFormatter: CurrencyFormatter,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          cardPresentConfiguration: CardPresentPaymentsConfiguration,
+         paymentGatewayAccount: PaymentGatewayAccount?,
          stores: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.details = details
@@ -108,8 +96,8 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
         self.alerts = alerts
         self.currencyFormatter = currencyFormatter
         self.cardPresentConfiguration = cardPresentConfiguration
+        self.paymentGatewayAccount = paymentGatewayAccount
         self.stores = stores
-        self.storageManager = storageManager
         self.analytics = analytics
     }
 
@@ -133,15 +121,21 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
         if let charge = details.charge, shouldRefundWithCardReader(details: details) {
             guard let refundAmount = currencyFormatter.convertToDecimal(from: details.amount) else {
                 DDLogError("Error: attempted to refund an order without a valid amount.")
-                onCompletion(.failure(RefundSubmissionError.invalidRefundAmount))
-                return
+                return onCompletion(.failure(RefundSubmissionError.invalidRefundAmount))
             }
+
+            guard let paymentGatewayAccount = paymentGatewayAccount else {
+                return onCompletion(.failure(RefundSubmissionError.unknownPaymentGatewayAccount))
+            }
+
             observeConnectedReadersForAnalytics()
             connectReader { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case .success:
-                    self.attemptCardPresentRefund(refundAmount: refundAmount as Decimal, charge: charge) { [weak self] result in
+                    self.attemptCardPresentRefund(refundAmount: refundAmount as Decimal,
+                                                  charge: charge,
+                                                  paymentGatewayAccount: paymentGatewayAccount) { [weak self] result in
                         guard let self = self else { return }
                         switch result {
                         case .success:
@@ -245,15 +239,12 @@ private extension RefundSubmissionUseCase {
     /// - Parameters:
     ///   - refundAmount: the amount to refund.
     ///   - charge: the charge of the order for the refund to match the payment method.
+    ///   - paymentGatewayAccount: the payment gateway account for the site to refund (e.g. WCPay or Stripe extension).
     ///   - onCompletion: called when the in-person refund completes.
-    func attemptCardPresentRefund(refundAmount: Decimal, charge: WCPayCharge, onCompletion: @escaping (Result<Void, Error>) -> ()) {
-        // Fetches payment gateway accounts, at least one is required for in-person refunds.
-        try? paymentGatewayAccountResultsController.performFetch()
-        guard let paymentGatewayAccount = paymentGatewayAccounts.first else {
-            onCompletion(.failure(RefundSubmissionError.unknownPaymentGatewayAccount))
-            return
-        }
-
+    func attemptCardPresentRefund(refundAmount: Decimal,
+                                  charge: WCPayCharge,
+                                  paymentGatewayAccount: PaymentGatewayAccount,
+                                  onCompletion: @escaping (Result<Void, Error>) -> ()) {
         // Shows reader ready alert.
         alerts.readerIsReady(title: Localization.refundPaymentTitle(username: order.billingAddress?.firstName),
                              amount: formattedAmount,
@@ -280,17 +271,25 @@ private extension RefundSubmissionUseCase {
             guard let self = self else { return }
             switch result {
             case .success:
-                self.trackClientSideRefundRequestSuccess(charge: charge)
+                self.trackClientSideRefundRequestSuccess(charge: charge, paymentGatewayAccount: paymentGatewayAccount)
                 onCompletion(.success(()))
             case .failure(let error):
-                self.trackClientSideRefundRequestFailed(charge: charge, error: error)
-                self.handleRefundFailureAndRetryRefund(error, refundAmount: refundAmount, charge: charge, onCompletion: onCompletion)
+                self.trackClientSideRefundRequestFailed(charge: charge, paymentGatewayAccount: paymentGatewayAccount, error: error)
+                self.handleRefundFailureAndRetryRefund(error,
+                                                       refundAmount: refundAmount,
+                                                       charge: charge,
+                                                       paymentGatewayAccount: paymentGatewayAccount,
+                                                       onCompletion: onCompletion)
             }
         })
     }
 
     /// Logs the failure reason, cancels the current refund, and offers retry if possible.
-    func handleRefundFailureAndRetryRefund(_ error: Error, refundAmount: Decimal, charge: WCPayCharge, onCompletion: @escaping (Result<Void, Error>) -> ()) {
+    func handleRefundFailureAndRetryRefund(_ error: Error,
+                                           refundAmount: Decimal,
+                                           charge: WCPayCharge,
+                                           paymentGatewayAccount: PaymentGatewayAccount,
+                                           onCompletion: @escaping (Result<Void, Error>) -> ()) {
         // TODO: 5984 - tracks in-person refund error
         DDLogError("Failed to refund: \(error.localizedDescription)")
         // Informs about the error.
@@ -299,7 +298,10 @@ private extension RefundSubmissionUseCase {
             // Cancels current refund, if possible.
             self?.cardPresentRefundOrchestrator.cancelRefund { [weak self] _ in
                 // Regardless of whether the refund could be cancelled (e.g. it completed but failed), retry the refund.
-                self?.attemptCardPresentRefund(refundAmount: refundAmount, charge: charge, onCompletion: onCompletion)
+                self?.attemptCardPresentRefund(refundAmount: refundAmount,
+                                               charge: charge,
+                                               paymentGatewayAccount: paymentGatewayAccount,
+                                               onCompletion: onCompletion)
             }
         }, dismissCompletion: {
             onCompletion(.failure(error))
@@ -355,11 +357,11 @@ private extension RefundSubmissionUseCase {
     }
 
     /// Tracks when the refund request succeeds on the client-side before submitting to the site.
-    func trackClientSideRefundRequestSuccess(charge: WCPayCharge) {
+    func trackClientSideRefundRequestSuccess(charge: WCPayCharge, paymentGatewayAccount: PaymentGatewayAccount) {
         switch charge.paymentMethodDetails {
         case .interacPresent:
             analytics.track(event: WooAnalyticsEvent.InPersonPayments
-                .interacRefundSuccess(gatewayID: paymentGatewayAccounts.first?.gatewayID,
+                .interacRefundSuccess(gatewayID: paymentGatewayAccount.gatewayID,
                                       countryCode: cardPresentConfiguration.countryCode,
                                       cardReaderModel: connectedReader?.readerType.model ?? ""))
         default:
@@ -369,12 +371,12 @@ private extension RefundSubmissionUseCase {
     }
 
     /// Tracks when the refund request fails on the client-side before submitting to the site.
-    func trackClientSideRefundRequestFailed(charge: WCPayCharge, error: Error) {
+    func trackClientSideRefundRequestFailed(charge: WCPayCharge, paymentGatewayAccount: PaymentGatewayAccount, error: Error) {
         switch charge.paymentMethodDetails {
         case .interacPresent:
             analytics.track(event: WooAnalyticsEvent.InPersonPayments
                 .interacRefundFailed(error: error,
-                                     gatewayID: paymentGatewayAccounts.first?.gatewayID,
+                                     gatewayID: paymentGatewayAccount.gatewayID,
                                      countryCode: cardPresentConfiguration.countryCode,
                                      cardReaderModel: connectedReader?.readerType.model ?? ""))
         default:

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -42,7 +42,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                    receipt: .init(accountType: .credit,
                                                                                   applicationPreferredName: "Stripe Credit",
                                                                                   dedicatedFileName: "A000000003101001")))),
-                                                   amount: "2.28"))
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
         mockServerSideRefund(result: .success(()))
 
         // When
@@ -66,7 +67,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                    receipt: .init(accountType: .credit,
                                                                                   applicationPreferredName: "Stripe Credit",
                                                                                   dedicatedFileName: "A000000003101001")))),
-                                                   amount: "2.28"))
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
 
         // When
         useCase.submitRefund(.fake(), showInProgressUI: {}, onCompletion: { _ in })
@@ -85,8 +87,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                    receipt: .init(accountType: .credit,
                                                                                   applicationPreferredName: "Stripe Credit",
                                                                                   dedicatedFileName: "A000000003101001")))),
-                                                   amount: "2.28"),
-                                    paymentGatewayAccount: nil)
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: nil))
         mockSuccessfulCardReaderConnection(clientSideRefundResult: .success(()))
 
         // When
@@ -102,9 +104,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
     func test_submitRefund_successfully_tracks_interacRefundSuccess_event_when_payment_method_is_interac() throws {
         // Given
-        let siteID: Int64 = 322
-        let useCase = createUseCase(siteID: siteID,
-                                    details: .init(order: .fake().copy(total: "2.28"),
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
                                                    charge: .fake().copy(paymentMethodDetails: .interacPresent(
                                                     details: .init(brand: .visa,
                                                                    last4: "9969",
@@ -112,7 +112,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                    receipt: .init(accountType: .credit,
                                                                                   applicationPreferredName: "Stripe Credit",
                                                                                   dedicatedFileName: "A000000003101001")))),
-                                                   amount: "2.28"))
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
         mockSuccessfulCardReaderConnection(clientSideRefundResult: .success(()))
         mockServerSideRefund(result: .success(()))
 
@@ -135,11 +136,10 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
     func test_submitRefund_successfully_does_not_track_interacRefundSuccess_event_when_payment_method_is_not_interac() throws {
         // Given
-        let siteID: Int64 = 322
-        let useCase = createUseCase(siteID: siteID,
-                                    details: .init(order: .fake().copy(total: "2.28"),
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
                                                    charge: .fake().copy(paymentMethodDetails: .unknown),
-                                                   amount: "2.28"))
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
         mockSuccessfulCardReaderConnection(clientSideRefundResult: .success(()))
         mockServerSideRefund(result: .success(()))
 
@@ -158,9 +158,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
     func test_submitRefund_with_client_side_success_and_server_side_failure_tracks_interacRefundSuccess_event_when_payment_method_is_interac() throws {
         // Given
-        let siteID: Int64 = 322
-        let useCase = createUseCase(siteID: siteID,
-                                    details: .init(order: .fake().copy(total: "2.28"),
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
                                                    charge: .fake().copy(paymentMethodDetails: .interacPresent(
                                                     details: .init(brand: .visa,
                                                                    last4: "9969",
@@ -168,7 +166,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                    receipt: .init(accountType: .credit,
                                                                                   applicationPreferredName: "Stripe Credit",
                                                                                   dedicatedFileName: "A000000003101001")))),
-                                                   amount: "2.28"))
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
         mockSuccessfulCardReaderConnection(clientSideRefundResult: .success(()))
         mockServerSideRefund(result: .failure(RefundSubmissionUseCase.RefundSubmissionError.cardReaderDisconnected))
 
@@ -192,9 +191,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
     func test_submitRefund_with_client_side_failure_tracks_interacRefundFailed_event_when_payment_method_is_interac() throws {
         // Given
-        let siteID: Int64 = 322
-        let useCase = createUseCase(siteID: siteID,
-                                    details: .init(order: .fake().copy(total: "2.28"),
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
                                                    charge: .fake().copy(paymentMethodDetails: .interacPresent(
                                                     details: .init(brand: .visa,
                                                                    last4: "9969",
@@ -202,7 +199,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                    receipt: .init(accountType: .credit,
                                                                                   applicationPreferredName: "Stripe Credit",
                                                                                   dedicatedFileName: "A000000003101001")))),
-                                                   amount: "2.28"))
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
         mockSuccessfulCardReaderConnection(clientSideRefundResult: .failure(RefundSubmissionUseCase.RefundSubmissionError.cardReaderDisconnected))
 
         // When
@@ -251,19 +249,29 @@ private extension RefundSubmissionUseCaseTests {
         }
     }
 
-    func createUseCase(siteID: Int64 = Mocks.siteID,
-                       details: RefundSubmissionUseCase.Details,
-                       paymentGatewayAccount: PaymentGatewayAccount? = Mocks.paymentGatewayAccount(siteID: Mocks.siteID)) -> RefundSubmissionUseCase {
-        RefundSubmissionUseCase(siteID: siteID,
-                                details: details,
+    func createUseCase(details: RefundSubmissionUseCase.Details) -> RefundSubmissionUseCase {
+        RefundSubmissionUseCase(details: details,
                                 rootViewController: .init(),
                                 alerts: alerts,
                                 currencyFormatter: CurrencyFormatter(currencySettings: .init()),
                                 currencySettings: .init(),
                                 cardPresentConfiguration: Mocks.configuration,
-                                paymentGatewayAccount: paymentGatewayAccount,
                                 stores: stores,
                                 analytics: analytics)
+    }
+
+    func createPaymentGatewayAccount(siteID: Int64) -> PaymentGatewayAccount {
+        .fake()
+        .copy(
+            siteID: siteID,
+            gatewayID: Mocks.paymentGatewayID,
+            status: "complete",
+            hasPendingRequirements: false,
+            hasOverdueRequirements: false,
+            isCardPresentEligible: true,
+            isLive: true,
+            isInTestMode: false
+        )
     }
 }
 
@@ -273,19 +281,5 @@ private extension RefundSubmissionUseCaseTests {
         static let cardReaderModel: String = "WISEPAD_3"
         static let paymentGatewayID: String = "woocommerce-payments"
         static let siteID: Int64 = 322
-
-        static func paymentGatewayAccount(siteID: Int64) -> PaymentGatewayAccount {
-            .fake()
-            .copy(
-                siteID: siteID,
-                gatewayID: Mocks.paymentGatewayID,
-                status: "complete",
-                hasPendingRequirements: false,
-                hasOverdueRequirements: false,
-                isCardPresentEligible: true,
-                isLive: true,
-                isInTestMode: false
-            )
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -616,6 +616,26 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertTrue(chargeFetched)
     }
 
+    func test_viewModel_does_not_fetch_charge_and_is_disabled_when_no_PaymentGatewayAccount_in_storage() throws {
+        // Given
+        // The order has a chargeID
+        let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .fetchWCPayCharge(siteID: _, chargeID: _, onCompletion: _) = action {
+                XCTFail("Charge should not be fetched when there is no `PaymentGatewayAccount` in storage.")
+            }
+        }
+        storageManager.reset()
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
+
+        // Then
+        XCTAssertFalse(viewModel.isNextButtonAnimating)
+        XCTAssertFalse(viewModel.isNextButtonEnabled)
+    }
+
     func test_viewModel_shows_spinner_when_charge_not_fetched_yet() {
         // Given
         // The order has a chargeID
@@ -623,7 +643,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         insertSamplePaymentGateway(siteID: order.siteID)
 
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
         // Then
         XCTAssertTrue(viewModel.isNextButtonAnimating)
@@ -636,7 +656,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         insertSamplePaymentGateway(siteID: order.siteID)
 
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonAnimating)
@@ -649,7 +669,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         insertSamplePaymentGateway(siteID: order.siteID)
 
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonAnimating)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -619,7 +619,10 @@ final class IssueRefundViewModelTests: XCTestCase {
     func test_viewModel_does_not_fetch_charge_and_is_disabled_when_no_PaymentGatewayAccount_in_storage() throws {
         // Given
         // The order has a chargeID
-        let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+        ]
+        let order = MockOrders().makeOrder(items: items).copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
             if case .fetchWCPayCharge(siteID: _, chargeID: _, onCompletion: _) = action {
@@ -630,6 +633,7 @@ final class IssueRefundViewModelTests: XCTestCase {
 
         // When
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
+        viewModel.selectAllOrderItems()
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonAnimating)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -598,6 +598,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        insertSamplePaymentGateway(siteID: order.siteID)
 
         // When
         let chargeFetched: Bool = waitFor { promise in
@@ -608,7 +609,7 @@ final class IssueRefundViewModelTests: XCTestCase {
                 promise(true)
             }
 
-            _ = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
+            _ = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: self.storageManager)
         }
 
         // Then
@@ -620,6 +621,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
 
@@ -632,6 +634,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: nil)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
 
@@ -644,6 +647,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores)
 
@@ -656,6 +660,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
@@ -665,5 +670,25 @@ final class IssueRefundViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonAnimating)
+    }
+}
+
+private extension IssueRefundViewModelTests {
+    func insertSamplePaymentGateway(siteID: Int64) {
+        let paymentGatewayAccount = PaymentGatewayAccount
+            .fake()
+            .copy(
+                siteID: siteID,
+                gatewayID: "woocommerce-payments",
+                status: "complete",
+                hasPendingRequirements: false,
+                hasOverdueRequirements: false,
+                isCardPresentEligible: true,
+                isLive: true,
+                isInTestMode: false
+            )
+        storageManager.reset()
+        let newAccount = storageManager.viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
+        newAccount.update(with: paymentGatewayAccount)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -43,7 +43,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
 
         let viewModel = RefundConfirmationViewModel(details: details, currencySettings: currencySettings)
 
@@ -70,7 +71,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, currencySettings: currencySettings)
@@ -89,7 +91,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: gateway)
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details)
@@ -113,7 +116,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: gateway)
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details)
@@ -140,7 +144,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: gateway)
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details)
@@ -164,7 +169,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
         let dispatcher = MockStoresManager(sessionManager: .testingInstance)
         dispatcher.whenReceivingAction(ofType: RefundAction.self) { action in
             switch action {
@@ -202,7 +208,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
         let dispatcher = MockStoresManager(sessionManager: .testingInstance)
         dispatcher.whenReceivingAction(ofType: RefundAction.self) { action in
             switch action {
@@ -244,7 +251,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: true,
                                                           refundsFees: true,
                                                           items: [],
-                                                          paymentGateway: gateway)
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
         let dispatcher = MockStoresManager(sessionManager: .testingInstance)
 
         // When
@@ -276,7 +284,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: true,
                                                           refundsFees: true,
                                                           items: [],
-                                                          paymentGateway: gateway)
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
         let dispatcher = MockStoresManager(sessionManager: .testingInstance)
 
         // When
@@ -306,7 +315,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
         let expectedError = NSError(domain: "Refund Error", code: 0, userInfo: nil)
         let dispatcher = MockStoresManager(sessionManager: .testingInstance)
         dispatcher.whenReceivingAction(ofType: RefundAction.self) { action in
@@ -346,7 +356,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
         let viewModel = RefundConfirmationViewModel(details: details, analytics: analytics)
 
         // When
@@ -367,7 +378,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: gateway)
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
         let viewModel = RefundConfirmationViewModel(details: details, analytics: analytics)
 
         // When
@@ -394,7 +406,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: gateway)
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
         let viewModel = RefundConfirmationViewModel(details: details, analytics: analytics)
 
         // When
@@ -420,7 +433,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
         let expectedError = NSError(domain: "Refund Error", code: 0, userInfo: nil)
         let dispatcher = MockStoresManager(sessionManager: .testingInstance)
         dispatcher.whenReceivingAction(ofType: RefundAction.self) { action in
@@ -456,7 +470,8 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                           refundsShipping: false,
                                                           refundsFees: false,
                                                           items: [],
-                                                          paymentGateway: nil)
+                                                          paymentGateway: nil,
+                                                          paymentGatewayAccount: nil)
         let dispatcher = MockStoresManager(sessionManager: .testingInstance)
         dispatcher.whenReceivingAction(ofType: RefundAction.self) { action in
             switch action {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6690 
Closes: #6692 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When responding to this comment pdfdoF-Fi-p2#comment-1346, I checked the iOS implementation and saw that we aren't currently checking if a payment gateway account (WCPay or Stripe) is available before fetching the refund charge to enable in-person refunds. During the in-person refund flow, we do check the payment gateway account, but it's after card reader connection while we can just fail early.

This PR moved payment gateway account fetching from `RefundSubmissionUseCase` to `IssueRefundViewModel`. When there is no payment gateway account, it sets the state's `fetchChargeError: FetchChargeError?` so that refund is currently disabled and refund charge isn't fetched when the order has a charge ID.

After this PR: as an improvement to the UX when the app cannot find a payment gateway account or if the refund charge API request fails, we can show a snack bar with a "Retry" CTA to check for payment gateway account and fetch the refund charge again (https://github.com/woocommerce/woocommerce-ios/issues/6716).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites: the store is in Canada and eligible for IPP (setup instructions PdfdoF-D-p2)

#### The happy path 🌞 

- Switch to a store in the prerequisites if needed
- Go to the orders tab
- Create an order and pay it with Interac using a physical card reader, if you don't have one already
- Go to the order above
- Tap "Issue Refund" and select the refund amount to confirm --> the "Next" CTA should be enabled
- Insert the Interac test card and enter pin number --> a success notice is shown with the updated order, and the refund should go through in wp-admin. In the console, IPP events should have a property `plugin_slug: "woocommerce-payments"` from the payment gateway account

#### The failure path 🌧️ 

- You can simulate the error without a payment gateway account by changing the predicate of `paymentGatewayAccountResultsController` in `IssueRefundViewModel.swift` to be like `let predicate = NSPredicate(format: "siteID = %ld", 0)`
- Switch to a store in the prerequisites if needed
- Go to the orders tab
- Create an order and pay it with Interac using a physical card reader, if you don't have one already
- Go to the order above
- Tap "Issue Refund" and select the refund amount to confirm --> the "Next" CTA should **not** be enabled (because there is no payment gateway account)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->