### PR TITLE
Edit Coupon: remove expiration date remotely passing an empty string

### DIFF
--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -175,7 +175,6 @@ public struct Coupon {
         try container.encode(amount, forKey: .amount)
         try container.encode(discountType, forKey: .discountType)
         try container.encode(description, forKey: .description)
-        try container.encode(dateExpires, forKey: .dateExpires)
         try container.encode(productIds, forKey: .productIds)
         try container.encode(excludedProductIds, forKey: .excludedProductIds)
         try container.encode(usageLimit, forKey: .usageLimit)
@@ -187,6 +186,17 @@ public struct Coupon {
         try container.encode(minimumAmount, forKey: .minimumAmount)
         try container.encode(maximumAmount, forKey: .maximumAmount)
         try container.encode(emailRestrictions, forKey: .emailRestrictions)
+
+        /// Encoding `dateExpires` has some special conditions.
+        /// - Encode the content to update the value.
+        /// - Encode an empty string to clear the value (nil is not allowed, and the value will be not updated).
+        ///
+        switch dateExpires {
+        case .some(let content):
+            try container.encode(content, forKey: .dateExpires)
+        case .none:
+            try container.encode("", forKey: .dateExpires)
+        }
     }
 
     /// JSON decoder appropriate for `Coupon` responses.

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -45,7 +45,6 @@ struct AddEditCoupon: View {
 
     init(_ viewModel: AddEditCouponViewModel) {
         self.viewModel = viewModel
-        //TODO: add analytics
     }
 
     var body: some View {


### PR DESCRIPTION
Fixes #6841 

### Description
Fixed the update of the expiration date on coupon. It was happening that when we was deleting the expiry date of coupon, it wasn't update correctly remotely. The reason is on the backend side, because also if `date_expires` is an optional field, the only way to reset the date expires is to pass an empty string. `null` values are not allowed.
cc @joshbetz @coreymckrill this could be interesting for you 🙇 

**Note**: before merging this PR, the PR https://github.com/woocommerce/woocommerce-ios/pull/6843 should be approved and merged.

### Testing instructions
1. Turn on Coupon Management experimental feature
2. Select a coupon
3. Edit Coupon > Coupon Expiry Date > Delete expiration date
4. Save the changes - Looks like save is successful, no error displayed
5. Go back to Coupon detail/list and see that Coupon has no more an expire date.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
