### PR TITLE
Order Creation: Percentage fee - preview amount, disable on editing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -51,7 +51,11 @@ struct FeeLineDetails: View {
                             case .fixed:
                                 inputFixedField
                             case .percentage:
-                                inputPercentageField
+                                VStack {
+                                    inputPercentageField
+                                    TitleAndValueRow(title: Localization.calculatedAmount,
+                                                     value: .init(placeHolder: viewModel.amountPlaceholder, content: viewModel.finalAmountString))
+                                }
                             }
                         }
                         .background(Color(.listForeground))
@@ -124,7 +128,7 @@ struct FeeLineDetails: View {
 
     private var inputPercentageField: some View {
         AdaptiveStack(horizontalAlignment: .leading) {
-            Text(String.localizedStringWithFormat(Localization.amountField, viewModel.percentSymbol))
+            Text(String.localizedStringWithFormat(Localization.percentageField, viewModel.percentSymbol))
                 .bodyStyle()
                 .fixedSize()
 
@@ -158,7 +162,13 @@ private extension FeeLineDetails {
         static let fee = NSLocalizedString("Fee", comment: "Title for the Fee Details screen during order creation")
 
         static let amountField = NSLocalizedString("Amount (%1$@)", comment: "Title for the amount field on the Fee Details screen during order creation"
-                                                   + "Parameters: %1$@ - fee type (percent sign or currency symbol)")
+                                                   + "Parameters: %1$@ - currency symbol")
+
+        static let percentageField = NSLocalizedString("Percentage (%1$@)",
+                                                       comment: "Title for the amount field on the Fee Details screen during order creation"
+                                                       + "Parameters: %1$@ - percent sign")
+        static let calculatedAmount = NSLocalizedString("Calculated amount",
+                                                        comment: "Title for the helper field describing calculated amount for given percentage")
 
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Fee Details screen")
         static let done = NSLocalizedString("Done", comment: "Text for the done button in the Fee Details screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -29,7 +29,7 @@ class FeeLineDetailsViewModel: ObservableObject {
         }
     }
 
-    /// Decimal value of currently entered fee. For percentage type it is calulcated final amount.
+    /// Decimal value of currently entered fee. For percentage type it is calculated final amount.
     ///
     private var finalAmountDecimal: Decimal {
         let inputString = feeType == .fixed ? amount : percentage
@@ -43,6 +43,12 @@ class FeeLineDetailsViewModel: ObservableObject {
         case .percentage:
             return baseAmountForPercentage * (decimalInput as Decimal) * 0.01
         }
+    }
+
+    /// Formatted string value of currently entered fee. For percentage type it is calculated final amount.
+    ///
+    var finalAmountString: String? {
+        currencyFormatter.formatAmount(finalAmountDecimal)
     }
 
     /// The base amount (items + shipping) to apply percentage fee on.
@@ -133,7 +139,7 @@ class FeeLineDetailsViewModel: ObservableObject {
     }
 
     func saveData() {
-        guard let finalAmountString = currencyFormatter.formatAmount(finalAmountDecimal) else {
+        guard let finalAmountString = finalAmountString else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -66,7 +66,7 @@ class FeeLineDetailsViewModel: ObservableObject {
     /// Returns true when base amount for percentage > 0.
     ///
     var isPercentageOptionAvailable: Bool {
-        baseAmountForPercentage > 0
+        !isExistingFeeLine && baseAmountForPercentage > 0
     }
 
     /// Returns true when there are no valid pending changes.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeLineDetailsViewModelTests.swift
@@ -85,6 +85,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
         viewModel.percentage = "hi:11.3005.02-"
 
         // Then
+        XCTAssertTrue(viewModel.isPercentageOptionAvailable)
         XCTAssertEqual(viewModel.percentage, "11.30")
         XCTAssertFalse(viewModel.shouldDisableDoneButton)
     }
@@ -117,7 +118,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
                                                 didSelectSave: { _ in })
 
         // Then
-        XCTAssertTrue(viewModel.isPercentageOptionAvailable)
+        XCTAssertFalse(viewModel.isPercentageOptionAvailable)
         XCTAssertTrue(viewModel.isExistingFeeLine)
         XCTAssertEqual(viewModel.feeType, .fixed)
         XCTAssertEqual(viewModel.amount, "10.00")
@@ -134,7 +135,7 @@ final class FeeLineDetailsViewModelTests: XCTestCase {
                                                 didSelectSave: { _ in })
 
         // Then
-        XCTAssertTrue(viewModel.isPercentageOptionAvailable)
+        XCTAssertFalse(viewModel.isPercentageOptionAvailable)
         XCTAssertTrue(viewModel.isExistingFeeLine)
         XCTAssertEqual(viewModel.feeType, .fixed)
         XCTAssertEqual(viewModel.amount, "-10.00")


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/6647.

## Description

This PR adds calculated amount for percentage fee preview and blocks percentage type for fee editing.
This is in line with current Android solution - for discussion check https://github.com/woocommerce/woocommerce-android/pull/6151.

## Testing

1. Go to the Orders tab, tap "+" in navbar and select "Create order".
2. Add a product to have non-zero order total.
3. Tap "Add Fee".
4. Switch to percentage type.
5. Try typing values and validate calculated amount.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/166295540-a6a9215c-5402-4d98-b255-a906e10be8ee.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/166295560-2dae6d26-d1f1-480b-b2da-a4c4ed7c63ca.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
