### PR TITLE
Coupons: Fix issue discarding changes on the edit coupon screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -5,8 +5,8 @@ import Yosemite
 ///
 final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 
-    init(viewModel: CouponDetailsViewModel, onUpdate: @escaping () -> Void, onDeletion: @escaping () -> Void) {
-        super.init(rootView: CouponDetails(viewModel: viewModel, onUpdate: onUpdate, onDeletion: onDeletion))
+    init(viewModel: CouponDetailsViewModel) {
+        super.init(rootView: CouponDetails(viewModel: viewModel))
         // The navigation title is set here instead of the SwiftUI view's `navigationTitle`
         // to avoid the blinking of the title label when pushed from UIKit view.
         title = viewModel.couponCode
@@ -21,14 +21,8 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
 }
 
 struct CouponDetails: View {
-    // Closure to be triggered when the coupon is updated successfully
-    private let onUpdate: () -> Void
-
-    // Closure to be triggered when the coupon is deleted successfully
-    private let onDeletion: () -> Void
 
     @ObservedObject private var viewModel: CouponDetailsViewModel
-    @ObservedObject private var addEditCouponViewModel: AddEditCouponViewModel
     @State private var showingActionSheet: Bool = false
     @State private var showingShareSheet: Bool = false
     @State private var showingAmountLoadingErrorPrompt: Bool = false
@@ -42,24 +36,11 @@ struct CouponDetails: View {
     /// It is kept internal so that the hosting controller can update its presenting controller to itself.
     let noticePresenter: DefaultNoticePresenter
 
-    init(viewModel: CouponDetailsViewModel, onUpdate: @escaping () -> Void, onDeletion: @escaping () -> Void) {
+    init(viewModel: CouponDetailsViewModel) {
         self.viewModel = viewModel
-        self.onDeletion = onDeletion
-        self.onUpdate = onUpdate
         self.noticePresenter = DefaultNoticePresenter()
         viewModel.syncCoupon()
         viewModel.loadCouponReport()
-
-        addEditCouponViewModel = AddEditCouponViewModel(existingCoupon: viewModel.coupon, onCompletion: { result in
-            switch result {
-            case .success(let updatedCoupon):
-                viewModel.updateCoupon(updatedCoupon)
-                viewModel.showingEditCoupon = false
-                onUpdate()
-            default:
-                break
-            }
-        })
 
         ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "loaded"])
     }
@@ -203,7 +184,7 @@ struct CouponDetails: View {
                 })
             }
             .sheet(isPresented: $viewModel.showingEditCoupon) {
-                AddEditCoupon(addEditCouponViewModel)
+                AddEditCoupon(viewModel.addEditCouponViewModel)
             }
             .alert(isPresented: $showingDeletionConfirmAlert, content: {
                 Alert(title: Text(Localization.deleteCoupon),
@@ -339,7 +320,7 @@ struct CouponDetails: View {
     }
 
     private func handleCouponDeletion() {
-        viewModel.deleteCoupon(onSuccess: onDeletion, onFailure: {
+        viewModel.deleteCoupon(onSuccess: viewModel.onDeletion, onFailure: {
             let notice = Notice(title: Localization.errorDeletingCoupon, feedbackType: .error)
             noticePresenter.enqueue(notice: notice)
         })
@@ -466,7 +447,7 @@ private extension CouponDetails {
 #if DEBUG
 struct CouponDetails_Previews: PreviewProvider {
     static var previews: some View {
-        CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon), onUpdate: {}, onDeletion: {})
+        CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon))
     }
 }
 #endif

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -207,6 +207,7 @@ struct CouponDetails: View {
                 }
             }
         }
+        .navigationTitle(viewModel.coupon.code)
         .wooNavigationBarStyle()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -185,6 +185,9 @@ struct CouponDetails: View {
             }
             .sheet(isPresented: $viewModel.showingEditCoupon) {
                 AddEditCoupon(viewModel.addEditCouponViewModel)
+                    .onDisappear {
+                        viewModel.resetAddEditViewModel()
+                    }
             }
             .alert(isPresented: $showingDeletionConfirmAlert, content: {
                 Alert(title: Text(Localization.deleteCoupon),

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -118,7 +118,6 @@ final class CouponDetailsViewModel: ObservableObject {
     @Published private(set) var coupon: Coupon {
         didSet {
             populateDetails()
-            addEditCouponViewModel = createAddEditCouponViewModel(with: coupon)
         }
     }
 
@@ -223,6 +222,10 @@ final class CouponDetailsViewModel: ObservableObject {
             }
         }
         stores.dispatch(action)
+    }
+
+    func resetAddEditViewModel() {
+        addEditCouponViewModel = createAddEditCouponViewModel(with: coupon)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -91,19 +91,7 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published var showingEditCoupon: Bool = false
 
-    var addEditCouponViewModel: AddEditCouponViewModel {
-        .init(existingCoupon: coupon, onCompletion: { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let updatedCoupon):
-                self.updateCoupon(updatedCoupon)
-                self.showingEditCoupon = false
-                self.onUpdate()
-            default:
-                break
-            }
-        })
-    }
+    private(set) lazy var addEditCouponViewModel: AddEditCouponViewModel = createAddEditCouponViewModel(with: coupon)
 
     /// The message to be shared about the coupon
     ///
@@ -130,6 +118,7 @@ final class CouponDetailsViewModel: ObservableObject {
     @Published private(set) var coupon: Coupon {
         didSet {
             populateDetails()
+            addEditCouponViewModel = createAddEditCouponViewModel(with: coupon)
         }
     }
 
@@ -285,6 +274,20 @@ private extension CouponDetailsViewModel {
     func retrieveAnalyticsSetting(completion: @escaping (Result<Bool, Error>) -> Void) {
         let action = SettingAction.retrieveAnalyticsSetting(siteID: coupon.siteID, onCompletion: completion)
         stores.dispatch(action)
+    }
+
+    func createAddEditCouponViewModel(with coupon: Coupon) -> AddEditCouponViewModel {
+        .init(existingCoupon: coupon, onCompletion: { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let updatedCoupon):
+                self.updateCoupon(updatedCoupon)
+                self.showingEditCoupon = false
+                self.onUpdate()
+            default:
+                break
+            }
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -91,6 +91,20 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published var showingEditCoupon: Bool = false
 
+    var addEditCouponViewModel: AddEditCouponViewModel {
+        .init(existingCoupon: coupon, onCompletion: { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let updatedCoupon):
+                self.updateCoupon(updatedCoupon)
+                self.showingEditCoupon = false
+                self.onUpdate()
+            default:
+                break
+            }
+        })
+    }
+
     /// The message to be shared about the coupon
     ///
     var shareMessage: String {
@@ -129,14 +143,25 @@ final class CouponDetailsViewModel: ObservableObject {
     let isEditingEnabled: Bool
     let isDeletingEnabled: Bool
 
+    // Closure to be triggered when the coupon is updated successfully
+    let onUpdate: () -> Void
+
+    // Closure to be triggered when the coupon is deleted successfully
+    let onDeletion: () -> Void
+
     init(coupon: Coupon,
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         featureFlags: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlags: FeatureFlagService = ServiceLocator.featureFlagService,
+         onUpdate: @escaping () -> Void = {},
+         onDeletion: @escaping () -> Void = {}) {
         self.siteID = coupon.siteID
         self.coupon = coupon
         self.stores = stores
         self.currencySettings = currencySettings
+        self.onDeletion = onDeletion
+        self.onUpdate = onUpdate
+
         isEditingEnabled = featureFlags.isFeatureFlagEnabled(.couponEditing) && coupon.discountType != .other
         isDeletingEnabled = featureFlags.isFeatureFlagEnabled(.couponDeletion)
         populateDetails()

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -193,16 +193,16 @@ extension CouponListViewController: UITableViewDelegate {
         guard let coupon = viewModel.coupon(at: indexPath) else {
             return
         }
-        let detailsViewModel = CouponDetailsViewModel(coupon: coupon)
-        let hostingController = CouponDetailsHostingController(viewModel: detailsViewModel) { [weak self] in
+        let detailsViewModel = CouponDetailsViewModel(coupon: coupon, onUpdate: { [weak self] in
             guard let self = self else { return }
             self.viewModel.refreshCoupons()
-        } onDeletion: { [weak self] in
+        }, onDeletion: { [weak self] in
             guard let self = self else { return }
             self.navigationController?.popViewController(animated: true)
             let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
             self.noticePresenter.enqueue(notice: notice)
-        }
+        })
+        let hostingController = CouponDetailsHostingController(viewModel: detailsViewModel)
         navigationController?.pushViewController(hostingController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -54,16 +54,16 @@ final class CouponSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-        let detailsViewModel = CouponDetailsViewModel(coupon: model)
-        let couponDetails = CouponDetails(viewModel: detailsViewModel) { [weak self] in
+        let detailsViewModel = CouponDetailsViewModel(coupon: model, onUpdate: { [weak self] in
             try? self?.createResultsController().performFetch()
-        } onDeletion: {
+        }, onDeletion: {
             viewController.navigationController?.popViewController(animated: true)
             let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
             let noticePresenter = DefaultNoticePresenter()
             noticePresenter.presentingViewController = viewController
             noticePresenter.enqueue(notice: notice)
-        }
+        })
+        let couponDetails = CouponDetails(viewModel: detailsViewModel)
         let hostingController = UIHostingController(rootView: couponDetails)
         viewController.navigationController?.pushViewController(hostingController, animated: true)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6844
Also closes: #6835 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, we're keeping the view model for the edit coupon view within the coupon details view, which persists the edit coupon view's states along with the details view.

This PR enables discarding changes on the edit screen by keeping the view model within the coupon details view model. This allows resetting the view model when the view is dismissed.

This PR also fixes #6835 by setting the navigation title on the coupon details view - I include it here since it's just a one-line change 😅 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu > Coupons > select a coupon.
- Select the ellipsis button at the top right and choose Edit Coupon.
- Change any details on the form and dismiss the view. 
- Repeat step 2, notice that no previous changes are persisted on the view.
- Edit the code of the coupon and tap Save. Notice that the title of the coupon details screen is updated correctly.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![record](https://user-images.githubusercontent.com/5533851/168261553-c1990361-cdde-40c9-bbff-12dadef8f622.gif)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
