### PR TITLE
[Mobile Payments] Refresh onboarding during pull-to-refresh

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Product Details: Update status badge layout and show it for more cases. [https://github.com/woocommerce/woocommerce-ios/pull/6768]
 - [*] Coupons: Filter initial search results to show only coupons of the currently selected store. [https://github.com/woocommerce/woocommerce-ios/pull/6800]
 - [*] Coupons: Fixed crash when there are duplicated items on the coupon list. [https://github.com/woocommerce/woocommerce-ios/pull/6798]
+- [*] In-Person Payments: Run onboarding checks when connecting a reader. [https://github.com/woocommerce/woocommerce-ios/pull/6761, https://github.com/woocommerce/woocommerce-ios/pull/6774, https://github.com/woocommerce/woocommerce-ios/pull/6789]
 
 9.1
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -484,6 +484,10 @@ extension OrderDetailsViewModel {
         ServiceLocator.stores.dispatch(action)
     }
 
+    func refreshCardPresentPaymentOnboarding() {
+        cardPresentPaymentsOnboardingPresenter.refresh()
+    }
+
     func checkOrderAddOnFeatureSwitchState(onCompletion: (() -> Void)? = nil) {
         let action = AppSettingsAction.loadOrderAddOnsSwitchState { [weak self] result in
             self?.dataSource.showAddOns = (try? result.get()) ?? false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView> {
-    init(viewModel: InPersonPaymentsViewModel) {
+    private let onWillDisappear: (() -> ())?
+
+    init(viewModel: InPersonPaymentsViewModel,
+         onWillDisappear: (() -> ())? = nil) {
+        self.onWillDisappear = onWillDisappear
         super.init(rootView: InPersonPaymentsView(viewModel: viewModel))
         rootView.showSupport = { [weak self] in
             guard let self = self else { return }
@@ -15,6 +19,11 @@ final class InPersonPaymentsViewController: UIHostingController<InPersonPayments
 
     @objc required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        onWillDisappear?()
+        super.viewWillDisappear(animated)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
@@ -21,8 +21,6 @@ final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardin
 
     private var readinessSubscription: AnyCancellable?
 
-    private var subscriptions = [AnyCancellable]()
-
     init(stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
         onboardingUseCase = CardPresentPaymentsOnboardingUseCase(stores: stores)
@@ -40,7 +38,10 @@ final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardin
 
     private func showOnboarding(from viewController: UIViewController,
                                 readyToCollectPayment completion: @escaping (() -> ())) {
-        let onboardingViewController = InPersonPaymentsViewController(viewModel: onboardingViewModel)
+        let onboardingViewController = InPersonPaymentsViewController(viewModel: onboardingViewModel,
+                                                                      onWillDisappear: { [weak self] in
+            self?.readinessSubscription?.cancel()
+        })
         viewController.show(onboardingViewController, sender: viewController)
 
         readinessSubscription = readinessUseCase.$readiness

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
@@ -5,11 +5,15 @@ import Combine
 protocol CardPresentPaymentsOnboardingPresenting {
     func showOnboardingIfRequired(from: UIViewController,
                                   readyToCollectPayment: @escaping (() -> ()))
+
+    func refresh()
 }
 
 final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting {
 
     private let stores: StoresManager
+
+    private let onboardingUseCase: CardPresentPaymentsOnboardingUseCase
 
     private let readinessUseCase: CardPresentPaymentsReadinessUseCase
 
@@ -21,7 +25,7 @@ final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardin
 
     init(stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
-        let onboardingUseCase = CardPresentPaymentsOnboardingUseCase(stores: stores)
+        onboardingUseCase = CardPresentPaymentsOnboardingUseCase(stores: stores)
         readinessUseCase = CardPresentPaymentsReadinessUseCase(onboardingUseCase: onboardingUseCase, stores: stores)
         onboardingViewModel = InPersonPaymentsViewModel(useCase: onboardingUseCase)
     }
@@ -55,4 +59,7 @@ final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardin
             })
     }
 
+    func refresh() {
+        onboardingUseCase.forceRefresh()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -387,6 +387,10 @@ private extension OrderDetailsViewController {
         group.leave()
 
         group.enter()
+        viewModel.refreshCardPresentPaymentOnboarding()
+        group.leave()
+
+        group.enter()
         syncSavedReceipts {_ in
             group.leave()
         }

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -129,7 +129,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-simulate-stripe-card-reader"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-force-crash-logging 1"

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
@@ -9,4 +9,8 @@ final class MockCardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboa
         spyShowOnboardingWasCalled = true
         completion()
     }
+
+    func refresh() {
+        // No-op
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6607 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the onboarding state requests to the pull-to-refresh control on Order Details. Prior to this, we would only refresh the onboarding status when you first open the Order Details, or when you tap a "Refresh after Updating" or similar button in the onboarding screens.

Not all onboarding screens have such a button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a Canadian store with both Stripe and WCPay plugins installed and activated

1. On the orders tab, tap + and use Create Order
2. Add a product, and tap next to go through to Order Details
3. Tap `Collect Payment`
4. Observe that you see the "We don't support In-Person Payments in Canada" onboarding screen.
5. Go back
6. Use the `Manage Plugins` CTA and disable stripe
7. Pull to refresh
8. Tap `Connect Payment`
9. Observe that reader connection flow starts.

### Screenshots

https://user-images.githubusercontent.com/2472348/167619459-fccde5cb-a595-43bf-94f2-a5158055897f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
