### PR TITLE
Coupons: Update button titles on Coupon Restrictions screen to reflect the number of selected items

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -180,63 +180,63 @@ private extension CouponRestrictions {
     enum Localization {
         static let usageRestriction = NSLocalizedString(
             "Usage Restrictions",
-            comment: "Title for the usage restrictions section on coupon usage details screen"
+            comment: "Title for the usage restrictions section on coupon usage restrictions screen"
         )
         static let minimumSpend = NSLocalizedString(
             "Min. Spend (%1$@)",
-            comment: "Title for the minimum spend row on coupon usage details screen with currency symbol within the brackets. " +
+            comment: "Title for the minimum spend row on coupon usage restrictions screen with currency symbol within the brackets. " +
             "Reads like: Min. Spend ($)"
         )
         static let maximumSpend = NSLocalizedString(
             "Max. Spend (%1$@)",
-            comment: "Title for the maximum spend row on coupon usage details screen with currency symbol within the brackets. " +
+            comment: "Title for the maximum spend row on coupon usage restrictions screen with currency symbol within the brackets. " +
             "Reads like: Max. Spend ($)"
         )
         static let usageLimitPerCoupon = NSLocalizedString(
             "Usage Limit Per Coupon",
-            comment: "Title for the usage limit per coupon row in coupon usage details screen."
+            comment: "Title for the usage limit per coupon row in coupon usage restrictions screen."
         )
         static let usageLimitPerUser = NSLocalizedString(
             "Usage Limit Per User",
-            comment: "Title for the usage limit per user row in coupon usage details screen."
+            comment: "Title for the usage limit per user row in coupon usage restrictions screen."
         )
         static let limitUsageToXItems = NSLocalizedString(
             "Limit Usage to X Items",
-            comment: "Title for the limit usage to X items row in coupon usage details screen."
+            comment: "Title for the limit usage to X items row in coupon usage restrictions screen."
         )
         static let allowedEmails = NSLocalizedString(
             "Allowed Emails",
-            comment: "Title for the allowed email row in coupon usage details screen."
+            comment: "Title for the allowed email row in coupon usage restrictions screen."
         )
         static let individualUseOnly = NSLocalizedString(
             "Individual Use Only",
-            comment: "Title for the individual use only row in coupon usage details screen."
+            comment: "Title for the individual use only row in coupon usage restrictions screen."
         )
         static let individualUseDescription = NSLocalizedString(
             "Turn this on if the coupon cannot be used in conjunction with other coupons.",
-            comment: "Description for the individual use only row in coupon usage details screen."
+            comment: "Description for the individual use only row in coupon usage restrictions screen."
         )
         static let excludeSaleItems = NSLocalizedString(
             "Exclude Sale Items",
-            comment: "Title for the exclude sale items row in coupon usage details screen."
+            comment: "Title for the exclude sale items row in coupon usage restrictions screen."
         )
         static let excludeSaleItemsDescription = NSLocalizedString(
             "Turn this on if the coupon should not apply to items on sale. " +
             "Per-item coupons will only work if the item is not on sale. " +
             "Per-cart coupons will only work if there are items in the cart that are not on sale.",
-            comment: "Description for the exclude sale items row in coupon usage details screen."
+            comment: "Description for the exclude sale items row in coupon usage restrictions screen."
         )
-        static let none = NSLocalizedString("None", comment: "Value for fields in Coupon Usage Details screen when no value is set")
-        static let unlimited = NSLocalizedString("Unlimited", comment: "Value for fields in Coupon Usage Details screen when no limit is set")
+        static let none = NSLocalizedString("None", comment: "Value for fields in Coupon Usage Restrictions screen when no value is set")
+        static let unlimited = NSLocalizedString("Unlimited", comment: "Value for fields in Coupon Usage Restrictions screen when no limit is set")
         static let allQualifyingInCart = NSLocalizedString(
             "All Qualifying",
-            comment: "Value for the limit usage to X items row in Coupon Usage Details screen when no limit is set"
+            comment: "Value for the limit usage to X items row in Coupon Usage Restrictions screen when no limit is set"
         )
         static let noRestrictions = NSLocalizedString(
             "No Restrictions",
-            comment: "Value for the allowed emails row in Coupon Usage Details screen when no restriction is set"
+            comment: "Value for the allowed emails row in Coupon Usage Restrictions screen when no restriction is set"
         )
-        static let exclusions = NSLocalizedString("Exclusions", comment: "Title of the exclusions section in Coupon Usage Details screen")
+        static let exclusions = NSLocalizedString("Exclusions", comment: "Title of the exclusions section in Coupon Usage Restrictions screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -121,10 +121,10 @@ struct CouponRestrictions: View {
                         showingExcludeProducts = true
                     }) {
                         HStack {
-                            Image(uiImage: UIImage.plusImage)
+                            Image(uiImage: viewModel.excludeProductsButtonIcon)
                                 .resizable()
                                 .frame(width: Constants.plusIconSize * scale, height: Constants.plusIconSize * scale)
-                            Text(Localization.excludeProducts)
+                            Text(viewModel.excludeProductsTitle)
                         }
                     }
                     .buttonStyle(SecondaryButtonStyle(labelFont: .body))
@@ -133,10 +133,10 @@ struct CouponRestrictions: View {
                         showingExcludeCategories = true
                     }) {
                         HStack {
-                            Image(uiImage: UIImage.plusImage)
+                            Image(uiImage: viewModel.excludeCategoriesButtonIcon)
                                 .resizable()
                                 .frame(width: Constants.plusIconSize * scale, height: Constants.plusIconSize * scale)
-                            Text(Localization.excludeProductCategories)
+                            Text(viewModel.excludeCategoriesButtonTitle)
                         }
                     }
                     .buttonStyle(SecondaryButtonStyle(labelFont: .body))
