### PR TITLE
[Mobile Payments] Charge flat $0.15 fee on PaymentIntent in Canada

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -237,7 +237,15 @@ private extension PaymentCaptureOrchestrator {
             return nil
         }
 
-        return Constants.canadaFlatFee as Decimal
+        let fee = orderTotal.multiplying(by: Constants.canadaPercentageFee).adding(Constants.canadaFlatFee)
+
+        let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
+                                                   scale: 2,
+                                                   raiseOnExactness: false,
+                                                   raiseOnOverflow: false,
+                                                   raiseOnUnderflow: false,
+                                                   raiseOnDivideByZero: false)
+        return fee.rounding(accordingToBehavior: numberHandler) as Decimal
     }
 
     func receiptDescription(orderNumber: String) -> String? {
@@ -265,6 +273,7 @@ private extension PaymentCaptureOrchestrator {
 private extension PaymentCaptureOrchestrator {
     enum Constants {
         static let canadaFlatFee = NSDecimalNumber(string: "0.15")
+        static let canadaPercentageFee = NSDecimalNumber(0)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -237,7 +237,7 @@ private extension PaymentCaptureOrchestrator {
             return nil
         }
 
-        let fee = orderTotal.multiplying(by: Constants.canadaPercentageFee).adding(Constants.canadaFlatFee)
+        let fee = orderTotal.adding(Constants.canadaFlatFee)
 
         let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
                                                    scale: 2,
@@ -272,9 +272,7 @@ private extension PaymentCaptureOrchestrator {
 
 private extension PaymentCaptureOrchestrator {
     enum Constants {
-        static let canadaFlatFee = NSDecimalNumber(string: "0.25")
-
-        static let canadaPercentageFee = NSDecimalNumber(string: "0.026")
+        static let canadaFlatFee = NSDecimalNumber(string: "0.15")
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -237,15 +237,7 @@ private extension PaymentCaptureOrchestrator {
             return nil
         }
 
-        let fee = orderTotal.adding(Constants.canadaFlatFee)
-
-        let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
-                                                   scale: 2,
-                                                   raiseOnExactness: false,
-                                                   raiseOnOverflow: false,
-                                                   raiseOnUnderflow: false,
-                                                   raiseOnDivideByZero: false)
-        return fee.rounding(accordingToBehavior: numberHandler) as Decimal
+        return Constants.canadaFlatFee as Decimal
     }
 
     func receiptDescription(orderNumber: String) -> String? {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -55,7 +55,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         XCTAssertNil(parameters.applicationFee)
     }
 
-    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_2point6percent_plus_25cents_applicationFee_in_the_payment_intent() throws {
+    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_15cents_applicationFee_in_the_payment_intent() throws {
         // Given
         let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
                                                         defaultCurrency: "CAD",
@@ -86,115 +86,9 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         }
 
         // Then
-        let expectedFee = NSDecimalNumber(string: "4.15").decimalValue
+        let expectedFee = NSDecimalNumber(string: "0.15").decimalValue
         assertEqual(expectedFee, parameters.applicationFee)
     }
-
-    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_rounds_up_applicationFees_to_2dp_where_next_digit_is_over_5() throws {
-        // Given
-        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
-                                                        defaultCurrency: "CAD",
-                                                        supportedCurrencies: ["CAD"],
-                                                        country: "CA",
-                                                        isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD")
-        let orderTotal: NSDecimalNumber = 153
-
-        // When
-        let parameters: PaymentParameters = waitFor { promise in
-            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
-                    promise(parameters)
-                }
-            }
-
-            self.sut.collectPayment(
-                for: order,
-                   orderTotal: orderTotal,
-                   paymentGatewayAccount: account,
-                   paymentMethodTypes: ["card_present"],
-                   onWaitingForInput: {},
-                   onProcessingMessage: {},
-                   onDisplayMessage: { _ in },
-                   onProcessingCompletion: { _ in },
-                   onCompletion: { _ in })
-        }
-
-        // Then
-        let expectedFee = NSDecimalNumber(string: "4.23").decimalValue // 153 * 0.026 + 0.25 = 422.8
-        assertEqual(expectedFee, parameters.applicationFee)
-    }
-
-    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_rounds_up_applicationFees_to_2dp_where_next_digit_is_exactly_5() throws {
-        // Given
-        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
-                                                        defaultCurrency: "CAD",
-                                                        supportedCurrencies: ["CAD"],
-                                                        country: "CA",
-                                                        isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD")
-        let orderTotal: NSDecimalNumber = 42.50
-
-        // When
-        let parameters: PaymentParameters = waitFor { promise in
-            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
-                    promise(parameters)
-                }
-            }
-
-            self.sut.collectPayment(
-                for: order,
-                   orderTotal: orderTotal,
-                   paymentGatewayAccount: account,
-                   paymentMethodTypes: ["card_present"],
-                   onWaitingForInput: {},
-                   onProcessingMessage: {},
-                   onDisplayMessage: { _ in },
-                   onProcessingCompletion: { _ in },
-                   onCompletion: { _ in })
-        }
-
-        // Then
-        let expectedFee = NSDecimalNumber(string: "1.36").decimalValue // 42.5 * 0.026 + 0.25 = 1.355
-        assertEqual(expectedFee, parameters.applicationFee)
-    }
-
-    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_rounds_down_applicationFees_to_2dp_where_next_digit_is_below_5() throws {
-        // Given
-        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
-                                                        defaultCurrency: "CAD",
-                                                        supportedCurrencies: ["CAD"],
-                                                        country: "CA",
-                                                        isCardPresentEligible: true)
-        let order = Order.fake().copy(siteID: sampleSiteID, currency: "CAD")
-        let orderTotal: NSDecimalNumber = 39
-
-        // When
-        let parameters: PaymentParameters = waitFor { promise in
-            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
-                    promise(parameters)
-                }
-            }
-
-            self.sut.collectPayment(
-                for: order,
-                   orderTotal: orderTotal,
-                   paymentGatewayAccount: account,
-                   paymentMethodTypes: ["card_present"],
-                   onWaitingForInput: {},
-                   onProcessingMessage: {},
-                   onDisplayMessage: { _ in },
-                   onProcessingCompletion: { _ in },
-                   onCompletion: { _ in })
-        }
-
-        // Then
-        let expectedFee = NSDecimalNumber(string: "1.26").decimalValue // 39 * 0.026 + 0.25 = 1.264
-        assertEqual(expectedFee, parameters.applicationFee)
-    }
-
 }
 
 struct MockReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6767
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we update the Payment intent fee for IPP payments in Canada. 
As stated in the original issue, the fees for Interac in Canada have been updated to use a flat rate of $0.15 for any transaction. Because of that, we add it as default in the code following the implementation of this [PR](https://github.com/woocommerce/woocommerce-ios/pull/6725), where we implemented the first approach for fees in Canada. For other payment methods in Canada, the fee will be set by WCPay at capture time, so they won't be affected by this default value.

### Changes
- Add new flat fee for Canada
- Remove percentage fee for Canada
- Update Unit tests

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Main scenario, Interac Canada

1. In the app, create an Order or Simple Payment and collect the payment with an Interac card

2. To check the fees, you'll need to open either the payment in WCPay, or the Stripe Dashboard. Here's how you find them:

**WCPay**: wp-admin > WooCommerce > Orders > {Select order} > Payment via Credit card / debit card 
<img width="772" alt="wp-admin order payment" src="https://user-images.githubusercontent.com/1864060/166454021-e3f1af81-d2fa-4d6f-82a0-cda5fbf0b1f7.png">

**Stripe**: You'll need access to the Stripe Dashboard for this: PdfdoF-1A-p2
Toggle `Test mode` viewing, and [find your site's account](https://dashboard.stripe.com/connect/accounts/overview) – use the filters and ⚙️ in the columns to help narrow it down. You can search for your account id to find it. You can find your account id under wp-admin > WooCommerce > status > account ID

<img width="772" alt="Screenshot 2022-05-03 at 13 16 54" src="https://user-images.githubusercontent.com/1864060/166454246-25e32a42-bd30-4553-ba55-0fdff31137d3.png">

#### Other scenarios

Repeat for the following:

- US transaction
- Canada non-Interac transaction

The fees shown should be the ones set by WCPay at capture time.

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
