### PR TITLE
[Mobile Payments] Add support to "stripe" payment method id

### DIFF
--- a/WooCommerce/Classes/Model/OrderPaymentMethod.swift
+++ b/WooCommerce/Classes/Model/OrderPaymentMethod.swift
@@ -9,6 +9,9 @@ enum OrderPaymentMethod: RawRepresentable {
     /// WooCommerce Payments
     case woocommercePayments
 
+    /// Stripe
+    case stripe
+
     /// No payment method assigned.
     case none
 
@@ -25,6 +28,8 @@ enum OrderPaymentMethod: RawRepresentable {
             self = .cod
         case Keys.woocommercePayments:
             self = .woocommercePayments
+        case Keys.stripe:
+            self = .stripe
         case Keys.none:
             self = .none
         default:
@@ -40,6 +45,8 @@ enum OrderPaymentMethod: RawRepresentable {
             return Keys.cod
         case .woocommercePayments:
             return Keys.woocommercePayments
+        case .stripe:
+            return Keys.stripe
         case .none:
             return Keys.none
         default:
@@ -53,6 +60,7 @@ private enum Keys {
     static let booking = "wc-booking-gateway"
     static let cod = "cod"
     static let woocommercePayments = "woocommerce_payments"
+    static let stripe = "stripe"
     static let none = ""
     static let unknown = "unknown"
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1536,7 +1536,7 @@ private extension OrderDetailsDataSource {
     func isOrderPaymentMethodEligibleForCardPayment() -> Bool {
         let paymentMethod = OrderPaymentMethod(rawValue: order.paymentMethodID)
         switch paymentMethod {
-        case .booking, .cod, .woocommercePayments, .none:
+        case .booking, .cod, .woocommercePayments, .stripe, .none:
             return true
         case .unknown:
             return false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -189,6 +189,28 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
     }
 
+    func test_collect_payment_button_is_visible_and_primary_style_if_order_status_is_on_hold_and_method_is_stripe() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .onHold, datePaid: .some(nil), paymentMethodID: "stripe")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
     func test_collect_payment_button_is_not_visible_if_order_is_processing_and_order_is_not_eligible_for_cash_on_delivery() throws {
         // Setup
         let account = storageManager.insertCardPresentEligibleAccount()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6820
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In some situations, like the one described in the testing instructions, the payment method identifier of an order is set to "`stripe`" by the Stripe plugin. Before this PR if a payment collection failed the collect payment button was not shown because this payment method id (stripe) was not on the list of accepted payment method ids:
```
func isOrderPaymentMethodEligibleForCardPayment() -> Bool {
        let paymentMethod = OrderPaymentMethod(rawValue: order.paymentMethodID)
        switch paymentMethod {
        case .booking, .cod, .woocommercePayments, .none:
            return true
        case .unknown:
            return false
        }
    }
```

With this PR we add support to this payment method id to make sure that the payment can be retried. This is similar to this [PR](https://github.com/woocommerce/woocommerce-ios/pull/5245), where we added support for the `woocommercePayments` payment method id.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Install both WooCommerce Stripe Gateway and Payment Plugins for Stripe WooCommerce 
2. Connect both of them to the same Stripe account (using test publishable and secret keys) More info [here](https://taptopayp2.wordpress.com/in-person-payments/ultimate-testing-guide-for-woocommerce-payments-in-person-payments/getting-started-with-stripe-terminal-on-stripe/)
3. Try to collect a payment
4. Generic error shown
5. Come back to the order. 
Before: Status of it became on hold and IPP collection button is not visible
After: Status of it became on hold and IPP collection button is visible

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
