### PR TITLE
Wait for payment gateway accounts to load before determining IPP eligibility in order details

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -77,11 +77,6 @@ final class OrderDetailsDataSource: NSObject {
             !isEligibleForCardPresentPayment
     }
 
-    func cardPresentPaymentGatewayAccounts() -> [PaymentGatewayAccount] {
-        resultsControllers.paymentGatewayAccounts.filter { $0.isCardPresentEligible }
-    }
-
-
     /// Whether the order has a receipt associated.
     ///
     var shouldShowReceipts: Bool = false
@@ -192,6 +187,10 @@ final class OrderDetailsDataSource: NSObject {
             orderNotesSections = computeOrderNotesSections()
         }
     }
+
+    /// Payment gateway accounts for card-present payments.
+    ///
+    var cardPresentPaymentGatewayAccounts: [PaymentGatewayAccount] = []
 
     /// Note from the customer about the order
     ///
@@ -1544,13 +1543,11 @@ private extension OrderDetailsDataSource {
     }
 
     func hasCardPresentEligiblePaymentGatewayAccount() -> Bool {
-        let accounts = resultsControllers.paymentGatewayAccounts
-
-        guard accounts.count <= 1 else {
+        guard cardPresentPaymentGatewayAccounts.count <= 1 else {
             return false
         }
 
-        return resultsControllers.paymentGatewayAccounts.contains(where: \.isCardPresentEligible)
+        return cardPresentPaymentGatewayAccounts.contains(where: \.isCardPresentEligible)
     }
 
     func orderContainsAnySubscription() -> Bool {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -65,13 +65,6 @@ final class OrderDetailsResultsControllers {
                                                        sortedBy: [dateCreatedDescriptor, shippingLabelIDDescriptor])
     }()
 
-    /// PaymentGatewayAccount Results Controller.
-    ///
-    private lazy var paymentGatewayAccountResultsController: ResultsController<StoragePaymentGatewayAccount> = {
-        let predicate = NSPredicate(format: "siteID = %ld", order.siteID)
-        return ResultsController<StoragePaymentGatewayAccount>(storageManager: storageManager, matching: predicate, sortedBy: [])
-    }()
-
     /// AddOnGroup ResultsController.
     ///
     private lazy var addOnGroupResultsController: ResultsController<StorageAddOnGroup> = {
@@ -115,11 +108,6 @@ final class OrderDetailsResultsControllers {
         return shippingLabelResultsController.fetchedObjects
     }
 
-    /// Payment Gateway Accounts for the Site (i.e. that can be used to collect payment for an order)
-    var paymentGatewayAccounts: [PaymentGatewayAccount] {
-        return paymentGatewayAccountResultsController.fetchedObjects
-    }
-
     /// Site's add-on groups.
     ///
     var addOnGroups: [AddOnGroup] {
@@ -145,7 +133,6 @@ final class OrderDetailsResultsControllers {
         configureProductVariationResultsController(onReload: onReload)
         configureRefundResultsController(onReload: onReload)
         configureShippingLabelResultsController(onReload: onReload)
-        configurePaymentGatewayAccountResultsController(onReload: onReload)
         configureAddOnGroupResultsController(onReload: onReload)
     }
 
@@ -257,23 +244,6 @@ private extension OrderDetailsResultsControllers {
         try? shippingLabelResultsController.performFetch()
     }
 
-    private func configurePaymentGatewayAccountResultsController(onReload: @escaping () -> Void) {
-        paymentGatewayAccountResultsController.onDidChangeContent = {
-            onReload()
-        }
-
-        paymentGatewayAccountResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.refetchAllResultsControllers()
-            onReload()
-        }
-
-        try? paymentGatewayAccountResultsController.performFetch()
-    }
-
     private func configureAddOnGroupResultsController(onReload: @escaping () -> Void) {
         addOnGroupResultsController.onDidChangeContent = {
             onReload()
@@ -297,7 +267,6 @@ private extension OrderDetailsResultsControllers {
         try? trackingResultsController.performFetch()
         try? statusResultsController.performFetch()
         try? shippingLabelResultsController.performFetch()
-        try? paymentGatewayAccountResultsController.performFetch()
         try? addOnGroupResultsController.performFetch()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -383,8 +383,9 @@ private extension OrderDetailsViewController {
         }
 
         group.enter()
-        refreshCardPresentPaymentEligibility()
-        group.leave()
+        refreshCardPresentPaymentEligibility {
+            group.leave()
+        }
 
         group.enter()
         syncSavedReceipts {_ in
@@ -460,8 +461,8 @@ private extension OrderDetailsViewController {
         }
     }
 
-    func refreshCardPresentPaymentEligibility() {
-        viewModel.refreshCardPresentPaymentEligibility()
+    func refreshCardPresentPaymentEligibility(onCompletion: (() -> Void)? = nil) {
+        viewModel.refreshCardPresentPaymentEligibility(onCompletion: onCompletion)
     }
 
     func checkOrderAddOnFeatureSwitchState(onCompletion: (() -> Void)? = nil) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -85,7 +85,7 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
             softwareUpdateSubject.send(.none)
         case .loadAccounts(let siteID, let onCompletion):
             insertSamplePaymentGateway(forSiteID: siteID)
-            onCompletion(Result.success(()))
+            onCompletion(Result.success([]))
         case .loadActivePaymentGatewayExtension(let onCompletion):
             onCompletion(paymentExtension)
         default:

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -17,7 +17,7 @@ public enum CardPresentPaymentAction: Action {
     /// the Stripe extension. Let's attempt to load each and update view storage with the results.
     /// Calls the passed completion with success after both loads have been attempted.
     ///
-    case loadAccounts(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+    case loadAccounts(siteID: Int64, onCompletion: (Result<[PaymentGatewayAccount], Error>) -> Void)
 
     /// Start the Card Reader discovery process.
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6583 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR aims to solve the "Collect Payment" CTA flickering whenever the payment gateway accounts change in storage since we delete both WCPay and Stripe accounts when the API requests are made and before the results come back. In order to rely on the accounts in the storage to determine IPP eligibility using Core Data results controller, I thought we could always use the latest accounts from the API right after the fetch. The changes only affect order details, since we don't use the result of `CardPresentPaymentAction.loadAccounts` in all other call sites.

The major difference in order details behavior other than the flickering issue is the initial state. With the storage payment gateway accounts monitoring before this PR, the "Collect Payment" CTA could be visible with the pre-existing payment gateway accounts which might be outdated.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the orders tab
- Tap on an order that is eligible for IPP
- Tap "Collect Payment" CTA --> the CTA stays after the collect payment process starts.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
