### PR TITLE
Fix unnecessary stats API requests after switching stores

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -279,7 +279,7 @@ private extension DashboardViewController {
 
     func updateUI(site: Site) {
         let siteName = site.name
-        guard siteName.isEmpty == false else {
+        guard siteName.isNotEmpty else {
             shouldShowStoreNameAsSubtitle = false
             storeNameLabel.text = nil
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -277,8 +277,9 @@ private extension DashboardViewController {
         spacerView.isHidden = true
     }
 
-    func updateUI(site: Site?) {
-        guard let siteName = site?.name, siteName.isEmpty == false else {
+    func updateUI(site: Site) {
+        let siteName = site.name
+        guard siteName.isEmpty == false else {
             shouldShowStoreNameAsSubtitle = false
             storeNameLabel.text = nil
             return
@@ -417,6 +418,11 @@ private extension DashboardViewController {
     func observeSiteForUIUpdates() {
         ServiceLocator.stores.site.sink { [weak self] site in
             guard let self = self else { return }
+            // We always want to update UI based on the latest site only if it matches the view controller's site ID.
+            // When switching stores, this is triggered on the view controller of the previous site ID.
+            guard let site = site, site.siteID == self.siteID else {
+                return
+            }
             self.updateUI(site: site)
             self.reloadData(forced: true)
         }.store(in: &subscriptions)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6855 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When switching stores, there are stats API requests (store stats, visitor stats, top performers) for the previous store in addition to the newly selected store and these data aren't used in the new store. The reason for this bug is because `DashboardViewController` observes `StoresManager.site` (since the `Site` object is fetched or loaded asynchronously after `siteID` is set) and when the store changes the view controller of the previous store also receives the site update and triggers API requests to refresh data.

To fix this, `DashboardViewController` now checks that the `Site` from `StoresManager.site` observable matches its site ID before making any updates based on the site changes. `DashboardViewController` of the previous store is deallocated shortly after being replaced by a new view controller.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the account is connected to at least two stores
- Log in to a store if needed
- Go to the Menu tab and tap "Switch store"
- Select a different store and continue --> you can use proxy tool (e.g. Charles) or Wormholy to see that the app is only fetching stats data for the new site ID

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
<img width="1086" alt="Screen Shot 2022-05-16 at 1 26 56 PM" src="https://user-images.githubusercontent.com/1945542/168526951-b94eaa7f-a136-40d9-9972-221dce22a0dc.png"> | <img width="1042" alt="Screen Shot 2022-05-16 at 1 27 49 PM" src="https://user-images.githubusercontent.com/1945542/168526963-20aa0e7d-4035-474e-bb3d-c43383778f0e.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
