### PR TITLE
Order Details: Reload navigation bar when needed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -137,6 +137,8 @@ private extension OrderDetailsViewController {
                                                                 style: .plain,
                                                                 target: self,
                                                                 action: #selector(presentActionMenuSheet(_:)))
+        } else {
+            navigationItem.rightBarButtonItem = nil
         }
     }
 
@@ -189,6 +191,7 @@ private extension OrderDetailsViewController {
     /// Reloads the tableView's sections and data.
     ///
     func reloadTableViewSectionsAndData() {
+        configureNavigationBar()
         reloadSections()
         reloadTableViewDataIfPossible()
     }


### PR DESCRIPTION
fixes #6743 

# Why

There is a bug where the payment link action keeps visible or invisible even after the order status changes.

# How

This PR fixes that by making sure the navigation bar items are reloaded each time there is an update data request.

# Demo

https://user-images.githubusercontent.com/562080/165989812-b42381fb-e2ab-44cb-aad9-ae97a4c16c57.mov

# Testing Steps

- Navigate to a pending order with a positive amount value.
- See that the payment link option is present.
- Change the order to "On Hold"
- See that the payment link option is not present.
- Change the order to "Pending" again.
- See that the payment link option is present.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
