### PR TITLE
[Mobile Payments] Handle payment amount under minimum value

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -34,6 +34,7 @@ final class PaymentCaptureOrchestrator {
     }
 
     func collectPayment(for order: Order,
+                        orderTotal: NSDecimalNumber,
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [String],
                         onWaitingForInput: @escaping () -> Void,
@@ -49,6 +50,7 @@ final class PaymentCaptureOrchestrator {
 
         paymentParameters(
                 order: order,
+                orderTotal: orderTotal,
                 country: paymentGatewayAccount.country,
                 statementDescriptor: paymentGatewayAccount.statementDescriptor,
                 paymentMethodTypes: paymentMethodTypes
@@ -220,17 +222,11 @@ private extension PaymentCaptureOrchestrator {
     }
 
     func paymentParameters(order: Order,
+                           orderTotal: NSDecimalNumber,
                            country: String,
                            statementDescriptor: String?,
                            paymentMethodTypes: [String],
                            onCompletion: @escaping ((Result<PaymentParameters, Error>) -> Void)) {
-        guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
-            DDLogError("Error: attempted to collect payment for an order without a valid total.")
-            onCompletion(Result.failure(CollectOrderPaymentUseCase.NotValidAmountError.other))
-
-            return
-        }
-
         paymentReceiptEmailParameterDeterminer.receiptEmail(from: order) { [weak self] result in
             guard let self = self else { return }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -41,14 +41,6 @@ final class PaymentCaptureOrchestrator {
                         onDisplayMessage: @escaping (String) -> Void,
                         onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                         onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void) {
-        /// Bail out if the order amount is below the minimum allowed:
-        /// https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
-        guard isTotalAmountValid(order: order) else {
-            DDLogError("💳 Error: failed to capture payment for order. Order amount is below minimum")
-            onCompletion(.failure(minimumAmountError(order: order, minimumAmount: Constants.minimumAmount)))
-            return
-        }
-
         /// Set state of CardPresentPaymentStore
         ///
         let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
@@ -234,7 +226,7 @@ private extension PaymentCaptureOrchestrator {
                            onCompletion: @escaping ((Result<PaymentParameters, Error>) -> Void)) {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
             DDLogError("Error: attempted to collect payment for an order without a valid total.")
-            onCompletion(Result.failure(NotValidAmountError.other))
+            onCompletion(Result.failure(CollectOrderPaymentUseCase.NotValidAmountError.other))
 
             return
         }
@@ -309,29 +301,9 @@ private extension PaymentCaptureOrchestrator {
 
 private extension PaymentCaptureOrchestrator {
     enum Constants {
-        /// Minimum order amount in USD or CAD:
-        /// https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
-        static let minimumAmount = NSDecimalNumber(string: "0.5")
-
         static let canadaFlatFee = NSDecimalNumber(string: "0.25")
 
         static let canadaPercentageFee = NSDecimalNumber(string: "0.026")
-    }
-
-    func isTotalAmountValid(order: Order) -> Bool {
-        guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
-            return false
-        }
-
-        return orderTotal as Decimal >= Constants.minimumAmount as Decimal
-    }
-
-    func minimumAmountError(order: Order, minimumAmount: NSDecimalNumber) -> Error {
-        guard let minimum = currencyFormatter.formatAmount(minimumAmount, with: order.currency) else {
-            return NotValidAmountError.other
-        }
-
-        return NotValidAmountError.belowMinimumAmount(amount: minimum)
     }
 }
 
@@ -343,33 +315,5 @@ private extension PaymentCaptureOrchestrator {
                                                             + "Order @{number} for @{store name} "
                                                             + "Parameters: %1$@ - order number, "
                                                             + "%2$@ - store name")
-    }
-}
-
-extension PaymentCaptureOrchestrator {
-    enum NotValidAmountError: Error, LocalizedError {
-        case belowMinimumAmount(amount: String)
-        case other
-
-        var errorDescription: String? {
-            switch self {
-            case .belowMinimumAmount(let amount):
-                return String.localizedStringWithFormat(Localization.belowMinimumAmount, amount)
-            case .other:
-                return Localization.defaultMessage
-            }
-        }
-
-        private enum Localization {
-            static let defaultMessage = NSLocalizedString(
-                "Unable to process payment. Order total amount is not valid.",
-                comment: "Error message when the order amount is not valid."
-            )
-
-            static let belowMinimumAmount = NSLocalizedString(
-                "Unable to process payment. Order total amount is below the minimum amount you can charge, which is %1$@",
-                comment: "Error message when the order amount is below the minimum amount allowed."
-            )
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -154,7 +154,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 
 // MARK: Private functions
 private extension CollectOrderPaymentUseCase {
-    /// Checks whether the amount to be collected is valid: (not nil, formattable, higher than minimum amount ...)
+    /// Checks whether the amount to be collected is valid: (not nil, convertible to decimal, higher than minimum amount ...)
     ///
     func isTotalAmountValid() -> Bool {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
@@ -169,9 +169,9 @@ private extension CollectOrderPaymentUseCase {
     /// Determines and returns the error that provoked the amount being invalid
     ///
     func totalAmountInvalidError() -> Error {
-        let orderTotalIsFormattable = currencyFormatter.convertToDecimal(from: order.total) != nil
+        let orderTotalAmountCanBeConverted = currencyFormatter.convertToDecimal(from: order.total) != nil
 
-        guard orderTotalIsFormattable,
+        guard orderTotalAmountCanBeConverted,
               let minimum = currencyFormatter.formatAmount(configuration.minimumAllowedChargeAmount, with: order.currency) else {
             return NotValidAmountError.other
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -122,9 +122,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
         guard isTotalAmountValid() else {
             DDLogError("💳 Error: failed to capture payment for order. Order amount is below minimum or not valid")
-            handlePaymentFailureAndRetryPayment(totalAmountInvalidError()) { _ in
-                onCompleted()
-            }
+            self.alerts.nonRetryableError(from: self.rootViewController, error: totalAmountInvalidError(), dismissCompletion: onCompleted)
 
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -33,7 +33,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private let order: Order
 
-    /// Order total in decimal number. It is lazy to avoid multiple conversions that can be costly.
+    /// Order total in decimal number. It is lazy so we avoid multiple conversions.
     /// It can be lazy because the order is a constant and never changes (this class is intended to be
     /// fired and disposed, not reused for multiple payment flows).
     ///

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -154,11 +154,10 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         }
 
         // Then
-        XCTAssertNotNil(result?.failure as? PaymentCaptureOrchestrator.NotValidAmountError)
+        XCTAssertNotNil(result?.failure as? CollectOrderPaymentUseCase.NotValidAmountError)
 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "card_present_collect_payment_failed"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
-        XCTAssertEqual(eventProperties["card_reader_model"] as? String, Mocks.cardReaderModel)
         XCTAssertEqual(eventProperties["country"] as? String, "US")
         XCTAssertEqual(eventProperties["plugin_slug"] as? String, Mocks.paymentGatewayAccount)
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -28,7 +28,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                                                         supportedCurrencies: ["USD"],
                                                         country: "US",
                                                         isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "USD", total: "150.00")
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "USD")
+        let orderTotal: NSDecimalNumber = 150
 
         // When
         let parameters: PaymentParameters = waitFor { promise in
@@ -40,6 +41,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
             self.sut.collectPayment(
                 for: order,
+                orderTotal: orderTotal,
                    paymentGatewayAccount: account,
                    paymentMethodTypes: ["card_present"],
                    onWaitingForInput: {},
@@ -60,7 +62,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                                                         supportedCurrencies: ["CAD"],
                                                         country: "CA",
                                                         isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "150.00")
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD")
+        let orderTotal: NSDecimalNumber = 150
 
         // When
         let parameters: PaymentParameters = waitFor { promise in
@@ -72,6 +75,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
             self.sut.collectPayment(
                 for: order,
+                   orderTotal: orderTotal,
                    paymentGatewayAccount: account,
                    paymentMethodTypes: ["card_present"],
                    onWaitingForInput: {},
@@ -93,7 +97,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                                                         supportedCurrencies: ["CAD"],
                                                         country: "CA",
                                                         isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "153.00")
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD")
+        let orderTotal: NSDecimalNumber = 153
 
         // When
         let parameters: PaymentParameters = waitFor { promise in
@@ -105,6 +110,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
             self.sut.collectPayment(
                 for: order,
+                   orderTotal: orderTotal,
                    paymentGatewayAccount: account,
                    paymentMethodTypes: ["card_present"],
                    onWaitingForInput: {},
@@ -126,7 +132,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                                                         supportedCurrencies: ["CAD"],
                                                         country: "CA",
                                                         isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "42.50")
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD")
+        let orderTotal: NSDecimalNumber = 42.50
 
         // When
         let parameters: PaymentParameters = waitFor { promise in
@@ -138,6 +145,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
             self.sut.collectPayment(
                 for: order,
+                   orderTotal: orderTotal,
                    paymentGatewayAccount: account,
                    paymentMethodTypes: ["card_present"],
                    onWaitingForInput: {},
@@ -159,7 +167,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                                                         supportedCurrencies: ["CAD"],
                                                         country: "CA",
                                                         isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD", total: "39")
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD")
+        let orderTotal: NSDecimalNumber = 39
 
         // When
         let parameters: PaymentParameters = waitFor { promise in
@@ -171,6 +180,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
             self.sut.collectPayment(
                 for: order,
+                   orderTotal: orderTotal,
                    paymentGatewayAccount: account,
                    paymentMethodTypes: ["card_present"],
                    onWaitingForInput: {},

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -9,6 +9,7 @@ public struct CardPresentPaymentsConfiguration {
     public let paymentGateways: [String]
     public let supportedReaders: [CardReaderType]
     public let supportedPluginVersions: [PaymentPluginVersionSupport]
+    public let minimumAllowedChargeAmount: NSDecimalNumber
 
     init(countryCode: String,
          stripeTerminalforCanadaEnabled: Bool,
@@ -16,7 +17,8 @@ public struct CardPresentPaymentsConfiguration {
          currencies: [CurrencyCode],
          paymentGateways: [String],
          supportedReaders: [CardReaderType],
-         supportedPluginVersions: [PaymentPluginVersionSupport]) {
+         supportedPluginVersions: [PaymentPluginVersionSupport],
+         minimumAllowedChargeAmount: NSDecimalNumber) {
         self.countryCode = countryCode
         self.stripeTerminalforCanadaEnabled = stripeTerminalforCanadaEnabled
         self.paymentMethods = paymentMethods
@@ -24,6 +26,7 @@ public struct CardPresentPaymentsConfiguration {
         self.paymentGateways = paymentGateways
         self.supportedReaders = supportedReaders
         self.supportedPluginVersions = supportedPluginVersions
+        self.minimumAllowedChargeAmount = minimumAllowedChargeAmount
     }
 
     public init(country: String, canadaEnabled: Bool) {
@@ -40,7 +43,8 @@ public struct CardPresentPaymentsConfiguration {
                 supportedPluginVersions: [
                     .init(plugin: .wcPay, minimumVersion: "3.2.1"),
                     .init(plugin: .stripe, minimumVersion: "6.2.0")
-                ]
+                ],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5")
             )
         case "CA" where canadaEnabled == true:
             self.init(
@@ -50,7 +54,8 @@ public struct CardPresentPaymentsConfiguration {
                 currencies: [.CAD],
                 paymentGateways: [WCPayAccount.gatewayID],
                 supportedReaders: [.wisepad3],
-                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.0.0")]
+                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.0.0")],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5")
             )
         default:
             self.init(
@@ -60,7 +65,8 @@ public struct CardPresentPaymentsConfiguration {
                 currencies: [],
                 paymentGateways: [],
                 supportedReaders: [],
-                supportedPluginVersions: []
+                supportedPluginVersions: [],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5")
             )
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6736
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we handle properly the attempt of collecting a payment with a card when the payment amount is under the [minimum allowed for that currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). To do that, we implement these changes in this PR:
- Move the "0.5" minimum amount to CardPresentPaymentsConfiguration so that we can configure different values in each country
- Move the minimum amount check from PaymentCaptureOrchestrator to CollectOrderPaymentUseCase before the card reader connection
- Make the alert for this error non-retryable

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisites: the test site is ready for mobile payments.

- Open app
- Go to orders
- Create an order or simple payment with a total amount lower than 0.50 (e.g 0.12)
- In the order detail screen, tap on the "Collect Payment" button
Results:
- It fails before connecting to the card reader
- Error alert is not retryable (there is no "Retry" button)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/1864060/165946760-a47f4318-b710-4ff6-82c7-0674f42e7bf4.PNG" width=375>

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
