### PR TITLE
HF: Add error messages when orders fail to sync

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -2,6 +2,7 @@ import Yosemite
 import Combine
 import protocol Storage.StorageManagerType
 import Experiments
+import enum Networking.DotcomError
 
 /// View model for `NewOrder`.
 ///
@@ -305,7 +306,7 @@ final class NewOrderViewModel: ObservableObject {
                 self.onOrderCreated(newOrder)
                 self.trackCreateOrderSuccess()
             case .failure(let error):
-                self.notice = NoticeFactory.createOrderErrorNotice()
+                self.notice = NoticeFactory.createOrderErrorNotice(error, order: self.orderSynchronizer.order)
                 self.trackCreateOrderFailure(error: error)
                 DDLogError("⛔️ Error creating new order: \(error)")
             }
@@ -525,7 +526,7 @@ private extension NewOrderViewModel {
                 switch state {
                 case .error(let error):
                     DDLogError("⛔️ Error syncing new order remotely: \(error)")
-                    return NoticeFactory.syncOrderErrorNotice(with: self.orderSynchronizer)
+                    return NoticeFactory.syncOrderErrorNotice(error, with: self.orderSynchronizer)
                 default:
                     return nil
                 }
@@ -795,15 +796,33 @@ extension NewOrderViewModel {
     enum NoticeFactory {
         /// Returns a default order creation error notice.
         ///
-        static func createOrderErrorNotice() -> Notice {
-            Notice(title: Localization.errorMessageOrderCreation, feedbackType: .error)
+        static func createOrderErrorNotice(_ error: Error, order: Order) -> Notice {
+            guard !isEmailError(error, order: order) else {
+                return Notice(title: Localization.invalidBillingParameters, message: Localization.invalidBillingSuggestion, feedbackType: .error)
+            }
+            return Notice(title: Localization.errorMessageOrderCreation, feedbackType: .error)
         }
 
         /// Returns an order sync error notice.
         ///
-        static func syncOrderErrorNotice(with orderSynchronizer: OrderSynchronizer) -> Notice {
-            Notice(title: Localization.errorMessageOrderSync, feedbackType: .error, actionTitle: Localization.retryOrderSync) {
+        static func syncOrderErrorNotice(_ error: Error, with orderSynchronizer: OrderSynchronizer) -> Notice {
+            guard !isEmailError(error, order: orderSynchronizer.order) else {
+                return Notice(title: Localization.invalidBillingParameters, message: Localization.invalidBillingSuggestion, feedbackType: .error)
+            }
+            return Notice(title: Localization.errorMessageOrderSync, feedbackType: .error, actionTitle: Localization.retryOrderSync) {
                 orderSynchronizer.retryTrigger.send()
+            }
+        }
+
+        /// Returns `true` if the provided error is about invalid shipping details and the latest order does not have a billing email.
+        /// This is needed because old stores error when sending empty emails.
+        ///
+        private static func isEmailError(_ error: Error, order: Order) -> Bool {
+            switch error as? DotcomError {
+            case .unknown(code: "rest_invalid_param", message: "Invalid parameter(s): billing"):
+                return order.billingAddress?.hasEmailAddress == false
+            default:
+                return false
             }
         }
     }
@@ -815,5 +834,10 @@ private extension NewOrderViewModel {
         static let errorMessageOrderSync = NSLocalizedString("Unable to load taxes for order",
                                                              comment: "Notice displayed when taxes cannot be synced for new order")
         static let retryOrderSync = NSLocalizedString("Retry", comment: "Action button to retry syncing the draft order")
+
+        static let invalidBillingParameters = NSLocalizedString("Unable to set customer details.",
+                                                                comment: "Error notice title when we fail to update an address when creating an order.")
+        static let invalidBillingSuggestion = NSLocalizedString("Please make sure you are running the latest version of WooCommerce and try again later.",
+                                                                comment: "Recovery suggestion when we fail to update an address when creating an order")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -819,8 +819,8 @@ extension NewOrderViewModel {
         ///
         private static func isEmailError(_ error: Error, order: Order) -> Bool {
             switch error as? DotcomError {
-            case .unknown(code: "rest_invalid_param", message: "Invalid parameter(s): billing"):
-                return order.billingAddress?.hasEmailAddress == false
+            case .unknown(code: "rest_invalid_param", let message?):
+                return message.contains("billing") && order.billingAddress?.hasEmailAddress == false
             default:
                 return false
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/NewOrderViewModelTests.swift
@@ -89,12 +89,13 @@ final class NewOrderViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let error = NSError(domain: "Error", code: 0)
 
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .createOrder(_, _, onCompletion):
-                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+                onCompletion(.failure(error))
             default:
                 XCTFail("Received unsupported action: \(action)")
             }
@@ -102,13 +103,14 @@ final class NewOrderViewModelTests: XCTestCase {
         viewModel.createOrder()
 
         // Then
-        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.createOrderErrorNotice())
+        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake()))
     }
 
     func test_view_model_fires_error_notice_when_order_sync_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let error = NSError(domain: "Error", code: 0)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
 
         // When
@@ -116,7 +118,7 @@ final class NewOrderViewModelTests: XCTestCase {
             stores.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {
                 case let .createOrder(_, _, onCompletion):
-                    onCompletion(.failure(NSError(domain: "Error", code: 0)))
+                    onCompletion(.failure(error))
                     expectation.fulfill()
                 default:
                     XCTFail("Received unsupported action: \(action)")
@@ -128,14 +130,15 @@ final class NewOrderViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.syncOrderErrorNotice(with: synchronizer))
+        XCTAssertEqual(viewModel.notice, NewOrderViewModel.NoticeFactory.syncOrderErrorNotice(error, with: synchronizer))
     }
 
     func test_view_model_clears_error_notice_when_order_is_syncing() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = NewOrderViewModel(siteID: sampleSiteID, stores: stores)
-        viewModel.notice = NewOrderViewModel.NoticeFactory.createOrderErrorNotice()
+        let error = NSError(domain: "Error", code: 0)
+        viewModel.notice = NewOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake())
 
         // When
         let notice: Notice? = waitFor { promise in


### PR DESCRIPTION
fix #6791 

# Why

When editing addresses, our app does not support sending empty emails for stores `<= 5.9` due to API limitations.

Prior to this PR, there was no clear error to the merchant. This PR adds a specific error telling the merchant to update its store in order to proceed to create orders.

# Demo

https://user-images.githubusercontent.com/562080/167685910-633b0125-9765-48b7-a695-527b52d0f9b2.mov

# Testing Steps

- Start with a store running WooCommerce 5.8 or earlier.
- Go to the Orders tab and create a new order.
- Select "Add Customer Details."
- Enter customer details but leave the Email field on the billing address blank.
- Notice that after you save the new customer details, you get a custom error message indicating to update the store.

