### PR TITLE
Coupons: Fix issues listing search results on category selector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -92,7 +92,7 @@ final class ProductCategoryListViewModel {
     @Published private(set) var syncCategoriesState: SyncingState = .initialized
 
     private lazy var resultController: ResultsController<StorageProductCategory> = {
-        let predicate = NSPredicate(format: "siteID = %ld", self.siteID)
+        let predicate = NSPredicate(format: "siteID = %lld", self.siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageProductCategory.name, ascending: true)
         return ResultsController<StorageProductCategory>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
@@ -236,14 +236,14 @@ final class ProductCategoryListViewModel {
                 guard let self = self else { return }
 
                 if newQuery.isNotEmpty {
-                    let searchPredicate = NSPredicate(format: "siteID = %ld AND ((name CONTAINS[cd] %@) OR (slug CONTAINS[cd] %@))",
+                    let searchPredicate = NSPredicate(format: "siteID = %lld AND ((name CONTAINS[cd] %@) OR (slug CONTAINS[cd] %@))",
                                                       self.siteID,
-                                                      newQuery,
-                                                      newQuery)
+                                                      newQuery.trimmingCharacters(in: .whitespacesAndNewlines),
+                                                      newQuery.trimmingCharacters(in: .whitespacesAndNewlines))
                     self.resultController.predicate = searchPredicate
                 } else {
                     // Resets the results to the full product list when there is no search query.
-                    self.resultController.predicate = NSPredicate(format: "siteID = %ld", self.siteID)
+                    self.resultController.predicate = NSPredicate(format: "siteID = %lld", self.siteID)
                 }
                 try? self.resultController.performFetch()
                 self.updateViewModelsArray()

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -203,7 +203,12 @@ final class ProductCategoryListViewModel {
     func updateViewModelsArray() {
         let fetchedCategories = resultController.fetchedObjects
         updateInitialItemsIfNeeded(with: fetchedCategories)
-        let baseViewModels = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: fetchedCategories, selectedCategories: selectedCategories)
+        let baseViewModels: [ProductCategoryCellViewModel]
+        if searchQuery.isNotEmpty {
+            baseViewModels = ProductCategoryListViewModel.CellViewModelBuilder.flatViewModels(from: fetchedCategories, selectedCategories: selectedCategories)
+        } else {
+            baseViewModels = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: fetchedCategories, selectedCategories: selectedCategories)
+        }
 
         categoryViewModels = enrichingDataSource?.enrichCategoryViewModels(baseViewModels) ?? baseViewModels
     }
@@ -230,7 +235,7 @@ final class ProductCategoryListViewModel {
                 guard let self = self else { return }
 
                 if newQuery.isNotEmpty {
-                    let searchPredicate = NSPredicate(format: "siteID = %ld AND (name CONTAINS[cd] %@) OR (slug CONTAINS[cd] %@)",
+                    let searchPredicate = NSPredicate(format: "siteID = %ld AND ((name CONTAINS[cd] %@) OR (slug CONTAINS[cd] %@))",
                                                       self.siteID,
                                                       newQuery,
                                                       newQuery)

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
@@ -47,7 +47,7 @@ extension ProductCategoryListViewModel {
         /// Provide an array of `selectedCategories` to properly reflect the selected state in the returned view model array.
         ///
         static func flatViewModels(from categories: [ProductCategory], selectedCategories: [ProductCategory]) -> [ProductCategoryCellViewModel] {
-            return categories.map { category in
+            categories.map { category in
                 viewModel(for: category, selectedCategories: selectedCategories, indentationLevel: 0)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
@@ -43,6 +43,15 @@ extension ProductCategoryListViewModel {
             }
         }
 
+        /// Returns a simple array of `ProductCategoryCellViewModel` from the provided `categories` disregarding the parent-child relationships.
+        /// Provide an array of `selectedCategories` to properly reflect the selected state in the returned view model array.
+        ///
+        static func flatViewModels(from categories: [ProductCategory], selectedCategories: [ProductCategory]) -> [ProductCategoryCellViewModel] {
+            return categories.map { category in
+                viewModel(for: category, selectedCategories: selectedCategories, indentationLevel: 0)
+            }
+        }
+
         /// Returns an array of `ProductCategoryCellViewModel` by sorting the provided `categories` following a `Category -> SubCategory` order.
         /// Provide an array of `selectedCategories` to properly reflect the selected state in the returned view model array.
         ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -163,7 +163,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         waitFor { promise in
             // wait for 500 milliseconds due to debouncing
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.searchDebounceTime) {
                 promise(())
             }
         }
@@ -201,7 +201,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         waitFor { promise in
             // wait for 500 milliseconds due to debouncing
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.searchDebounceTime) {
                 promise(())
             }
         }
@@ -225,7 +225,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         waitFor { promise in
             // wait for 500 milliseconds due to debouncing
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.searchDebounceTime) {
                 promise(())
             }
         }
@@ -254,5 +254,9 @@ private extension ProductCategoryListViewModelTests {
     func insert(_ readOnlyProductCategory: Yosemite.ProductCategory) {
         let category = storage.insertNewObject(ofType: StorageProductCategory.self)
         category.update(with: readOnlyProductCategory)
+    }
+
+    enum Constants {
+        static let searchDebounceTime: Double = 0.5
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -16,6 +16,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         storageManager.viewStorage
     }
     private var subscription: AnyCancellable?
+    private static let searchDebounceTime: Double = 0.5
 
     override func setUp() {
         super.setUp()
@@ -163,7 +164,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         waitFor { promise in
             // wait for 500 milliseconds due to debouncing
-            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.searchDebounceTime) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.searchDebounceTime) {
                 promise(())
             }
         }
@@ -201,7 +202,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         waitFor { promise in
             // wait for 500 milliseconds due to debouncing
-            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.searchDebounceTime) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.searchDebounceTime) {
                 promise(())
             }
         }
@@ -225,7 +226,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         waitFor { promise in
             // wait for 500 milliseconds due to debouncing
-            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.searchDebounceTime) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.searchDebounceTime) {
                 promise(())
             }
         }
@@ -254,9 +255,5 @@ private extension ProductCategoryListViewModelTests {
     func insert(_ readOnlyProductCategory: Yosemite.ProductCategory) {
         let category = storage.insertNewObject(ofType: StorageProductCategory.self)
         category.update(with: readOnlyProductCategory)
-    }
-
-    enum Constants {
-        static let searchDebounceTime: Double = 0.5
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -183,6 +183,70 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.selectedCategories.count, 0)
     }
+
+    func test_searching_returns_subcategories() {
+        // Given
+        let siteID: Int64 = 132
+        let category1 = Yosemite.ProductCategory(categoryID: 33, siteID: siteID, parentID: 0, name: "Food", slug: "food")
+        insert(category1)
+        let category2 = Yosemite.ProductCategory(categoryID: 12, siteID: siteID, parentID: 33, name: "Oriental", slug: "oriental")
+        insert(category2)
+
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, storageManager: storageManager)
+        XCTAssertEqual(viewModel.categoryViewModels.count, 2) // confidence check
+
+        // When
+        viewModel.searchQuery = "orien"
+
+        // Then
+        waitFor { promise in
+            // wait for 500 milliseconds due to debouncing
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                promise(())
+            }
+        }
+        XCTAssertEqual(viewModel.categoryViewModels.count, 1)
+    }
+
+    func test_searchQuery_with_space_returns_results_without_space() {
+        // Given
+        let siteID: Int64 = 132
+        let category1 = Yosemite.ProductCategory(categoryID: 33, siteID: siteID, parentID: 0, name: "Western", slug: "western")
+        insert(category1)
+        let category2 = Yosemite.ProductCategory(categoryID: 12, siteID: siteID, parentID: 0, name: "Oriental", slug: "oriental")
+        insert(category2)
+
+        let viewModel = ProductCategoryListViewModel(siteID: siteID, storageManager: storageManager)
+        XCTAssertEqual(viewModel.categoryViewModels.count, 2) // confidence check
+
+        // When
+        viewModel.searchQuery = " western "
+
+        // Then
+        waitFor { promise in
+            // wait for 500 milliseconds due to debouncing
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                promise(())
+            }
+        }
+        XCTAssertEqual(viewModel.categoryViewModels.count, 1)
+    }
+
+    func test_category_list_displays_only_categories_of_current_site() {
+        // Given
+        let siteID1: Int64 = 132
+        let siteID2: Int64 = 98
+        let category1 = Yosemite.ProductCategory(categoryID: 33, siteID: siteID1, parentID: 0, name: "Western", slug: "western")
+        insert(category1)
+        let category2 = Yosemite.ProductCategory(categoryID: 12, siteID: siteID2, parentID: 0, name: "Oriental", slug: "oriental")
+        insert(category2)
+
+        // When
+        let viewModel = ProductCategoryListViewModel(siteID: siteID1, selectedCategoryIDs: [], storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.categoryViewModels.count, 1)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6840 
Also closes: #6839 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Due to the small size of changes, this PR fixes a few issues of the search functionality on the product category selector screen:
- Fix the issue displaying subcategories on search results. We were ignoring the subcategories without parents on the list, I added another helper method to display all results disregarding the parent-child relationships. This is used only when displaying search results.
- Fix the incorrect predicate for searching categories. Previously there were missing brackets which made the filter for `siteID` being ignored. This was fixed with extra brackets around the check for matching search queries.
- Fix the issue searching with queries that have space around them. This was fixed by trimming space on both ends of the queries.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to the edit screen of any coupon and select the edit categories button.
- Enter a keyword in the search bar that matches at least one subcategory. Notice that the result shows the correct item(s).
- Add space before or after the query, and notice that the result is still correct.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/168208248-df7db941-672b-497a-b63a-816a32a2a708.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
