### PR TITLE
[In-person refunds] Allow retry after failure fetching refund charge details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 9.2
 -----
 - [*] Order Creation: Updated percentage fee flow - added amount preview, disabled percentage option when editing. [https://github.com/woocommerce/woocommerce-ios/pull/6763]
-- [*] Refunds: Allow retry after failure fetching refund charge details. [https://github.com/woocommerce/woocommerce-ios/pull/6772]
 
 9.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 9.2
 -----
 - [*] Order Creation: Updated percentage fee flow - added amount preview, disabled percentage option when editing. [https://github.com/woocommerce/woocommerce-ios/pull/6763]
+- [*] Refunds: Allow retry after failure fetching refund charge details. [https://github.com/woocommerce/woocommerce-ios/pull/6772]
 
 9.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -72,6 +72,8 @@ private extension IssueRefundViewController {
         }
 
         viewModel.showFetchChargeErrorNotice = { [weak self] retryAction in
+            guard let self = self else { return }
+            
             let notice = Notice(title: Localization.retryFetchChargeNoticeTitle,
                                 feedbackType: .error,
                                 actionTitle: Localization.retryFetchChargeNoticeRetryActionTitle,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -71,7 +71,7 @@ private extension IssueRefundViewController {
             self?.updateWithViewModelContent()
         }
 
-        viewModel.onChargeFetchErrorNoticeShowRequest = { [weak self] retryAction in
+        viewModel.showFetchChargeErrorNotice = { [weak self] retryAction in
             let notice = Notice(title: Localization.retryFetchChargeNoticeTitle,
                                 feedbackType: .error,
                                 actionTitle: Localization.retryFetchChargeNoticeRetryActionTitle,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -70,7 +70,7 @@ private extension IssueRefundViewController {
             self?.updateWithViewModelContent()
         }
 
-        viewModel.onChargeFetchError = { [weak self] retryAction in
+        viewModel.onChargeFetchErrorNoticeShowRequest = { [weak self] retryAction in
             let notice = Notice(title: Localization.retryFetchChargeNoticeTitle,
                                 feedbackType: .error,
                                 actionTitle: Localization.retryFetchChargeNoticeRetryActionTitle,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -44,6 +44,7 @@ final class IssueRefundViewController: UIViewController {
         configureNavigationBar()
         configureTableView()
         observeViewModel()
+        viewModel.fetch()
         updateWithViewModelContent()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -73,7 +73,7 @@ private extension IssueRefundViewController {
 
         viewModel.showFetchChargeErrorNotice = { [weak self] retryAction in
             guard let self = self else { return }
-            
+
             let notice = Notice(title: Localization.retryFetchChargeNoticeTitle,
                                 feedbackType: .error,
                                 actionTitle: Localization.retryFetchChargeNoticeRetryActionTitle,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -69,6 +69,16 @@ private extension IssueRefundViewController {
         viewModel.onChange = { [weak self] in
             self?.updateWithViewModelContent()
         }
+
+        viewModel.onChargeFetchError = { [weak self] retryAction in
+            let notice = Notice(title: Localization.retryFetchChargeNoticeTitle,
+                                feedbackType: .error,
+                                actionTitle: Localization.retryFetchChargeNoticeRetryActionTitle,
+                                actionHandler: retryAction)
+            let noticePresenter = DefaultNoticePresenter()
+            noticePresenter.presentingViewController = self
+            noticePresenter.enqueue(notice: notice)
+        }
     }
 
     func updateWithViewModelContent() {
@@ -265,5 +275,11 @@ private extension IssueRefundViewController {
         static let nextTitle = NSLocalizedString("Next", comment: "Title of the next button in the issue refund screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title in the issue refund screen")
         static let selectAllTitle = NSLocalizedString("Select All", comment: "Select all button title in the issue refund screen")
+        static let retryFetchChargeNoticeTitle = NSLocalizedString(
+            "Failed to fetch your charge details. Please try again.",
+            comment: "Error message on the Issue Refund screen when fetching the charge details failed")
+        static let retryFetchChargeNoticeRetryActionTitle = NSLocalizedString(
+            "Retry",
+            comment: "Action button that will retry fetching the charge details on the Issue Refund screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -310,7 +310,15 @@ private extension IssueRefundViewModel {
         let setPaymentGatewayAccountAction = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
         stores.dispatch(setPaymentGatewayAccountAction)
 
-        let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: state.order.siteID, chargeID: chargeID, onCompletion: { _ in })
+        let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: state.order.siteID, chargeID: chargeID, onCompletion: { [weak self] result in
+            switch result {
+            case .success(_):
+                self?.state.fetchChargeError = nil
+            case .failure(_):
+                self?.state.fetchChargeError = .requestError
+            }
+        })
+        
         stores.dispatch(action)
     }
 }
@@ -522,6 +530,7 @@ extension IssueRefundViewModel {
     /// Error from fetching refund charge details.
     enum FetchChargeError: Error, Equatable {
         case unknownPaymentGatewayAccount
+        case requestError
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -67,7 +67,7 @@ final class IssueRefundViewModel {
     /// This closure is executed when fetching the charge details failed.
     /// Implement the input parameter with a closure to be execured when the user wants to retry the fetch action.
     ///
-    var onChargeFetchError: ((@escaping (() -> Void)) -> (Void))?
+    var onChargeFetchErrorNoticeShowRequest: ((@escaping (() -> Void)) -> (Void))?
 
     /// Title for the navigation bar
     ///
@@ -319,7 +319,7 @@ private extension IssueRefundViewModel {
             if case .failure(_) = result {
                 self?.state.fetchChargeError = .requestError
 
-                self?.onChargeFetchError?({ [weak self] in
+                self?.onChargeFetchErrorNoticeShowRequest?({ [weak self] in
                     self?.fetchCharge()
                 })
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -67,7 +67,7 @@ final class IssueRefundViewModel {
     /// This closure is executed when fetching the charge details failed.
     /// Implement the input parameter with a closure to be execured when the user wants to retry the fetch action.
     ///
-    var onChargeFetchErrorNoticeShowRequest: ((@escaping (() -> Void)) -> (Void))?
+    var showFetchChargeErrorNotice: ((@escaping (() -> Void)) -> (Void))?
 
     /// Title for the navigation bar
     ///
@@ -324,7 +324,7 @@ private extension IssueRefundViewModel {
             if case .failure(_) = result {
                 self?.state.fetchChargeError = .requestError
 
-                self?.onChargeFetchErrorNoticeShowRequest?({ [weak self] in
+                self?.showFetchChargeErrorNotice?({ [weak self] in
                     self?.fetchCharge()
                 })
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -321,7 +321,7 @@ private extension IssueRefundViewModel {
         stores.dispatch(setPaymentGatewayAccountAction)
 
         let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: state.order.siteID, chargeID: chargeID, onCompletion: { [weak self] result in
-            if case .failure(_) = result {
+            if case .failure = result {
                 self?.state.fetchChargeError = .requestError
 
                 self?.showFetchChargeErrorNotice?({ [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -168,7 +168,6 @@ final class IssueRefundViewModel {
         selectedItemsTitle = createSelectedItemsCount()
         hasUnsavedChanges = calculatePendingChangesState()
         observeCharge()
-        fetchCharge()
     }
 
     /// Creates the `ViewModel` to be used when navigating to the page where the user can
@@ -236,6 +235,12 @@ extension IssueRefundViewModel {
         }
 
         trackSelectAllButtonTapped()
+    }
+
+    /// Fetches the necessary information to show the issue refund screen.
+    ///
+    func fetch() {
+        fetchCharge()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -593,7 +593,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSelectAllButtonVisible)
     }
 
-    func test_viewModel_fetches_charge_before_creating_refundConfirmationViewModel() throws {
+    func test_fetch_when_there_is_a_payment_gateway_stored_then_calls_to_fetch_charge() throws {
         // Given
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
@@ -603,20 +603,22 @@ final class IssueRefundViewModelTests: XCTestCase {
         // When
         let chargeFetched: Bool = waitFor { promise in
             stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                guard case .fetchWCPayCharge(siteID: _, chargeID: "ch_id", onCompletion: _) = action else {
+                guard case let .fetchWCPayCharge(siteID: _, chargeID: "ch_id", onCompletion: onCompletion) = action else {
                     return
                 }
+                onCompletion(.success(WCPayCharge.fake()))
                 promise(true)
             }
 
-            _ = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: self.storageManager)
+            let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: self.storageManager)
+            viewModel.fetch()
         }
 
         // Then
         XCTAssertTrue(chargeFetched)
     }
 
-    func test_viewModel_does_not_fetch_charge_and_is_disabled_when_no_PaymentGatewayAccount_in_storage() throws {
+    func test_fetch_when_no_PaymentGatewayAccount_in_storage_then_it_does_not_fetch_charge_and_button_is_disabled() throws {
         // Given
         // The order has a chargeID
         let items = [
@@ -633,11 +635,38 @@ final class IssueRefundViewModelTests: XCTestCase {
 
         // When
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
-        viewModel.selectAllOrderItems()
+        viewModel.fetch()
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonAnimating)
         XCTAssertFalse(viewModel.isNextButtonEnabled)
+    }
+
+    func test_fetch_when_fetching_charge_fails_then_it_notifies_it() throws {
+        // Given
+        var onChargeFetchErrorNoticeShowRequest = false
+        // The order has a chargeID
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+        ]
+        let order = MockOrders().makeOrder(items: items).copy(chargeID: "ch_id")
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        insertSamplePaymentGateway(siteID: order.siteID)
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case let .fetchWCPayCharge(siteID: _, chargeID: _, onCompletion: onCompletion) = action {
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+            }
+        }
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
+        viewModel.onChargeFetchErrorNoticeShowRequest = { _ in
+            onChargeFetchErrorNoticeShowRequest = true
+        }
+        viewModel.fetch()
+
+        // Then
+        XCTAssertTrue(onChargeFetchErrorNoticeShowRequest)
     }
 
     func test_viewModel_shows_spinner_when_charge_not_fetched_yet() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -644,7 +644,7 @@ final class IssueRefundViewModelTests: XCTestCase {
 
     func test_fetch_when_fetching_charge_fails_then_it_notifies_it() throws {
         // Given
-        var onChargeFetchErrorNoticeShowRequest = false
+        var showFetchChargeErrorNotice = false
         // The order has a chargeID
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
@@ -660,13 +660,13 @@ final class IssueRefundViewModelTests: XCTestCase {
 
         // When
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
-        viewModel.onChargeFetchErrorNoticeShowRequest = { _ in
-            onChargeFetchErrorNoticeShowRequest = true
+        viewModel.showFetchChargeErrorNotice = { _ in
+            showFetchChargeErrorNotice = true
         }
         viewModel.fetch()
 
         // Then
-        XCTAssertTrue(onChargeFetchErrorNoticeShowRequest)
+        XCTAssertTrue(showFetchChargeErrorNotice)
     }
 
     func test_viewModel_shows_spinner_when_charge_not_fetched_yet() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6716
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the possibility of retrying the charge fetch in the "Issue Refund" screen in case the request failed. In order to achieve that, we show the notice view with a message and a retry button.
Furthermore, I moved the `fetchCharge` method outside the view model initializer, so it can be observed before it is triggered (we cannot observe it in the view controller `init` because it would imply calling `self` before `super.init`). The opposite could result in the closure being called without being set. Because of that, we call to fetch on `viewDidLoad`. We also adapt the unit tests to this new implementation.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Prerequisites
Have a completed order to be refunded

#### Steps

1. Go to Orders tab
2. Tap on the Order you want to test
3. We want to open the Issue Refund screen, but before that, we have to make sure that the fetch charge request is going to fail. I used the [Network Link Conditioner](https://nshipster.com/network-link-conditioner/) with 100% loss to ensure that the request would fail. You can also hardcode an error response.
4. Once the Issue Refund screen is opened, wait until the request fails.
5. When it does you can see the Notice with the Retry button. The button loading indicator disappears but the button stays disabled.
6. Tapping on retry calls to fetch the charge again

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/1864060/166656815-28dee898-b31b-41b9-80f4-1f3c9d97757c.png" width=375>



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
