### PR TITLE
Coupons: Fix issue clearing all items on the category selector screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -166,6 +166,7 @@ final class ProductCategoryListViewModel {
     /// Resets the selected categories and triggers UI reload
     ///
     func resetSelectedCategoriesAndReload() {
+        initiallySelectedIDs = []
         resetSelectedCategories()
         updateViewModelsArray()
         reloadData()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -169,6 +169,20 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         }
         XCTAssertEqual(viewModel.categoryViewModels.count, 1)
     }
+
+    func test_resetSelectedCategoriesAndReload_clears_all_selection() {
+        // Given
+        let siteID: Int64 = 132
+        let category = Yosemite.ProductCategory(categoryID: 33, siteID: siteID, parentID: 1, name: "Test", slug: "test")
+        insert(category)
+
+        // When
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, selectedCategoryIDs: [category.categoryID], storageManager: storageManager)
+        viewModel.resetSelectedCategories()
+
+        // Then
+        XCTAssertEqual(viewModel.selectedCategories.count, 0)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6838 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the Clear Selection button on the category selector screen by making sure that the initial selected items are cleared as well

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Edit Coupon screen of a coupon that is applicable to only a few categories.
- Select the edit categories button and tap Clear Selection. 
- Notice that all the select items in the list are cleared.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/168108967-3e2f9888-08bd-4266-b10b-9e52ea9c2cd8.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