@@ -237,14 +237,6 @@ private extension CouponRestrictions {
             comment: "Value for the allowed emails row in Coupon Usage Details screen when no restriction is set"
         )
         static let exclusions = NSLocalizedString("Exclusions", comment: "Title of the exclusions section in Coupon Usage Details screen")
-        static let excludeProducts = NSLocalizedString(
-            "Exclude Products",
-            comment: "Title of the action button to add products to the exclusion list in Coupon Usage Details screen"
-        )
-        static let excludeProductCategories = NSLocalizedString(
-            "Exclude Product Categories",
-            comment: "Title of the action button to add product categories to the exclusion list in Coupon Usage Details screen"
-        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -9,6 +9,30 @@ final class CouponRestrictionsViewModel: ObservableObject {
 
     let currencySymbol: String
 
+    var excludeProductsButtonIcon: UIImage {
+        excludedProductOrVariationIDs.isEmpty ? .plusImage : .pencilImage
+    }
+
+    var excludeProductsTitle: String {
+        if excludedProductOrVariationIDs.isEmpty {
+            return Localization.excludeProducts
+        } else {
+            return String.localizedStringWithFormat(Localization.excludedProducts, excludedProductOrVariationIDs.count)
+        }
+    }
+
+    var excludeCategoriesButtonIcon: UIImage {
+        excludedCategoryIDs.isEmpty ? .plusImage : .pencilImage
+    }
+
+    var excludeCategoriesButtonTitle: String {
+        if excludedCategoryIDs.isEmpty {
+            return Localization.excludeProductCategories
+        } else {
+            return String.localizedStringWithFormat(Localization.excludedProductCategories, excludedCategoryIDs.count)
+        }
+    }
+
     @Published var minimumSpend: String
 
     @Published var maximumSpend: String
@@ -111,5 +135,28 @@ final class CouponRestrictionsViewModel: ObservableObject {
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager
+    }
+}
+
+private extension CouponRestrictionsViewModel {
+    enum Localization {
+        static let excludeProducts = NSLocalizedString(
+            "Exclude Products",
+            comment: "Title of the action button to add products to the exclusion list in Coupon Usage Details screen"
+        )
+        static let excludedProducts = NSLocalizedString(
+            "Exclude Products (%1$d)",
+            comment: "Title of the action button to add excluded products on Coupon Usage Details screen. " +
+            "The number of selected items is included between the brackets. Reads like: Exclude Products (2)"
+        )
+        static let excludeProductCategories = NSLocalizedString(
+            "Exclude Product Categories",
+            comment: "Title of the action button to add product categories on Coupon Usage Details screen"
+        )
+        static let excludedProductCategories = NSLocalizedString(
+            "Exclude Product Categories (%1$d)",
+            comment: "Title of the action button to add excluded product categories on Coupon Usage Details screen. " +
+            "The number of selected items is included between the brackets. Reads like: Exclude Product Categories (4)"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -142,21 +142,21 @@ private extension CouponRestrictionsViewModel {
     enum Localization {
         static let excludeProducts = NSLocalizedString(
             "Exclude Products",
-            comment: "Title of the action button to add products to the exclusion list in Coupon Usage Details screen"
+            comment: "Title of the action button to add products to the exclusion list in Coupon Usage Restrictions screen"
         )
         static let excludedProducts = NSLocalizedString(
             "Exclude Products (%1$d)",
-            comment: "Title of the action button to add excluded products on Coupon Usage Details screen. " +
+            comment: "Title of the action button to add excluded products on Coupon Usage Restrictions screen. " +
             "The number of selected items is included between the brackets. Reads like: Exclude Products (2)"
         )
         static let excludeProductCategories = NSLocalizedString(
             "Exclude Product Categories",
-            comment: "Title of the action button to add product categories on Coupon Usage Details screen"
+            comment: "Title of the action button to exclude product categories on Coupon Usage Restrictions screen"
         )
         static let excludedProductCategories = NSLocalizedString(
             "Exclude Product Categories (%1$d)",
-            comment: "Title of the action button to add excluded product categories on Coupon Usage Details screen. " +
-            "The number of selected items is included between the brackets. Reads like: Exclude Product Categories (4)"
+            comment: "Title of the action button to add excluded product categories on Coupon Usage Restrictions screen. " +
+            "The number of selected items is mentioned between the brackets. Reads like: Exclude Product Categories (4)"
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -26,4 +26,46 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.individualUseOnly, true)
         XCTAssertEqual(viewModel.excludeSaleItems, false)
     }
+
+    func test_exclude_products_button_icon_and_title_when_no_product_is_selected() {
+        // Given
+        let coupon = Coupon.fake()
+        let viewModel = CouponRestrictionsViewModel(coupon: coupon)
+
+        // Then
+        XCTAssertEqual(viewModel.excludeProductsButtonIcon.pngData(), UIImage.plusImage.pngData())
+        XCTAssertEqual(viewModel.excludeProductsTitle, NSLocalizedString("Exclude Products", comment: ""))
+    }
+
+    func test_exclude_products_button_icon_and_title_when_some_products_are_selected() {
+        // Given
+        let coupon = Coupon.fake().copy(excludedProductIds: [123, 2, 56])
+        let viewModel = CouponRestrictionsViewModel(coupon: coupon)
+
+        // Then
+        XCTAssertEqual(viewModel.excludeProductsButtonIcon.pngData(), UIImage.pencilImage.pngData())
+        let expectedTitle = String.localizedStringWithFormat(NSLocalizedString("Exclude Products (%1$d)", comment: ""), 3)
+        XCTAssertEqual(viewModel.excludeProductsTitle, expectedTitle)
+    }
+
+    func test_exclude_product_categories_button_icon_and_title_when_no_product_is_selected() {
+        // Given
+        let coupon = Coupon.fake()
+        let viewModel = CouponRestrictionsViewModel(coupon: coupon)
+
+        // Then
+        XCTAssertEqual(viewModel.excludeCategoriesButtonIcon.pngData(), UIImage.plusImage.pngData())
+        XCTAssertEqual(viewModel.excludeCategoriesButtonTitle, NSLocalizedString("Exclude Product Categories", comment: ""))
+    }
+
+    func test_exclude_product_categories_button_icon_and_title_when_some_products_are_selected() {
+        // Given
+        let coupon = Coupon.fake().copy(excludedProductCategories: [44, 6])
+        let viewModel = CouponRestrictionsViewModel(coupon: coupon)
+
+        // Then
+        XCTAssertEqual(viewModel.excludeCategoriesButtonIcon.pngData(), UIImage.pencilImage.pngData())
+        let expectedTitle = String.localizedStringWithFormat(NSLocalizedString("Exclude Product Categories (%1$d)", comment: ""), 2)
+        XCTAssertEqual(viewModel.excludeCategoriesButtonTitle, expectedTitle)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6491 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR wraps up the Coupon Restrictions screen by updating the titles and icons of Exclude Products and Exclude Product Categories buttons.

This was handled by updating the view model with logic to check for selected items to return the appropriate icons and titles.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu > Coupons > select a coupon in your store.
- Select the ellipsis button on the top right and select Edit Coupon.
- On the Edit Coupon screen select Usage Restrictions.
- Select the Exclude Products and Exclude Product Categories button, select and deselect any items to see if the buttons are updated correctly on the Usage Restrictions screen.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/167060522-83c2268d-fe9a-4641-88e4-ee5d091b75ce.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
