### PR TITLE
Coupons: Add category selector 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -149,12 +149,12 @@ struct AddEditCoupon: View {
                                 showingSelectProducts = true
                             } label: {
                                 HStack {
-                                    if viewModel.productOrVariationIDs.isNotEmpty {
+                                    if viewModel.hasSelectedProducts {
                                         Image(uiImage: .pencilImage)
                                             .resizable()
                                             .colorMultiply(Color(.text))
                                             .frame(width: Constants.iconSize, height: Constants.iconSize)
-                                        Text(String.localizedStringWithFormat(Localization.editProductsButton, viewModel.productOrVariationIDs.count))
+                                        Text(viewModel.editProductsButtonTitle)
                                             .bodyStyle()
                                     } else {
                                         Text(Localization.allProductsButton)
@@ -170,12 +170,12 @@ struct AddEditCoupon: View {
                                 showingSelectCategories = true
                             } label: {
                                 HStack {
-                                    if viewModel.categoryIDs.isNotEmpty {
+                                    if viewModel.hasSelectedCategories {
                                         Image(uiImage: .pencilImage)
                                             .resizable()
                                             .colorMultiply(Color(.text))
                                             .frame(width: Constants.iconSize, height: Constants.iconSize)
-                                        Text(String.localizedStringWithFormat(Localization.editProductCategoriesButton, viewModel.categoryIDs.count))
+                                        Text(viewModel.editCategoriesButtonTitle)
                                             .bodyStyle()
                                     } else {
                                         Image(uiImage: .plusImage)
@@ -302,17 +302,9 @@ private extension AddEditCoupon {
         static let allProductsButton = NSLocalizedString(
             "All Products",
             comment: "Button indicating that coupon can be applied to all products in the view for adding or editing a coupon.")
-        static let editProductsButton = NSLocalizedString(
-            "Edit Products (%1$d)",
-            comment: "Button specifying the number of products applicable to a coupon in the view for adding or editing a coupon. " +
-            "Reads like: Edit Products (2)")
         static let selectCategoriesButton = NSLocalizedString(
             "Select Product Categories",
             comment: "Button to select specific categories applicable for a coupon in the view for adding or editing a coupon.")
-        static let editProductCategoriesButton = NSLocalizedString(
-            "Edit Product Categories (%1$d)",
-            comment: "Button for specify the product categories where a coupon can be applied in the view for adding or editing a coupon. " +
-            "Reads like: Edit Categories")
         static let headerUsageDetails = NSLocalizedString(
             "Usage Details",
             comment: "Header of the section usage details in the view for adding or editing a coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -357,3 +357,21 @@ private extension ProductSelector.Configuration {
         )
     }
 }
+
+private extension ProductCategorySelector.Configuration {
+    static let categoriesForCoupons: Self = .init(
+        title: Localization.title,
+        doneButtonSingularFormat: Localization.doneSingularFormat,
+        doneButtonPluralFormat: Localization.donePluralFormat
+    )
+
+    enum Localization {
+        static let title = NSLocalizedString("Select categories", comment: "Title for the Select Categories screen")
+        static let doneSingularFormat = NSLocalizedString("Select %1$@ Category", comment: "Button to submit selection on the Select Category screen when 1 item is selected")
+        static let donePluralFormat = NSLocalizedString(
+            "Select %1$@ Categories",
+            comment: "Button to submit selection on the Select Category screen " +
+            "when more than 1 item is selected. " +
+            "Reads like: Select 10 Categories")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -11,6 +11,7 @@ struct AddEditCoupon: View {
     @State private var showingCouponExpiryDate: Bool = false
     @State private var showingCouponRestrictions: Bool = false
     @State private var showingSelectProducts: Bool = false
+    @State private var showingSelectCategories: Bool = false
     @Environment(\.presentationMode) var presentation
 
     private var expiryDateActionSheetButtons: [Alert.Button] {
@@ -163,7 +164,7 @@ struct AddEditCoupon: View {
                             .padding(.bottom, Constants.verticalSpacing)
 
                             Button {
-                                //TODO: handle action
+                                showingSelectCategories = true
                             } label: {
                                 HStack {
                                     Image(uiImage: .pencilImage)
@@ -228,6 +229,11 @@ struct AddEditCoupon: View {
                     .onDisappear {
                         viewModel.productSelectorViewModel.clearSearchAndFilters()
                     }
+            }
+            .sheet(isPresented: $showingSelectCategories) {
+                ProductCategorySelector(isPresented: $showingSelectCategories,
+                                        config: ProductCategorySelector.Configuration.categoriesForCoupons,
+                                        viewModel: viewModel.categorySelectorViewModel)
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -367,9 +373,11 @@ private extension ProductCategorySelector.Configuration {
 
     enum Localization {
         static let title = NSLocalizedString("Select categories", comment: "Title for the Select Categories screen")
-        static let doneSingularFormat = NSLocalizedString("Select %1$@ Category", comment: "Button to submit selection on the Select Category screen when 1 item is selected")
+        static let doneSingularFormat = NSLocalizedString(
+            "Select %1$d Category",
+            comment: "Button to submit selection on the Select Category screen when 1 item is selected")
         static let donePluralFormat = NSLocalizedString(
-            "Select %1$@ Categories",
+            "Select %1$d Categories",
             comment: "Button to submit selection on the Select Category screen " +
             "when more than 1 item is selected. " +
             "Reads like: Select 10 Categories")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -104,6 +104,7 @@ struct AddEditCoupon: View {
                             } label: {
                                 HStack {
                                     Image(uiImage: viewModel.editDescriptionIcon)
+                                        .resizable()
                                         .colorMultiply(Color(.text))
                                         .frame(width: Constants.iconSize, height: Constants.iconSize)
                                     Text(viewModel.editDescriptionLabel)
@@ -149,7 +150,9 @@ struct AddEditCoupon: View {
                             } label: {
                                 HStack {
                                     if viewModel.productOrVariationIDs.isNotEmpty {
-                                        Image(uiImage: .pencilImage).colorMultiply(Color(.text))
+                                        Image(uiImage: .pencilImage)
+                                            .resizable()
+                                            .colorMultiply(Color(.text))
                                             .frame(width: Constants.iconSize, height: Constants.iconSize)
                                         Text(String.localizedStringWithFormat(Localization.editProductsButton, viewModel.productOrVariationIDs.count))
                                             .bodyStyle()
@@ -167,11 +170,20 @@ struct AddEditCoupon: View {
                                 showingSelectCategories = true
                             } label: {
                                 HStack {
-                                    Image(uiImage: .pencilImage)
-                                        .colorMultiply(Color(.text))
-                                        .frame(width: Constants.iconSize, height: Constants.iconSize)
-                                    Text(Localization.editProductCategoriesButton)
-                                        .bodyStyle()
+                                    if viewModel.categoryIDs.isNotEmpty {
+                                        Image(uiImage: .pencilImage)
+                                            .resizable()
+                                            .colorMultiply(Color(.text))
+                                            .frame(width: Constants.iconSize, height: Constants.iconSize)
+                                        Text(String.localizedStringWithFormat(Localization.editProductCategoriesButton, viewModel.categoryIDs.count))
+                                            .bodyStyle()
+                                    } else {
+                                        Image(uiImage: .plusImage)
+                                            .resizable()
+                                            .frame(width: Constants.iconSize, height: Constants.iconSize)
+                                        Text(Localization.selectCategoriesButton)
+                                            .bodyStyle()
+                                    }
                                 }
                             }
                             .buttonStyle(SecondaryButtonStyle())
@@ -294,9 +306,13 @@ private extension AddEditCoupon {
             "Edit Products (%1$d)",
             comment: "Button specifying the number of products applicable to a coupon in the view for adding or editing a coupon. " +
             "Reads like: Edit Products (2)")
+        static let selectCategoriesButton = NSLocalizedString(
+            "Select Product Categories",
+            comment: "Button to select specific categories applicable for a coupon in the view for adding or editing a coupon.")
         static let editProductCategoriesButton = NSLocalizedString(
-            "Edit Product Categories",
-            comment: "Button for specify the product categories where a coupon can be applied in the view for adding or editing a coupon.")
+            "Edit Product Categories (%1$d)",
+            comment: "Button for specify the product categories where a coupon can be applied in the view for adding or editing a coupon. " +
+            "Reads like: Edit Categories")
         static let headerUsageDetails = NSLocalizedString(
             "Usage Details",
             comment: "Header of the section usage details in the view for adding or editing a coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -391,10 +391,10 @@ private extension ProductCategorySelector.Configuration {
         static let title = NSLocalizedString("Select categories", comment: "Title for the Select Categories screen")
         static let doneSingularFormat = NSLocalizedString(
             "Select %1$d Category",
-            comment: "Button to submit selection on the Select Category screen when 1 item is selected")
+            comment: "Button to submit selection on the Select Categories screen when 1 item is selected")
         static let donePluralFormat = NSLocalizedString(
             "Select %1$d Categories",
-            comment: "Button to submit selection on the Select Category screen " +
+            comment: "Button to submit selection on the Select Categories screen " +
             "when more than 1 item is selected. " +
             "Reads like: Select 10 Categories")
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -86,12 +86,36 @@ final class AddEditCouponViewModel: ObservableObject {
         })
     }
 
+    /// Title for the Edit Products button with the number of selected products.
+    ///
+    var editProductsButtonTitle: String {
+        String.localizedStringWithFormat(Localization.editProductsButton, productOrVariationIDs.count)
+    }
+
     /// View model for the category selector
     ///
     var categorySelectorViewModel: ProductCategorySelectorViewModel {
         .init(siteID: siteID, selectedCategories: categoryIDs) { [weak self] categories in
             self?.categoryIDs = categories.map { $0.categoryID }
         }
+    }
+
+    /// Title for the Edit Categories button with the number of selected product categories.
+    ///
+    var editCategoriesButtonTitle: String {
+        String.localizedStringWithFormat(Localization.editProductCategoriesButton, categoryIDs.count)
+    }
+
+    /// Whether the coupon is applicable to any specified products.
+    ///
+    var hasSelectedProducts: Bool {
+        productOrVariationIDs.isNotEmpty
+    }
+
+    /// Whether the coupon is applicable to any specified product categories.
+    ///
+    var hasSelectedCategories: Bool {
+        categoryIDs.isNotEmpty
     }
 
     private(set) var coupon: Coupon?
@@ -109,8 +133,8 @@ final class AddEditCouponViewModel: ObservableObject {
     @Published var expiryDateField: Date?
     @Published var freeShipping: Bool
     @Published var couponRestrictionsViewModel: CouponRestrictionsViewModel
-    @Published var productOrVariationIDs: [Int64]
-    @Published var categoryIDs: [Int64]
+    @Published private var productOrVariationIDs: [Int64]
+    @Published private var categoryIDs: [Int64]
 
     /// Init method for coupon creation
     ///
@@ -264,5 +288,13 @@ private extension AddEditCouponViewModel {
         static let couponExpiryDatePlaceholder = NSLocalizedString(
             "None",
             comment: "Coupon expiry date placeholder in the view for adding or editing a coupon")
+        static let editProductsButton = NSLocalizedString(
+            "Edit Products (%1$d)",
+            comment: "Button specifying the number of products applicable to a coupon in the view for adding or editing a coupon. " +
+            "Reads like: Edit Products (2)")
+        static let editProductCategoriesButton = NSLocalizedString(
+            "Edit Product Categories (%1$d)",
+            comment: "Button for specify the product categories where a coupon can be applied in the view for adding or editing a coupon. " +
+            "Reads like: Edit Categories")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -90,7 +90,7 @@ final class AddEditCouponViewModel: ObservableObject {
     ///
     var categorySelectorViewModel: ProductCategorySelectorViewModel {
         .init(siteID: siteID, selectedCategories: categoryIDs) { [weak self] categories in
-            self?.categoryIDs = categories.map { $0.categoryID } 
+            self?.categoryIDs = categories.map { $0.categoryID }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -86,6 +86,14 @@ final class AddEditCouponViewModel: ObservableObject {
         })
     }
 
+    /// View model for the category selector
+    ///
+    var categorySelectorViewModel: ProductCategorySelectorViewModel {
+        .init(siteID: siteID, selectedCategories: categoryIDs) { [weak self] categories in
+            self?.categoryIDs = categories.map { $0.categoryID } 
+        }
+    }
+
     private(set) var coupon: Coupon?
     private let stores: StoresManager
     private let storageManager: StorageManagerType
@@ -102,6 +110,7 @@ final class AddEditCouponViewModel: ObservableObject {
     @Published var freeShipping: Bool
     @Published var couponRestrictionsViewModel: CouponRestrictionsViewModel
     @Published var productOrVariationIDs: [Int64]
+    @Published var categoryIDs: [Int64]
 
     /// Init method for coupon creation
     ///
@@ -122,6 +131,7 @@ final class AddEditCouponViewModel: ObservableObject {
         freeShipping = false
         couponRestrictionsViewModel = CouponRestrictionsViewModel(siteID: siteID)
         productOrVariationIDs = []
+        categoryIDs = []
     }
 
     /// Init method for coupon editing
@@ -142,6 +152,7 @@ final class AddEditCouponViewModel: ObservableObject {
         freeShipping = existingCoupon.freeShipping
         couponRestrictionsViewModel = CouponRestrictionsViewModel(coupon: existingCoupon)
         productOrVariationIDs = existingCoupon.productIds
+        categoryIDs = existingCoupon.productCategories
         self.stores = stores
         self.storageManager = storageManager
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponRestrictions.swift
@@ -4,6 +4,7 @@ struct CouponRestrictions: View {
 
     @State private var showingAllowedEmails: Bool = false
     @State private var showingExcludeProducts: Bool = false
+    @State private var showingExcludeCategories: Bool = false
     @ObservedObject private var viewModel: CouponRestrictionsViewModel
 
     // Tracks the scale of the view due to accessibility changes
@@ -124,7 +125,7 @@ struct CouponRestrictions: View {
                     .buttonStyle(SecondaryButtonStyle(labelFont: .body))
 
                     Button(action: {
-                        // TODO: show category selection
+                        showingExcludeCategories = true
                     }) {
                         HStack {
                             Image(uiImage: UIImage.plusImage)
@@ -150,7 +151,11 @@ struct CouponRestrictions: View {
                         viewModel.productSelectorViewModel.clearSearchAndFilters()
                     }
             }
-
+            .sheet(isPresented: $showingExcludeCategories) {
+                ProductCategorySelector(isPresented: $showingExcludeCategories,
+                                        config: ProductCategorySelector.Configuration.excludedCategories,
+                                        viewModel: viewModel.categorySelectorViewModel)
+            }
             LazyNavigationLink(destination: CouponAllowedEmails(emailFormats: $viewModel.allowedEmails), isActive: $showingAllowedEmails) {
                 EmptyView()
             }
@@ -278,5 +283,25 @@ private extension ProductSelector.Configuration {
             comment: "Title of the action button at the bottom of the Exclude Products screen " +
             "when more than 1 item is selected, reads like: Exclude 5 Products"
         )
+    }
+}
+
+private extension ProductCategorySelector.Configuration {
+    static let excludedCategories: Self = .init(
+        title: Localization.title,
+        doneButtonSingularFormat: Localization.doneSingularFormat,
+        doneButtonPluralFormat: Localization.donePluralFormat
+    )
+
+    enum Localization {
+        static let title = NSLocalizedString("Exclude categories", comment: "Title for the Exclude Categories screen")
+        static let doneSingularFormat = NSLocalizedString(
+            "Exclude %1$d Category",
+            comment: "Button to submit selection on the Exclude Categories screen when 1 item is selected")
+        static let donePluralFormat = NSLocalizedString(
+            "Exclude %1$d Categories",
+            comment: "Button to submit selection on the Exclude Categories screen " +
+            "when more than 1 item is selected. " +
+            "Reads like: Exclude 10 Categories")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -25,9 +25,9 @@ final class CouponRestrictionsViewModel: ObservableObject {
 
     @Published var excludeSaleItems: Bool
 
-    @Published var excludedProductOrVariationIDs: [Int64]
+    @Published private var excludedProductOrVariationIDs: [Int64]
 
-    @Published var excludedCategoryIDs: [Int64]
+    @Published private var excludedCategoryIDs: [Int64]
 
     /// View model for the product selector
     ///

--- a/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -27,12 +27,25 @@ final class CouponRestrictionsViewModel: ObservableObject {
 
     @Published var excludedProductOrVariationIDs: [Int64]
 
+    @Published var excludedCategoryIDs: [Int64]
+
     /// View model for the product selector
     ///
     lazy var productSelectorViewModel = {
         ProductSelectorViewModel(siteID: siteID, selectedItemIDs: excludedProductOrVariationIDs, onMultipleSelectionCompleted: { [weak self] ids in
             self?.excludedProductOrVariationIDs = ids
         })
+    }()
+
+    /// View model for the category selector
+    ///
+    lazy var categorySelectorViewModel = {
+        ProductCategorySelectorViewModel(siteID: siteID,
+                                         selectedCategories: excludedCategoryIDs,
+                                         storesManager: stores,
+                                         storageManager: storageManager) { [weak self] categories in
+            self?.excludedCategoryIDs = categories.map { $0.categoryID }
+        }
     }()
 
     private let siteID: Int64
@@ -77,6 +90,7 @@ final class CouponRestrictionsViewModel: ObservableObject {
         individualUseOnly = coupon.individualUse
         excludeSaleItems = coupon.excludeSaleItems
         excludedProductOrVariationIDs = coupon.excludedProductIds
+        excludedCategoryIDs = coupon.excludedProductCategories
     }
 
     init(siteID: Int64,
@@ -93,6 +107,7 @@ final class CouponRestrictionsViewModel: ObservableObject {
         individualUseOnly = false
         excludeSaleItems = false
         excludedProductOrVariationIDs = []
+        excludedCategoryIDs = []
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryList.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryList.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// SwiftUI wrapper of `ProductCategoryListViewController`.
 ///
-struct ProductCategorySelector: UIViewControllerRepresentable {
+struct ProductCategoryList: UIViewControllerRepresentable {
     private let viewModel: ProductCategoryListViewModel
 
     init(viewModel: ProductCategoryListViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -60,17 +60,20 @@ private extension ProductCategoryListViewController {
             self?.tableView.reloadData()
         }
         viewModel.observeCategoryListStateChanges { [weak self] syncState in
+            guard let self = self else { return }
             switch syncState {
             case .initialized:
                 break
             case .syncing:
-                self?.displayGhostContent()
+                if self.viewModel.categoryViewModels.isEmpty {
+                    self.displayGhostContent()
+                }
             case let .failed(retryToken):
-                self?.removeGhostContent()
-                self?.displaySyncingErrorNotice(retryToken: retryToken)
+                self.removeGhostContent()
+                self.displaySyncingErrorNotice(retryToken: retryToken)
             case .synced:
-                self?.tableView.reloadData()
-                self?.removeGhostContent()
+                self.tableView.reloadData()
+                self.removeGhostContent()
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -45,6 +45,10 @@ final class ProductCategoryListViewModel {
     ///
     private let siteID: Int64
 
+    /// Initially selected category IDs
+    ///
+    private let initiallySelectedIDs: [Int64]
+
     /// Product categories that will be eventually modified by the user
     ///
     private(set) var selectedCategories: [ProductCategory]
@@ -105,6 +109,7 @@ final class ProductCategoryListViewModel {
         self.enrichingDataSource = enrichingDataSource
         self.delegate = delegate
         self.onProductCategorySelection = onProductCategorySelection
+        self.initiallySelectedIDs = selectedCategoryIDs
     }
 
     /// Load existing categories from storage and fire the synchronize all categories action.
@@ -190,9 +195,21 @@ final class ProductCategoryListViewModel {
     ///
     func updateViewModelsArray() {
         let fetchedCategories = resultController.fetchedObjects
+        updateInitialItemsIfNeeded(with: fetchedCategories)
         let baseViewModels = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: fetchedCategories, selectedCategories: selectedCategories)
 
         categoryViewModels = enrichingDataSource?.enrichCategoryViewModels( baseViewModels) ?? baseViewModels
+    }
+
+    /// Update `selectedCategories` based on initially selected items.
+    ///
+    private func updateInitialItemsIfNeeded(with categories: [ProductCategory]) {
+        guard initiallySelectedIDs.isNotEmpty && selectedCategories.isEmpty else {
+            return
+        }
+        selectedCategories = initiallySelectedIDs.compactMap { id in
+            categories.first(where: { $0.categoryID == id })
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// Classes conforming to this protocol can enrich the Product Category List UI,
 /// e.g by adding extra rows
@@ -40,6 +41,10 @@ final class ProductCategoryListViewModel {
     /// Reference to the StoresManager to dispatch Yosemite Actions.
     ///
     private let storesManager: StoresManager
+
+    /// Storage to fetch categories from.
+    ///
+    private let storageManager: StorageManagerType
 
     /// Site Id of the related categories
     ///
@@ -91,20 +96,21 @@ final class ProductCategoryListViewModel {
     }
 
     private lazy var resultController: ResultsController<StorageProductCategory> = {
-        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID = %ld", self.siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageProductCategory.name, ascending: true)
         return ResultsController<StorageProductCategory>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
 
-    init(storesManager: StoresManager = ServiceLocator.stores,
-         siteID: Int64,
+    init(siteID: Int64,
          selectedCategoryIDs: [Int64] = [],
          selectedCategories: [ProductCategory] = [],
+         storesManager: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
          enrichingDataSource: ProductCategoryListViewModelEnrichingDataSource? = nil,
          delegate: ProductCategoryListViewModelDelegate? = nil,
          onProductCategorySelection: ProductCategorySelection? = nil) {
         self.storesManager = storesManager
+        self.storageManager = storageManager
         self.siteID = siteID
         self.selectedCategories = selectedCategories
         self.enrichingDataSource = enrichingDataSource

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -94,6 +94,7 @@ final class ProductCategoryListViewModel {
 
     init(storesManager: StoresManager = ServiceLocator.stores,
          siteID: Int64,
+         selectedCategoryIDs: [Int64] = [],
          selectedCategories: [ProductCategory] = [],
          enrichingDataSource: ProductCategoryListViewModelEnrichingDataSource? = nil,
          delegate: ProductCategoryListViewModelDelegate? = nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -111,13 +111,15 @@ final class ProductCategoryListViewModel {
         self.delegate = delegate
         self.onProductCategorySelection = onProductCategorySelection
         self.initiallySelectedIDs = selectedCategoryIDs
+
+        try? resultController.performFetch()
+        updateViewModelsArray()
     }
 
     /// Load existing categories from storage and fire the synchronize all categories action.
     ///
     func performFetch() {
         synchronizeAllCategories()
-        try? resultController.performFetch()
     }
 
     /// Retry product categories synchronization when `syncCategoriesState` is on a `.failed` state.

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -45,13 +45,14 @@ final class ProductCategoryListViewModel {
     ///
     private let siteID: Int64
 
-    /// Initially selected category IDs
+    /// Initially selected category IDs.
+    /// This is mutable so that we can remove any item when unselecting it manually.
     ///
-    private let initiallySelectedIDs: [Int64]
+    private var initiallySelectedIDs: [Int64]
 
     /// Product categories that will be eventually modified by the user
     ///
-    private(set) var selectedCategories: [ProductCategory]
+    @Published private(set) var selectedCategories: [ProductCategory]
 
     /// Array of view models to be rendered by the View Controller.
     ///
@@ -176,7 +177,8 @@ final class ProductCategoryListViewModel {
 
         // If the category selected exist, remove it, otherwise, add it to `selectedCategories`.
         if let indexCategory = selectedCategories.firstIndex(where: { $0.categoryID == categoryViewModel.categoryID}) {
-            selectedCategories.remove(at: indexCategory)
+            let discardedItem = selectedCategories.remove(at: indexCategory)
+            initiallySelectedIDs.removeAll(where: { $0 == discardedItem.categoryID })
         } else {
             let selectedCategory = resultController.fetchedObjects.first(where: { $0.categoryID == categoryViewModel.categoryID })
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategorySelector.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// SwiftUI wrapper of `ProductCategoryListViewController`.
+///
+struct ProductCategorySelector: UIViewControllerRepresentable {
+    private let viewModel: ProductCategoryListViewModel
+
+    init(viewModel: ProductCategoryListViewModel) {
+        self.viewModel = viewModel
+    }
+
+    func makeUIViewController(context: Context) -> ProductCategoryListViewController {
+        return ProductCategoryListViewController(viewModel: viewModel)
+    }
+
+    func updateUIViewController(_ uiViewController: ProductCategoryListViewController, context: Context) {
+        // no=op
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// View showing a list of product categories to select from.
+///
+struct ProductCategorySelector: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct ProductCategorySelector_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductCategorySelector()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -8,6 +8,7 @@ struct ProductCategorySelector: View {
 
     private let config: Configuration
 
+    /// Title of the done button calculated based on number of selected items
     private var doneButtonTitle: String {
         if viewModel.selectedItemsCount == 0 {
             return Localization.doneButton
@@ -54,6 +55,8 @@ struct ProductCategorySelector: View {
     }
 }
 
+// MARK: - Configuration
+//
 extension ProductCategorySelector {
     struct Configuration {
         let title: String
@@ -62,6 +65,8 @@ extension ProductCategorySelector {
     }
 }
 
+// MARK: - Localization
+//
 private extension ProductCategorySelector {
     enum Localization {
         static let doneButton = NSLocalizedString("Done", comment: "Button to submit selection on Select Categories screen")

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -16,7 +16,7 @@ struct ProductCategorySelector: View {
 
 struct ProductCategorySelector_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ProductCategorySelectorViewModel()
+        let viewModel = ProductCategorySelectorViewModel(siteID: 123) { _ in }
         ProductCategorySelector(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -3,6 +3,12 @@ import SwiftUI
 /// View showing a list of product categories to select from.
 ///
 struct ProductCategorySelector: View {
+    @ObservedObject private var viewModel: ProductCategorySelectorViewModel
+
+    init(viewModel: ProductCategorySelectorViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         Text("Hello, World!")
     }
@@ -10,6 +16,7 @@ struct ProductCategorySelector: View {
 
 struct ProductCategorySelector_Previews: PreviewProvider {
     static var previews: some View {
-        ProductCategorySelector()
+        let viewModel = ProductCategorySelectorViewModel()
+        ProductCategorySelector(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -9,12 +9,11 @@ struct ProductCategorySelector: View {
     private let config: Configuration
 
     private var doneButtonTitle: String {
-        let itemsCount = viewModel.listViewModel.selectedCategories.count
-        if itemsCount == 0 {
+        if viewModel.selectedItemsCount == 0 {
             return Localization.doneButton
         } else {
             return String.pluralize(
-                itemsCount,
+                viewModel.selectedItemsCount,
                 singular: config.doneButtonSingularFormat,
                 plural: config.doneButtonPluralFormat
             )

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -49,9 +49,9 @@ struct ProductCategorySelector: View {
             }
             .navigationTitle(config.title)
             .navigationBarTitleDisplayMode(.large)
-            .navigationViewStyle(.stack)
             .wooNavigationBarStyle()
         }
+        .navigationViewStyle(.stack)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -10,7 +10,27 @@ struct ProductCategorySelector: View {
     }
 
     var body: some View {
-        Text("Hello, World!")
+        NavigationView {
+            VStack(spacing: 0) {
+                ProductCategoryList(viewModel: viewModel.listViewModel)
+                Button("Done") {
+                    // TODO
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding()
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        // TODO
+                    }
+                }
+            }
+            .navigationTitle("Select Products")
+            .navigationBarTitleDisplayMode(.large)
+            .navigationViewStyle(.stack)
+            .wooNavigationBarStyle()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -3,17 +3,37 @@ import SwiftUI
 /// View showing a list of product categories to select from.
 ///
 struct ProductCategorySelector: View {
+    @Binding private var isPresented: Bool
     @ObservedObject private var viewModel: ProductCategorySelectorViewModel
 
-    init(viewModel: ProductCategorySelectorViewModel) {
+    private let config: Configuration
+
+    private var doneButtonTitle: String {
+        let itemsCount = viewModel.listViewModel.selectedCategories.count
+        if itemsCount == 0 {
+            return Localization.doneButton
+        } else {
+            return String.pluralize(
+                itemsCount,
+                singular: config.doneButtonSingularFormat,
+                plural: config.doneButtonPluralFormat
+            )
+        }
+    }
+
+    init(isPresented: Binding<Bool>,
+         config: Configuration,
+         viewModel: ProductCategorySelectorViewModel) {
         self.viewModel = viewModel
+        self.config = config
+        self._isPresented = isPresented
     }
 
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
                 ProductCategoryList(viewModel: viewModel.listViewModel)
-                Button("Done") {
+                Button(doneButtonTitle) {
                     // TODO
                 }
                 .buttonStyle(PrimaryButtonStyle())
@@ -21,12 +41,12 @@ struct ProductCategorySelector: View {
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        // TODO
+                    Button(Localization.cancelButton) {
+                        isPresented.toggle()
                     }
                 }
             }
-            .navigationTitle("Select Products")
+            .navigationTitle(config.title)
             .navigationBarTitleDisplayMode(.large)
             .navigationViewStyle(.stack)
             .wooNavigationBarStyle()
@@ -34,9 +54,31 @@ struct ProductCategorySelector: View {
     }
 }
 
+extension ProductCategorySelector {
+    struct Configuration {
+        let title: String
+        var doneButtonSingularFormat: String
+        var doneButtonPluralFormat: String
+    }
+}
+
+private extension ProductCategorySelector {
+    enum Localization {
+        static let doneButton = NSLocalizedString("Done", comment: "Button to submit selection on Select Categories screen")
+        static let cancelButton = NSLocalizedString("Cancel", comment: "Button to dismiss Select Categories screen")
+    }
+}
+
 struct ProductCategorySelector_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ProductCategorySelectorViewModel(siteID: 123) { _ in }
-        ProductCategorySelector(viewModel: viewModel)
+        let config = ProductCategorySelector.Configuration(
+            title: "Select Categories",
+            doneButtonSingularFormat: "",
+            doneButtonPluralFormat: ""
+        )
+        ProductCategorySelector(isPresented: .constant(true),
+                                config: config,
+                                viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelector.swift
@@ -34,7 +34,8 @@ struct ProductCategorySelector: View {
             VStack(spacing: 0) {
                 ProductCategoryList(viewModel: viewModel.listViewModel)
                 Button(doneButtonTitle) {
-                    // TODO
+                    viewModel.submitSelection()
+                    isPresented = false
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .padding()

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -11,14 +11,7 @@ final class ProductCategorySelectorViewModel: ObservableObject {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
 
-    private(set) lazy var listViewModel: ProductCategoryListViewModel = {
-        .init(storesManager: stores,
-              siteID: siteID,
-              selectedCategoryIDs: selectedCategories) { [weak self] _ in
-            guard let self = self else { return }
-            self.selectedItemsCount = self.listViewModel.selectedCategories.count
-        }
-    }()
+    let listViewModel: ProductCategoryListViewModel
 
     @Published private(set) var selectedItemsCount: Int = 0
 
@@ -32,6 +25,13 @@ final class ProductCategorySelectorViewModel: ObservableObject {
         self.onCategorySelection = onCategorySelection
         self.stores = storesManager
         self.storageManager = storageManager
+
+        listViewModel = .init(storesManager: stores,
+                              siteID: siteID,
+                              selectedCategoryIDs: selectedCategories)
+        listViewModel.$selectedCategories
+            .map { $0.count }
+            .assign(to: &$selectedItemsCount)
     }
 
     /// Triggered when selection is done.

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -28,7 +28,8 @@ final class ProductCategorySelectorViewModel: ObservableObject {
 
         listViewModel = .init(siteID: siteID,
                               selectedCategoryIDs: selectedCategories,
-                              storesManager: stores)
+                              storesManager: stores,
+                              storageManager: storageManager)
         listViewModel.$selectedCategories
             .map { $0.count }
             .assign(to: &$selectedItemsCount)

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -14,9 +14,13 @@ final class ProductCategorySelectorViewModel: ObservableObject {
     private(set) lazy var listViewModel: ProductCategoryListViewModel = {
         .init(storesManager: stores,
               siteID: siteID,
-              selectedCategoryIDs: selectedCategories,
-              delegate: self)
+              selectedCategoryIDs: selectedCategories) { [weak self] _ in
+            guard let self = self else { return }
+            self.selectedItemsCount = self.listViewModel.selectedCategories.count
+        }
     }()
+
+    @Published private(set) var selectedItemsCount: Int = 0
 
     init(siteID: Int64,
          selectedCategories: [Int64] = [],
@@ -34,11 +38,5 @@ final class ProductCategorySelectorViewModel: ObservableObject {
     ///
     func submitSelection() {
         onCategorySelection(listViewModel.selectedCategories)
-    }
-}
-
-extension ProductCategorySelectorViewModel: ProductCategoryListViewModelDelegate {
-    func viewModel(_ viewModel: ProductCategoryListViewModel, didSelectRowAt index: Int) {
-        // TODO
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -1,7 +1,38 @@
 import Foundation
+import protocol Storage.StorageManagerType
+import Yosemite
 
 /// View model for `ProductCategorySelector`.
 ///
 final class ProductCategorySelectorViewModel: ObservableObject {
-    // TODO
+    private let siteID: Int64
+    private let onCategorySelection: ([ProductCategory]) -> Void
+    private var selectedCategories: [Int64]
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
+
+    private(set) lazy var listViewModel: ProductCategoryListViewModel = {
+        .init(storesManager: stores,
+              siteID: siteID,
+              selectedCategoryIDs: selectedCategories,
+              delegate: self)
+    }()
+
+    init(siteID: Int64,
+         selectedCategories: [Int64] = [],
+         storesManager: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         onCategorySelection: @escaping ([ProductCategory]) -> Void) {
+        self.siteID = siteID
+        self.selectedCategories = selectedCategories
+        self.onCategorySelection = onCategorySelection
+        self.stores = storesManager
+        self.storageManager = storageManager
+    }
+}
+
+extension ProductCategorySelectorViewModel: ProductCategoryListViewModelDelegate {
+    func viewModel(_ viewModel: ProductCategoryListViewModel, didSelectRowAt index: Int) {
+        // TODO
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -29,6 +29,12 @@ final class ProductCategorySelectorViewModel: ObservableObject {
         self.stores = storesManager
         self.storageManager = storageManager
     }
+
+    /// Triggered when selection is done.
+    ///
+    func submitSelection() {
+        onCategorySelection(listViewModel.selectedCategories)
+    }
 }
 
 extension ProductCategorySelectorViewModel: ProductCategoryListViewModelDelegate {

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -11,6 +11,8 @@ final class ProductCategorySelectorViewModel: ObservableObject {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
 
+    /// View model for the category list.
+    ///
     let listViewModel: ProductCategoryListViewModel
 
     @Published private(set) var selectedItemsCount: Int = 0

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -26,9 +26,9 @@ final class ProductCategorySelectorViewModel: ObservableObject {
         self.stores = storesManager
         self.storageManager = storageManager
 
-        listViewModel = .init(storesManager: stores,
-                              siteID: siteID,
-                              selectedCategoryIDs: selectedCategories)
+        listViewModel = .init(siteID: siteID,
+                              selectedCategoryIDs: selectedCategories,
+                              storesManager: stores)
         listViewModel.$selectedCategories
             .map { $0.count }
             .assign(to: &$selectedItemsCount)

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/Selector/ProductCategorySelectorViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// View model for `ProductCategorySelector`.
+///
+final class ProductCategorySelectorViewModel: ObservableObject {
+    // TODO
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelector.swift
@@ -53,6 +53,7 @@ struct ProductSelector: View {
                     .fixedSize()
                     .renderedIf(configuration.showsFilters)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
 
                 switch viewModel.syncStatus {
                 case .results:
@@ -120,6 +121,7 @@ struct ProductSelector: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .wooNavigationBarStyle()
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1528,6 +1528,7 @@
 		DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE001322279A793A00EB0350 /* CouponWooTests.swift */; };
 		DE0A2EAA281BA083007A8015 /* ProductCategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */; };
 		DE0A2EAD281BA1FA007A8015 /* ProductCategorySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */; };
+		DE0A2EAF281BA278007A8015 /* ProductCategorySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -3254,6 +3255,7 @@
 		DE001322279A793A00EB0350 /* CouponWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponWooTests.swift; sourceTree = "<group>"; };
 		DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryList.swift; sourceTree = "<group>"; };
 		DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelector.swift; sourceTree = "<group>"; };
+		DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelectorViewModel.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -7587,6 +7589,7 @@
 			isa = PBXGroup;
 			children = (
 				DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */,
+				DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */,
 			);
 			path = Selector;
 			sourceTree = "<group>";
@@ -9004,6 +9007,7 @@
 				02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */,
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				451526392577D89E0076B03C /* AddAttributeViewModel.swift in Sources */,
+				DE0A2EAF281BA278007A8015 /* ProductCategorySelectorViewModel.swift in Sources */,
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,
 				E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */,
 				DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1526,7 +1526,7 @@
 		D8F01DD325DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE001322279A793A00EB0350 /* CouponWooTests.swift */; };
-		DE0A2EAA281BA083007A8015 /* ProductCategorySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EA9281BA083007A8015 /* ProductCategorySelector.swift */; };
+		DE0A2EAA281BA083007A8015 /* ProductCategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -3251,7 +3251,7 @@
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE001322279A793A00EB0350 /* CouponWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponWooTests.swift; sourceTree = "<group>"; };
-		DE0A2EA9281BA083007A8015 /* ProductCategorySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelector.swift; sourceTree = "<group>"; };
+		DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryList.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -5804,7 +5804,7 @@
 				7E7C5F7E2719A93B00315B61 /* ProductCategoryListViewController.xib */,
 				7E7C5F7D2719A93B00315B61 /* ProductCategoryListViewModel.swift */,
 				7E7C5F802719A93C00315B61 /* ProductCategoryViewModelBuilder.swift */,
-				DE0A2EA9281BA083007A8015 /* ProductCategorySelector.swift */,
+				DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -9338,7 +9338,7 @@
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
 				260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */,
 				4521397027FF53E400964ED3 /* CouponExpiryDateView.swift in Sources */,
-				DE0A2EAA281BA083007A8015 /* ProductCategorySelector.swift in Sources */,
+				DE0A2EAA281BA083007A8015 /* ProductCategoryList.swift in Sources */,
 				2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */,
 				E1E125AA26EB42530068A9B0 /* CardPresentModalUpdateProgress.swift in Sources */,
 				E1C5E78226C2A971008D4C47 /* InPersonPaymentsPluginNotSetup.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1207,7 +1207,6 @@
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B92FF9AE27FC7217005C34E3 /* OrderListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B92FF9AD27FC7217005C34E3 /* OrderListViewController.xib */; };
 		B92FF9B027FC7821005C34E3 /* ProductsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B92FF9AF27FC7821005C34E3 /* ProductsViewController.xib */; };
-		B9C4AB2527FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */; };
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B9C4AB2527FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */; };
 		B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */; };
@@ -1527,6 +1526,7 @@
 		D8F01DD325DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE001322279A793A00EB0350 /* CouponWooTests.swift */; };
+		DE0A2EAA281BA083007A8015 /* ProductCategorySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EA9281BA083007A8015 /* ProductCategorySelector.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -2921,7 +2921,6 @@
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B92FF9AD27FC7217005C34E3 /* OrderListViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderListViewController.xib; sourceTree = "<group>"; };
 		B92FF9AF27FC7821005C34E3 /* ProductsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductsViewController.xib; sourceTree = "<group>"; };
-		B9C4AB2427FDE4B6007008B8 /* PaymentsPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsPluginsDataProvider.swift; sourceTree = "<group>"; };
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProvider.swift; sourceTree = "<group>"; };
 		B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminer.swift; sourceTree = "<group>"; };
@@ -3252,6 +3251,7 @@
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE001322279A793A00EB0350 /* CouponWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponWooTests.swift; sourceTree = "<group>"; };
+		DE0A2EA9281BA083007A8015 /* ProductCategorySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelector.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -5804,6 +5804,7 @@
 				7E7C5F7E2719A93B00315B61 /* ProductCategoryListViewController.xib */,
 				7E7C5F7D2719A93B00315B61 /* ProductCategoryListViewModel.swift */,
 				7E7C5F802719A93C00315B61 /* ProductCategoryViewModelBuilder.swift */,
+				DE0A2EA9281BA083007A8015 /* ProductCategorySelector.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -9337,6 +9338,7 @@
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
 				260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */,
 				4521397027FF53E400964ED3 /* CouponExpiryDateView.swift in Sources */,
+				DE0A2EAA281BA083007A8015 /* ProductCategorySelector.swift in Sources */,
 				2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */,
 				E1E125AA26EB42530068A9B0 /* CardPresentModalUpdateProgress.swift in Sources */,
 				E1C5E78226C2A971008D4C47 /* InPersonPaymentsPluginNotSetup.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1527,6 +1527,7 @@
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE001322279A793A00EB0350 /* CouponWooTests.swift */; };
 		DE0A2EAA281BA083007A8015 /* ProductCategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */; };
+		DE0A2EAD281BA1FA007A8015 /* ProductCategorySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -3252,6 +3253,7 @@
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE001322279A793A00EB0350 /* CouponWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponWooTests.swift; sourceTree = "<group>"; };
 		DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryList.swift; sourceTree = "<group>"; };
+		DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelector.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -5799,6 +5801,7 @@
 		7E7C5F7B2719A91600315B61 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				DE0A2EAB281BA1DB007A8015 /* Selector */,
 				7E7C5F8E2719BA7300315B61 /* ProductCategoryCellViewModel.swift */,
 				7E7C5F812719A93C00315B61 /* ProductCategoryListViewController.swift */,
 				7E7C5F7E2719A93B00315B61 /* ProductCategoryListViewController.xib */,
@@ -7580,6 +7583,14 @@
 			path = "Stripe Integration Tests";
 			sourceTree = "<group>";
 		};
+		DE0A2EAB281BA1DB007A8015 /* Selector */ = {
+			isa = PBXGroup;
+			children = (
+				DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */,
+			);
+			path = Selector;
+			sourceTree = "<group>";
+		};
 		DE19BB1626C3B5A800AB70D9 /* ItemDetails */ = {
 			isa = PBXGroup;
 			children = (
@@ -9111,6 +9122,7 @@
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
 				D8B4D5F426C30E7C00F34E94 /* InPersonPaymentsStripeRejectedView.swift in Sources */,
+				DE0A2EAD281BA1FA007A8015 /* ProductCategorySelector.swift in Sources */,
 				57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */,
 				B5A8532220BDBFAF00FAAB4D /* CircularImageView.swift in Sources */,
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1529,6 +1529,7 @@
 		DE0A2EAA281BA083007A8015 /* ProductCategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */; };
 		DE0A2EAD281BA1FA007A8015 /* ProductCategorySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */; };
 		DE0A2EAF281BA278007A8015 /* ProductCategorySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */; };
+		DE0A2EB1281BED38007A8015 /* ProductCategorySelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EB0281BED38007A8015 /* ProductCategorySelectorViewModelTests.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -3256,6 +3257,7 @@
 		DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryList.swift; sourceTree = "<group>"; };
 		DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelector.swift; sourceTree = "<group>"; };
 		DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelectorViewModel.swift; sourceTree = "<group>"; };
+		DE0A2EB0281BED38007A8015 /* ProductCategorySelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelectorViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -5819,6 +5821,7 @@
 			children = (
 				2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */,
 				267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */,
+				DE0A2EB0281BED38007A8015 /* ProductCategorySelectorViewModelTests.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -9618,6 +9621,7 @@
 				0277AEAB256CAA5300F45C4A /* MockShippingLabelAddress.swift in Sources */,
 				D83F593D225B4B5000626E75 /* ManualTrackingViewControllerTests.swift in Sources */,
 				CC53FB402759042600C4CA4F /* ProductSelectorViewModelTests.swift in Sources */,
+				DE0A2EB1281BED38007A8015 /* ProductCategorySelectorViewModelTests.swift in Sources */,
 				03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */,
 				CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */,
 				263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -150,11 +150,4 @@ private extension ProductCategoryListViewModelTests {
         let category = storage.insertNewObject(ofType: StorageProductCategory.self)
         category.update(with: readOnlyProductCategory)
     }
-
-    func insert(_ readOnlyProductCategories: [Yosemite.ProductCategory]) {
-        for readOnlyProductCategory in readOnlyProductCategories {
-            let category = storage.insertNewObject(ofType: StorageProductCategory.self)
-            category.update(with: readOnlyProductCategory)
-        }
-    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 @testable import Networking
+@testable import Storage
 
 
 /// Tests for `ProductCategoryListViewModel`.
@@ -10,21 +11,27 @@ import XCTest
 final class ProductCategoryListViewModelTests: XCTestCase {
 
     private var storesManager: MockProductCategoryStoresManager!
+    private var storageManager: StorageManagerType!
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
 
     override func setUp() {
         super.setUp()
         storesManager = MockProductCategoryStoresManager()
+        storageManager = MockStorageManager()
     }
 
     override func tearDown() {
         super.tearDown()
         storesManager = nil
+        storageManager = nil
     }
 
     func test_resetSelectedCategories_then_it_does_not_return_any_view_model() {
         // Given
         let exp = expectation(description: #function)
-        let viewModel = ProductCategoryListViewModel(storesManager: storesManager, siteID: 0)
+        let viewModel = ProductCategoryListViewModel(siteID: 0, storesManager: storesManager)
         let productCategory = ProductCategory(categoryID: 443, siteID: 123, parentID: 0, name: name, slug: "")
 
         // When
@@ -47,12 +54,12 @@ final class ProductCategoryListViewModelTests: XCTestCase {
     func test_select_category_then_it_calls_onProductCategorySelection() {
         let productCategory = ProductCategory(categoryID: 443, siteID: 123, parentID: 0, name: name, slug: "")
 
-        let passedCategory: ProductCategory? = waitFor { [weak self] promise in
+        let passedCategory: Yosemite.ProductCategory? = waitFor { [weak self] promise in
             guard let self = self else {
                 return
             }
 
-            let viewModel = ProductCategoryListViewModel(storesManager: self.storesManager, siteID: 0, onProductCategorySelection: { category in
+            let viewModel = ProductCategoryListViewModel(siteID: 0, storesManager: self.storesManager, onProductCategorySelection: { category in
                 promise(category)
             })
 
@@ -67,7 +74,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Given
         let exp = expectation(description: #function)
         let siteID: Int64 = 1
-        let viewModel = ProductCategoryListViewModel(storesManager: storesManager, siteID: siteID)
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, storesManager: storesManager)
         storesManager.productCategoryResponse = nil
 
         // When
@@ -88,7 +95,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Given
         let exp = expectation(description: #function)
         let siteID: Int64 = 1
-        let viewModel = ProductCategoryListViewModel(storesManager: storesManager, siteID: siteID)
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, storesManager: storesManager)
         let rawError = NSError(domain: "Category Error", code: 1, userInfo: nil)
         let error = ProductCategoryActionError.categoriesSynchronization(pageNumber: 1, rawError: rawError)
         storesManager.productCategoryResponse = error
@@ -109,7 +116,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
     func test_reloadData_then_it_calls_reload_needed() {
         // Given
         let siteID: Int64 = 1
-        let viewModel = ProductCategoryListViewModel(storesManager: storesManager, siteID: siteID)
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, storesManager: storesManager)
         var reloadNeededIsCalled = false
         viewModel.observeReloadNeeded {
             reloadNeededIsCalled = true
@@ -120,5 +127,34 @@ final class ProductCategoryListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(reloadNeededIsCalled)
+    }
+
+    func test_selectedCategories_are_updated_with_initially_selected_IDs() {
+        // Given
+        let siteID: Int64 = 132
+        let category = Yosemite.ProductCategory(categoryID: 33, siteID: siteID, parentID: 1, name: "Test", slug: "test")
+        insert(category)
+
+        // When
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, selectedCategoryIDs: [category.categoryID], storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedCategories.count, 1)
+        XCTAssertEqual(viewModel.selectedCategories.first?.categoryID, category.categoryID)
+    }
+}
+
+// MARK: - Utils
+private extension ProductCategoryListViewModelTests {
+    func insert(_ readOnlyProductCategory: Yosemite.ProductCategory) {
+        let category = storage.insertNewObject(ofType: StorageProductCategory.self)
+        category.update(with: readOnlyProductCategory)
+    }
+
+    func insert(_ readOnlyProductCategories: [Yosemite.ProductCategory]) {
+        for readOnlyProductCategory in readOnlyProductCategories {
+            let category = storage.insertNewObject(ofType: StorageProductCategory.self)
+            category.update(with: readOnlyProductCategory)
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategorySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategorySelectorViewModelTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+@testable import Storage
+
+final class ProductCategorySelectorViewModelTests: XCTestCase {
+
+    private var storageManager: StorageManagerType!
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        storageManager = nil
+    }
+
+    func test_selectedItemsCount_is_correct_with_preselected_items() {
+        // Given
+        let siteID: Int64 = 123
+        let category = Yosemite.ProductCategory(categoryID: 33, siteID: siteID, parentID: 1, name: "Test", slug: "test")
+        insert(category)
+
+        // When
+        let viewModel = ProductCategorySelectorViewModel(siteID: siteID, selectedCategories: [category.categoryID], storageManager: storageManager) { _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.selectedItemsCount, 1)
+    }
+}
+
+private extension ProductCategorySelectorViewModelTests {
+    func insert(_ readOnlyProductCategory: Yosemite.ProductCategory) {
+        let category = storage.insertNewObject(ofType: StorageProductCategory.self)
+        category.update(with: readOnlyProductCategory)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
@@ -13,8 +13,8 @@ final class FilterProductCategoryListViewModelTests: XCTestCase {
         super.setUp()
 
         filterProductCategoryListViewModel = FilterProductCategoryListViewModel(anyCategoryIsSelected: anyCategoryIsSelectedDefaultValue)
-        productCategoryListViewModel = ProductCategoryListViewModel(storesManager: MockProductCategoryStoresManager(),
-                                                                    siteID: 0,
+        productCategoryListViewModel = ProductCategoryListViewModel(siteID: 0,
+                                                                    storesManager: MockProductCategoryStoresManager(),
                                                                     enrichingDataSource: filterProductCategoryListViewModel,
                                                                     delegate: filterProductCategoryListViewModel)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6490
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the category selector to the Add/Edit Coupon screen and Coupon Restrictions screen.
Changes:
- Wrap `ProductCategoryListViewController` in a SwiftUI view named `ProductCategoryList`.
- Update `ProductCategoryListViewModel` to accept selected IDs and fetch categories immediately upon initializing to avoid ghost animations.
- Add a new SwiftUI view `ProductCategorySelector` that contains `ProductCategoryList`.
- Present `ProductCategorySelector` from Add/Edit Coupon screen.
- Present `ProductCategorySelector` from Coupon Restrictions screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu > Coupons > Select a coupon > Select the ellipsis button > Edit Coupon
- If the coupon is restricted to any category, notice that the category button is displayed as "Edit Product Categories <number of items>". Otherwise, it displays "Select Product Categories".
- Select the category button, notice that a new screen is presented with a list of categories to select from. Any pre-selected categories should be displayed with a check icon.
- Try select/unselect any item to see that the Done button displays the correct number of selected items. If none is selected, it should simply show "Done".
- Tap the Done button, notice that the category button is correct on the Edit Coupon screen.
- Select Usage Restrictions - notice that you can see the Exclude Categories screen when tapping the Exclude Categories button.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/165919620-46c6d124-0962-4783-8b0f-2a6850badbf2.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
