### PR TITLE
Bump Kingfisher pod to version 7.2.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,7 @@ target 'WooCommerce' do
   pod 'Charts', '~> 3.6.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
   pod 'StripeTerminal', '~> 2.7'
-  pod 'Kingfisher', '~> 6.0.0'
+  pod 'Kingfisher', '~> 7.2.2'
   pod 'Wormholy', '~> 1.6.5', configurations: ['Debug']
 
   # Unit Tests

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,7 +31,7 @@ PODS:
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.7.0)
   - KeychainAccess (3.2.1)
-  - Kingfisher (6.0.1)
+  - Kingfisher (7.2.2)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
   - Sentry (6.2.1):
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 1.2.0)
   - KeychainAccess (~> 3.2)
-  - Kingfisher (~> 6.0.0)
+  - Kingfisher (~> 7.2.2)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
@@ -158,7 +158,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
-  Kingfisher: adde87a4f74f6a3845395769354efff593581740
+  Kingfisher: 184d4d1a8c36666e663caf8e08abe87898595c53
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
@@ -185,6 +185,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 537aa9c47a806d11c2e319e1a76494dcae5d4ac2
+PODFILE CHECKSUM: f7102ea355609049f4306feb9e5d957c3890971f
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/1894

### Description
As part of maintaining our app up-to-date with the latest external libraries updates, I started updating some of our pods.
In this case, I updated **Kingfisher** from version 6.0.0 to version 7.2.2. [Here](https://github.com/onevcat/Kingfisher/releases) you can find the main changes on release 7. On our side, no code update is needed.


### Testing instructions
1. Checkout the branch
2. Run `bundle exec rake dependencies`
3. Build and run. Do a quick smoke test of the part of the app where we download remote images (like in Products).


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
