### PR TITLE
Optimize search view controller to prevent redundant search requests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -357,9 +357,11 @@ private extension SearchViewController {
         keyboardFrameObserver.startObservingKeyboardFrame()
     }
 
+    /// Handles debouncing search upon update of search query to optimize search requests.
+    ///
     func configureSearchFunctionality() {
         searchQuerySubscription = $searchQuery
-            .dropFirst()
+            .dropFirst() // ignores initial value as it's not user's input
             .removeDuplicates()
             .debounce(for: .milliseconds(Settings.searchDebounceTime), scheduler: DispatchQueue.main)
             .sink { [weak self] query in

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -361,7 +361,7 @@ private extension SearchViewController {
         searchQuerySubscription = $searchQuery
             .dropFirst()
             .removeDuplicates()
-            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .debounce(for: .milliseconds(Settings.searchDebounceTime), scheduler: DispatchQueue.main)
             .sink { [weak self] query in
                 self?.synchronizeSearchResults(with: query)
             }
@@ -578,6 +578,7 @@ private extension SearchViewController {
 private enum Settings {
     static let estimatedHeaderHeight = CGFloat(43)
     static let estimatedRowHeight = CGFloat(86)
+    static let searchDebounceTime = 500
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import UIKit
 import Yosemite
@@ -26,6 +27,14 @@ where Cell.SearchModel == Command.CellViewModel {
 
 
     @IBOutlet private weak var bordersView: BordersView!
+
+    /// Current query in the search bar
+    ///
+    @Published private var searchQuery = ""
+
+    /// A reference to the subscription of the search query.
+    ///
+    private var searchQuerySubscription: AnyCancellable?
 
     /// Footer "Loading More" Spinner.
     ///
@@ -65,12 +74,6 @@ where Cell.SearchModel == Command.CellViewModel {
     ///
     private var isEmpty: Bool {
         return resultsController.isEmpty
-    }
-
-    /// Returns the active Keyword
-    ///
-    private var keyword: String {
-        return searchBar.text ?? String()
     }
 
     /// UI Active State
@@ -135,6 +138,7 @@ where Cell.SearchModel == Command.CellViewModel {
         startListeningToNotifications()
 
         transitionToResultsUpdatedState()
+        configureSearchFunctionality()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -205,7 +209,7 @@ where Cell.SearchModel == Command.CellViewModel {
     // MARK: - UISearchBarDelegate Conformance
     //
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        synchronizeSearchResults(with: searchText)
+        searchQuery = searchText
     }
 
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
@@ -352,6 +356,16 @@ private extension SearchViewController {
     func startListeningToNotifications() {
         keyboardFrameObserver.startObservingKeyboardFrame()
     }
+
+    func configureSearchFunctionality() {
+        searchQuerySubscription = $searchQuery
+            .dropFirst()
+            .removeDuplicates()
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] query in
+                self?.synchronizeSearchResults(with: query)
+            }
+    }
 }
 
 
@@ -362,18 +376,18 @@ extension SearchViewController: SyncingCoordinatorDelegate {
     /// Synchronizes the models for the Default Store (if any).
     ///
     func sync(pageNumber: Int, pageSize: Int, reason: String?, onCompletion: ((Bool) -> Void)? = nil) {
-        let keyword = searchUICommand.sanitizeKeyword(self.keyword)
+        let keyword = searchUICommand.sanitizeKeyword(searchQuery)
         searchUICommand.synchronizeModels(siteID: storeID,
                                           keyword: keyword,
                                           pageNumber: pageNumber,
                                           pageSize: pageSize,
                                           onCompletion: { [weak self] isCompleted in
-                                            guard let self = self else { return }
-                                            // Disregard OPs that don't really match the latest keyword
-                                            if keyword == self.searchUICommand.sanitizeKeyword(self.keyword) {
-                                                self.transitionToResultsUpdatedState()
-                                            }
-                                            onCompletion?(isCompleted)
+            guard let self = self else { return }
+            // Disregard OPs that don't really match the latest keyword
+            if keyword == self.searchUICommand.sanitizeKeyword(self.searchQuery) {
+                self.transitionToResultsUpdatedState()
+            }
+            onCompletion?(isCompleted)
         })
         transitionToSyncingState()
     }
@@ -458,7 +472,7 @@ private extension SearchViewController {
         }
 
         searchUICommand.configureEmptyStateViewControllerBeforeDisplay(viewController: childController,
-                                                                       searchKeyword: keyword)
+                                                                       searchKeyword: searchQuery)
 
         childView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -536,7 +550,7 @@ private extension SearchViewController {
     /// See `State` for the rules.
     ///
     func transitionToSyncingState() {
-        state = keyword.isEmpty ? stateIfSearchKeywordIsEmpty : .syncing
+        state = searchQuery.isEmpty ? stateIfSearchKeywordIsEmpty : .syncing
     }
 
     /// Transition to the appropriate `State` after search results were received.
@@ -546,7 +560,7 @@ private extension SearchViewController {
     func transitionToResultsUpdatedState() {
         let nextState: State
 
-        if keyword.isEmpty {
+        if searchQuery.isEmpty {
             nextState = stateIfSearchKeywordIsEmpty
         } else if isEmpty {
             nextState = .empty


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6783 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, we're firing a new search request upon every update of the search query on search screens. This creates a large number of redundant API requests as a user is typing.

This PR tackles that by keeping the search query as a published property that is observed and debounced to only start a search after the user stops typing for at least 500 milliseconds. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The easiest way to test this is to use a proxy app to monitor network activities on our app. 
- Start Proxyman/Charles Proxy and launch the app. You can also use Instrument's Network tool but this requires testing on a physical device instead of a simulator.
- Navigate to Order search / Product search / Coupon search flow.
- On the search bar, quickly type a long keyword. Notice that only one API request is made for that word after you stop typing; the previous characters don't trigger any request.


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/167359057-81534fd7-5d07-4ae4-8986-892f808bb000.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
