### PR TITLE
[Mobile Payments] Define smallestCurrencyUnitMultiplier per currency in CardPresentPaymentsConfiguration

### DIFF
--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -10,6 +10,10 @@ public struct PaymentIntentParameters {
     @CurrencyCode
     public private(set) var currency: String
 
+    /// The amount of the payment needs to be provided in the currency’s smallest unit.
+    /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)amount
+    public let stripeSmallestCurrencyUnitMultiplier: Decimal
+
     /// The base fee to charge the Merchant for the payment. This is for client-side transactions, e.g. Interac, and will
     /// be overridden server-side for transactions which are captured on the Server.
     public let applicationFee: Decimal?
@@ -44,6 +48,7 @@ public struct PaymentIntentParameters {
 
     public init(amount: Decimal,
                 currency: String,
+                stripeSmallestCurrencyUnitMultiplier: Decimal,
                 applicationFee: Decimal? = nil,
                 receiptDescription: String? = nil,
                 statementDescription: String? = nil,
@@ -52,6 +57,7 @@ public struct PaymentIntentParameters {
                 metadata: [AnyHashable: Any]? = nil) {
         self.amount = amount
         self.currency = currency
+        self.stripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
         self.applicationFee = applicationFee
         self.receiptDescription = receiptDescription
         self.statementDescription = statementDescription

--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -10,7 +10,8 @@ public struct PaymentIntentParameters {
     @CurrencyCode
     public private(set) var currency: String
 
-    /// The amount of the payment needs to be provided in the currency’s smallest unit.
+    /// The amount of the payment needs to be provided in the currency’s smallest unit, determined by Stripe.
+    /// We calculate that amount for each currency multiplying the original amount by this value.
     /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)amount
     public let stripeSmallestCurrencyUnitMultiplier: Decimal
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -44,14 +44,8 @@ extension Hardware.PaymentIntentParameters {
 }
 
 private extension Hardware.PaymentIntentParameters {
-    enum Constants {
-        static let smallestCurrencyUnitMultiplier: Decimal = 100
-    }
-
     func prepareAmountForStripe(_ amount: Decimal) -> UInt {
-        /// The amount of the payment needs to be provided in the currency’s smallest unit.
-        /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)amount
-        let amountInSmallestUnit = amount * Constants.smallestCurrencyUnitMultiplier
+        let amountInSmallestUnit = amount * stripeSmallestCurrencyUnitMultiplier
         return NSDecimalNumber(decimal: amountInSmallestUnit).uintValue
     }
 }

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -59,10 +59,15 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_amount_is_converted_to_smallest_unit_before_being_passed_to_stripe() throws {
+        let stripeSmallestCurrencyUnitMultiplier: Decimal = 200
         let amount = Decimal(120.10)
-        let expectation = UInt(12010)
+        let amountInSmallestUnit = amount * stripeSmallestCurrencyUnitMultiplier
+        let expectation = NSDecimalNumber(decimal: amountInSmallestUnit).uintValue
 
-        let params = PaymentIntentParameters(amount: amount, currency: "usd", stripeSmallestCurrencyUnitMultiplier: 100, paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: amount,
+                                             currency: "usd",
+                                             stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
+                                             paymentMethodTypes: ["card_present"])
         let stripeParams = try XCTUnwrap(params.toStripe())
 
         XCTAssertEqual(expectation, stripeParams.amount)

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -3,37 +3,57 @@ import XCTest
 
 final class PaymentIntentParametersTests: XCTestCase {
     func test_validEmail_is_saved() {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "validemail@validdomain.us", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "usd",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             receiptEmail: "validemail@validdomain.us",
+                                             paymentMethodTypes: ["card_present"])
 
         XCTAssertNotNil(params.receiptEmail)
     }
 
     func test_not_validEmail_is_ignored() {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", receiptEmail: "woocommerce", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "usd",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             receiptEmail: "woocommerce",
+                                             paymentMethodTypes: ["card_present"])
 
         XCTAssertNil(params.receiptEmail)
     }
 
     func test_currency_is_lowercased() {
-        let params = PaymentIntentParameters(amount: 100, currency: "USD", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "USD",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             paymentMethodTypes: ["card_present"])
 
         XCTAssertEqual(params.currency, "usd")
     }
 
     func test_parameters_do_not_validate_if_currency_code_is_not_supported() {
-        let params = PaymentIntentParameters(amount: 100, currency: "cesar", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "cesar",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             paymentMethodTypes: ["card_present"])
 
         XCTAssertNil(params.toStripe())
     }
 
     func test_parameters_do_not_validate_if_currency_code_is_empty() {
-        let params = PaymentIntentParameters(amount: 100, currency: "", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             paymentMethodTypes: ["card_present"])
 
         XCTAssertNil(params.toStripe())
     }
 
     func test_parameters_do_not_validate_if_payment_methods_is_empty() {
-        let params = PaymentIntentParameters(amount: 100, currency: "", paymentMethodTypes: [])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             paymentMethodTypes: [])
 
         XCTAssertNil(params.toStripe())
     }
@@ -42,7 +62,7 @@ final class PaymentIntentParametersTests: XCTestCase {
         let amount = Decimal(120.10)
         let expectation = UInt(12010)
 
-        let params = PaymentIntentParameters(amount: amount, currency: "usd", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: amount, currency: "usd", stripeSmallestCurrencyUnitMultiplier: 100, paymentMethodTypes: ["card_present"])
         let stripeParams = try XCTUnwrap(params.toStripe())
 
         XCTAssertEqual(expectation, stripeParams.amount)
@@ -52,6 +72,7 @@ final class PaymentIntentParametersTests: XCTestCase {
         let params = PaymentIntentParameters(
             amount: 100,
             currency: "usd",
+            stripeSmallestCurrencyUnitMultiplier: 100,
             statementDescription: "A < DESCRIPTION' longer THAN 22 Characters",
             paymentMethodTypes: ["card_present"]
         )
@@ -63,7 +84,11 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_statementDescription_leaves_strings_untouched_when_no_replacement_is_necessary() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "usd",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             statementDescription: "A DESCRIPTION",
+                                             paymentMethodTypes: ["card_present"])
 
         let statementDescription = try XCTUnwrap(params.statementDescription)
 
@@ -74,6 +99,7 @@ final class PaymentIntentParametersTests: XCTestCase {
         let params = PaymentIntentParameters(
             amount: 100,
             currency: "usd",
+            stripeSmallestCurrencyUnitMultiplier: 100,
             statementDescription: "A DESCRIPTION LONGER THAN 22 CHARACTERS",
             paymentMethodTypes: ["card_present"]
         )
@@ -84,7 +110,11 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_statementDescription_is_passed_as_nil_when_empty() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "", paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "usd",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             statementDescription: "",
+                                             paymentMethodTypes: ["card_present"])
 
         let stripeParameters = params.toStripe()
 
@@ -92,7 +122,11 @@ final class PaymentIntentParametersTests: XCTestCase {
     }
 
     func test_statementDescription_is_passed_as_nil_when_nil() throws {
-        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: nil, paymentMethodTypes: ["card_present"])
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "usd",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             statementDescription: nil,
+                                             paymentMethodTypes: ["card_present"])
 
         let stripeParameters = params.toStripe()
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -37,6 +37,7 @@ final class PaymentCaptureOrchestrator {
                         orderTotal: NSDecimalNumber,
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [String],
+                        stripeSmallestCurrencyUnitMultiplier: Decimal,
                         onWaitingForInput: @escaping () -> Void,
                         onProcessingMessage: @escaping () -> Void,
                         onDisplayMessage: @escaping (String) -> Void,
@@ -53,7 +54,8 @@ final class PaymentCaptureOrchestrator {
                 orderTotal: orderTotal,
                 country: paymentGatewayAccount.country,
                 statementDescriptor: paymentGatewayAccount.statementDescriptor,
-                paymentMethodTypes: paymentMethodTypes
+                paymentMethodTypes: paymentMethodTypes,
+                stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier
         ) { [weak self] result in
             guard let self = self else { return }
 
@@ -201,6 +203,7 @@ private extension PaymentCaptureOrchestrator {
                            country: String,
                            statementDescriptor: String?,
                            paymentMethodTypes: [String],
+                           stripeSmallestCurrencyUnitMultiplier: Decimal,
                            onCompletion: @escaping ((Result<PaymentParameters, Error>) -> Void)) {
         paymentReceiptEmailParameterDeterminer.receiptEmail(from: order) { [weak self] result in
             guard let self = self else { return }
@@ -221,6 +224,7 @@ private extension PaymentCaptureOrchestrator {
 
             let parameters = PaymentParameters(amount: orderTotal as Decimal,
                                                currency: order.currency,
+                                               stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
                                                applicationFee: self.applicationFee(for: orderTotal, country: country),
                                                receiptDescription: self.receiptDescription(orderNumber: order.number),
                                                statementDescription: statementDescriptor,

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -278,6 +278,7 @@ private extension CollectOrderPaymentUseCase {
             orderTotal: orderTotal,
             paymentGatewayAccount: paymentGatewayAccount,
             paymentMethodTypes: configuration.paymentMethods.map(\.rawValue),
+            stripeSmallestCurrencyUnitMultiplier: configuration.stripeSmallestCurrencyUnitMultiplier,
             onWaitingForInput: { [weak self] in
                    // Request card input
                    self?.alerts.tapOrInsertCard(onCancel: { [weak self] in

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -42,13 +42,14 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
             self.sut.collectPayment(
                 for: order,
                 orderTotal: orderTotal,
-                   paymentGatewayAccount: account,
-                   paymentMethodTypes: ["card_present"],
-                   onWaitingForInput: {},
-                   onProcessingMessage: {},
-                   onDisplayMessage: { _ in },
-                   onProcessingCompletion: { _ in },
-                   onCompletion: { _ in })
+                paymentGatewayAccount: account,
+                paymentMethodTypes: ["card_present"],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                onWaitingForInput: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
         }
 
         // Then
@@ -75,14 +76,15 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
             self.sut.collectPayment(
                 for: order,
-                   orderTotal: orderTotal,
-                   paymentGatewayAccount: account,
-                   paymentMethodTypes: ["card_present"],
-                   onWaitingForInput: {},
-                   onProcessingMessage: {},
-                   onDisplayMessage: { _ in },
-                   onProcessingCompletion: { _ in },
-                   onCompletion: { _ in })
+                orderTotal: orderTotal,
+                paymentGatewayAccount: account,
+                paymentMethodTypes: ["card_present"],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                onWaitingForInput: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
         }
 
         // Then

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -10,6 +10,7 @@ public struct CardPresentPaymentsConfiguration {
     public let supportedReaders: [CardReaderType]
     public let supportedPluginVersions: [PaymentPluginVersionSupport]
     public let minimumAllowedChargeAmount: NSDecimalNumber
+    public let stripeSmallestCurrencyUnitMultiplier: Decimal
 
     init(countryCode: String,
          stripeTerminalforCanadaEnabled: Bool,
@@ -18,7 +19,8 @@ public struct CardPresentPaymentsConfiguration {
          paymentGateways: [String],
          supportedReaders: [CardReaderType],
          supportedPluginVersions: [PaymentPluginVersionSupport],
-         minimumAllowedChargeAmount: NSDecimalNumber) {
+         minimumAllowedChargeAmount: NSDecimalNumber,
+         stripeSmallestCurrencyUnitMultiplier: Decimal) {
         self.countryCode = countryCode
         self.stripeTerminalforCanadaEnabled = stripeTerminalforCanadaEnabled
         self.paymentMethods = paymentMethods
@@ -27,6 +29,7 @@ public struct CardPresentPaymentsConfiguration {
         self.supportedReaders = supportedReaders
         self.supportedPluginVersions = supportedPluginVersions
         self.minimumAllowedChargeAmount = minimumAllowedChargeAmount
+        self.stripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
     }
 
     public init(country: String, canadaEnabled: Bool) {
@@ -44,7 +47,8 @@ public struct CardPresentPaymentsConfiguration {
                     .init(plugin: .wcPay, minimumVersion: "3.2.1"),
                     .init(plugin: .stripe, minimumVersion: "6.2.0")
                 ],
-                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5")
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100
             )
         case "CA" where canadaEnabled == true:
             self.init(
@@ -55,7 +59,8 @@ public struct CardPresentPaymentsConfiguration {
                 paymentGateways: [WCPayAccount.gatewayID],
                 supportedReaders: [.wisepad3],
                 supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.0.0")],
-                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5")
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100
             )
         default:
             self.init(
@@ -66,7 +71,8 @@ public struct CardPresentPaymentsConfiguration {
                 paymentGateways: [],
                 supportedReaders: [],
                 supportedPluginVersions: [],
-                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5")
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100
             )
         }
     }

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -557,7 +557,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD")) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
 
                 } onProcessingCompletion: { intent in
                     promise(intent)
@@ -596,7 +596,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD")) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                 } onCompletion: { result in
                     promise(result)
@@ -636,7 +636,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD")) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                 } onCompletion: { result in
                     promise(result)
@@ -677,7 +677,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: self.sampleSiteID,
                                 orderID: self.sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD")) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
                     cardReaderEvents.append(cardReaderEvent)
                     if cardReaderEvent == .cardRemovedAfterClientSidePaymentCapture {
                         promise(())
@@ -715,7 +715,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD")) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                     XCTFail("`onProcessingCompletion` should only be called when payment capture succeeds.")
                 } onCompletion: { result in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6739
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we move the `smallestCurrencyUnitMultiplier` from PaymentIntentParameters+Stripe.swift, where it was hardcoded for all currencies, to `CardPresentPaymentsConfiguration`, where we can customize it for each country following [Stripe's doc](https://stripe.com/docs/currencies#zero-decimal)
Furthermore, we enhance the intermediate methods interfaces so that value can be passed along, as well as the `PaymentIntentParameters` model. In addition, we adapt the unit tests to these changes.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create an order or simple payment in a Canadian based store, and collect payment.
2. Check the paid amount on **Stripe**: You'll need access to the Stripe Dashboard for this: PdfdoF-1A-p2
Toggle `Test mode` viewing, and [find your site's account](https://dashboard.stripe.com/connect/accounts/overview) – use the filters and ⚙️ in the columns to help narrow it down. You can search for your account id to find it. You can find your account id under wp-admin > WooCommerce > status > account ID 
3. Once there, you can check that the amount is still the same as the order

Repeat for an American based stored if desired.

<img width="772" alt="Screenshot 2022-05-03 at 13 16 54" src="https://user-images.githubusercontent.com/1864060/166454246-25e32a42-bd30-4553-ba55-0fdff31137d3.png">

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
