### PR TITLE
Coupons: Add Limit section missing fields to Coupon Details

### DIFF
--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -24,6 +24,14 @@ extension String {
         }
     }
 
+    static func pluralize(_ count: Int64, singular: String, plural: String) -> String {
+        if count == 1 {
+            return String.localizedStringWithFormat(singular, count)
+        } else {
+            return String.localizedStringWithFormat(plural, count)
+        }
+    }
+
     /// Helper method to provide the singular or plural (formatted) version of a
     /// string based on a count.
     ///

--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -24,14 +24,6 @@ extension String {
         }
     }
 
-    static func pluralize(_ count: Int64, singular: String, plural: String) -> String {
-        if count == 1 {
-            return String.localizedStringWithFormat(singular, count)
-        } else {
-            return String.localizedStringWithFormat(plural, count)
-        }
-    }
-
     /// Helper method to provide the singular or plural (formatted) version of a
     /// string based on a count.
     ///

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -265,7 +265,7 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.pluralLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser > 1)
 
-                Text(String.localizedStringWithFormat(Localization.itemsLimitUsage, viewModel.limitUsageToXItems))
+                Text(String.localizedStringWithFormat(Localization.itemsInCartUsageLimit, viewModel.limitUsageToXItems))
                     .renderedIf(viewModel.limitUsageToXItems > 0)
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
@@ -385,18 +385,19 @@ private extension CouponDetails {
             "%1$d uses per user",
             comment: "The plural limit of time for each user to apply a coupon, reads like: 10 uses per user"
         )
+        static let itemsInCartUsageLimit = NSLocalizedString(
+                "Limited to %1$d items in cart",
+                comment: "The limit of the same item in cart to apply a coupon, reads like: Limited to 10 items in cart"
+        )
+        static let usageLimitPerCoupon = NSLocalizedString(
+                "Can be used %1$d times",
+                comment: "The total limit where the same coupon can be applied for everyone, " +
+                        "reads like: Can be used 10 times"
+        )
         static let emailRestriction = NSLocalizedString(
             "Restricted to customers with emails: %1$@",
             comment: "Restriction for customers with specified emails to use a coupon, " +
             "reads like: Restricted to customers with emails: *@a8c.com, *@vip.com"
-        )
-        static let itemsLimitUsage = NSLocalizedString(
-            "Limited to %1$d items in cart",
-            comment: ""
-        )
-        static let usageLimitPerCoupon = NSLocalizedString(
-            "Can be used %1$d times",
-            comment: ""
         )
 
         static let manageCoupon = NSLocalizedString("Manage Coupon", comment: "Title of the action sheet displayed from the Coupon Details screen")

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -256,7 +256,7 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.maximumSpend, viewModel.maximumAmount))
                     .renderedIf(viewModel.maximumAmount.isNotEmpty)
 
-                Text(String.localizedStringWithFormat(Localization.usageLimitPerCoupon, viewModel.usageLimit))
+                Text(String.localizedStringWithFormat(Localization.pluralUsageLimitPerCoupon, viewModel.usageLimit))
                     .renderedIf(viewModel.usageLimit > 0)
 
                 Text(String.localizedStringWithFormat(Localization.singularLimitPerUser, viewModel.usageLimitPerUser))
@@ -265,7 +265,7 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.pluralLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser > 1)
 
-                Text(String.localizedStringWithFormat(Localization.itemsInCartUsageLimit, viewModel.limitUsageToXItems))
+                Text(String.localizedStringWithFormat(Localization.pluralItemsInCartUsageLimit, viewModel.limitUsageToXItems))
                     .renderedIf(viewModel.limitUsageToXItems > 0)
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
@@ -385,13 +385,24 @@ private extension CouponDetails {
             "%1$d uses per user",
             comment: "The plural limit of time for each user to apply a coupon, reads like: 10 uses per user"
         )
