### PR TITLE
Bump KeychainAccess pod to version 4.2.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -60,7 +60,7 @@ target 'WooCommerce' do
   # ==================
   #
   pod 'Alamofire', '~> 4.8'
-  pod 'KeychainAccess', '~> 3.2'
+  pod 'KeychainAccess', '~> 4.2.2'
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
   pod 'XLPagerTabStrip', '~> 9.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,7 +30,7 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.7.0)
-  - KeychainAccess (3.2.1)
+  - KeychainAccess (4.2.2)
   - Kingfisher (6.0.1)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 1.2.0)
-  - KeychainAccess (~> 3.2)
+  - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 6.0.0)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
@@ -157,7 +157,7 @@ SPEC CHECKSUMS:
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
-  KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
+  KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   Kingfisher: adde87a4f74f6a3845395769354efff593581740
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
@@ -185,6 +185,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 537aa9c47a806d11c2e319e1a76494dcae5d4ac2
+PODFILE CHECKSUM: f1a5345adf59ad723217bd8973c73acbe5e3f7cf
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,13 +30,8 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.7.0)
-<<<<<<< HEAD
   - KeychainAccess (4.2.2)
-  - Kingfisher (6.0.1)
-=======
-  - KeychainAccess (3.2.1)
   - Kingfisher (7.2.2)
->>>>>>> trunk
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
   - Sentry (6.2.1):
@@ -96,13 +91,8 @@ DEPENDENCIES:
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 1.2.0)
-<<<<<<< HEAD
   - KeychainAccess (~> 4.2.2)
-  - Kingfisher (~> 6.0.0)
-=======
-  - KeychainAccess (~> 3.2)
   - Kingfisher (~> 7.2.2)
->>>>>>> trunk
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
@@ -167,13 +157,8 @@ SPEC CHECKSUMS:
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
-<<<<<<< HEAD
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
-  Kingfisher: adde87a4f74f6a3845395769354efff593581740
-=======
-  KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
   Kingfisher: 184d4d1a8c36666e663caf8e08abe87898595c53
->>>>>>> trunk
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
@@ -200,10 +185,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-<<<<<<< HEAD
-PODFILE CHECKSUM: f1a5345adf59ad723217bd8973c73acbe5e3f7cf
-=======
-PODFILE CHECKSUM: f7102ea355609049f4306feb9e5d957c3890971f
->>>>>>> trunk
+PODFILE CHECKSUM: d17e5960357f6d1adb66778ab3ecee5c0cd7dc1e
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/1894

### Description
As part of maintaining our app up-to-date with the latest external libraries updates, I started updating some of our pods.
In this case, I updated **KeychainAccess** from version 3.2 (released in 2019) to version 4.2.2 (released on March 2022). [Here](https://github.com/kishikawakatsumi/KeychainAccess/tags), you can find the main changes on release 4.2.2. On our side, no code update is needed.


### Testing instructions
1. Checkout the branch
2. Run `bundle exec rake dependencies`
3. Build and run. Do a quick smoke test of the part of the app where we do the user's authentication. Try to login-logout, close the app, reopen it, etc...


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
