### PR TITLE
Coupons: Fix crash due to duplicated identifiers in the coupon list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Order Creation: Updated percentage fee flow - added amount preview, disabled percentage option when editing. [https://github.com/woocommerce/woocommerce-ios/pull/6763]
 - [*] Product Details: Update status badge layout and show it for more cases. [https://github.com/woocommerce/woocommerce-ios/pull/6768]
+- [*] Fix crash when there are duplicated items on the coupon list. [https://github.com/woocommerce/woocommerce-ios/pull/6798]
 
 9.1
 -----

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndSubtitleAndStatusTableViewCell.swift
@@ -36,6 +36,9 @@ final class TitleAndSubtitleAndStatusTableViewCell: UITableViewCell, SearchResul
 //
 extension TitleAndSubtitleAndStatusTableViewCell {
     struct ViewModel: Hashable {
+        /// A unique ID to avoid duplicated identifier for the view model in diffable datasource
+        private let id = UUID()
+
         let title: String
         let subtitle: String
         let accessibilityLabel: String


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6796 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For the coupon list, we are using the (relatively) shiny new diffable-datasource, which relies on the identifier of each cell to determine the change of data in the coupon list.

This difference is currently determined by the cell view model's `Hashable` conformance, which calculates the hash for each cell based on the values of the view model's properties. There's an edge case that users can create coupons with duplicated details on WP-admin: same coupon code, amount, discount type, expiry date - this is where it goes wrong since we end up with duplicated hash for different cells 💥 

A quick fix here is to add a private unique identifier for each view model - that way we can make sure that cells that contain similar data are actually different and avoid crashes due to duplicated identifiers.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- On WP Admin, create at least 2 coupons with the same details. A quick way to do this is to select Add Coupon > Publish immediately without updating any detail.
- Open the app, navigate to the coupon list: Menu > Coupons. Make sure that the app doesn't crash and there are items with the same content on the list.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/167366196-06b4eabe-627d-4af9-8209-73a76eaa8851.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