-        static let itemsInCartUsageLimit = NSLocalizedString(
-                "Limited to %1$d items in cart",
-                comment: "The limit of the same item in cart to apply a coupon, reads like: Limited to 10 items in cart"
+        static let singularItemsInCartUsageLimit = NSLocalizedString(
+                "Limited to %1$d item in cart",
+                comment: "The singular limit of the same item in cart to apply a coupon, reads like: " +
+                        "Limited to 10 item in cart"
         )
-        static let usageLimitPerCoupon = NSLocalizedString(
+        static let pluralItemsInCartUsageLimit = NSLocalizedString(
+                "Limited to %1$d items in cart",
+                comment: "The plural limit of the same item in cart to apply a coupon, reads like: " +
+                        "Limited to 10 items in cart"
+        )
+        static let singularUsageLimitPerCoupon = NSLocalizedString(
+                "Can be used %1$d time",
+                comment: "The singular total limit where the same coupon can be applied for everyone, " +
+                        "reads like: Can be used 1 time"
+        )
+        static let pluralUsageLimitPerCoupon = NSLocalizedString(
                 "Can be used %1$d times",
-                comment: "The total limit where the same coupon can be applied for everyone, " +
+                comment: "The plural total limit where the same coupon can be applied for everyone, " +
                         "reads like: Can be used 10 times"
         )
         static let emailRestriction = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -256,8 +256,11 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.maximumSpend, viewModel.maximumAmount))
                     .renderedIf(viewModel.maximumAmount.isNotEmpty)
 
+                Text(String.localizedStringWithFormat(Localization.singularUsageLimitPerCoupon, viewModel.usageLimit))
+                        .renderedIf(viewModel.usageLimit == 1)
+
                 Text(String.localizedStringWithFormat(Localization.pluralUsageLimitPerCoupon, viewModel.usageLimit))
-                    .renderedIf(viewModel.usageLimit > 0)
+                    .renderedIf(viewModel.usageLimit > 1)
 
                 Text(String.localizedStringWithFormat(Localization.singularLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser == 1)
@@ -265,8 +268,11 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.pluralLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser > 1)
 
+                Text(String.localizedStringWithFormat(Localization.singularItemsInCartUsageLimit, viewModel.limitUsageToXItems))
+                        .renderedIf(viewModel.limitUsageToXItems == 1)
+
                 Text(String.localizedStringWithFormat(Localization.pluralItemsInCartUsageLimit, viewModel.limitUsageToXItems))
-                    .renderedIf(viewModel.limitUsageToXItems > 0)
+                    .renderedIf(viewModel.limitUsageToXItems > 1)
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
                         viewModel.maximumAmount.isNotEmpty ||

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -273,7 +273,9 @@ struct CouponDetails: View {
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
                         viewModel.maximumAmount.isNotEmpty ||
-                        viewModel.usageLimitPerUser > 0)
+                        viewModel.usageLimit > 0 ||
+                        viewModel.usageLimitPerUser > 0 ||
+                        viewModel.limitUsageToXItems > 0)
 
             Text(String.localizedStringWithFormat(Localization.expiryFormat, viewModel.expiryDate))
                 .renderedIf(viewModel.expiryDate.isNotEmpty)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -259,17 +259,17 @@ struct CouponDetails: View {
                 Text(String.pluralize(viewModel.usageLimit,
                                       singular: Localization.singularUsageLimitPerCoupon,
                                       plural: Localization.pluralUsageLimitPerCoupon))
-                    .renderedIf(viewModel.usageLimit > 0)
+                .renderedIf(viewModel.usageLimit > 0)
                 
                 Text(String.pluralize(viewModel.usageLimitPerUser,
                                       singular: Localization.singularLimitPerUser,
                                       plural: Localization.pluralLimitPerUser))
-                    .renderedIf(viewModel.usageLimitPerUser > 0)
+                .renderedIf(viewModel.usageLimitPerUser > 0)
                 
                 Text(String.pluralize(viewModel.limitUsageToXItems,
                                       singular: Localization.singularItemsInCartUsageLimit,
                                       plural: Localization.pluralItemsInCartUsageLimit))
-                    .renderedIf(viewModel.limitUsageToXItems > 0)
+                .renderedIf(viewModel.limitUsageToXItems > 0)
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
                         viewModel.maximumAmount.isNotEmpty ||

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -256,23 +256,20 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.maximumSpend, viewModel.maximumAmount))
                     .renderedIf(viewModel.maximumAmount.isNotEmpty)
 
