### PR TITLE
[Mobile Payments] Charge fees on payment intent creation in Canada

### DIFF
--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -10,6 +10,10 @@ public struct PaymentIntentParameters {
     @CurrencyCode
     public private(set) var currency: String
 
+    /// The base fee to charge the Merchant for the payment. This is for client-side transactions, e.g. Interac, and will
+    /// be overridden server-side for transactions which are captured on the Server.
+    public let applicationFee: Decimal?
+
     /// An arbitrary string attached to the object. If you send a receipt email for this payment, the email will include the description.
     public let receiptDescription: String?
 
@@ -40,6 +44,7 @@ public struct PaymentIntentParameters {
 
     public init(amount: Decimal,
                 currency: String,
+                applicationFee: Decimal? = nil,
                 receiptDescription: String? = nil,
                 statementDescription: String? = nil,
                 receiptEmail: String? = nil,
@@ -47,6 +52,7 @@ public struct PaymentIntentParameters {
                 metadata: [AnyHashable: Any]? = nil) {
         self.amount = amount
         self.currency = currency
+        self.applicationFee = applicationFee
         self.receiptDescription = receiptDescription
         self.statementDescription = statementDescription
         self.receiptEmail = receiptEmail

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -270,7 +270,7 @@ private extension PaymentCaptureOrchestrator {
     }
 
     private func applicationFee(for orderTotal: NSDecimalNumber, country: String) -> Decimal? {
-        guard country.uppercased() == "CA" else {
+        guard country.uppercased() == SiteAddress.CountryCode.CA.rawValue else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -19,7 +19,7 @@ struct CardPresentCapturedPaymentData {
 final class PaymentCaptureOrchestrator {
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
     private let personNameComponentsFormatter = PersonNameComponentsFormatter()
-    private let paymentReceiptEmailParameterDeterminer = PaymentReceiptEmailParameterDeterminer()
+    private let paymentReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer
 
     private let celebration = PaymentCaptureCelebration()
 
@@ -27,8 +27,10 @@ final class PaymentCaptureOrchestrator {
 
     private let stores: StoresManager
 
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(stores: StoresManager = ServiceLocator.stores,
+         paymentReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer = PaymentReceiptEmailParameterDeterminer()) {
         self.stores = stores
+        self.paymentReceiptEmailParameterDeterminer = paymentReceiptEmailParameterDeterminer
     }
 
     func collectPayment(for order: Order,

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -1,9 +1,15 @@
 import Foundation
 import Yosemite
 
+/// Determines the email to be set (if any) on a receipt
+///
+protocol ReceiptEmailParameterDeterminer {
+    func receiptEmail(from order: Order, onCompletion: @escaping ((Result<String?, Error>) -> Void))
+}
+
 /// Determines the email to be set (if any) on a payment receipt depending on the current payment plugins (WCPay, Stripe) configuration
-/// 
-struct PaymentReceiptEmailParameterDeterminer {
+///
+struct PaymentReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {
     private let cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol
     private let stores: StoresManager
     private static let defaultConfiguration = CardPresentConfigurationLoader(stores: ServiceLocator.stores).configuration

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
+		036F6EA6281847D5006D84F8 /* PaymentCaptureOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036F6EA5281847D5006D84F8 /* PaymentCaptureOrchestratorTests.swift */; };
 		0379C51727BFCE9800A7E284 /* WCPayCardBrand+icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0379C51627BFCE9800A7E284 /* WCPayCardBrand+icons.swift */; };
 		0379C51927BFE23400A7E284 /* RefundConfirmationCardDetailsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0379C51827BFE23400A7E284 /* RefundConfirmationCardDetailsCell.xib */; };
 		0379C51B27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0379C51A27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift */; };
@@ -2130,6 +2131,7 @@
 		031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectionFailedUpdateAddress.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingFailedUpdatePostalCode.swift; sourceTree = "<group>"; };
+		036F6EA5281847D5006D84F8 /* PaymentCaptureOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCaptureOrchestratorTests.swift; sourceTree = "<group>"; };
 		0379C51627BFCE9800A7E284 /* WCPayCardBrand+icons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+icons.swift"; sourceTree = "<group>"; };
 		0379C51827BFE23400A7E284 /* RefundConfirmationCardDetailsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundConfirmationCardDetailsCell.xib; sourceTree = "<group>"; };
 		0379C51A27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundConfirmationCardDetailsCell.swift; sourceTree = "<group>"; };
@@ -7396,6 +7398,7 @@
 				026D4A23280461960090164F /* CollectOrderPaymentUseCaseTests.swift */,
 				028E19BB2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift */,
 				B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */,
+				036F6EA5281847D5006D84F8 /* PaymentCaptureOrchestratorTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -9586,6 +9589,7 @@
 				265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */,
 				265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */,
 				03FBDAFD263EE4E800ACE257 /* CouponListViewModelTests.swift in Sources */,
+				036F6EA6281847D5006D84F8 /* PaymentCaptureOrchestratorTests.swift in Sources */,
 				B555531321B57E8800449E71 /* MockUserNotificationsCenterAdapter.swift in Sources */,
 				4590B652261C8D1E00A6FCE0 /* WeightFormatterTests.swift in Sources */,
 				D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -1,8 +1,6 @@
 import XCTest
 import Yosemite
 @testable import WooCommerce
-import SwiftUI
-import simd
 
 final class PaymentCaptureOrchestratorTests: XCTestCase {
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -1,0 +1,218 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+class PaymentCaptureOrchestratorTests: XCTestCase {
+
+    private var stores: MockStoresManager! = nil
+    private var sut: PaymentCaptureOrchestrator! = nil
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUpWithError() throws {
+        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        sut = PaymentCaptureOrchestrator(stores: stores)
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func test_collectPayment_for_a_payment_to_a_US_gateway_account_does_not_include_applicationFee_in_the_payment_intent() throws {
+        // Given
+        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
+                                                        defaultCurrency: "USD",
+                                                        supportedCurrencies: ["USD"],
+                                                        country: "US",
+                                                        isCardPresentEligible: true)
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "USD", total: "150.00")
+        mockCollectPaymentActionReaderMessage()
+
+        // When
+        waitFor { [weak self] promise in
+            self?.sut.collectPayment(
+                for: order,
+                   paymentGatewayAccount: account,
+                   paymentMethodTypes: ["card_present"],
+                   onWaitingForInput: {
+                       promise(())
+                   },
+                   onProcessingMessage: {},
+                   onDisplayMessage: { _ in },
+                   onProcessingCompletion: { _ in },
+                   onCompletion: { _ in })
+        }
+
+        // Then
+        let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
+
+        switch action {
+        case .collectPayment(siteID: _, orderID: _, parameters: let parameters, onCardReaderMessage: _, onProcessingCompletion: _, onCompletion: _):
+            XCTAssertNil(parameters.applicationFee)
+        default:
+            XCTFail("Collecting Payment did not send collectPayment CardPresentPaymentAction")
+        }
+    }
+
+    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_2point6percent_plus_25cents_applicationFee_in_the_payment_intent() throws {
+        // Given
+        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
+                                                        defaultCurrency: "CAD",
+                                                        supportedCurrencies: ["CAD"],
+                                                        country: "CA",
+                                                        isCardPresentEligible: true)
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "150.00")
+        mockCollectPaymentActionReaderMessage()
+
+        // When
+        waitFor { [weak self] promise in
+            self?.sut.collectPayment(
+                for: order,
+                   paymentGatewayAccount: account,
+                   paymentMethodTypes: ["card_present"],
+                   onWaitingForInput: {
+                       promise(())
+                   },
+                   onProcessingMessage: {},
+                   onDisplayMessage: { _ in },
+                   onProcessingCompletion: { _ in },
+                   onCompletion: { _ in })
+        }
+
+        // Then
+        let expectedFee = NSDecimalNumber(string: "4.15").decimalValue
+
+        let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
+
+        switch action {
+        case .collectPayment(siteID: _, orderID: _, parameters: let parameters, onCardReaderMessage: _, onProcessingCompletion: _, onCompletion: _):
+            assertEqual(expectedFee, parameters.applicationFee)
+        default:
+            XCTFail("Collecting Payment did not send collectPayment CardPresentPaymentAction")
+        }
+    }
+
+    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_rounds_up_applicationFees_to_2dp_where_next_digit_is_over_5() throws {
+        // Given
+        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
+                                                        defaultCurrency: "CAD",
+                                                        supportedCurrencies: ["CAD"],
+                                                        country: "CA",
+                                                        isCardPresentEligible: true)
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "153.00")
+        mockCollectPaymentActionReaderMessage()
+
+        // When
+        waitFor { [weak self] promise in
+            self?.sut.collectPayment(
+                for: order,
+                   paymentGatewayAccount: account,
+                   paymentMethodTypes: ["card_present"],
+                   onWaitingForInput: {
+                       promise(())
+                   },
+                   onProcessingMessage: {},
+                   onDisplayMessage: { _ in },
+                   onProcessingCompletion: { _ in },
+                   onCompletion: { _ in })
+        }
+
+        // Then
+        let expectedFee = NSDecimalNumber(string: "4.23").decimalValue // 153 * 0.026 + 0.25 = 422.8
+
+        let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
+
+        switch action {
+        case .collectPayment(siteID: _, orderID: _, parameters: let parameters, onCardReaderMessage: _, onProcessingCompletion: _, onCompletion: _):
+            assertEqual(expectedFee, parameters.applicationFee)
+        default:
+            XCTFail("Collecting Payment did not send collectPayment CardPresentPaymentAction")
+        }
+    }
+
+    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_rounds_up_applicationFees_to_2dp_where_next_digit_is_exactly_5() throws {
+        // Given
+        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
+                                                        defaultCurrency: "CAD",
+                                                        supportedCurrencies: ["CAD"],
+                                                        country: "CA",
+                                                        isCardPresentEligible: true)
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "42.50")
+        mockCollectPaymentActionReaderMessage()
+
+        // When
+        waitFor { [weak self] promise in
+            self?.sut.collectPayment(
+                for: order,
+                   paymentGatewayAccount: account,
+                   paymentMethodTypes: ["card_present"],
+                   onWaitingForInput: {
+                       promise(())
+                   },
+                   onProcessingMessage: {},
+                   onDisplayMessage: { _ in },
+                   onProcessingCompletion: { _ in },
+                   onCompletion: { _ in })
+        }
+
+        // Then
+        let expectedFee = NSDecimalNumber(string: "1.36").decimalValue // 42.5 * 0.026 + 0.25 = 1.355
+
+        let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
+
+        switch action {
+        case .collectPayment(siteID: _, orderID: _, parameters: let parameters, onCardReaderMessage: _, onProcessingCompletion: _, onCompletion: _):
+            assertEqual(expectedFee, parameters.applicationFee)
+        default:
+            XCTFail("Collecting Payment did not send collectPayment CardPresentPaymentAction")
+        }
+    }
+
+    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_rounds_down_applicationFees_to_2dp_where_next_digit_is_below_5() throws {
+        // Given
+        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
+                                                        defaultCurrency: "CAD",
+                                                        supportedCurrencies: ["CAD"],
+                                                        country: "CA",
+                                                        isCardPresentEligible: true)
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "39")
+        mockCollectPaymentActionReaderMessage()
+
+        // When
+        waitFor { [weak self] promise in
+            self?.sut.collectPayment(
+                for: order,
+                   paymentGatewayAccount: account,
+                   paymentMethodTypes: ["card_present"],
+                   onWaitingForInput: {
+                       promise(())
+                   },
+                   onProcessingMessage: {},
+                   onDisplayMessage: { _ in },
+                   onProcessingCompletion: { _ in },
+                   onCompletion: { _ in })
+        }
+
+        // Then
+        let expectedFee = NSDecimalNumber(string: "1.26").decimalValue // 39 * 0.026 + 0.25 = 1.264
+
+        let action = try XCTUnwrap(stores.receivedActions.last as? CardPresentPaymentAction)
+
+        switch action {
+        case .collectPayment(siteID: _, orderID: _, parameters: let parameters, onCardReaderMessage: _, onProcessingCompletion: _, onCompletion: _):
+            assertEqual(expectedFee, parameters.applicationFee)
+        default:
+            XCTFail("Collecting Payment did not send collectPayment CardPresentPaymentAction")
+        }
+    }
+
+}
+
+extension PaymentCaptureOrchestratorTests {
+    func mockCollectPaymentActionReaderMessage() {
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case let .collectPayment(_, _, _, onCardReaderMessage, _, _) = action {
+                onCardReaderMessage(.waitingForInput("Present card"))
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -10,7 +10,8 @@ class PaymentCaptureOrchestratorTests: XCTestCase {
 
     override func setUpWithError() throws {
         stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
-        sut = PaymentCaptureOrchestrator(stores: stores)
+        sut = PaymentCaptureOrchestrator(stores: stores,
+                                         paymentReceiptEmailParameterDeterminer: MockReceiptEmailParameterDeterminer())
     }
 
     override func tearDownWithError() throws {
@@ -214,5 +215,11 @@ extension PaymentCaptureOrchestratorTests {
                 onCardReaderMessage(.waitingForInput("Present card"))
             }
         }
+    }
+}
+
+struct MockReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {
+    func receiptEmail(from order: Order, onCompletion: @escaping ((Result<String?, Error>) -> Void)) {
+        onCompletion(.success(nil))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6708
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We charge merchants a fee for processing transactions, which is applied by WCPay Server on the capture step. 

Interac card-present payments do not do the capture step on the WCPay Server, so did not have any fees applied.

This adds the Interac fees to all payment intents in Canada. For non-Interac CA transactions, these fees are overwritten with the correct rate at the capture step as normal.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

To check the fees, you'll need to open either the payment in WCPay, or the Stripe Dashboard. Here's how you find them:

**WCPay**: wp-admin > WooCommerce > Orders > {Select order} > Payment via Credit card / debit card (pi_3KltEV2EdyGr1FMV0HIiVlDl)
<img width="451" alt="Payment details on WCPay" src="https://user-images.githubusercontent.com/2472348/165477911-e40aa3ff-7872-4b75-8e70-b73943ae914e.png">

**Stripe**: You'll need access to the Stripe Dashboard for this: PdfdoF-1A-p2
Toggle `Test mode` viewing, and [find your site's account](https://dashboard.stripe.com/connect/accounts/overview) – use the filters and ⚙️ in the columns to help narrow it down.
Select `Payments` under Activity
Select the payment for your order
<img width="626" alt="Payment details in Stripe Dashboard" src="https://user-images.githubusercontent.com/2472348/165479306-539db3fb-df03-4e42-b323-6e536e8e2051.png">



#### Testing fees
1. Make an order or simple payment
2. Take a card-present payment for the order
3. Check the payment in the WCPay Dashboard or Stripe Dashboard – the fee should show. 

Calculate it to check it's correct! The formula is shown in WCPay, so do that calculation manually.

Repeat for the following:

- US transaction
- Canada non-Interac transaction
- Canada Interac transaction

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![US Visa Credit Payment Fees@2x](https://user-images.githubusercontent.com/2472348/165484038-843bb75e-073b-4d63-bb8b-a694dc98c157.jpg)
Visa US: expected 2.6% + 0.10 = $2.70

![Canada Visa Credit Payment Fees@2x](https://user-images.githubusercontent.com/2472348/165484036-7803844b-848c-4906-bed9-a796ccb502cb.jpg)
Visa CA: expected 2.6% + 0.10 = $2.70

![Canada Interac Payment Fees@2x](https://user-images.githubusercontent.com/2472348/165484028-2e21c47a-05f7-48a2-a284-5951b7b08312.jpg)
Interac: expected 2.6% + 0.25 = $2.85


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
