### PR TITLE
[Mobile Payments] Simple Payment gets dismissed if reader connection is canceled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -5,8 +5,7 @@ import MessageUI
 import protocol Storage.StorageManagerType
 
 enum CollectOrderPaymentUseCaseError: Error {
-    case cardReaderDisconnected
-    case cancelled
+    case flowCanceledByUser
 }
 
 /// Protocol to abstract the `CollectOrderPaymentUseCase`.
@@ -237,7 +236,7 @@ private extension CollectOrderPaymentUseCase {
                                 switch connectionResult {
                                 case .canceled:
                                     self.readerSubscription = nil
-                                    onCompletion(.failure(CollectOrderPaymentUseCaseError.cardReaderDisconnected))
+                                    onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                                 case .connected:
                                     // Connected case will be handled in `if readers.isNotEmpty`.
                                     break
@@ -272,7 +271,7 @@ private extension CollectOrderPaymentUseCase {
                              amount: formattedAmount,
                              onCancel: { [weak self] in
             self?.cancelPayment {
-                onCompletion(.failure(CollectOrderPaymentUseCaseError.cancelled))
+                onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
             }
         })
 
@@ -287,7 +286,7 @@ private extension CollectOrderPaymentUseCase {
                    // Request card input
                    self?.alerts.tapOrInsertCard(onCancel: { [weak self] in
                        self?.cancelPayment {
-                           onCompletion(.failure(CollectOrderPaymentUseCaseError.cancelled))
+                           onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                        }
                    })
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -150,8 +150,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                     }
                     self?.presentReceiptAlert(receiptParameters: paymentData.receiptParameters, backButtonTitle: backButtonTitle, onCompleted: onCompleted)
                 })
-            case .failure:
-                onCompleted()
+            case .failure(let error):
+                onCollect(.failure(error))
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -4,6 +4,11 @@ import Yosemite
 import MessageUI
 import protocol Storage.StorageManagerType
 
+enum CollectOrderPaymentUseCaseError: Error {
+    case cardReaderDisconnected
+    case cancelled
+}
+
 /// Protocol to abstract the `CollectOrderPaymentUseCase`.
 /// Currently only used to facilitate unit tests.
 ///
@@ -487,10 +492,7 @@ private extension CollectOrderPaymentUseCase {
     /// Mailing a receipt failed but the SDK didn't return a more specific error
     ///
     struct UnknownEmailError: Error {}
-    enum CollectOrderPaymentUseCaseError: Error {
-        case cardReaderDisconnected
-        case cancelled
-    }
+
 
     enum Localization {
         private static let emailSubjectWithStoreName = NSLocalizedString("Your receipt from %1$@",

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -211,9 +211,12 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                 self.collectPaymentsUseCase?.collectPayment(
                     backButtonTitle: Localization.continueToOrders,
                     onCollect: { [weak self] result in
-                        if result.isFailure {
-                            self?.trackFlowFailed()
-                        }
+                        guard case let .failure(error) = result else { return }
+
+                        let collectOrderPaymentUseCaseError = error as? CollectOrderPaymentUseCaseError
+                        guard collectOrderPaymentUseCaseError != CollectOrderPaymentUseCaseError.cardReaderDisconnected else { return }
+
+                        self?.trackFlowFailed()
                     },
                     onCompleted: { [weak self] in
                         // Inform success to consumer

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -214,7 +214,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                         guard case let .failure(error) = result else { return }
 
                         let collectOrderPaymentUseCaseError = error as? CollectOrderPaymentUseCaseError
-                        guard collectOrderPaymentUseCaseError != CollectOrderPaymentUseCaseError.cardReaderDisconnected else { return }
+                        guard collectOrderPaymentUseCaseError != CollectOrderPaymentUseCaseError.flowCanceledByUser else { return }
 
                         self?.trackFlowFailed()
                     },


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6856
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When canceling the connection to a card reader on the Simple Payments flow we used to dismiss the flow and advertise the payment as successful, what does not correlate with what really happened.
The reason behind was that we were calling `onCompleted ` on the `CollectOrderPaymentUseCase` when the connection to a reader failed. According to the docs `onCompleted ` means that:

> - Parameter onCompleted: Closure Invoked after the flow has been totally completed, Currently after merchant has handled the receipt.

which again does not align to the scenario here. Since `SimplePaymentsMethodsViewModel` reacts to the completion callback as specified, it was treating it as if the flow ended successfully.
A more appropriate approach consists on calling `onCollect(.failure(error))`, passing the error from the reader, ~~so it can be tracked~~ (Edit: We do not track canceling the reader connection as an error here). This way the flow is not dismissed, no notice of success is displayed, and the user can retry the reader connection at their request.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Before
Go to Orders, tap +, create a simple payment
Enter an amount and continue
Tap Collect Payment and select Card
When the modal to search readers appears, tap cancel
The simple payments flow is dismissed and the app announces that the order is complete

#### After
Go to Orders, tap +, create a simple payment
Enter an amount and continue
Tap Collect Payment and select Card
When the modal to search readers appears, tap cancel
The simple payments flow is **not** dismissed and the app **does not** announce that the order is complete

---
Check as well that the Order collect payment CTA works as expected when canceling the connection to a reader.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### Before
https://user-images.githubusercontent.com/8739/168243344-37c0bcb3-2cca-415b-819d-da4c81d91a5d.mp4

#### After

https://user-images.githubusercontent.com/1864060/168286269-9db8203a-12c8-4a54-a058-1118b9a11e77.mp4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