-                Text(String.localizedStringWithFormat(Localization.singularUsageLimitPerCoupon, viewModel.usageLimit))
-                    .renderedIf(viewModel.usageLimit == 1)
-
-                Text(String.localizedStringWithFormat(Localization.pluralUsageLimitPerCoupon, viewModel.usageLimit))
-                    .renderedIf(viewModel.usageLimit > 1)
-
-                Text(String.localizedStringWithFormat(Localization.singularLimitPerUser, viewModel.usageLimitPerUser))
-                    .renderedIf(viewModel.usageLimitPerUser == 1)
-
-                Text(String.localizedStringWithFormat(Localization.pluralLimitPerUser, viewModel.usageLimitPerUser))
-                    .renderedIf(viewModel.usageLimitPerUser > 1)
-
-                Text(String.localizedStringWithFormat(Localization.singularItemsInCartUsageLimit, viewModel.limitUsageToXItems))
-                    .renderedIf(viewModel.limitUsageToXItems == 1)
-
-                Text(String.localizedStringWithFormat(Localization.pluralItemsInCartUsageLimit, viewModel.limitUsageToXItems))
-                    .renderedIf(viewModel.limitUsageToXItems > 1)
+                Text(String.pluralize(viewModel.usageLimit,
+                                      singular: Localization.singularUsageLimitPerCoupon,
+                                      plural: Localization.pluralUsageLimitPerCoupon))
+                    .renderedIf(viewModel.usageLimit > 0)
+                
+                Text(String.pluralize(viewModel.usageLimitPerUser,
+                                      singular: Localization.singularLimitPerUser,
+                                      plural: Localization.pluralLimitPerUser))
+                    .renderedIf(viewModel.usageLimitPerUser > 0)
+                
+                Text(String.pluralize(viewModel.limitUsageToXItems,
+                                      singular: Localization.singularItemsInCartUsageLimit,
+                                      plural: Localization.pluralItemsInCartUsageLimit))
+                    .renderedIf(viewModel.limitUsageToXItems > 0)
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
                         viewModel.maximumAmount.isNotEmpty ||

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -384,6 +384,14 @@ private extension CouponDetails {
             comment: "Restriction for customers with specified emails to use a coupon, " +
             "reads like: Restricted to customers with emails: *@a8c.com, *@vip.com"
         )
+        static let itemsLimitUsage = NSLocalizedString(
+            "Limited to %1$d items in cart",
+            comment: ""
+        )
+        static let usageLimitPerCoupon = NSLocalizedString(
+            "Can be used %1$d times",
+            comment: ""
+        )
 
         static let manageCoupon = NSLocalizedString("Manage Coupon", comment: "Title of the action sheet displayed from the Coupon Details screen")
         static let copyCode = NSLocalizedString("Copy Code", comment: "Action title for copying coupon code from the Coupon Details screen")

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -257,7 +257,7 @@ struct CouponDetails: View {
                     .renderedIf(viewModel.maximumAmount.isNotEmpty)
 
                 Text(String.localizedStringWithFormat(Localization.singularUsageLimitPerCoupon, viewModel.usageLimit))
-                        .renderedIf(viewModel.usageLimit == 1)
+                    .renderedIf(viewModel.usageLimit == 1)
 
                 Text(String.localizedStringWithFormat(Localization.pluralUsageLimitPerCoupon, viewModel.usageLimit))
                     .renderedIf(viewModel.usageLimit > 1)
@@ -269,7 +269,7 @@ struct CouponDetails: View {
                     .renderedIf(viewModel.usageLimitPerUser > 1)
 
                 Text(String.localizedStringWithFormat(Localization.singularItemsInCartUsageLimit, viewModel.limitUsageToXItems))
-                        .renderedIf(viewModel.limitUsageToXItems == 1)
+                    .renderedIf(viewModel.limitUsageToXItems == 1)
 
                 Text(String.localizedStringWithFormat(Localization.pluralItemsInCartUsageLimit, viewModel.limitUsageToXItems))
                     .renderedIf(viewModel.limitUsageToXItems > 1)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -259,8 +259,12 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.singularLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser == 1)
 
+                Text(String.localizedStringWithFormat(Localization.usageLimitPerCoupon, viewModel.usageLimit))
+
                 Text(String.localizedStringWithFormat(Localization.pluralLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser > 1)
+
+                Text(String.localizedStringWithFormat(Localization.itemsLimitUsage, viewModel.limitUsageToXItems))
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
                         viewModel.maximumAmount.isNotEmpty ||

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -393,12 +393,12 @@ private extension CouponDetails {
         )
         static let singularItemsInCartUsageLimit = NSLocalizedString(
                 "Limited to %1$d item in cart",
-                comment: "The singular limit of the same item in cart to apply a coupon, reads like: " +
-                        "Limited to 10 item in cart"
+                comment: "The required number of items in the cart to apply a coupon in singular form, reads like: " +
+                        "Limited to 1 item in cart"
         )
         static let pluralItemsInCartUsageLimit = NSLocalizedString(
                 "Limited to %1$d items in cart",
-                comment: "The plural limit of the same item in cart to apply a coupon, reads like: " +
+                comment: "The required number of items in the cart to apply a coupon in plural form, reads like: " +
                         "Limited to 10 items in cart"
         )
         static let singularUsageLimitPerCoupon = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -256,17 +256,17 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.maximumSpend, viewModel.maximumAmount))
                     .renderedIf(viewModel.maximumAmount.isNotEmpty)
 
