### PR TITLE
Order Creation: Always display taxes row and $0.00 value

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -430,7 +430,6 @@ extension NewOrderViewModel {
         let feesBaseAmountForPercentage: Decimal
         let feesTotal: String
 
-        let shouldShowTaxes: Bool
         let taxesTotal: String
 
         /// Whether payment data is being reloaded (during remote sync)
@@ -447,7 +446,6 @@ extension NewOrderViewModel {
              shouldShowFees: Bool = false,
              feesBaseAmountForPercentage: Decimal = 0,
              feesTotal: String = "",
-             shouldShowTaxes: Bool = false,
              taxesTotal: String = "",
              orderTotal: String = "",
              isLoading: Bool = false,
@@ -461,7 +459,6 @@ extension NewOrderViewModel {
             self.shouldShowFees = shouldShowFees
             self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? ""
-            self.shouldShowTaxes = shouldShowTaxes
             self.taxesTotal = currencyFormatter.formatAmount(taxesTotal) ?? ""
             self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? ""
             self.isLoading = isLoading
@@ -629,7 +626,6 @@ private extension NewOrderViewModel {
                                             shouldShowFees: order.fees.filter { $0.name != nil }.isNotEmpty,
                                             feesBaseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
                                             feesTotal: orderTotals.feesTotal.stringValue,
-                                            shouldShowTaxes: order.totalTax.isNotEmpty,
                                             taxesTotal: order.totalTax,
                                             orderTotal: order.total,
                                             isLoading: isDataSyncing,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -439,28 +439,28 @@ extension NewOrderViewModel {
         let shippingLineViewModel: ShippingLineDetailsViewModel
         let feeLineViewModel: FeeLineDetailsViewModel
 
-        init(itemsTotal: String = "",
+        init(itemsTotal: String = "0",
              shouldShowShippingTotal: Bool = false,
-             shippingTotal: String = "",
+             shippingTotal: String = "0",
              shippingMethodTitle: String = "",
              shouldShowFees: Bool = false,
              feesBaseAmountForPercentage: Decimal = 0,
-             feesTotal: String = "",
-             taxesTotal: String = "",
-             orderTotal: String = "",
+             feesTotal: String = "0",
+             taxesTotal: String = "0",
+             orderTotal: String = "0",
              isLoading: Bool = false,
              saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
              saveFeeLineClosure: @escaping (OrderFeeLine?) -> Void = { _ in },
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
-            self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? ""
+            self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? "0.00"
             self.shouldShowShippingTotal = shouldShowShippingTotal
-            self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? ""
+            self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? "0.00"
             self.shippingMethodTitle = shippingMethodTitle
             self.shouldShowFees = shouldShowFees
             self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
-            self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? ""
-            self.taxesTotal = currencyFormatter.formatAmount(taxesTotal) ?? ""
-            self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? ""
+            self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? "0.00"
+            self.taxesTotal = currencyFormatter.formatAmount(taxesTotal) ?? "0.00"
+            self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? "0.00"
             self.isLoading = isLoading
             self.shippingLineViewModel = ShippingLineDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
                                                                       initialMethodTitle: shippingMethodTitle,
@@ -621,13 +621,13 @@ private extension NewOrderViewModel {
 
                 return PaymentDataViewModel(itemsTotal: orderTotals.itemsTotal.stringValue,
                                             shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
-                                            shippingTotal: order.shippingTotal,
+                                            shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
                                             shippingMethodTitle: shippingMethodTitle,
                                             shouldShowFees: order.fees.filter { $0.name != nil }.isNotEmpty,
                                             feesBaseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
                                             feesTotal: orderTotals.feesTotal.stringValue,
-                                            taxesTotal: order.totalTax,
-                                            orderTotal: order.total,
+                                            taxesTotal: order.totalTax.isNotEmpty ? order.totalTax : "0",
+                                            orderTotal: order.total.isNotEmpty ? order.total : "0",
                                             isLoading: isDataSyncing,
                                             saveShippingLineClosure: self.saveShippingLine,
                                             saveFeeLineClosure: self.saveFeeLine,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -46,9 +46,7 @@ struct OrderPaymentSection: View {
                     FeeLineDetails(viewModel: viewModel.feeLineViewModel)
                 }
 
-            if viewModel.shouldShowTaxes {
-                TitleAndValueRow(title: Localization.taxesTotal, value: .content(viewModel.taxesTotal))
-            }
+            TitleAndValueRow(title: Localization.taxesTotal, value: .content(viewModel.taxesTotal))
 
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -669,7 +669,6 @@ final class NewOrderViewModelTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
-        XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowTaxes)
         XCTAssertEqual(viewModel.paymentDataViewModel.taxesTotal, "$2.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 2.50)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -403,6 +403,21 @@ final class NewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(paymentDataViewModel.orderTotal, "£30.00")
     }
 
+    func test_payment_data_view_model_is_initialized_with_expected_default_values_for_new_order() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+
+        // When
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, currencySettings: currencySettings)
+
+        // Then
+        XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.feesTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.taxesTotal, "£0.00")
+        XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£0.00")
+    }
+
     // MARK: - Payment Section Tests
 
     func test_payment_section_is_updated_when_products_update() {


### PR DESCRIPTION
Closes: #6734

## Description

This updates the New Order screen during Order Creation to match Android:

* The taxes row is always visible.
* The totals in the Payment section default to showing a $0.00 value (not an empty string).

## Changes

* Removes the `shouldShowTaxes` property from `PaymentDataViewModel` and removes that check from the taxes row in the `OrderPaymentSection` view.
* To make sure the totals in the Payment section default to $0.00 instead of an empty string:
   * Updates the `init` method for `PaymentDataViewModel` to set `"0"` default values for each of the payment totals in the order, and `"0.00"` for the default formatted value.
   * Updates `configurePaymentDataViewModel()` to default to `"0"` if any of the payment total strings are empty.
* Adds a unit test to confirm that the correct default payment totals are initialized for a new (empty) order.

I considered just updating `Order.empty` to set those properties to `"0"` for empty new orders, but since this is mostly a concern with how those values are displayed (and because in theory those properties could still have empty strings) I decided to focus on the view model.

## Testing

1. Run the app and go to the Orders tab.
2. Create a new order.
3. Confirm that the Taxes row is immediately visible and all of the rows in the Payment section display $0.00 values by default.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-05 at 15 26 58](https://user-images.githubusercontent.com/8658164/166945460-d6448c03-511f-4d0d-8890-198aefb67e31.png)|![After](https://user-images.githubusercontent.com/8658164/166944962-6f6335e8-ea1c-4d1c-bd68-a4cc14de56f2.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
