### PR TITLE
[Mobile Payments] Perform card-present refund onboarding check earlier

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -54,6 +54,8 @@ final class RefundConfirmationViewModel {
 
     private let analytics: Analytics
 
+    private let cardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting = CardPresentPaymentsOnboardingPresenter()
+
     init(details: Details,
          actionProcessor: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
@@ -97,6 +99,7 @@ final class RefundConfirmationViewModel {
             cardPresentConfiguration: CardPresentConfigurationLoader(stores: actionProcessor).configuration,
             dependencies: RefundSubmissionUseCase.Dependencies(
                 currencyFormatter: currencyFormatter,
+                cardPresentPaymentsOnboardingPresenter: cardPresentPaymentsOnboardingPresenter,
                 stores: actionProcessor,
                 analytics: analytics))
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6807 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, the `Connecting to your account` onboarding screen would show for all attempts to perform a card present refund (i.e. an Interac refund).

This was due to the CardPresentPaymentsOnboardingPresenter being created then used in the submission step.

This change moves the creation of the presenter to the confirmation step, so that the readiness check has been completed by the time the merchant confirms the refund.

When the merchant confirms the refund, most of the time there will be no onboarding issues, so now they won’t see the onboarding flow at all.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a Canada WCPay store:

1. Create an order, and take payment using an Interac card.
2. In `Menu > ⚙️ > In-Person Payments > Manage card reader`, disconnect the reader.
3. Open the Order Details, tap `Issue Refund`, and get through to the Refund Confirmation Screen
4. Tap `Refund` and confirm the alert
5. Observe that you see the card reader connection flow, without first seeing the "Connecting to your store" onboarding loading screen

N.B. these repro steps won't be 100%: it would be possible to tap through quickly enough that you beat a slow network, and do see the loading screen!

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Scenario | Before | After
---|---|---
Failing onboarding | ![failing-onboarding-before](https://user-images.githubusercontent.com/2472348/167439341-f60ed8d5-a06a-4eb7-874c-7a06700abe95.mp4) | ![failing-onboarding-after](https://user-images.githubusercontent.com/2472348/167439320-bd7d129f-8b35-4da4-958f-98f6cc1803d4.mp4)
Passing onboarding | ![passing-onboarding-before](https://user-images.githubusercontent.com/2472348/167440775-0a8e5e17-fe6a-415f-9170-eb1eaa615ee8.mp4) | ![passing-onboarding-after](https://user-images.githubusercontent.com/2472348/167440828-96971c3f-6cfa-4465-a422-03c53bb8a8d4.mp4)





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
