### PR TITLE
Product Details: Fix status badge layout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 9.2
 -----
 - [*] Order Creation: Updated percentage fee flow - added amount preview, disabled percentage option when editing. [https://github.com/woocommerce/woocommerce-ios/pull/6763]
+- [*] Product Details: Update status badge layout and show it for more cases. [https://github.com/woocommerce/woocommerce-ios/pull/6768]
 
 9.1
 -----

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -47,15 +47,25 @@ private extension LabeledTextViewTableViewCell {
     func configureLabelStyle() {
         productStatusLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
         productStatusLabel.textAlignment = .center
-        productStatusLabel.textColor = UIColor.black
-        productLabelHolder.backgroundColor = .gray(.shade5)
-        productLabelHolder.layer.cornerRadius = CGFloat(4.0)
+        productStatusLabel.textColor = BadgeStyle.Colors.textColor
+        productLabelHolder.backgroundColor = BadgeStyle.Colors.defaultBg
+        productLabelHolder.layer.cornerRadius = BadgeStyle.cornerRadius
     }
 
     func configureProductStatusLabel(productStatus: ProductStatus) {
         productStatusLabel.text = productStatus.description
-        productLabelHolder.backgroundColor = productStatus == .pending ? .withColorStudio(.orange, shade: .shade10) : .gray(.shade5)
+        productLabelHolder.backgroundColor = productStatus == .pending ? BadgeStyle.Colors.pendingBg : BadgeStyle.Colors.defaultBg
         productLabelHolder.isHidden = productStatus == .published
+    }
+
+    enum BadgeStyle {
+        static let cornerRadius: CGFloat = 4
+
+        enum Colors {
+            static let textColor: UIColor = .black
+            static let defaultBg: UIColor = .gray(.shade5)
+            static let pendingBg: UIColor = .withColorStudio(.orange, shade: .shade10)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -15,7 +15,9 @@ final class LabeledTextViewTableViewCell: UITableViewCell {
         var style: Style = .headline
 
     }
-    @IBOutlet weak var productLabelHolder: UIView!
+
+    @IBOutlet weak var productStatusBadgeHolder: UIView! // container with extra top margin for badge alignment
+    @IBOutlet weak var productStatusBadgeBg: UIView!
     @IBOutlet weak var productStatusLabel: UILabel!
     @IBOutlet var productTextField: EnhancedTextView!
 
@@ -48,14 +50,14 @@ private extension LabeledTextViewTableViewCell {
         productStatusLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
         productStatusLabel.textAlignment = .center
         productStatusLabel.textColor = BadgeStyle.Colors.textColor
-        productLabelHolder.backgroundColor = BadgeStyle.Colors.defaultBg
-        productLabelHolder.layer.cornerRadius = BadgeStyle.cornerRadius
+        productStatusBadgeBg.backgroundColor = BadgeStyle.Colors.defaultBg
+        productStatusBadgeBg.layer.cornerRadius = BadgeStyle.cornerRadius
     }
 
     func configureProductStatusLabel(productStatus: ProductStatus) {
         productStatusLabel.text = productStatus.description
-        productLabelHolder.backgroundColor = productStatus == .pending ? BadgeStyle.Colors.pendingBg : BadgeStyle.Colors.defaultBg
-        productLabelHolder.isHidden = productStatus == .published
+        productStatusBadgeBg.backgroundColor = productStatus == .pending ? BadgeStyle.Colors.pendingBg : BadgeStyle.Colors.defaultBg
+        productStatusBadgeHolder.isHidden = productStatus == .published
     }
 
     enum BadgeStyle {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -56,7 +56,14 @@ private extension LabeledTextViewTableViewCell {
 
     func configureProductStatusLabel(productStatus: ProductStatus) {
         productStatusLabel.text = productStatus.description
-        productStatusBadgeBg.backgroundColor = productStatus == .pending ? BadgeStyle.Colors.pendingBg : BadgeStyle.Colors.defaultBg
+
+        switch productStatus {
+        case .pending:
+            productStatusBadgeBg.backgroundColor = BadgeStyle.Colors.pendingBg
+        default:
+            productStatusBadgeBg.backgroundColor = BadgeStyle.Colors.defaultBg
+        }
+
         productStatusBadgeHolder.isHidden = productStatus == .published
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -28,7 +28,6 @@ final class LabeledTextViewTableViewCell: UITableViewCell {
     func configure(with viewModel: ViewModel) {
         productTextField.text = viewModel.text
         productTextField.placeholder = viewModel.placeholder
-        productStatusLabel.text = viewModel.productStatus.description
         productTextField.isScrollEnabled = viewModel.isScrollEnabled
         productTextField.onTextChange = viewModel.onNameChange
         productTextField.onTextDidBeginEditing = viewModel.onTextDidBeginEditing
@@ -55,16 +54,9 @@ private extension LabeledTextViewTableViewCell {
     }
 
     func configureProductStatusLabel(productStatus: ProductStatus) {
-        if productStatus == ProductStatus.draft {
-                let statusLabel = NSLocalizedString("Draft", comment: "Display label for the product's draft status")
-                productLabelHolder.isHidden = false
-                productStatusLabel.isHidden = false
-                productStatusLabel.text? = statusLabel
-            } else {
-                productLabelHolder.isHidden = true
-                productStatusLabel.isHidden = true
-            }
-        }
+        productStatusLabel.text = productStatus.description
+        productLabelHolder.isHidden = productStatus == ProductStatus.published
+    }
 }
 
 // Styles

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -44,7 +44,6 @@ private extension LabeledTextViewTableViewCell {
         productTextField.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
     }
 
-
     func configureLabelStyle() {
         productStatusLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
         productStatusLabel.textAlignment = .center
@@ -55,7 +54,8 @@ private extension LabeledTextViewTableViewCell {
 
     func configureProductStatusLabel(productStatus: ProductStatus) {
         productStatusLabel.text = productStatus.description
-        productLabelHolder.isHidden = productStatus == ProductStatus.published
+        productLabelHolder.backgroundColor = productStatus == .pending ? .withColorStudio(.orange, shade: .shade10) : .gray(.shade5)
+        productLabelHolder.isHidden = productStatus == .published
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
@@ -21,8 +21,15 @@
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UC5-pp-RCE">
                         <rect key="frame" x="16" y="8" width="288" height="28"/>
                         <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="gvh-NZ-8It" customClass="EnhancedTextView" customModule="WooCommerce" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="231.5" height="28"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                             <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="A6r-Hf-px7" userLabel="Product Status Label Holder">
-                                <rect key="frame" x="0.0" y="0.0" width="51.5" height="28"/>
+                                <rect key="frame" x="236.5" y="0.0" width="51.5" height="28"/>
                                 <subviews>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ls-Wz-Lz4">
                                         <rect key="frame" x="8" y="0.0" width="35.5" height="28"/>
@@ -39,13 +46,6 @@
                                     <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="top" secondItem="A6r-Hf-px7" secondAttribute="top" id="bhG-qZ-Kzw"/>
                                 </constraints>
                             </view>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="gvh-NZ-8It" customClass="EnhancedTextView" customModule="WooCommerce" customModuleProvider="target">
-                                <rect key="frame" x="56.5" y="0.0" width="231.5" height="28"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <color key="textColor" systemColor="labelColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
                         </subviews>
                     </stackView>
                 </subviews>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
@@ -28,22 +28,34 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="A6r-Hf-px7" userLabel="Product Status Label Holder">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n4n-89-c1P">
                                 <rect key="frame" x="236.5" y="0.0" width="51.5" height="28"/>
                                 <subviews>
-                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ls-Wz-Lz4">
-                                        <rect key="frame" x="8" y="8" width="35.5" height="12"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="A6r-Hf-px7" userLabel="Product Status Label Holder">
+                                        <rect key="frame" x="0.0" y="8" width="51.5" height="20"/>
+                                        <subviews>
+                                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ls-Wz-Lz4">
+                                                <rect key="frame" x="12" y="4" width="27.5" height="12"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="leading" secondItem="A6r-Hf-px7" secondAttribute="leading" constant="12" id="6pg-Hg-H1r"/>
+                                            <constraint firstAttribute="trailing" secondItem="9Ls-Wz-Lz4" secondAttribute="trailing" constant="12" id="AqL-XT-p8y"/>
+                                            <constraint firstAttribute="bottom" secondItem="9Ls-Wz-Lz4" secondAttribute="bottom" constant="4" id="TaL-NL-uMD"/>
+                                            <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="top" secondItem="A6r-Hf-px7" secondAttribute="top" constant="4" id="bhG-qZ-Kzw"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="leading" secondItem="A6r-Hf-px7" secondAttribute="leading" constant="8" id="6pg-Hg-H1r"/>
-                                    <constraint firstAttribute="trailing" secondItem="9Ls-Wz-Lz4" secondAttribute="trailing" constant="8" id="AqL-XT-p8y"/>
-                                    <constraint firstAttribute="bottom" secondItem="9Ls-Wz-Lz4" secondAttribute="bottom" constant="8" id="TaL-NL-uMD"/>
-                                    <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="top" secondItem="A6r-Hf-px7" secondAttribute="top" constant="8" id="bhG-qZ-Kzw"/>
+                                    <constraint firstItem="A6r-Hf-px7" firstAttribute="leading" secondItem="n4n-89-c1P" secondAttribute="leading" id="8Gc-ie-yqV"/>
+                                    <constraint firstAttribute="trailing" secondItem="A6r-Hf-px7" secondAttribute="trailing" id="8S3-Eg-y1t"/>
+                                    <constraint firstAttribute="bottom" secondItem="A6r-Hf-px7" secondAttribute="bottom" id="RHK-yM-8zU"/>
+                                    <constraint firstItem="A6r-Hf-px7" firstAttribute="top" secondItem="n4n-89-c1P" secondAttribute="top" constant="8" id="tf8-dM-rbR"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -58,7 +70,8 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="SEn-yL-fY3"/>
             <connections>
-                <outlet property="productLabelHolder" destination="A6r-Hf-px7" id="qn3-Hp-bGK"/>
+                <outlet property="productStatusBadgeBg" destination="A6r-Hf-px7" id="VXc-gx-hSr"/>
+                <outlet property="productStatusBadgeHolder" destination="n4n-89-c1P" id="biC-UT-Equ"/>
                 <outlet property="productStatusLabel" destination="9Ls-Wz-Lz4" id="CgG-SY-xHN"/>
                 <outlet property="productTextField" destination="gvh-NZ-8It" id="nRN-le-nFL"/>
             </connections>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
@@ -18,7 +18,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UC5-pp-RCE">
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UC5-pp-RCE">
                         <rect key="frame" x="16" y="8" width="288" height="28"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="gvh-NZ-8It" customClass="EnhancedTextView" customModule="WooCommerce" customModuleProvider="target">
@@ -32,7 +32,7 @@
                                 <rect key="frame" x="236.5" y="0.0" width="51.5" height="28"/>
                                 <subviews>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ls-Wz-Lz4">
-                                        <rect key="frame" x="8" y="0.0" width="35.5" height="28"/>
+                                        <rect key="frame" x="8" y="8" width="35.5" height="12"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -42,8 +42,8 @@
                                 <constraints>
                                     <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="leading" secondItem="A6r-Hf-px7" secondAttribute="leading" constant="8" id="6pg-Hg-H1r"/>
                                     <constraint firstAttribute="trailing" secondItem="9Ls-Wz-Lz4" secondAttribute="trailing" constant="8" id="AqL-XT-p8y"/>
-                                    <constraint firstAttribute="bottom" secondItem="9Ls-Wz-Lz4" secondAttribute="bottom" id="TaL-NL-uMD"/>
-                                    <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="top" secondItem="A6r-Hf-px7" secondAttribute="top" id="bhG-qZ-Kzw"/>
+                                    <constraint firstAttribute="bottom" secondItem="9Ls-Wz-Lz4" secondAttribute="bottom" constant="8" id="TaL-NL-uMD"/>
+                                    <constraint firstItem="9Ls-Wz-Lz4" firstAttribute="top" secondItem="A6r-Hf-px7" secondAttribute="top" constant="8" id="bhG-qZ-Kzw"/>
                                 </constraints>
                             </view>
                         </subviews>


### PR DESCRIPTION
## Description

This PR updates status badge layout on product details screen and enables badge display for all types other than "published". Previously it was displayed only for "draft".
Related discussion: https://github.com/woocommerce/woocommerce-android/pull/6369.

## Testing

1. Go to the Products tab, open any existing product or start creating new one.
2. Tap "•••" in navbar. Select "Product Settings".
3. Change "Status" to anything other than "Published" and tap "Done".
4. Confirm that badge is correctly displayed for selected status.
5. Edit product title to have multiple lines, confirm it doesn't overlap with status badge.
6. Open "Product Settings", change "Visibility" to "Private" and tap "Done".
7. Check expected "Privately published" badge.

## Screenshots and Video

before|after
--|--
![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 29 03](https://user-images.githubusercontent.com/3132438/166445210-8f41b2e1-f45d-43d5-9ea9-cc1343db7d74.png)|![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 29 38](https://user-images.githubusercontent.com/3132438/166445218-9bd817e1-031c-454b-b1b9-7d597f5821cc.png)

https://user-images.githubusercontent.com/3132438/166447028-851df8b8-4b66-471c-8da8-5336161f85e7.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
