### PR TITLE
Enable feature flags for coupon deletion and editing

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -28,9 +28,9 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .splitViewInOrdersTab:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .couponDeletion:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .couponEditing:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 9.2
 -----
+- [***] Experimental Features: Coupons editing and deletion features are now enabled as part of coupon management. [https://github.com/woocommerce/woocommerce-ios/pull/6853]
 - [*] Order Creation: Updated percentage fee flow - added amount preview, disabled percentage option when editing. [https://github.com/woocommerce/woocommerce-ios/pull/6763]
 - [*] Product Details: Update status badge layout and show it for more cases. [https://github.com/woocommerce/woocommerce-ios/pull/6768]
 - [*] Coupons: now, the percentage amount of coupons will be displayed correctly in the listing and in coupon detail if the amount contains fraction digits. [https://github.com/woocommerce/woocommerce-ios/pull/6804]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables feature flags to make coupon deletion and editing accessible to merchants.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- On Production builds, make sure to enable Coupon Management in Settings > Experimental Features.
- Make sure that your store has coupons enabled in WPAdmin > WooCommerce > Settings > Enable Coupons. The store should have at least one coupon set up too.
- Navigate to Menu > Coupons > select any coupon on the list. Select the ellipsis button at the top right - notice that there are 2 new options: Edit Coupon and Delete Coupon. Please note that Edit Coupon is only enabled if your coupon's discount type is either percentage, fixed-cart, or fixed-product.
- The deletion and editing features should work properly.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/168235093-e899d3dd-02b7-49d5-b432-8ddc28953652.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
