### PR TITLE
Category selector: Handle search query

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -9,7 +9,7 @@ import WordPressUI
 ///
 final class ProductCategoryListViewController: UIViewController, GhostableViewController {
 
-    @IBOutlet var contentStackView: UIStackView!
+    @IBOutlet private var contentStackView: UIStackView!
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private var searchBar: UISearchBar!
     @IBOutlet private var clearSelectionButtonBarView: UIView!

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -71,6 +71,7 @@ private extension ProductCategoryListViewController {
     func configureSearchBar() {
         searchBar.isHidden = !configuration.searchEnabled
         searchBar.placeholder = Localization.searchBarPlaceholder
+        searchBar.searchTextField.textColor = .text
         searchBar.delegate = self
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -50,13 +50,18 @@ final class ProductCategoryListViewController: UIViewController, GhostableViewCo
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        configureSearchBar()
         configureClearSelectionButton()
         registerTableViewCells()
         configureTableView()
         configureEmptyView()
         configureViewModel()
         handleSwipeBackGesture()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Note: configuring the search bar text color does not work in `viewDidLoad` and `viewWillAppear`.
+        configureSearchBar()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -9,6 +9,7 @@ import WordPressUI
 ///
 final class ProductCategoryListViewController: UIViewController, GhostableViewController {
 
+    @IBOutlet var contentStackView: UIStackView!
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private var searchBar: UISearchBar!
     @IBOutlet private var clearSelectionButtonBarView: UIView!
@@ -19,7 +20,21 @@ final class ProductCategoryListViewController: UIViewController, GhostableViewCo
     let viewModel: ProductCategoryListViewModel
 
     private let configuration: Configuration
-    private var selectedListSubscription: AnyCancellable?
+    private var subscriptions: Set<AnyCancellable> = []
+
+    /// The controller of the view to show if the search results are empty.
+    ///
+    /// - SeeAlso: State.empty
+    ///
+    private lazy var emptyStateViewController: EmptyStateViewController = {
+        let emptyStateViewController = EmptyStateViewController(style: .list)
+        let config: EmptyStateViewController.Config = .simple(
+            message: .init(string: Localization.emptyStateMessage),
+            image: .emptySearchResultsImage
+        )
+        emptyStateViewController.configure(config)
+        return emptyStateViewController
+    }()
 
     init(viewModel: ProductCategoryListViewModel, configuration: Configuration = .init()) {
         self.viewModel = viewModel
@@ -39,6 +54,7 @@ final class ProductCategoryListViewController: UIViewController, GhostableViewCo
         configureClearSelectionButton()
         registerTableViewCells()
         configureTableView()
+        configureEmptyView()
         configureViewModel()
         handleSwipeBackGesture()
     }
@@ -61,7 +77,7 @@ private extension ProductCategoryListViewController {
     }
 
     func configureTableView() {
-        view.backgroundColor = .listBackground
+        view.backgroundColor = .listForeground
         tableView.backgroundColor = .listBackground
         tableView.dataSource = self
         tableView.delegate = self
@@ -82,16 +98,28 @@ private extension ProductCategoryListViewController {
             self?.viewModel.resetSelectedCategoriesAndReload()
         }, for: .touchUpInside)
 
-        selectedListSubscription = viewModel.$selectedCategories
-            .map { [weak self] selectedItems -> Bool in
+        viewModel.$selectedCategories.combineLatest(viewModel.$categoryViewModels)
+            .map { [weak self] selectedItems, models -> Bool in
                 guard let self = self, self.configuration.clearSelectionEnabled else {
                     return true
                 }
-                return selectedItems.isEmpty
+                return selectedItems.isEmpty || models.isEmpty
             }
             .sink { [weak self] shouldHideClearSelection in
                 self?.clearSelectionButtonBarView.isHidden = shouldHideClearSelection
             }
+            .store(in: &subscriptions)
+    }
+
+    func configureEmptyView() {
+        addChild(emptyStateViewController)
+
+        emptyStateViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.addSubview(emptyStateViewController.view)
+        contentStackView.addArrangedSubview(emptyStateViewController.view)
+
+        emptyStateViewController.didMove(toParent: self)
+        emptyStateViewController.view.isHidden = true
     }
 }
 
@@ -103,23 +131,32 @@ private extension ProductCategoryListViewController {
         viewModel.observeReloadNeeded { [weak self] in
             self?.tableView.reloadData()
         }
-        viewModel.observeCategoryListStateChanges { [weak self] syncState in
-            guard let self = self else { return }
-            switch syncState {
-            case .initialized:
-                break
-            case .syncing:
-                if self.viewModel.categoryViewModels.isEmpty {
-                    self.displayGhostContent()
+
+        viewModel.$syncCategoriesState.combineLatest(viewModel.$categoryViewModels)
+            .sink { [weak self] syncState, models in
+                guard let self = self else { return }
+                self.emptyStateViewController.view.isHidden = true
+                self.tableView.isHidden = false
+                switch syncState {
+                case .initialized:
+                    break
+                case .syncing:
+                    if self.viewModel.categoryViewModels.isEmpty {
+                        self.displayGhostContent()
+                    }
+                case let .failed(retryToken):
+                    self.removeGhostContent()
+                    self.displaySyncingErrorNotice(retryToken: retryToken)
+                case .synced:
+                    self.tableView.reloadData()
+                    self.removeGhostContent()
+                    if models.isEmpty {
+                        self.emptyStateViewController.view.isHidden = false
+                        self.tableView.isHidden = true
+                    }
                 }
-            case let .failed(retryToken):
-                self.removeGhostContent()
-                self.displaySyncingErrorNotice(retryToken: retryToken)
-            case .synced:
-                self.tableView.reloadData()
-                self.removeGhostContent()
             }
-        }
+            .store(in: &subscriptions)
     }
 }
 
@@ -169,6 +206,8 @@ private extension ProductCategoryListViewController {
         static let synchErrorMessage = NSLocalizedString("Unable to load categories", comment: "Notice message when loading product categories fails")
         static let retryButtonTitle = NSLocalizedString("Retry", comment: "Retry Action on the notice when loading product categories fails")
         static let clearSelectionButtonTitle = NSLocalizedString("Clear Selection", comment: "Button to clear selection on the product categories list")
+        static let emptyStateMessage = NSLocalizedString("No product categories found",
+                                                         comment: "Message on the empty view when the category list or its search result is empty.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -71,6 +71,7 @@ private extension ProductCategoryListViewController {
     func configureSearchBar() {
         searchBar.isHidden = !configuration.searchEnabled
         searchBar.placeholder = Localization.searchBarPlaceholder
+        searchBar.delegate = self
     }
 
     func configureClearSelectionButton() {
@@ -167,5 +168,13 @@ private extension ProductCategoryListViewController {
         static let synchErrorMessage = NSLocalizedString("Unable to load categories", comment: "Notice message when loading product categories fails")
         static let retryButtonTitle = NSLocalizedString("Retry", comment: "Retry Action on the notice when loading product categories fails")
         static let clearSelectionButtonTitle = NSLocalizedString("Clear Selection", comment: "Button to clear selection on the product categories list")
+    }
+}
+
+// MARK: - UISearchBarDelegate conformance
+//
+extension ProductCategoryListViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        viewModel.searchQuery = searchText
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -82,6 +82,7 @@ private extension ProductCategoryListViewController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.removeLastCellSeparator()
+        tableView.keyboardDismissMode = .onDrag
     }
 
     func configureSearchBar() {
@@ -197,6 +198,7 @@ extension ProductCategoryListViewController: UITableViewDataSource, UITableViewD
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         viewModel.selectOrDeselectCategory(index: indexPath.row)
         tableView.reloadData()
+        searchBar.resignFirstResponder()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -145,7 +145,7 @@ private extension ProductCategoryListViewController {
                 case .initialized:
                     break
                 case .syncing:
-                    if self.viewModel.categoryViewModels.isEmpty {
+                    if models.isEmpty {
                         self.displayGhostContent()
                     }
                 case let .failed(retryToken):

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -24,8 +24,6 @@ final class ProductCategoryListViewController: UIViewController, GhostableViewCo
 
     /// The controller of the view to show if the search results are empty.
     ///
-    /// - SeeAlso: State.empty
-    ///
     private lazy var emptyStateViewController: EmptyStateViewController = {
         let emptyStateViewController = EmptyStateViewController(style: .list)
         let config: EmptyStateViewController.Config = .simple(

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="clearSelectionButton" destination="fdL-Fv-YUq" id="4pY-Cu-W62"/>
                 <outlet property="clearSelectionButtonBarView" destination="pl0-eW-IeX" id="FS6-rQ-VQ4"/>
+                <outlet property="contentStackView" destination="WLv-21-ggw" id="lVG-TT-gMH"/>
                 <outlet property="searchBar" destination="1Sw-bB-VbX" id="7pD-i5-lVf"/>
                 <outlet property="tableView" destination="2Yi-Za-cWv" id="M3B-lU-YYO"/>
                 <outlet property="view" destination="lKf-zg-URS" id="g1c-gC-3eC"/>

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.xib
@@ -26,7 +26,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="WLv-21-ggw">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
-                        <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="1Sw-bB-VbX">
+                        <searchBar contentMode="redraw" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="1Sw-bB-VbX">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="51"/>
                             <textInputTraits key="textInputTraits"/>
                         </searchBar>

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -68,11 +68,7 @@ final class ProductCategoryListViewModel {
 
     /// Array of view models to be rendered by the View Controller.
     ///
-    private(set) var categoryViewModels: [ProductCategoryCellViewModel] = []
-
-    /// Closure to be invoked when `synchronizeCategories` state  changes
-    ///
-    private var onSyncStateChange: ((SyncingState) -> Void)?
+    @Published private(set) var categoryViewModels: [ProductCategoryCellViewModel] = []
 
     /// Closure invoked when the list needs to reload
     ///
@@ -93,14 +89,7 @@ final class ProductCategoryListViewModel {
 
     /// Current  category synchronization state
     ///
-    private var syncCategoriesState: SyncingState = .initialized {
-        didSet {
-            guard syncCategoriesState != oldValue else {
-                return
-            }
-            onSyncStateChange?(syncCategoriesState)
-        }
-    }
+    @Published private(set) var syncCategoriesState: SyncingState = .initialized
 
     private lazy var resultController: ResultsController<StorageProductCategory> = {
         let predicate = NSPredicate(format: "siteID = %ld", self.siteID)
@@ -143,14 +132,6 @@ final class ProductCategoryListViewModel {
             return
         }
         synchronizeAllCategories(fromPageNumber: retryToken.fromPageNumber)
-    }
-
-    /// Observes and notifies of changes made to product categories. the current state will be dispatched upon subscription.
-    /// Calling this method will remove any other previous observer.
-    ///
-    func observeCategoryListStateChanges(onStateChanges: @escaping (SyncingState) -> Void) {
-        onSyncStateChange = onStateChanges
-        onSyncStateChange?(syncCategoriesState)
     }
 
     /// Observe the need of reload by passing a closure that will be invoked when there is a need to reload the data.

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -205,7 +205,7 @@ final class ProductCategoryListViewModel {
         updateInitialItemsIfNeeded(with: fetchedCategories)
         let baseViewModels = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: fetchedCategories, selectedCategories: selectedCategories)
 
-        categoryViewModels = enrichingDataSource?.enrichCategoryViewModels( baseViewModels) ?? baseViewModels
+        categoryViewModels = enrichingDataSource?.enrichCategoryViewModels(baseViewModels) ?? baseViewModels
     }
 
     /// Update `selectedCategories` based on initially selected items.

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -59,6 +59,10 @@ final class ProductCategoryListViewModel {
     ///
     @Published private(set) var selectedCategories: [ProductCategory]
 
+    /// Search query from the search bar
+    /// 
+    @Published var searchQuery: String = ""
+
     /// Array of view models to be rendered by the View Controller.
     ///
     private(set) var categoryViewModels: [ProductCategoryCellViewModel] = []

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -145,6 +145,30 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedCategories.count, 1)
         XCTAssertEqual(viewModel.selectedCategories.first?.categoryID, category.categoryID)
     }
+
+    func test_searchQuery_change_updates_view_model_array_correctly() {
+        // Given
+        let siteID: Int64 = 132
+        let category1 = Yosemite.ProductCategory(categoryID: 33, siteID: siteID, parentID: 0, name: "Western", slug: "western")
+        insert(category1)
+        let category2 = Yosemite.ProductCategory(categoryID: 12, siteID: siteID, parentID: 0, name: "Oriental", slug: "oriental")
+        insert(category2)
+
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, storageManager: storageManager)
+        XCTAssertEqual(viewModel.categoryViewModels.count, 2) // confidence check
+
+        // When
+        viewModel.searchQuery = "a"
+
+        // Then
+        waitFor { promise in
+            // wait for 500 milliseconds due to debouncing
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                promise(())
+            }
+        }
+        XCTAssertEqual(viewModel.categoryViewModels.count, 1)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 import TestKit
 @testable import WooCommerce
@@ -8,6 +9,7 @@ final class FilterProductCategoryListViewModelTests: XCTestCase {
     private var filterProductCategoryListViewModel: FilterProductCategoryListViewModel!
     private var productCategoryListViewModel: ProductCategoryListViewModel!
     private let anyCategoryIsSelectedDefaultValue = false
+    private var subscription: AnyCancellable?
 
     override func setUp() {
         super.setUp()
@@ -24,6 +26,7 @@ final class FilterProductCategoryListViewModelTests: XCTestCase {
 
         filterProductCategoryListViewModel = nil
         productCategoryListViewModel = nil
+        subscription = nil
     }
 
     func test_enrichCategoryViewModels_then_it_adds_the_any_category_view_model_with_the_right_selected_state() {
@@ -77,7 +80,8 @@ final class FilterProductCategoryListViewModelTests: XCTestCase {
         productCategoryListViewModel.performFetch()
 
         let categoryViewModels: [ProductCategoryCellViewModel] = waitFor { [weak self] promise in
-            self?.productCategoryListViewModel.observeCategoryListStateChanges { [weak self] state in
+            guard let self = self else { return }
+            self.subscription = self.productCategoryListViewModel.$syncCategoriesState.sink { [weak self] state in
                 guard let self = self else {
                     return
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6490
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR completes the category selector by implementing searches using the search query in the search bar.
Since we're already fetching all categories using recursion in `ProductCategoryStore`, here we'll only search within the local storage for simplicity. This means when the search query changes, we update the predicate to fetch the result list again.

To improve the UX when a search returns an empty result, this PR also adds an empty view to the content stack view of the category list.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu > Coupons > select a coupon and to its edit flow (ellipsis button > Edit Coupon)
- Tap Select Product Category button. Notice that the category selector now has a search bar.
- Enter any keyword to the search bar, and notice that the list is updated with matching results.
- If no result is found, notice that an empty view is displayed. This view should be hidden again if there is any result for the list.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/167113698-a5e3ae13-3dcf-4fc8-9982-5dd825b86042.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
