### PR TITLE
IPP Analytics: add `card_reader_model` event prop to email/print receipt events after collecting a payment

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1014,72 +1014,106 @@ extension WooAnalyticsEvent {
 
         /// Tracked when the user taps on the "Email receipt" button after successfully collecting a payment to email a receipt.
         /// - Parameter countryCode: the country code of the store.
+        /// - Parameter cardReaderModel: the model type of the card reader.
         ///
-        static func receiptEmailTapped(countryCode: String) -> WooAnalyticsEvent {
+        static func receiptEmailTapped(countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailTapped,
-                              properties: [Keys.countryCode: countryCode])
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.cardReaderModel: cardReaderModel
+                              ])
         }
 
         /// Tracked when sending or saving the receipt email failed.
         /// - Parameters:
         ///   - error: the error to be included in the event properties.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func receiptEmailFailed(error: Error, countryCode: String) -> WooAnalyticsEvent {
+        static func receiptEmailFailed(error: Error, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailFailed,
-                              properties: [Keys.countryCode: countryCode],
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.cardReaderModel: cardReaderModel
+                              ],
                               error: error)
         }
 
         /// Tracked when the user canceled sending the receipt by email.
         /// - Parameter countryCode: the country code of the store.
+        /// - Parameter cardReaderModel: the model type of the card reader.
         ///
-        static func receiptEmailCanceled(countryCode: String) -> WooAnalyticsEvent {
+        static func receiptEmailCanceled(countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailCanceled,
-                              properties: [Keys.countryCode: countryCode])
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.cardReaderModel: cardReaderModel
+                              ])
         }
 
         /// Tracked when the receipt was sent by email.
         /// - Parameter countryCode: the country code of the store.
         ///
-        static func receiptEmailSuccess(countryCode: String) -> WooAnalyticsEvent {
+        static func receiptEmailSuccess(countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailSuccess,
-                              properties: [Keys.countryCode: countryCode])
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.cardReaderModel: cardReaderModel
+                              ])
         }
 
         /// Tracked when the user tapped on the button to print a receipt.
         /// - Parameter countryCode: the country code of the store.
         ///
-        static func receiptPrintTapped(countryCode: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .receiptPrintTapped,
-                              properties: [Keys.countryCode: countryCode])
+        static func receiptPrintTapped(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+            let properties: [String: WooAnalyticsEventPropertyType?] = [
+                Keys.countryCode: countryCode,
+                Keys.cardReaderModel: cardReaderModel
+            ]
+            return WooAnalyticsEvent(statName: .receiptPrintTapped,
+                                     properties: properties.compactMapValues { $0 })
         }
 
         /// Tracked when printing the receipt failed.
         /// - Parameters:
         ///   - error: the error to be included in the event properties.
         ///   - countryCode: the country code of the store.
+        ///   - cardReaderModel: the country code of the store.
         ///
-        static func receiptPrintFailed(error: Error, countryCode: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .receiptPrintFailed,
-                              properties: [Keys.countryCode: countryCode],
-                              error: error)
+        static func receiptPrintFailed(error: Error, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+            let properties: [String: WooAnalyticsEventPropertyType?] = [
+                Keys.countryCode: countryCode,
+                Keys.cardReaderModel: cardReaderModel
+            ]
+            return WooAnalyticsEvent(statName: .receiptPrintFailed,
+                                     properties: properties.compactMapValues { $0 },
+                                     error: error)
         }
 
         /// Tracked when the user canceled printing the receipt.
         /// - Parameter countryCode: the country code of the store.
+        /// - Parameter cardReaderModel: the country code of the store.
         ///
-        static func receiptPrintCanceled(countryCode: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .receiptPrintCanceled,
-                              properties: [Keys.countryCode: countryCode])
+        static func receiptPrintCanceled(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+            let properties: [String: WooAnalyticsEventPropertyType?] = [
+                Keys.countryCode: countryCode,
+                Keys.cardReaderModel: cardReaderModel
+            ]
+            return WooAnalyticsEvent(statName: .receiptPrintCanceled,
+                                     properties: properties.compactMapValues { $0 })
         }
 
         /// Tracked when the receipt was successfully sent to the printer. iOS won't guarantee that the receipt has actually printed.
         /// - Parameter countryCode: the country code of the store.
+        /// - Parameter cardReaderModel: the country code of the store.
         ///
