### PR TITLE
Coupons: Filter initial search results by site ID

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Order Creation: Updated percentage fee flow - added amount preview, disabled percentage option when editing. [https://github.com/woocommerce/woocommerce-ios/pull/6763]
 - [*] Product Details: Update status badge layout and show it for more cases. [https://github.com/woocommerce/woocommerce-ios/pull/6768]
+- [*] Coupons: Filter initial search results to show only coupons of the currently selected store. [https://github.com/woocommerce/woocommerce-ios/pull/6800]
 
 9.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -249,7 +249,7 @@ private extension CouponListViewController {
         ServiceLocator.analytics.track(.couponsListSearchTapped)
         let searchViewController = SearchViewController<TitleAndSubtitleAndStatusTableViewCell, CouponSearchUICommand>(
             storeID: siteID,
-            command: CouponSearchUICommand(),
+            command: CouponSearchUICommand(siteID: siteID),
             cellType: TitleAndSubtitleAndStatusTableViewCell.self,
             cellSeparator: .singleLine
         )

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -15,10 +15,17 @@ final class CouponSearchUICommand: SearchUICommand {
 
     let cancelButtonAccessibilityIdentifier = "coupon-search-screen-cancel-button"
 
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
+    }
+
     func createResultsController() -> ResultsController<StorageCoupon> {
         let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated, ascending: false)
-        return ResultsController<StorageCoupon>(storageManager: storageManager, sortedBy: [descriptor])
+        return ResultsController<StorageCoupon>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }
 
     func createStarterViewController() -> UIViewController? {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -51,7 +51,6 @@ final class CouponSearchUICommand: SearchUICommand {
         }
 
         ServiceLocator.stores.dispatch(action)
-        // TODO: add analytics
     }
 
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6604 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, there is a predicate missing in the initial results of the coupon search screen.

This PR fixes that by adding a predicate by site ID to the initial results controller to make sure that users can only see the coupons for their currently selected site.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that your account has access to at least two stores and they both have at least one coupon.
- Navigate to the coupon search flow: Menu > Coupons > Select the Search icon. 
- Notice that only coupons of the selected site are displayed initially.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/167383102-4c9fad09-3075-4724-8bf2-a9b3fadd40da.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
