### PR TITLE
[Mobile Payments] Show completed onboarding step instead of Menu when shown in payment flows

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -49,7 +49,6 @@ final class OrderDetailsDataSource: NSObject {
             isOrderCurrencyEligibleForCardPayment() &&
             isOrderStatusEligibleForCardPayment() &&
             isOrderPaymentMethodEligibleForCardPayment() &&
-            hasCardPresentEligiblePaymentGatewayAccount() &&
             !orderContainsAnySubscription()
     }
 
@@ -1541,16 +1540,6 @@ private extension OrderDetailsDataSource {
         case .unknown:
             return false
         }
-    }
-
-    func hasCardPresentEligiblePaymentGatewayAccount() -> Bool {
-        let accounts = resultsControllers.paymentGatewayAccounts
-
-        guard accounts.count <= 1 else {
-            return false
-        }
-
-        return resultsControllers.paymentGatewayAccounts.contains(where: \.isCardPresentEligible)
     }
 
     func orderContainsAnySubscription() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCompletedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCompletedView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct InPersonPaymentsLoading: View {
+struct InPersonPaymentsCompleted: View {
     var body: some View {
         ScrollableVStack {
             Spacer()
@@ -8,7 +8,7 @@ struct InPersonPaymentsLoading: View {
             VStack(alignment: .center, spacing: 42) {
                 Text(Localization.title)
                     .font(.headline)
-                Image(uiImage: .paymentsLoading)
+                Image(uiImage: .cardReaderConnect)
                 Text(Localization.message)
                     .font(.callout)
             }
@@ -21,18 +21,18 @@ struct InPersonPaymentsLoading: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "Connecting to your account",
-        comment: "Title when checking if WooCommerce Payments is supported"
+        "Account connected",
+        comment: "Title when a payments account is successfully connected for Card Present Payments"
     )
 
     static let message = NSLocalizedString(
-        "Please wait",
-        comment: "Message when checking if WooCommerce Payments is supported"
+        "Taking you back to accept a payment",
+        comment: "Message when a payments account is successfully connected for Card Present Payments"
     )
 }
 
-struct InPersonPaymentsLoading_Previews: PreviewProvider {
+struct InPersonPaymentsCompleted_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsLoading()
+        InPersonPaymentsCompleted()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCompletedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCompletedView.swift
@@ -26,7 +26,7 @@ private enum Localization {
     )
 
     static let message = NSLocalizedString(
-        "Taking you back to accept a payment",
+        "Taking you back to collect a payment",
         comment: "Message when a payments account is successfully connected for Card Present Payments"
     )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -32,6 +32,7 @@ struct InPersonPaymentsView: View {
 
     var showSupport: (() -> Void)? = nil
     var showURL: ((URL) -> Void)? = nil
+    var shouldShowMenuOnCompletion: Bool = true
 
     var body: some View {
         Group {
@@ -68,7 +69,11 @@ struct InPersonPaymentsView: View {
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected()
             case .completed(let plugin):
-                InPersonPaymentsMenu(plugin: plugin)
+                if viewModel.showMenuOnCompletion {
+                    InPersonPaymentsMenu(plugin: plugin)
+                } else {
+                    InPersonPaymentsCompleted()
+                }
             case .noConnectionError:
                 InPersonPaymentsNoConnection(onRefresh: viewModel.refresh)
             default:
@@ -101,7 +106,7 @@ private enum Localization {
 struct InPersonPaymentsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            InPersonPaymentsView(viewModel: InPersonPaymentsViewModel(fixedState: .genericError))
+            InPersonPaymentsView(viewModel: InPersonPaymentsViewModel(fixedState: .completed(plugin: .stripe)))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -5,15 +5,18 @@ final class InPersonPaymentsViewModel: ObservableObject {
     @Published var state: CardPresentPaymentOnboardingState
     var userIsAdministrator: Bool
     var learnMoreURL: URL? = nil
+    let showMenuOnCompletion: Bool
     private let useCase: CardPresentPaymentsOnboardingUseCase
     let stores: StoresManager
 
     /// Initializes the view model for a specific site
     ///
     init(stores: StoresManager = ServiceLocator.stores,
-         useCase: CardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase()) {
+         useCase: CardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase(),
+         showMenuOnCompletion: Bool = true) {
         self.stores = stores
         self.useCase = useCase
+        self.showMenuOnCompletion = showMenuOnCompletion
         state = useCase.state
         userIsAdministrator = ServiceLocator.stores.sessionManager.defaultRoles.contains(.administrator)
 
@@ -36,6 +39,7 @@ final class InPersonPaymentsViewModel: ObservableObject {
         fixedUserIsAdministrator: Bool = false,
         stores: StoresManager = ServiceLocator.stores) {
             self.stores = stores
+            self.showMenuOnCompletion = false
             state = fixedState
             useCase = CardPresentPaymentsOnboardingUseCase()
             userIsAdministrator = fixedUserIsAdministrator

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
@@ -50,11 +50,11 @@ final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardin
                     return
                 }
 
-                if let navigationController = viewController as? UINavigationController {
-                    navigationController.popViewController(animated: true)
-                } else {
-                    viewController.navigationController?.popViewController(animated: true)
-                }
+//                if let navigationController = viewController as? UINavigationController {
+//                    navigationController.popViewController(animated: true)
+//                } else {
+//                    viewController.navigationController?.popViewController(animated: true)
+//                }
 
                 completion()
             })

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
@@ -25,7 +25,7 @@ final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardin
         self.stores = stores
         onboardingUseCase = CardPresentPaymentsOnboardingUseCase(stores: stores)
         readinessUseCase = CardPresentPaymentsReadinessUseCase(onboardingUseCase: onboardingUseCase, stores: stores)
-        onboardingViewModel = InPersonPaymentsViewModel(useCase: onboardingUseCase)
+        onboardingViewModel = InPersonPaymentsViewModel(useCase: onboardingUseCase, showMenuOnCompletion: false)
     }
 
     func showOnboardingIfRequired(from viewController: UIViewController,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -383,10 +383,6 @@ private extension OrderDetailsViewController {
         }
 
         group.enter()
-        refreshCardPresentPaymentEligibility()
-        group.leave()
-
-        group.enter()
         viewModel.refreshCardPresentPaymentOnboarding()
         group.leave()
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
+		03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
@@ -2158,6 +2159,7 @@
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
+		03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCompletedView.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
@@ -7871,6 +7873,7 @@
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
 				E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */,
+				03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */,
 				319A626027ACAE3400BC96C3 /* InPersonPaymentsPluginChoicesView.swift */,
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
 				E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */,
@@ -9547,6 +9550,7 @@
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
 				5783FB3F25D7369F00B9984B /* WooAnalyticsEventPropertyType.swift in Sources */,
 				CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */,
+				03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */,
 				D449C52626DFBBDB00D75B02 /* WhatsNewFactory.swift in Sources */,
 				028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */,
 				0235595924496D70004BE2B8 /* ProductsSortOrderBottomSheetListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -14,7 +14,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     private typealias Title = OrderDetailsDataSource.Title
 
-    private var storageManager: MockPaymentGatewayAccountStoresManager!
+    private var storageManager: MockStorageManager!
 
     private var storage: StorageType {
         storageManager.viewStorage
@@ -22,7 +22,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        storageManager = MockPaymentGatewayAccountStoresManager()
+        storageManager = MockStorageManager()
     }
 
     override func tearDown() {
@@ -146,10 +146,6 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     }
 
     func test_collect_payment_button_is_visible_and_primary_style_if_order_status_is_processing_and_method_is_cash_on_delivery() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -161,17 +157,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_visible_and_primary_style_if_order_status_is_on_hold_and_method_is_woocommerce_payments() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .onHold, datePaid: .some(nil), paymentMethodID: "woocommerce_payments")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -183,17 +171,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_not_visible_if_order_is_processing_and_order_is_not_eligible_for_cash_on_delivery() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "stripe")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -205,17 +185,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_not_visible_if_account_not_eligible_for_card_present_payments() throws {
-        // Setup
-        let account = storageManager.insertCardPresentIneligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "stripe")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -227,17 +199,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_not_visible_if_order_is_eligible_for_cash_on_delivery_and_total_amount_is_zero() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -249,17 +213,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_visible_if_order_is_eligible_for_cash_on_delivery_and_total_amount_is_greater_than_zero() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "1", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -271,17 +227,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_not_visible_if_order_is_a_confirmed_booking_and_total_amount_is_zero() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "wc-booking-gateway")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -293,17 +241,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_visible_if_order_is_a_confirmed_booking_and_total_amount_is_greater_than_zero() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "1", paymentMethodID: "wc-booking-gateway")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -315,18 +255,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
 
     func test_collect_payment_button_is_not_visible_if_date_paid_is_not_nil() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: Date(), total: "0", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -338,17 +270,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_visible_if_order_is_eligible_and_currency_is_usd() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let order = makeOrder().copy(status: .processing, currency: "usd", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -360,17 +284,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_visible_if_order_is_eligible_and_currency_is_in_configuration() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: true)
         let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
@@ -383,17 +299,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_not_visible_if_order_currency_is_not_in_configuration() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
         let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
@@ -406,17 +314,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_collect_payment_button_is_not_visible_if_order_currency_would_be_in_configuration_but_not_enabled() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
         // Given
         let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: false)
         let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
@@ -429,10 +329,6 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
     }
 
     func test_create_shipping_label_button_is_visible_for_eligible_order_with_no_labels() throws {
@@ -506,8 +402,6 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_create_shipping_label_button_is_not_visible_for_cash_on_delivery_order() throws {
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100", paymentMethodID: "cod")
-        storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
@@ -601,11 +495,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
     }
 
-    func test_morel_button_is_not_visible_in_product_section_for_cash_on_delivery_order() throws {
+    func test_more_button_is_not_visible_in_product_section_for_cash_on_delivery_order() throws {
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100", paymentMethodID: "cod")
-        storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
@@ -708,52 +600,6 @@ private extension OrderDetailsDataSourceTests {
     ///
     func row(row: OrderDetailsDataSource.Row, in section: OrderDetailsDataSource.Section) -> OrderDetailsDataSource.Row? {
         section.rows.first { $0 == row }
-    }
-}
-
-/// Mock Payment Gateway Account Store Manager
-///
-///
-private final class MockPaymentGatewayAccountStoresManager: MockStorageManager {
-
-    /// Inserts an account into the specified context that IS eligible for card present payments
-    ///
-    @discardableResult
-    func insertCardPresentEligibleAccount() -> StoragePaymentGatewayAccount {
-        let newAccount = viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
-        newAccount.siteID = 1234
-        newAccount.gatewayID = "woocommerce-payments"
-        newAccount.status = "complete"
-        newAccount.hasPendingRequirements = false
-        newAccount.hasOverdueRequirements = false
-        newAccount.currentDeadline = nil
-        newAccount.statementDescriptor = "STAGING.BAR"
-        newAccount.defaultCurrency = "USD"
-        newAccount.supportedCurrencies = ["USD"]
-        newAccount.country = "US"
-        newAccount.isCardPresentEligible = true
-
-        return newAccount
-    }
-
-    /// Inserts an account into the specified context that IS NOT eligible for card present payments
-    ///
-    @discardableResult
-    func insertCardPresentIneligibleAccount() -> StoragePaymentGatewayAccount {
-        let newAccount = viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
-        newAccount.siteID = 1234
-        newAccount.gatewayID = "woocommerce-payments"
-        newAccount.status = "complete"
-        newAccount.hasPendingRequirements = false
-        newAccount.hasOverdueRequirements = false
-        newAccount.currentDeadline = nil
-        newAccount.statementDescriptor = "STAGING.BAZ"
-        newAccount.defaultCurrency = "USD"
-        newAccount.supportedCurrencies = ["USD"]
-        newAccount.country = "US"
-        newAccount.isCardPresentEligible = false
-
-        return newAccount
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6607 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We now present the onboarding flow to merchants who have issues with their account connection when they attempt to connect a reader during a payment flow.

Since this was reused from settings, it used to show the menu at the end (see the video below). This was only shown briefly, because the onboarding flow was pushed off screen as soon as it was complete... but it was a little strange.

This PR adds a new "Complete" step, which is displayed in this case. We still push it off immediately, to get the merchant back to the flow of taking the payment, but if there were any delay we avoid showing a confusing menu in the background.

c9e3407d6199743e319161eda8c256a2f9078d67 changes the code for testing purposes: this will be reverted before merging. It has the following effects:

1. The `Collect Payment` button on Order Details is available even when there are onboarding issues.
2. The Onboarding flow is not dismissed on completion.
3. The eligibility account status is not refreshed outside of the onboarding flow.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a US store with both WCPay and Stripe payment plugins installed and activated:

Create a new order, add products, and tap through to the Order Details

1. Tap `Collect Payment`
2. Observe that you see the onboarding flow
3. Use the CTA and webview to deactivate the Stripe payment plugin
4. Observe that you see the new completed step (and the card reader connection flow on top)

N.B. The card reader connection flow is presented from the order details screen. It's shown here above onboarding because the testing c9e3407d6199743e319161eda8c256a2f9078d67 commit has not yet been reverted: it will be reverted before merging.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

New behaviour with artificial delay to show completion step on screen

https://user-images.githubusercontent.com/2472348/167897874-31dc76e6-57d7-4e45-a6b4-5c38b980160d.mp4

Previous behaviour: shows menu on completion (with artificial delay to show on screen)

https://user-images.githubusercontent.com/2472348/167897900-b5f9ab4b-4db2-45a2-bebd-d3b1c96e672f.mp4

New behaviour, no artificial delay (new screen not actually shown until after it's pushed away)

https://user-images.githubusercontent.com/2472348/167897906-884ec961-4207-4d2a-b59a-0143948a30b8.mp4

### Design review

@joe-keenan I've used an existing image here on the new screen, for connect card reader, as it seemed appropriate for the success we're showing this for: the user still needs to connect a reader. I've also made up the wording myself. Let me know if you have any improvements on this, but the screen shouldn't actually ever really be visible, so it's not an especially high priority!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