-        static func receiptPrintSuccess(countryCode: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .receiptPrintSuccess,
-                              properties: [Keys.countryCode: countryCode])
+        static func receiptPrintSuccess(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+            let properties: [String: WooAnalyticsEventPropertyType?] = [
+                Keys.countryCode: countryCode,
+                Keys.cardReaderModel: cardReaderModel
+            ]
+            return WooAnalyticsEvent(statName: .receiptPrintSuccess,
+                                     properties: properties.compactMapValues { $0 })
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
@@ -2,21 +2,26 @@ import Foundation
 import Yosemite
 
 struct ReceiptActionCoordinator {
-    static func printReceipt(for order: Order, params: CardPresentReceiptParameters, countryCode: String) {
-        ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintTapped(countryCode: countryCode))
+    static func printReceipt(for order: Order,
+                             params: CardPresentReceiptParameters,
+                             countryCode: String,
+                             cardReaderModel: String?,
+                             stores: StoresManager,
+                             analytics: Analytics) {
+        analytics.track(event: .InPersonPayments.receiptPrintTapped(countryCode: countryCode, cardReaderModel: cardReaderModel))
 
         let action = ReceiptAction.print(order: order, parameters: params) { (result) in
             switch result {
             case .success:
-                ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintSuccess(countryCode: countryCode))
+                analytics.track(event: .InPersonPayments.receiptPrintSuccess(countryCode: countryCode, cardReaderModel: cardReaderModel))
             case .cancel:
-                ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintCanceled(countryCode: countryCode))
+                analytics.track(event: .InPersonPayments.receiptPrintCanceled(countryCode: countryCode, cardReaderModel: cardReaderModel))
             case .failure(let error):
-                ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintFailed(error: error, countryCode: countryCode))
+                analytics.track(event: .InPersonPayments.receiptPrintFailed(error: error, countryCode: countryCode, cardReaderModel: cardReaderModel))
                 DDLogError("⛔️ Failed to print receipt: \(error.localizedDescription)")
             }
         }
 
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -32,6 +32,11 @@ final class ReceiptViewModel {
 
     /// Prints the receipt
     func printReceipt() {
-        ReceiptActionCoordinator.printReceipt(for: order, params: receipt, countryCode: countryCode)
+        ReceiptActionCoordinator.printReceipt(for: order,
+                                              params: receipt,
+                                              countryCode: countryCode,
+                                              cardReaderModel: nil,
+                                              stores: ServiceLocator.stores,
+                                              analytics: ServiceLocator.analytics)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -53,7 +53,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private let stores: StoresManager
 
-    /// Analytics manager,
+    /// Analytics manager.
     ///
     private let analytics: Analytics
 
@@ -376,16 +376,27 @@ private extension CollectOrderPaymentUseCase {
     ///
     func presentReceiptAlert(receiptParameters: CardPresentReceiptParameters, backButtonTitle: String, onCompleted: @escaping () -> ()) {
         // Present receipt alert
-        alerts.success(printReceipt: { [order, configuration] in
+        alerts.success(printReceipt: { [order, configuration, weak self] in
+            guard let self = self else { return }
+
             // Inform about flow completion.
             onCompleted()
 
             // Delegate print action
-            ReceiptActionCoordinator.printReceipt(for: order, params: receiptParameters, countryCode: configuration.countryCode)
+            ReceiptActionCoordinator.printReceipt(for: order,
+                                                  params: receiptParameters,
+                                                  countryCode: configuration.countryCode,
+                                                  cardReaderModel: self.connectedReader?.readerType.model,
+                                                  stores: self.stores,
+                                                  analytics: self.analytics)
 
-        }, emailReceipt: { [order, analytics, paymentOrchestrator, configuration] in
+        }, emailReceipt: { [order, analytics, paymentOrchestrator, configuration, weak self] in
+            guard let self = self else { return }
+
             // Record button tapped
-            analytics.track(event: .InPersonPayments.receiptEmailTapped(countryCode: configuration.countryCode))
+            analytics.track(event: .InPersonPayments
+                .receiptEmailTapped(countryCode: configuration.countryCode,
+                                    cardReaderModel: self.connectedReader?.readerType.model ?? ""))
 
             // Request & present email
             paymentOrchestrator.emailReceipt(for: order, params: receiptParameters) { [weak self] emailContent in
@@ -448,15 +459,17 @@ private extension CollectOrderPaymentUseCase {
 // MARK: MailComposer Delegate
 extension CollectOrderPaymentUseCase: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        let cardReaderModel = connectedReader?.readerType.model ?? ""
         switch result {
         case .cancelled:
-            analytics.track(event: .InPersonPayments.receiptEmailCanceled(countryCode: configuration.countryCode))
+            analytics.track(event: .InPersonPayments.receiptEmailCanceled(countryCode: configuration.countryCode, cardReaderModel: cardReaderModel))
         case .sent, .saved:
-            analytics.track(event: .InPersonPayments.receiptEmailSuccess(countryCode: configuration.countryCode))
+            analytics.track(event: .InPersonPayments.receiptEmailSuccess(countryCode: configuration.countryCode, cardReaderModel: cardReaderModel))
         case .failed:
             analytics.track(event: .InPersonPayments
                 .receiptEmailFailed(error: error ?? UnknownEmailError(),
-                                    countryCode: configuration.countryCode))
+                                    countryCode: configuration.countryCode,
+                                    cardReaderModel: cardReaderModel))
         @unknown default:
             assertionFailure("MFMailComposeViewController finished with an unknown result type")
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
@@ -2,7 +2,8 @@
 import UIKit
 
 /// Mock for `OrderDetailsPaymentAlertsProtocol`.
-final class MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
+final class MockOrderDetailsPaymentAlerts {
+    // Public closures to mock alert actions and properties for assertions.
     var cancelReaderIsReadyAlert: (() -> Void)?
 
     var cancelTapOrInsertCardAlert: (() -> Void)?
@@ -12,6 +13,12 @@ final class MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
     var dismissErrorCompletion: (() -> Void)?
     var nonRetryableErrorWasCalled = false
 
+    // Success alert.
+    var printReceiptFromSuccessAlert: (() -> Void)?
+    var emailReceiptFromSuccessAlert: (() -> Void)?
+}
+
+extension MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
         // no-op
     }
@@ -33,7 +40,8 @@ final class MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
     }
 
     func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptTitle: String, noReceiptAction: @escaping () -> Void) {
-        // no-op
+        printReceiptFromSuccessAlert = printReceipt
+        emailReceiptFromSuccessAlert = emailReceipt
     }
 
     func error(error: Error, tryAgain: @escaping () -> Void, dismissCompletion: @escaping () -> Void) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5984 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR added `card_reader_model` property to the remaining applicable IPP events: print/email a receipt from the alert modal after collecting payment.

After testing and some thinking, there are some events that we _could_ also track the card reader model property but it requires some extra work which I'm not sure if it adds values:

- `*_receipt_view_tapped`: when the user taps to view the receipt for an order in order details. This is outside the IPP flow, and I'm not sure the knowledge of the connected card reader model is important here
- `*_card_present_onboarding_learn_more_tapped` and `*_card_present_onboarding_not_completed`: when the user taps on the "Learn more" button on one of the screens shown during "onboarding to in-person payments" flow. After some testing, the only scenario I've reproduced where a reader is connected but the "learn more" button is shown is when I activate both WCPay and Stripe plugins after connecting to a reader. This is a very edge case and I also don't think the card reader model matters much for these two events

I decided not to implement the event property for the above events, but if you think otherwise I'm open to changes!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

(Borrowing the testing instructions from https://github.com/woocommerce/woocommerce-ios/pull/4213) Please note that the failure events are not easy to test and feel free to skip them, I haven't seen any failed events in Tracks.

- After completing payment:  --> all events below should have a `card_reader_model` event prop
  -  Tap on Email receipt: `receipt_email_tapped`
      - Send email: `receipt_email_success`
      - Cancel and save as draft: `receipt_email_success`
      - Cancel and discard draft: `receipt_email_canceled`
      - ❓Make the email fail: `receipt_email_failed`
  - Tap on Print receipt: `receipt_print_tapped `
      - Print receipt: `receipt_print_success`
      - Cancel printing: `receipt_print_canceled`
      - ❓Make printing fail: `receipt_print_failed`
- From an order with a saved receipt:  --> all events below should **not** have a `card_reader_model` event prop
  - Tap See Receipt: `receipt_view_tapped`
    - Tap on Print receipt: `receipt_print_tapped `
        - Print receipt: `receipt_print_success`
        - Cancel printing: `receipt_print_canceled`
        - ❓Make printing fail: `receipt_print_failed`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
