### PR TITLE
Order Creation: Track when new order fails to sync remotely

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -419,6 +419,13 @@ extension WooAnalyticsEvent {
                 Keys.errorDescription: errorDescription
             ])
         }
+
+        static func orderSyncFailed(errorContext: String, errorDescription: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderSyncFailed, properties: [
+                Keys.errorContext: errorContext,
+                Keys.errorDescription: errorDescription
+            ])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -236,6 +236,7 @@ public enum WooAnalyticsStat: String {
     case orderTrackingProvidersLoaded = "order_tracking_providers_loaded"
     case orderFeeAdd = "order_fee_add"
     case orderShippingMethodAdd = "order_shipping_method_add"
+    case orderSyncFailed = "order_sync_failed"
 
     // MARK: Order List Sorting/Filtering
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -526,6 +526,7 @@ private extension NewOrderViewModel {
                 switch state {
                 case .error(let error):
                     DDLogError("⛔️ Error syncing new order remotely: \(error)")
+                    self.trackSyncOrderFailure(error: error)
                     return NoticeFactory.syncOrderErrorNotice(error, with: self.orderSynchronizer)
                 default:
                     return nil
@@ -686,6 +687,13 @@ private extension NewOrderViewModel {
     ///
     func trackCreateOrderFailure(error: Error) {
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationFailed(errorContext: String(describing: error),
+                                                                            errorDescription: error.localizedDescription))
+    }
+
+    /// Tracks an order remote sync failure
+    ///
+    func trackSyncOrderFailure(error: Error) {
+        analytics.track(event: WooAnalyticsEvent.Orders.orderSyncFailed(errorContext: String(describing: error),
                                                                             errorDescription: error.localizedDescription))
     }
 


### PR DESCRIPTION
Closes: #6824 

## Description

Adds tracking for the following event when a new order fails to sync remotely during Order Creation:

* `woocommerceios_order_sync_failed` (853-gh-Automattic/tracks-events-registration)

Note: I'm not seeing the event in the Tracks Events directory yet, but it does appear with the expected properties in the Tracks Live view.

## Testing

1. Go to the Orders tab.
2. Create a new order.
3. Disable your network connection (to force a sync failure).
4. Add a product, shipping, fee, or customer details to the new order.
5. Confirm you see a sync failure notice in the UI and the event is fired with the expected properties.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.