### PR TITLE
[Mobile Payments] Do not delete WCPay or Stripe gateway account before requesting them remotely

### DIFF
--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -470,9 +470,6 @@ private extension CardPresentPaymentStore {
     }
 
     func loadWCPayAccount(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        /// Delete any WCPay account present. There can be only one.
-        self.deleteStaleAccount(siteID: siteID, gatewayID: WCPayAccount.gatewayID)
-
         /// Fetch the WCPay account
         remote.loadAccount(for: siteID) { [weak self] result in
             guard let self = self else {
@@ -492,9 +489,6 @@ private extension CardPresentPaymentStore {
     }
 
     func loadStripeAccount(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        /// Delete any Stripe account present. There can be only one.
-        self.deleteStaleAccount(siteID: siteID, gatewayID: StripeAccount.gatewayID)
-
         stripeRemote.loadAccount(for: siteID) { [weak self] result in
             guard let self = self else {
                 return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6583
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As described in the issue, the Collect Payment CTA changes to some other CTA or disappears right after tapping on it and then comes back a bit after, which makes the UX a bit jarring.
The reason behind that is that we used to delete the gateway account (WCPay or Stripe) before requesting them remotely, something that is triggered when the user taps on the Collect Payment CTA. Since the `OrderDetailsDataSource` is observing for changes in the storage related to `PaymentGatewayAccounts`, the screen is reloaded when this deletion takes place, thus not showing the Collect Payment CTA. After the account request finishes and we properly update the store the screen is again reloaded and the button shown. 
The easiest solution is to avoid deleting the stale accounts before requesting them remotely. This should not have any side effect whatsoever, because:
- The new account is upsert into the storage, which means that the old one is replaced and only one instance is in place (they always have the same id)
- It is deleted in case there was an error when requesting it remotely.

If however, you think this solution has indeed some risks or undesired effects please let me know and I will be glad to rethink this approach.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Go to the orders tab
Tap on an order that is eligible for IPP
Tap "Collect Payment" CTA --> the CTA stays after the collect payment process starts.
### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1864060/166963260-517a7b6c-2619-4578-a004-fdb788d4ff03.mp4


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
