### PR TITLE
Dismiss Coupon Editing view and refresh Coupon Detail + Coupon List after the remote coupon update

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -333,7 +333,7 @@ struct AddEditCoupon_Previews: PreviewProvider {
 
         /// Edit Coupon
         ///
-        let editingViewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon, onCompletion: nil)
+        let editingViewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon, onCompletion: { _ in })
         AddEditCoupon(editingViewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -50,7 +50,6 @@ struct AddEditCoupon: View {
             GeometryReader { geometry in
                 ScrollView {
                     VStack (alignment: .leading, spacing: 0) {
-
                         Group {
                             ListHeaderView(text: Localization.headerCouponDetails.uppercased(), alignment: .left)
 
@@ -334,7 +333,7 @@ struct AddEditCoupon_Previews: PreviewProvider {
 
         /// Edit Coupon
         ///
-        let editingViewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon)
+        let editingViewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon, onCompletion: nil)
         AddEditCoupon(editingViewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -15,7 +15,7 @@ final class AddEditCouponViewModel: ObservableObject {
 
     private let discountType: Coupon.DiscountType
 
-    private let onCompletion: ((Result<Coupon, Error>) -> Void)?
+    private let onCompletion: ((Result<Coupon, Error>) -> Void)
 
     /// Defines the current notice that should be shown.
     /// Defaults to `nil`.
@@ -149,7 +149,7 @@ final class AddEditCouponViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          timezone: TimeZone = .siteTimezone,
-         onCompletion: ((Result<Coupon, Error>) -> Void)? = nil) {
+         onCompletion: @escaping ((Result<Coupon, Error>) -> Void)) {
         self.siteID = siteID
         editingOption = .creation
         self.discountType = discountType
@@ -174,7 +174,7 @@ final class AddEditCouponViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          timezone: TimeZone = .siteTimezone,
-         onCompletion: ((Result<Coupon, Error>) -> Void)? = nil) {
+         onCompletion: @escaping ((Result<Coupon, Error>) -> Void)) {
         siteID = existingCoupon.siteID
         coupon = existingCoupon
         editingOption = .editing
@@ -216,7 +216,7 @@ final class AddEditCouponViewModel: ObservableObject {
         if let validationError = validateCouponLocally(coupon) {
             notice = NoticeFactory.createCouponErrorNotice(validationError,
                                                            editingOption: editingOption)
-            onCompletion?(.failure(validationError))
+            onCompletion(.failure(validationError))
             return
         }
 
@@ -232,7 +232,7 @@ final class AddEditCouponViewModel: ObservableObject {
                                                                     editingOption: self.editingOption)
             }
             self.isLoading = false
-            self.onCompletion?(result)
+            self.onCompletion(result)
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -15,7 +15,7 @@ final class AddEditCouponViewModel: ObservableObject {
 
     private let discountType: Coupon.DiscountType
 
-    var onCompletion: ((Result<Coupon, Error>) -> Void)?
+    private let onCompletion: ((Result<Coupon, Error>) -> Void)?
 
     /// Defines the current notice that should be shown.
     /// Defaults to `nil`.
@@ -148,13 +148,15 @@ final class AddEditCouponViewModel: ObservableObject {
          discountType: Coupon.DiscountType,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         timezone: TimeZone = .siteTimezone) {
+         timezone: TimeZone = .siteTimezone,
+         onCompletion: ((Result<Coupon, Error>) -> Void)? = nil) {
         self.siteID = siteID
         editingOption = .creation
         self.discountType = discountType
         self.stores = stores
         self.storageManager = storageManager
         self.timezone = timezone
+        self.onCompletion = onCompletion
 
         amountField = String()
         codeField = String()
@@ -171,7 +173,8 @@ final class AddEditCouponViewModel: ObservableObject {
     init(existingCoupon: Coupon,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         timezone: TimeZone = .siteTimezone) {
+         timezone: TimeZone = .siteTimezone,
+         onCompletion: ((Result<Coupon, Error>) -> Void)? = nil) {
         siteID = existingCoupon.siteID
         coupon = existingCoupon
         editingOption = .editing
@@ -179,6 +182,7 @@ final class AddEditCouponViewModel: ObservableObject {
         self.stores = stores
         self.storageManager = storageManager
         self.timezone = timezone
+        self.onCompletion = onCompletion
 
         // Populate fields
         amountField = existingCoupon.amount

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -5,8 +5,8 @@ import Yosemite
 ///
 final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 
-    init(viewModel: CouponDetailsViewModel, onDeletion: @escaping () -> Void) {
-        super.init(rootView: CouponDetails(viewModel: viewModel, onDeletion: onDeletion))
+    init(viewModel: CouponDetailsViewModel, onUpdate: @escaping () -> Void, onDeletion: @escaping () -> Void) {
+        super.init(rootView: CouponDetails(viewModel: viewModel, onUpdate: onUpdate, onDeletion: onDeletion))
         // The navigation title is set here instead of the SwiftUI view's `navigationTitle`
         // to avoid the blinking of the title label when pushed from UIKit view.
         title = viewModel.couponCode
@@ -21,6 +21,9 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 }
 
 struct CouponDetails: View {
+    // Closure to be triggered when the coupon is updated successfully
+    private let onUpdate: () -> Void
+
     // Closure to be triggered when the coupon is deleted successfully
     private let onDeletion: () -> Void
 
@@ -39,9 +42,10 @@ struct CouponDetails: View {
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
     let noticePresenter: DefaultNoticePresenter
 
-    init(viewModel: CouponDetailsViewModel, onDeletion: @escaping () -> Void) {
+    init(viewModel: CouponDetailsViewModel, onUpdate: @escaping () -> Void, onDeletion: @escaping () -> Void) {
         self.viewModel = viewModel
         self.onDeletion = onDeletion
+        self.onUpdate = onUpdate
         self.noticePresenter = DefaultNoticePresenter()
         viewModel.syncCoupon()
         viewModel.loadCouponReport()
@@ -51,6 +55,7 @@ struct CouponDetails: View {
             case .success(let updatedCoupon):
                 viewModel.updateCoupon(updatedCoupon)
                 viewModel.showingEditCoupon = false
+                onUpdate()
             default:
                 break
             }
@@ -429,7 +434,7 @@ private extension CouponDetails {
 #if DEBUG
 struct CouponDetails_Previews: PreviewProvider {
     static var previews: some View {
-        CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon), onDeletion: {})
+        CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon), onUpdate: {}, onDeletion: {})
     }
 }
 #endif

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -78,6 +78,10 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var isDeletionInProgress: Bool = false
 
+    /// Handle when the Edit Coupon Screen should be shown.
+    ///
+    @Published var showingEditCoupon: Bool = false
+
     /// The message to be shared about the coupon
     ///
     var shareMessage: String {
@@ -140,6 +144,10 @@ final class CouponDetailsViewModel: ObservableObject {
             }
         }
         stores.dispatch(action)
+    }
+
+    func updateCoupon(_ coupon: Coupon) {
+        self.coupon = coupon
     }
 
     func loadCouponReport() {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -196,6 +196,9 @@ extension CouponListViewController: UITableViewDelegate {
         let detailsViewModel = CouponDetailsViewModel(coupon: coupon)
         let hostingController = CouponDetailsHostingController(viewModel: detailsViewModel) { [weak self] in
             guard let self = self else { return }
+            self.viewModel.refreshCoupons()
+        } onDeletion: { [weak self] in
+            guard let self = self else { return }
             self.navigationController?.popViewController(animated: true)
             let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
             self.noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -49,7 +49,9 @@ final class CouponSearchUICommand: SearchUICommand {
 
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
         let detailsViewModel = CouponDetailsViewModel(coupon: model)
-        let couponDetails = CouponDetails(viewModel: detailsViewModel) {
+        let couponDetails = CouponDetails(viewModel: detailsViewModel) { [weak self] in
+            try? self?.createResultsController().performFetch()
+        } onDeletion: {
             viewController.navigationController?.popViewController(animated: true)
             let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
             let noticePresenter = DefaultNoticePresenter()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -5,36 +5,36 @@ import XCTest
 final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_titleView_property_return_expected_values_on_creation_depending_on_discountType() {
-        let viewModel1 = AddEditCouponViewModel(siteID: 123, discountType: .percent)
+        let viewModel1 = AddEditCouponViewModel(siteID: 123, discountType: .percent, onCompletion: { _ in })
         XCTAssertEqual(viewModel1.title, Localization.titleCreatePercentageDiscount)
 
-        let viewModel2 = AddEditCouponViewModel(siteID: 123, discountType: .fixedCart)
+        let viewModel2 = AddEditCouponViewModel(siteID: 123, discountType: .fixedCart, onCompletion: { _ in })
         XCTAssertEqual(viewModel2.title, Localization.titleCreateFixedCartDiscount)
 
-        let viewModel3 = AddEditCouponViewModel(siteID: 123, discountType: .fixedProduct)
+        let viewModel3 = AddEditCouponViewModel(siteID: 123, discountType: .fixedProduct, onCompletion: { _ in })
         XCTAssertEqual(viewModel3.title, Localization.titleCreateFixedProductDiscount)
 
-        let viewModel4 = AddEditCouponViewModel(siteID: 123, discountType: .other)
+        let viewModel4 = AddEditCouponViewModel(siteID: 123, discountType: .other, onCompletion: { _ in })
         XCTAssertEqual(viewModel4.title, Localization.titleCreateGenericDiscount)
     }
 
     func test_titleView_property_return_expected_values_on_editing_depending_on_discountType() {
-        let viewModel1 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent))
+        let viewModel1 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent), onCompletion: { _ in })
         XCTAssertEqual(viewModel1.title, Localization.titleEditPercentageDiscount)
 
-        let viewModel2 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedCart))
+        let viewModel2 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedCart), onCompletion: { _ in })
         XCTAssertEqual(viewModel2.title, Localization.titleEditFixedCartDiscount)
 
-        let viewModel3 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedProduct))
+        let viewModel3 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .fixedProduct), onCompletion: { _ in })
         XCTAssertEqual(viewModel3.title, Localization.titleEditFixedProductDiscount)
 
-        let viewModel4 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .other))
+        let viewModel4 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .other), onCompletion: { _ in })
         XCTAssertEqual(viewModel4.title, Localization.titleEditGenericDiscount)
     }
 
     func test_generateRandomCouponCode_populate_correctly_the_codeField() {
         // Given
-        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(code: ""))
+        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(code: ""), onCompletion: { _ in })
         XCTAssertEqual(viewModel.codeField, "")
 
         // When
@@ -49,7 +49,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_populatedCoupon_return_expected_coupon_during_editing() {
         // Given
-        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent), timezone: .current)
+        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent), timezone: .current, onCompletion: { _ in })
         let expiryDate = Date().startOfDay(timezone: viewModel.timezone)
         XCTAssertEqual(viewModel.populatedCoupon, Coupon.sampleCoupon.copy(discountType: .percent,
                                                                            dateExpires: expiryDate))
