### PR TITLE
[Mobile Payments] Replace link because previous one was giving 404 back

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -248,7 +248,7 @@ private enum Row: CaseIterable {
 }
 
 private enum Constants {
-    static let bbposChipper2XBTManualURL = URL(string: "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf")!
+    static let bbposChipper2XBTManualURL = URL(string: "https://stripe.com/files/docs/terminal/c2xbt_product_sheet.pdf")!
     static let stripeM2ManualURL = URL(string: "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf")!
     static let wisepad3ManualURL = URL(string: "https://stripe.com/files/docs/terminal/wp3_product_sheet.pdf")!
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6710
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The BBPOs card reader manual link is currently returning a 404 error because it seems to have been moved behind a login page. Following this convo p1650664840720759-slack-C025A8VV728 this PR replaces the old link in the InPersonPaymentsMenuViewController.swift file with the correct link provided by Stripe:

https://stripe.com/files/docs/terminal/c2xbt_product_sheet.pdf

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites: Have setup an american based store with access to IPP.

- Go to the Settings Page
- Click on IPP tab
- Click on the BBPOS Chipper Card Reader Manual tab 
- Confirm the link works. 

### Screenshots

https://user-images.githubusercontent.com/1864060/165309136-e271b47d-b67d-4658-9a5d-2d3383bc4b2d.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
