### PR TITLE
[Mobile Payments] Replace calls to checkCardReaderConnected

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -204,44 +204,43 @@ private extension CollectOrderPaymentUseCase {
         // `checkCardReaderConnected` action will return a publisher that:
         // - Sends one value if there is no reader connected.
         // - Completes when a reader is connected.
-        let readerConnected = CardPresentPaymentAction.checkCardReaderConnected { [weak self] connectPublisher in
+        let readerConnected = CardPresentPaymentAction.publishCardReaderConnections() { [weak self] connectPublisher in
             guard let self = self else { return }
             self.readerSubscription = connectPublisher
-                .sink(receiveCompletion: { [weak self] _ in
+                .sink(receiveValue: { [weak self] readers in
                     guard let self = self else { return }
 
-                    // Dismiss the current connection alert before notifying the completion.
-                    // If no presented controller is found(because the reader was already connected), just notify the completion.
-                    if let connectionController = self.rootViewController.presentedViewController {
-                        connectionController.dismiss(animated: true) {
+                    if readers.isNotEmpty {
+                        // Dismiss the current connection alert before notifying the completion.
+                        // If no presented controller is found(because the reader was already connected), just notify the completion.
+                        if let connectionController = self.rootViewController.presentedViewController {
+                            connectionController.dismiss(animated: true) {
+                                onCompletion(.success(()))
+                            }
+                        } else {
                             onCompletion(.success(()))
                         }
+
+                        // Nil the subscription since we are done with the connection.
+                        self.readerSubscription = nil
                     } else {
-                        onCompletion(.success(()))
-                    }
-
-                    // Nil the subscription since we are done with the connection.
-                    self.readerSubscription = nil
-
-                }, receiveValue: { [weak self] _ in
-                    guard let self = self else { return }
-
-                    // Attempt reader connection
-                    self.connectionController.searchAndConnect(from: self.rootViewController) { [weak self] result in
-                        guard let self = self else { return }
-                        switch result {
-                        case let .success(connectionResult):
-                            switch connectionResult {
-                            case .canceled:
+                        // Attempt reader connection
+                        self.connectionController.searchAndConnect(from: self.rootViewController) { [weak self] result in
+                            guard let self = self else { return }
+                            switch result {
+                            case let .success(connectionResult):
+                                switch connectionResult {
+                                case .canceled:
+                                    self.readerSubscription = nil
+                                    onCompletion(.failure(CollectOrderPaymentUseCaseError.cardReaderDisconnected))
+                                case .connected:
+                                    // Connected case will be handled in `if readers.isNotEmpty`.
+                                    break
+                                }
+                            case .failure(let error):
                                 self.readerSubscription = nil
-                                onCompletion(.failure(CollectOrderPaymentUseCaseError.cardReaderDisconnected))
-                            case .connected:
-                                // Connected case will be handled in `receiveCompletion`.
-                                break
+                                onCompletion(.failure(error))
                             }
-                        case .failure(let error):
-                            self.readerSubscription = nil
-                            onCompletion(.failure(error))
                         }
                     }
                 })

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -242,7 +242,7 @@ private extension RefundSubmissionUseCase {
             self.readerSubscription = connectPublisher
                 .sink() { [weak self] readers in
                     guard let self = self else { return }
-                    
+
                     if readers.isNotEmpty {
                         // Dismisses the current connection alert before notifying the completion.
                         // If no presented controller is found(because the reader was already connected), just notify the completion.
@@ -253,7 +253,7 @@ private extension RefundSubmissionUseCase {
                         } else {
                             onCompletion(.success(()))
                         }
-                        
+
                         // Nil the subscription since we are done with the connection.
                         self.readerSubscription = nil
                     } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -237,46 +237,47 @@ private extension RefundSubmissionUseCase {
         // `checkCardReaderConnected` action will return a publisher that:
         // - Sends one value if there is no reader connected.
         // - Completes when a reader is connected.
-        let readerConnected = CardPresentPaymentAction.checkCardReaderConnected { [weak self] connectPublisher in
+        let readerConnected = CardPresentPaymentAction.publishCardReaderConnections { [weak self] connectPublisher in
             guard let self = self else { return }
             self.readerSubscription = connectPublisher
-                .sink(receiveCompletion: { [weak self] _ in
-                    // Dismisses the current connection alert before notifying the completion.
-                    // If no presented controller is found(because the reader was already connected), just notify the completion.
-                    if let connectionController = self?.rootViewController.presentedViewController {
-                        connectionController.dismiss(animated: true) {
+                .sink() { [weak self] readers in
+                    guard let self = self else { return }
+                    
+                    if readers.isNotEmpty {
+                        // Dismisses the current connection alert before notifying the completion.
+                        // If no presented controller is found(because the reader was already connected), just notify the completion.
+                        if let connectionController = self.rootViewController.presentedViewController {
+                            connectionController.dismiss(animated: true) {
+                                onCompletion(.success(()))
+                            }
+                        } else {
                             onCompletion(.success(()))
                         }
+                        
+                        // Nil the subscription since we are done with the connection.
+                        self.readerSubscription = nil
                     } else {
-                        onCompletion(.success(()))
-                    }
-
-                    // Nil the subscription since we are done with the connection.
-                    self?.readerSubscription = nil
-
-                }, receiveValue: { [weak self] _ in
-                    guard let self = self else { return }
-
-                    // Attempts reader connection
-                    self.cardReaderConnectionController.searchAndConnect(from: self.rootViewController) { [weak self] result in
-                        guard let self = self else { return }
-                        switch result {
-                        case let .success(connectionResult):
-                            switch connectionResult {
-                            case .canceled:
+                        // Attempts reader connection
+                        self.cardReaderConnectionController.searchAndConnect(from: self.rootViewController) { [weak self] result in
+                            guard let self = self else { return }
+                            switch result {
+                            case let .success(connectionResult):
+                                switch connectionResult {
+                                case .canceled:
+                                    self.readerSubscription = nil
+                                    self.trackClientSideRefundCanceled(charge: charge, paymentGatewayAccount: paymentGatewayAccount)
+                                    onCompletion(.failure(RefundSubmissionError.cardReaderDisconnected))
+                                case .connected:
+                                    // Connected case will be handled in `if readers.isNotEmpty`.
+                                    break
+                                }
+                            case .failure(let error):
                                 self.readerSubscription = nil
-                                self.trackClientSideRefundCanceled(charge: charge, paymentGatewayAccount: paymentGatewayAccount)
-                                onCompletion(.failure(RefundSubmissionError.cardReaderDisconnected))
-                            case .connected:
-                                // Connected case will be handled in `receiveCompletion`.
-                                break
+                                onCompletion(.failure(error))
                             }
-                        case .failure(let error):
-                            self.readerSubscription = nil
-                            onCompletion(.failure(error))
                         }
                     }
-                })
+                }
         }
         stores.dispatch(readerConnected)
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -275,7 +275,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 private extension CollectOrderPaymentUseCaseTests {
     func mockCardPresentPaymentActions() {
         stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-            if case let .checkCardReaderConnected(completion) = action {
+            if case let .publishCardReaderConnections(completion) = action {
                 completion(Just<[CardReader]>([MockCardReader.wisePad3()]).eraseToAnyPublisher())
             } else if case let .observeConnectedReaders(completion) = action {
                 completion([MockCardReader.wisePad3()])
@@ -287,7 +287,7 @@ private extension CollectOrderPaymentUseCaseTests {
 
     func mockSuccessfulCardPresentPaymentActions(intent: PaymentIntent) {
         stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-            if case let .checkCardReaderConnected(completion) = action {
+            if case let .publishCardReaderConnections(completion) = action {
                 completion(Just<[CardReader]>([MockCardReader.wisePad3()]).eraseToAnyPublisher())
             } else if case let .observeConnectedReaders(completion) = action {
                 completion([MockCardReader.wisePad3()])

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -457,7 +457,7 @@ private extension RefundSubmissionUseCaseTests {
                                        returnCardReaderMessage: CardReaderEvent? = nil,
                                        cancelCardReaderDiscoveryResult: Result<Void, Error> = .success(())) {
         stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-            if case let .checkCardReaderConnected(completion) = action {
+            if case let .publishCardReaderConnections(completion) = action {
                 if connectedCardReaders.isEmpty {
                     // If there are no connected readers, we don't want the publisher to finish which is considered a reader is connected.
                     let subject = CurrentValueSubject<[CardReader], Never>([])

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -73,9 +73,6 @@ public enum CardPresentPaymentAction: Action {
     /// 3. Reset all status indicators
     case reset
 
-    /// Checks if a reader is connected
-    case checkCardReaderConnected(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void)
-
     /// Provides a publisher for card reader connections
     case publishCardReaderConnections(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void)
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -95,8 +95,6 @@ public final class CardPresentPaymentStore: Store {
             startCardReaderUpdate()
         case .reset:
             reset()
-        case .checkCardReaderConnected(onCompletion: let completion):
-            checkCardReaderConnected(onCompletion: completion)
         case .publishCardReaderConnections(onCompletion: let completion):
             publishCardReaderConnections(onCompletion: completion)
         case .fetchWCPayCharge(let siteID, let chargeID, let completion):
@@ -317,23 +315,6 @@ private extension CardPresentPaymentStore {
                         },
                         receiveValue: { _ in }
             ))
-    }
-
-    // TODO: Replace `checkCardReaderConnected` with `publishCardReaderConnections`, which emits an event for a connected reader.
-    // See https://github.com/woocommerce/woocommerce-ios/issues/6766
-    func checkCardReaderConnected(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void) {
-        let publisher = cardReaderService.connectedReaders
-            // We only emit values when there is no reader connected, including an initial value
-            .prefix(while: { cardReaders in
-                cardReaders.count == 0
-            })
-            // Remove duplicates since we don't want to present the connection modal twice
-            .removeDuplicates()
-            // Beyond this point, the publisher should emit an empty initial value once
-            // and then finish when a reader is connected.
-            .eraseToAnyPublisher()
-
-        onCompletion(publisher)
     }
 
     func publishCardReaderConnections(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6766
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #6770, we introduced a new action `CardPresentPaymentAction.publishCardReaderConnections`, which is very similar to the existing `checkCardReaderConnected`, used on Order Details and the Refund flow to find out whether there's a reader connected when attempting to take a payment. 

- #6770 

`publishCardReaderConnections` is a more flexible option, as it does not rely on a `sink(recieveCompletion:)` subscription, instead the values are published for connection and no readers connected.

These two actions are so similar, that it doesn’t make sense to keep both implementations around. This commit refactors existing calls to `checkCardReaderConnected` to use `publishCardReaderConnections` instead.

The lack of a completion having moved away from the `prefix()` operator does not impact the way this works, since we nil our subscription when we would have previously received completion anyway.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run through the payment and connect reader flows in the various places they can be triggered:

Collecting a payment from a Simple Payment
Collecting a payment from Order Details
Refunding an Interac-presen payment on a CA store
Connecting a reader from Settings

Try each with no reader connected, and with a reader already connected.

There should be no change in behaviour here.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
