### PR TITLE
[Orders list] Remove extra space on top of Orders table view when dismissing feedback banner and login out

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -360,7 +360,12 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
     ///
     private func hideTopBannerView() {
         topBannerView?.removeFromSuperview()
-        tableView.tableHeaderView = nil
+        if tableView.tableHeaderView != nil {
+            // Setting tableHeaderView = nil when having a previous value keeps an extra header space (See p5T066-3c3#comment-12307)
+            // This solution avoids it by adding an almost zero height header (Originally from https://stackoverflow.com/a/18938763/428353)
+            tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.size.width, height: CGFloat.leastNonzeroMagnitude))
+        }
+
         tableView.updateHeaderHeight()
     }
 }


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #6818 From p5T066-3c3-p2#comment-12307
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When dismissing the banner feedback, login out and log in again, the header table view keeps an extra space on top:

<img src="https://user-images.githubusercontent.com/1864060/167832885-5a63e925-5d9d-4296-8d8f-123f9749e0c5.png" width="375">

The reason behind this is that, as explained [here](https://stackoverflow.com/a/18938763/428353), the table view keeps an extra space when the special conditions of a new login after dismissing the feedback in the same session. With this PR fix we ensure that this will not happen and that the header height will be zero when the banner should be hidden.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Steps to reproduce the behavior:
2. Go to Orders and dismiss the banner
3. Logout and re-login
4. Return to Orders screen
5. The banner is no longer displayed, and there is no extra space for the table view header

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/1864060/167833270-f3106815-a3f5-4500-a30c-1f44892cc3a0.png" width="375">


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