@@ -94,7 +94,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_validateCouponLocally_return_expected_error_if_coupon_code_is_empty() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(code: "")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon)
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onCompletion: { _ in })
 
         // When
         let result = viewModel.validateCouponLocally(coupon)
@@ -106,7 +106,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_validateCouponLocally_return_nil_if_coupon_code_is_not_empty() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(code: "ABCDEF")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon)
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onCompletion: { _ in })
 
         // When
         let result = viewModel.validateCouponLocally(coupon)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -49,7 +49,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_populatedCoupon_return_expected_coupon_during_editing() {
         // Given
-        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent))
+        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent), timezone: .current)
         let expiryDate = Date().startOfDay(timezone: viewModel.timezone)
         XCTAssertEqual(viewModel.populatedCoupon, Coupon.sampleCoupon.copy(discountType: .percent,
                                                                            dateExpires: expiryDate))


### PR DESCRIPTION
Part of #6488 

### Description
As part of the Coupon Editing, we should refresh a Coupon Detail's local data and the Coupon list. So, in this PR, I implemented some callbacks for passing the new coupon back to the coupon detail screen after a successful update and the dismissal of the editing screen. Plus, we refresh the coupon list if there is a successful coupon update.

### Testing instructions
1. Open a Coupon Detail, then open the editing screen.
2. Try to edit some information that is visible also on the coupon editing screen.
3. Press the save button.
4. The edit screen should be dismissed if the coupon was updated correctly.
5. The coupon detail screen should be updated with the new information.
6. Close the coupon detail screen; you should be able to see the updated coupon in the coupon list. If the info is not immediately visible in the list (you updated information not displayed in the list), try to re-open the coupon from the list, in that case, the coupon detail should contain the new information.

### Video
https://user-images.githubusercontent.com/495617/167159374-22dc792c-c56a-4fbc-b04d-f284264f2ee7.mp4




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
