### PR TITLE
Coupon Editing: update remotely products, categories, excluded products and excluded categories

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -139,8 +139,8 @@ final class AddEditCouponViewModel: ObservableObject {
     @Published var expiryDateField: Date?
     @Published var freeShipping: Bool
     @Published var couponRestrictionsViewModel: CouponRestrictionsViewModel
-    @Published private var productOrVariationIDs: [Int64]
-    @Published private var categoryIDs: [Int64]
+    @Published var productOrVariationIDs: [Int64]
+    @Published var categoryIDs: [Int64]
 
     /// Init method for coupon creation
     ///
@@ -245,10 +245,14 @@ final class AddEditCouponViewModel: ObservableObject {
                      description: descriptionField,
                      dateExpires: expiryDateField?.startOfDay(timezone: TimeZone.siteTimezone),
                      individualUse: couponRestrictionsViewModel.individualUseOnly,
+                     productIds: productOrVariationIDs,
+                     excludedProductIds: couponRestrictionsViewModel.excludedProductOrVariationIDs,
                      usageLimit: Int64(couponRestrictionsViewModel.usageLimitPerCoupon),
                      usageLimitPerUser: Int64(couponRestrictionsViewModel.usageLimitPerUser),
                      limitUsageToXItems: Int64(couponRestrictionsViewModel.limitUsageToXItems),
                      freeShipping: freeShipping,
+                     productCategories: categoryIDs,
+                     excludedProductCategories: couponRestrictionsViewModel.excludedCategoryIDs,
                      excludeSaleItems: couponRestrictionsViewModel.excludeSaleItems,
                      minimumAmount: couponRestrictionsViewModel.minimumSpend,
                      maximumAmount: couponRestrictionsViewModel.maximumSpend,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -49,9 +49,9 @@ final class CouponRestrictionsViewModel: ObservableObject {
 
     @Published var excludeSaleItems: Bool
 
-    @Published private var excludedProductOrVariationIDs: [Int64]
+    @Published var excludedProductOrVariationIDs: [Int64]
 
-    @Published private var excludedCategoryIDs: [Int64]
+    @Published var excludedCategoryIDs: [Int64]
 
     /// View model for the product selector
     ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -60,6 +60,8 @@ final class AddEditCouponViewModelTests: XCTestCase {
         viewModel.descriptionField = "This is a test description"
         viewModel.expiryDateField = Date().endOfDay(timezone: viewModel.timezone)
         viewModel.freeShipping = true
+        viewModel.productOrVariationIDs = [10, 50]
+        viewModel.categoryIDs = [3, 9, 44]
         viewModel.couponRestrictionsViewModel.minimumSpend = "10"
         viewModel.couponRestrictionsViewModel.maximumSpend = "50"
         viewModel.couponRestrictionsViewModel.usageLimitPerCoupon = "40"
@@ -68,6 +70,8 @@ final class AddEditCouponViewModelTests: XCTestCase {
         viewModel.couponRestrictionsViewModel.allowedEmails = "*@gmail.com, *@wordpress.com"
         viewModel.couponRestrictionsViewModel.individualUseOnly = true
         viewModel.couponRestrictionsViewModel.excludeSaleItems = true
+        viewModel.couponRestrictionsViewModel.excludedProductOrVariationIDs = [11, 30]
+        viewModel.couponRestrictionsViewModel.excludedCategoryIDs = [4, 10]
 
 
         // Then
@@ -77,10 +81,14 @@ final class AddEditCouponViewModelTests: XCTestCase {
                                                                            description: "This is a test description",
                                                                            dateExpires: expiryDate,
                                                                            individualUse: true,
+                                                                           productIds: [10, 50],
+                                                                           excludedProductIds: [11, 30],
                                                                            usageLimit: 40,
                                                                            usageLimitPerUser: 1,
                                                                            limitUsageToXItems: 10,
                                                                            freeShipping: true,
+                                                                           productCategories: [3, 9, 44],
+                                                                           excludedProductCategories: [4, 10],
                                                                            excludeSaleItems: true,
                                                                            minimumAmount: "10",
                                                                            maximumAmount: "50",


### PR DESCRIPTION
Closes #6488 

### Description
This should be the last thing that should be implemented in the coupon editing, before adding the analytics and before enabling the feature flag when we are ready.


### Testing instructions
- Open a coupon that could be edited.
- Try to edit in the main screen the Products and the Categories.
- Open the "Usage Restrictions" screen.
- Try to edit the excluded products and excluded product categories.
- Go back, and save. You should be able to see the changes applied to the coupon remotely (on the app and on wp-admin).




### Video
https://user-images.githubusercontent.com/495617/167435061-147fd6e5-76d5-4b3f-99a1-9c584faa3600.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
