### PR TITLE
Order Creation: Update banner text on Orders tab

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTopBannerFactory.swift
@@ -25,9 +25,9 @@ struct OrdersTopBannerFactory {
 
 private extension OrdersTopBannerFactory {
     enum Localization {
-        static let title = NSLocalizedString("Create orders and take payments!", comment: "Title of the banner notice in the Orders tab")
+        static let title = NSLocalizedString("Create orders & take payments!", comment: "Title of the banner notice in the Orders tab")
         static let infoText = NSLocalizedString("We've been working on making it possible to create orders and take payments from your device! " +
-                                                "You can try these features out by tapping on the \"+\" icon",
+                                                "You can try these features out by tapping on the \"+\" button",
                                                 comment: "Content of the banner notice in the Orders tab")
         static let dismiss = NSLocalizedString("Dismiss", comment: "The title of the button to dismiss the Orders top banner")
         static let giveFeedback = NSLocalizedString("Give feedback", comment: "Title of the button to give feedback about the Orders features")


### PR DESCRIPTION
Closes: #6666

## Description

Updates the banner text on the Orders tab announcing Order Creation to match Android.

## Changes

1. Changes "and" to `&` in banner title: `Create orders and take payments` → `Create orders & take payments`
2. Changes "icon" to "button" in banner text: `tapping on the + icon` → `tapping on the + button`

## Testing

1. If you have dismissed the banner before, delete and perform a fresh install of the app to ensure it shows up again.
2. Run the app and go to the Orders tab.
3. Confirm the expected changes appear in the banner at the top of the screen.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-05 at 13 54 07](https://user-images.githubusercontent.com/8658164/166927800-2f5c94c0-3ef8-42dd-8c54-1c10e655b90b.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-05-05 at 13 55 10](https://user-images.githubusercontent.com/8658164/166927827-a5a095e7-a367-4426-95b4-121ead2287e2.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
