### PR TITLE
Analytics: track time range instead of granularity for 4 dashboard events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -7,18 +7,26 @@ extension WooAnalyticsEvent {
             static let range = "range"
         }
 
+        /// Tracked when the store stats are loaded with fresh data either via first load, event driven refresh, or manual refresh.
+        /// - Parameter timeRange: the range of store stats (e.g. Today, This Week, This Month, This Year).
         static func dashboardMainStatsLoaded(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardMainStatsLoaded, properties: [Keys.range: timeRange.analyticsValue])
         }
 
+        /// Tracked when the date range on the store stats view changes.
+        /// - Parameter timeRange: the range of store stats (e.g. Today, This Week, This Month, This Year).
         static func dashboardMainStatsDate(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardMainStatsDate, properties: [Keys.range: timeRange.analyticsValue])
         }
 
+        /// Tracked when the top performers are loaded with fresh data either via first load, event driven refresh, or manual refresh.
+        /// - Parameter timeRange: the range of store stats (e.g. Today, This Week, This Month, This Year).
         static func dashboardTopPerformersLoaded(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardTopPerformersLoaded, properties: [Keys.range: timeRange.analyticsValue])
         }
 
+        /// Tracked when the date range on the top performers view changes.
+        /// - Parameter timeRange: the range of store stats (e.g. Today, This Week, This Month, This Year).
         static func dashboardTopPerformersDate(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardTopPerformersDate, properties: [Keys.range: timeRange.analyticsValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -1,0 +1,29 @@
+import enum Yosemite.StatsTimeRangeV4
+
+extension WooAnalyticsEvent {
+    enum Dashboard {
+        /// Common event keys.
+        private enum Keys {
+            static let range = "range"
+        }
+
+        static func dashboardMainStatsLoaded(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardMainStatsLoaded, properties: [Keys.range: timeRange.analyticsValue])
+        }
+    }
+}
+
+private extension StatsTimeRangeV4 {
+    var analyticsValue: String {
+        switch self {
+        case .today:
+            return "days"
+        case .thisWeek:
+            return "weeks"
+        case .thisMonth:
+            return "months"
+        case .thisYear:
+            return "years"
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -10,6 +10,18 @@ extension WooAnalyticsEvent {
         static func dashboardMainStatsLoaded(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardMainStatsLoaded, properties: [Keys.range: timeRange.analyticsValue])
         }
+
+        static func dashboardMainStatsDate(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardMainStatsDate, properties: [Keys.range: timeRange.analyticsValue])
+        }
+
+        static func dashboardTopPerformersLoaded(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardTopPerformersLoaded, properties: [Keys.range: timeRange.analyticsValue])
+        }
+
+        static func dashboardTopPerformersDate(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardTopPerformersDate, properties: [Keys.range: timeRange.analyticsValue])
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -250,7 +250,7 @@ private extension TopPerformerDataViewController {
             isInitialLoad = false
             return
         }
-        ServiceLocator.analytics.track(.dashboardTopPerformersDate, withProperties: ["range": granularity.rawValue])
+        ServiceLocator.analytics.track(event: .Dashboard.dashboardTopPerformersDate(timeRange: timeRange))
         isInitialLoad = false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -19,9 +19,6 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     /// Time range for this period
     let timeRange: StatsTimeRangeV4
 
-    /// Stats interval granularity
-    let granularity: StatsGranularityV4
-
     /// Whether site visit stats can be shown
     var siteVisitStatsMode: SiteVisitStatsMode = .default {
         didSet {
@@ -124,7 +121,6 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) {
         self.siteID = siteID
         self.timeRange = timeRange
-        self.granularity = timeRange.intervalGranularity
         self.currentDate = currentDate
         self.viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: canDisplayInAppFeedbackCard)
         self.usageTracksEventEmitter = usageTracksEventEmitter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -162,7 +162,7 @@ private extension StoreStatsAndTopPerformersViewController {
                            latestDateToInclude: latestDateToInclude) { [weak self] result in
                 switch result {
                 case .success:
-                    self?.trackStatsLoaded(for: vc.granularity)
+                    self?.trackStatsLoaded(for: vc.timeRange)
                 case .failure(let error):
                     DDLogError("⛔️ Error synchronizing order stats: \(error)")
                     periodSyncError = error
@@ -458,12 +458,12 @@ private extension StoreStatsAndTopPerformersViewController {
 // MARK: - Private Helpers
 //
 private extension StoreStatsAndTopPerformersViewController {
-    func trackStatsLoaded(for granularity: StatsGranularityV4) {
+    func trackStatsLoaded(for timeRange: StatsTimeRangeV4) {
         guard ServiceLocator.stores.isAuthenticated else {
             return
         }
 
-        ServiceLocator.analytics.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
+        ServiceLocator.analytics.track(event: .Dashboard.dashboardMainStatsLoaded(timeRange: timeRange))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -407,10 +407,7 @@ private extension StoreStatsAndTopPerformersViewController {
                                                           onCompletion: { result in
                                                             switch result {
                                                             case .success:
-                                                                ServiceLocator.analytics.track(.dashboardTopPerformersLoaded,
-                                                                                               withProperties: [
-                                                                                                "granularity": timeRange.topEarnerStatsGranularity.rawValue
-                                                                                               ])
+                                                                ServiceLocator.analytics.track(event: .Dashboard.dashboardTopPerformersLoaded(timeRange: timeRange))
                                                             case .failure(let error):
                                                                 DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
                                                             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -407,7 +407,8 @@ private extension StoreStatsAndTopPerformersViewController {
                                                           onCompletion: { result in
                                                             switch result {
                                                             case .success:
-                                                                ServiceLocator.analytics.track(event: .Dashboard.dashboardTopPerformersLoaded(timeRange: timeRange))
+                                                                ServiceLocator.analytics.track(event:
+                                                                        .Dashboard.dashboardTopPerformersLoaded(timeRange: timeRange))
                                                             case .failure(let error):
                                                                 DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
                                                             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -589,7 +589,7 @@ private extension StoreStatsV4PeriodViewController {
             return
         }
         usageTracksEventEmitter.interacted()
-        ServiceLocator.analytics.track(.dashboardMainStatsDate, withProperties: ["range": granularity.rawValue])
+        ServiceLocator.analytics.track(event: .Dashboard.dashboardMainStatsDate(timeRange: timeRange))
         isInitialLoad = false
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		02C2756824F4E77F00286C04 /* ProductShippingSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2756724F4E77F00286C04 /* ProductShippingSettingsViewModel.swift */; };
 		02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2756C24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift */; };
 		02C2756F24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C2756E24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift */; };
+		02C3FACE282A93020095440A /* WooAnalyticsEvent+Dashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3FACD282A93020095440A /* WooAnalyticsEvent+Dashboard.swift */; };
 		02C3FDEA251091CE009569EE /* ProductFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3FDE9251091CE009569EE /* ProductFactoryTests.swift */; };
 		02C8876D24501FAC00E4470F /* FilterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C8876B24501FAC00E4470F /* FilterListViewController.swift */; };
 		02C8876E24501FAC00E4470F /* FilterListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02C8876C24501FAC00E4470F /* FilterListViewController.xib */; };
@@ -2077,6 +2078,7 @@
 		02C2756724F4E77F00286C04 /* ProductShippingSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingSettingsViewModel.swift; sourceTree = "<group>"; };
 		02C2756C24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		02C2756E24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductShippingSettingsViewModel+ProductVariationTests.swift"; sourceTree = "<group>"; };
+		02C3FACD282A93020095440A /* WooAnalyticsEvent+Dashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Dashboard.swift"; sourceTree = "<group>"; };
 		02C3FDE9251091CE009569EE /* ProductFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFactoryTests.swift; sourceTree = "<group>"; };
 		02C8876B24501FAC00E4470F /* FilterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListViewController.swift; sourceTree = "<group>"; };
 		02C8876C24501FAC00E4470F /* FilterListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterListViewController.xib; sourceTree = "<group>"; };
@@ -5741,6 +5743,7 @@
 				747AA0882107CEC60047A89B /* AnalyticsProvider.swift */,
 				747AA08A2107CF8D0047A89B /* TracksProvider.swift */,
 				5783FB3E25D7369F00B9984B /* WooAnalyticsEventPropertyType.swift */,
+				02C3FACD282A93020095440A /* WooAnalyticsEvent+Dashboard.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -9278,6 +9281,7 @@
 				26F94E21267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift in Sources */,
 				45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */,
 				45C8B2582313FA570002FA77 /* CustomerNoteTableViewCell.swift in Sources */,
+				02C3FACE282A93020095440A /* WooAnalyticsEvent+Dashboard.swift in Sources */,
 				DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */,
 				7493BB8E2149852A003071A9 /* TopPerformersHeaderView.swift in Sources */,
 				D88CA756237CE515005D2F44 /* UITabBar+Appearance.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6801 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For the 4 dashboard events, `*_dashboard_main_stats_date`/`*_dashboard_main_stats_loaded`/`*_dashboard_top_performers_date`/`*_dashboard_top_performers_loaded`, the app has been logging the `range`/`granularity` property with "granularity" `hour`/`day`/`day`/`month` for Today/This Week/This Month/This Year tabs. This PR updated these 4 events to always track `range` property with `days`/`weeks`/`months`/`years` for Today/This Week/This Month/This Year tabs for the following reasons:
- To match Android p1651829140771439/1651829033.920079-slack-CGPNUU63E
- The granularity is the same for "This Week" and "This Month" tabs and we can't tell them apart

I think it's okay to udpate events that used to track under `range` because the previous granularity isn't helpful and I don't see any existing funnels that use any any of these events. The events spreadsheet is updated with the expected property values.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app --> after stats are loaded, `dashboard_main_stats_loaded` and `dashboard_top_performers_loaded` should be tracked in the console with 4 `range` values: `days`/`weeks`/`months`/`years`
- Tap on another time range tab like "This Week" --> `dashboard_main_stats_date` and `dashboard_top_performers_date` should be tracked in the console with the expected `range` values: `days`/`weeks`/`months`/`years` for Today/This Week/This Month/This Year

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->