### PR TITLE
Fix two flaky test cases in local runs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -77,7 +77,7 @@ final class AddEditCouponViewModel: ObservableObject {
     ///
     var expiryDateValue: TitleAndValueRow.Value {
         guard expiryDateField == nil else {
-            return .content(expiryDateField?.toString(dateStyle: .long, timeStyle: .none, timeZone: TimeZone.siteTimezone) ?? "")
+            return .content(expiryDateField?.toString(dateStyle: .long, timeStyle: .none, timeZone: timezone) ?? "")
         }
 
         return .placeholder(Localization.couponExpiryDatePlaceholder)
@@ -217,7 +217,7 @@ final class AddEditCouponViewModel: ObservableObject {
         }
 
         isLoading = true
-        let action = CouponAction.updateCoupon(coupon, siteTimezone: TimeZone.siteTimezone) { [weak self] result in
+        let action = CouponAction.updateCoupon(coupon, siteTimezone: timezone) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(_):
@@ -239,7 +239,7 @@ final class AddEditCouponViewModel: ObservableObject {
                      amount: amountField,
                      discountType: discountType,
                      description: descriptionField,
-                     dateExpires: expiryDateField?.startOfDay(timezone: TimeZone.siteTimezone),
+                     dateExpires: expiryDateField?.startOfDay(timezone: timezone),
                      individualUse: couponRestrictionsViewModel.individualUseOnly,
                      usageLimit: Int64(couponRestrictionsViewModel.usageLimitPerCoupon),
                      usageLimitPerUser: Int64(couponRestrictionsViewModel.usageLimitPerUser),
@@ -257,7 +257,7 @@ final class AddEditCouponViewModel: ObservableObject {
                dateModified: Date(),
                discountType: discountType,
                description: descriptionField,
-               dateExpires: expiryDateField?.startOfDay(timezone: TimeZone.siteTimezone),
+               dateExpires: expiryDateField?.startOfDay(timezone: timezone),
                usageCount: 0,
                individualUse: couponRestrictionsViewModel.individualUseOnly,
                productIds: [],

--- a/WooCommerce/WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift
@@ -99,6 +99,7 @@ final class AddManualCustomTrackingViewModelTests: XCTestCase {
 
     func testCanCommitReturnsFalseWithoutName() {
         subject?.trackingNumber = "123"
+        subject?.providerName = nil
 
         XCTAssertFalse(subject!.canCommit)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -49,16 +49,18 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_populatedCoupon_return_expected_coupon_during_editing() {
         // Given
-        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent))
-        let expiryDate = Date().startOfDay(timezone: viewModel.timezone)
-        XCTAssertEqual(viewModel.populatedCoupon, Coupon.sampleCoupon.copy(discountType: .percent,
-                                                                           dateExpires: expiryDate))
+        let timeZone = TimeZone.current
+        let expiryDate = Date().startOfDay(timezone: timeZone)
+        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent, dateExpires: expiryDate),
+                                               timezone: timeZone)
+        assertEqual(viewModel.populatedCoupon, Coupon.sampleCoupon.copy(discountType: .percent,
+                                                                        dateExpires: expiryDate))
 
         // When
         viewModel.amountField = "24.23"
         viewModel.codeField = "TEST"
         viewModel.descriptionField = "This is a test description"
-        viewModel.expiryDateField = Date().endOfDay(timezone: viewModel.timezone)
+        viewModel.expiryDateField = Date().endOfDay(timezone: timeZone)
         viewModel.freeShipping = true
         viewModel.couponRestrictionsViewModel.minimumSpend = "10"
         viewModel.couponRestrictionsViewModel.maximumSpend = "50"
@@ -71,20 +73,20 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
 
         // Then
-        XCTAssertEqual(viewModel.populatedCoupon, Coupon.sampleCoupon.copy(code: "TEST",
-                                                                           amount: "24.23",
-                                                                           discountType: .percent,
-                                                                           description: "This is a test description",
-                                                                           dateExpires: expiryDate,
-                                                                           individualUse: true,
-                                                                           usageLimit: 40,
-                                                                           usageLimitPerUser: 1,
-                                                                           limitUsageToXItems: 10,
-                                                                           freeShipping: true,
-                                                                           excludeSaleItems: true,
-                                                                           minimumAmount: "10",
-                                                                           maximumAmount: "50",
-                                                                           emailRestrictions: ["*@gmail.com", "*@wordpress.com"]))
+        assertEqual(viewModel.populatedCoupon, Coupon.sampleCoupon.copy(code: "TEST",
+                                                                        amount: "24.23",
+                                                                        discountType: .percent,
+                                                                        description: "This is a test description",
+                                                                        dateExpires: expiryDate,
+                                                                        individualUse: true,
+                                                                        usageLimit: 40,
+                                                                        usageLimitPerUser: 1,
+                                                                        limitUsageToXItems: 10,
+                                                                        freeShipping: true,
+                                                                        excludeSaleItems: true,
+                                                                        minimumAmount: "10",
+                                                                        maximumAmount: "50",
+                                                                        emailRestrictions: ["*@gmail.com", "*@wordpress.com"]))
     }
 
     func test_populatedCoupon_return_expected_coupon_during_creation() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6792 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While running WooCommerceTests locally as a whole, I noticed two test cases failing consistently:

#### Case 1 `AddManualCustomTrackingViewModelTests.testCanCommitReturnsFalseWithoutName`

This one is from 2019 https://github.com/woocommerce/woocommerce-ios/issues/1687 that we never got to reproduce consistently. I'm not so sure why it only starts failing consistently when I run a subset of tests locally, perhaps it's the order of the tests. The reason of failing is because in `AddCustomTrackingViewModel.init`, [if `providerName` is `nil` or empty it loads tracking providers in app settings](https://github.com/woocommerce/woocommerce-ios/blob/a848bb14f1c2c1aedbf860aef989778e7b78b297/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift#L254-L259). In this case, because a previous test case set a tracking provider in app settings and it stays in the storage the `providerName` is no longer `nil` as expected in `testCanCommitReturnsFalseWithoutName`.

To fix this behavior, I added a line to manually unset `providerName` in the test case to ensure that a name is not set.

#### Case 2 `AddEditCouponViewModelTests.test_populatedCoupon_return_expected_coupon_during_editing`

First, I used the `assertEqual` helper in our TestKit to visualize the diffs more easily. The failure showed the difference: 
```
Found difference for 
dateExpires:
|	timeIntervalSinceReferenceDate:
|	|	Received: 673747200.0
|	|	Expected: 673660800.0
  File: AddEditCouponViewModelTests.swift:54
```

The cause is because `AddEditCouponViewModel` uses a time zone (sometimes `TimeZone.siteTimezone` and sometimes the injected one) for the expiry date of a coupon, but [the value in the existing coupon is using `TimeZone.current`](https://github.com/woocommerce/woocommerce-ios/blob/a848bb14f1c2c1aedbf860aef989778e7b78b297/WooCommerce/Classes/Model/Coupon%2BWoo.swift#L263) which might be different from the site time zone. In my simulator, `TimeZone.siteTimezone` and `TimeZone.current` are different from previous app runs. CI probably has the same time zone for both so this test always passes on CI.

This PR fixes this by setting the existing coupon's expiry date manually. Also, a time zone is now DI'ed to the view model in the test and the view model only uses the DI'ed time zone throughout the class. I think generally it's better to avoid using `Date()` but I didn't want to make too many changes that aren't directly related.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can run WooCommerceTests altogether, or disable test cases after the 5th one, and make sure all tests pass.

<img width="559" alt="Screen Shot 2022-05-09 at 10 33 01 AM" src="https://user-images.githubusercontent.com/1945542/167330918-85641490-0550-487e-be6d-970d195b0786.png">

If you've run the app in the simulator with a site that has a different time zone from the simulator, `AddEditCouponViewModelTests.test_populatedCoupon_return_expected_coupon_during_editing` should not be passing before this PR. For `AddManualCustomTrackingViewModelTests.testCanCommitReturnsFalseWithoutName`, I only saw the failure when I disabled test cases after the 5th one.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