-                Text(String.pluralize(Int(truncatingIfNeeded: viewModel.usageLimit),
+                Text(String.pluralize(Int(viewModel.usageLimit),
                                       singular: Localization.singularUsageLimitPerCoupon,
                                       plural: Localization.pluralUsageLimitPerCoupon))
                 .renderedIf(viewModel.usageLimit > 0)
 
-                Text(String.pluralize(Int(truncatingIfNeeded: viewModel.usageLimitPerUser),
+                Text(String.pluralize(Int(viewModel.usageLimitPerUser),
                                       singular: Localization.singularLimitPerUser,
                                       plural: Localization.pluralLimitPerUser))
                 .renderedIf(viewModel.usageLimitPerUser > 0)
 
-                Text(String.pluralize(Int(truncatingIfNeeded: viewModel.limitUsageToXItems),
+                Text(String.pluralize(Int(viewModel.limitUsageToXItems),
                                       singular: Localization.singularItemsInCartUsageLimit,
                                       plural: Localization.pluralItemsInCartUsageLimit))
                 .renderedIf(viewModel.limitUsageToXItems > 0)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -256,17 +256,17 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.maximumSpend, viewModel.maximumAmount))
                     .renderedIf(viewModel.maximumAmount.isNotEmpty)
 
-                Text(String.pluralize(viewModel.usageLimit,
+                Text(String.pluralize(Int(truncatingIfNeeded: viewModel.usageLimit),
                                       singular: Localization.singularUsageLimitPerCoupon,
                                       plural: Localization.pluralUsageLimitPerCoupon))
                 .renderedIf(viewModel.usageLimit > 0)
-                
-                Text(String.pluralize(viewModel.usageLimitPerUser,
+
+                Text(String.pluralize(Int(truncatingIfNeeded: viewModel.usageLimitPerUser),
                                       singular: Localization.singularLimitPerUser,
                                       plural: Localization.pluralLimitPerUser))
                 .renderedIf(viewModel.usageLimitPerUser > 0)
-                
-                Text(String.pluralize(viewModel.limitUsageToXItems,
+
+                Text(String.pluralize(Int(truncatingIfNeeded: viewModel.limitUsageToXItems),
                                       singular: Localization.singularItemsInCartUsageLimit,
                                       plural: Localization.pluralItemsInCartUsageLimit))
                 .renderedIf(viewModel.limitUsageToXItems > 0)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -256,15 +256,17 @@ struct CouponDetails: View {
                 Text(String.localizedStringWithFormat(Localization.maximumSpend, viewModel.maximumAmount))
                     .renderedIf(viewModel.maximumAmount.isNotEmpty)
 
+                Text(String.localizedStringWithFormat(Localization.usageLimitPerCoupon, viewModel.usageLimit))
+                    .renderedIf(viewModel.usageLimit > 0)
+
                 Text(String.localizedStringWithFormat(Localization.singularLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser == 1)
-
-                Text(String.localizedStringWithFormat(Localization.usageLimitPerCoupon, viewModel.usageLimit))
 
                 Text(String.localizedStringWithFormat(Localization.pluralLimitPerUser, viewModel.usageLimitPerUser))
                     .renderedIf(viewModel.usageLimitPerUser > 1)
 
                 Text(String.localizedStringWithFormat(Localization.itemsLimitUsage, viewModel.limitUsageToXItems))
+                    .renderedIf(viewModel.limitUsageToXItems > 0)
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
                         viewModel.maximumAmount.isNotEmpty ||

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -225,7 +225,9 @@ private extension CouponDetailsViewModel {
         summary = coupon.summary(currencySettings: currencySettings)
 
         expiryDate = coupon.dateExpires?.toString(dateStyle: .long, timeStyle: .none, timeZone: TimeZone.siteTimezone) ?? ""
+        usageLimit = coupon.usageLimit ?? Constants.noLimit
         usageLimitPerUser = coupon.usageLimitPerUser ?? Constants.noLimit
+        limitUsageToXItems = coupon.limitUsageToXItems ?? Constants.noLimit
         excludeSaleItems = coupon.excludeSaleItems
 
         if let digitMinimumAmount = Double(coupon.minimumAmount), digitMinimumAmount > 0 {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -32,12 +32,15 @@ final class CouponDetailsViewModel: ObservableObject {
     @Published private(set) var amount: String = ""
 
     /// Total number of times this coupon can be used
+    ///
     @Published private(set) var usageLimit: Int64 = Constants.noLimit
 
     /// Number of times this coupon be used per customer
+    ///
     @Published private(set) var usageLimitPerUser: Int64 = Constants.noLimit
 
     /// Maximum number of items which the coupon can be applied to in the cart
+    /// 
     @Published private(set) var limitUsageToXItems: Int64 = Constants.noLimit
 
     /// If `true`, this coupon will not be applied to items that have sale prices

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -31,8 +31,14 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var amount: String = ""
 
+    /// Total number of times this coupon can be used
+    @Published private(set) var usageLimit: Int64 = Constants.noLimit
+
     /// Number of times this coupon be used per customer
     @Published private(set) var usageLimitPerUser: Int64 = Constants.noLimit
+
+    /// Maximum number of items which the coupon can be applied to in the cart
+    @Published private(set) var limitUsageToXItems: Int64 = Constants.noLimit
 
     /// If `true`, this coupon will not be applied to items that have sale prices
     ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -37,7 +37,9 @@ final class CouponDetailsViewModelTests: XCTestCase {
             dateExpires: Date(timeIntervalSince1970: 1642755825), // GMT: January 21, 2022
             individualUse: true,
             productIds: [],
+            usageLimit: 1200,
             usageLimitPerUser: 3,
+            limitUsageToXItems: 10,
             freeShipping: true,
             excludeSaleItems: false,
             minimumAmount: "5.00",
@@ -53,7 +55,9 @@ final class CouponDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.discountType, NSLocalizedString("Percentage Discount", comment: ""))
         XCTAssertFalse(viewModel.excludeSaleItems)
         XCTAssertTrue(viewModel.allowsFreeShipping)
+        XCTAssertEqual(viewModel.usageLimit, 1200)
         XCTAssertEqual(viewModel.usageLimitPerUser, 3)
+        XCTAssertEqual(viewModel.limitUsageToXItems, 10)
         XCTAssertEqual(viewModel.minimumAmount, "$5.00")
         XCTAssertEqual(viewModel.maximumAmount, "")
         XCTAssertEqual(viewModel.emailRestrictions, ["*@a8c.com", "someone.else@example.com"])


### PR DESCRIPTION
Summary
==========
Fix issue #6693 by introducing two missing usage limits fields into the Coupon Details view: Usage limit per coupon and Usage limit by item amount in the cart.

Screenshots
==========
| Limit info in plural  | Limit info in singular |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-11 at 23 07 04](https://user-images.githubusercontent.com/5920403/167977828-4fc224bb-807a-4bd1-b532-bb44ad471d3e.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-11 at 23 06 59](https://user-images.githubusercontent.com/5920403/167977836-3b438d6d-1c9c-4e6d-990b-c49b78def1d3.png) |

| Android Coupon details view  | iOS coupon details view |
| ------------- | ------------- |
| ![Screenshot_20220511_231531](https://user-images.githubusercontent.com/5920403/167978661-8f9f273c-3ca9-4286-bf9a-8cd9ec90c75a.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-11 at 23 07 04](https://user-images.githubusercontent.com/5920403/167977828-4fc224bb-807a-4bd1-b532-bb44ad471d3e.png) |




How to Test
==========
1. Make sure the app has the Coupons experimental features toggle activated
2. Make sure there are at least two coupons configured with the Usage limits configuration, one with the `Usage limit per coupon` and `Limit usage to X Items` fields set to any number higher than 1, the other with both fields set as exactly 1, and a third coupon with none of these fields set.
3. Go to the Coupon list and select these three configured Coupons, the one with the limits set as higher than 1 must display data using plural info, the one with the limits set as 1 must display data using singular info, and the one with no limits set must not display anything related to those fields.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
