### PR TITLE
Update order status to `Completed` locally after collecting a Simple Payment successfully

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -85,7 +85,7 @@ struct SimplePaymentsMethod: View {
                   message: Text(viewModel.payByCashInfo()),
                   primaryButton: .cancel(),
                   secondaryButton: .default(Text(Localization.markAsPaidButton), action: {
-                viewModel.markOrderAsPaid {
+                viewModel.markOrderAsPaid(paymentMethod: .cash) {
                     dismiss()
                 }
             }))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsMethodsViewModelTests.swift
@@ -38,7 +38,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
                     promise(loadingStates)
                 }
                 .store(in: &self.subscriptions)
-            viewModel.markOrderAsPaid(onSuccess: {})
+            viewModel.markOrderAsPaid(paymentMethod: .cash, onSuccess: {})
         }
 
         // Then
@@ -63,7 +63,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
                 }
             }
 
-            viewModel.markOrderAsPaid(onSuccess: {})
+            viewModel.markOrderAsPaid(paymentMethod: .cash, onSuccess: {})
         }
 
         // Then
@@ -88,7 +88,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
 
         // When
         let onSuccessInvoked: Bool = waitFor { promise in
-            viewModel.markOrderAsPaid(onSuccess: {
+            viewModel.markOrderAsPaid(paymentMethod: .cash, onSuccess: {
                 promise(true)
             })
         }
@@ -124,7 +124,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
                 }
             }
             .store(in: &self.subscriptions)
-            viewModel.markOrderAsPaid(onSuccess: {})
+            viewModel.markOrderAsPaid(paymentMethod: .cash, onSuccess: {})
         }
 
         // Then
@@ -158,7 +158,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
                 }
             }
             .store(in: &self.subscriptions)
-            viewModel.markOrderAsPaid(onSuccess: {})
+            viewModel.markOrderAsPaid(paymentMethod: .cash, onSuccess: {})
         }
 
         // Then
@@ -184,7 +184,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
                                                        dependencies: dependencies)
 
         // When
-        viewModel.markOrderAsPaid(onSuccess: {})
+        viewModel.markOrderAsPaid(paymentMethod: .cash, onSuccess: {})
 
         // Then
         assertEqual(analytics.receivedEvents.first, WooAnalyticsStat.simplePaymentsFlowCompleted.rawValue)
@@ -198,11 +198,22 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         storage.insertSampleOrder(readOnlyOrder: .fake())
         storage.insertSamplePaymentGatewayAccount(readOnlyAccount: .fake())
 
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrderStatus(_, _, _, onCompletion):
+                onCompletion(nil)
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
         let analytics = MockAnalyticsProvider()
         let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
         let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
         let dependencies = Dependencies(
             cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+            stores: stores,
             storage: storage,
             analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00",
@@ -252,7 +263,7 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
                                                        dependencies: dependencies)
 
         // When
-        viewModel.markOrderAsPaid(onSuccess: {})
+        viewModel.markOrderAsPaid(paymentMethod: .cash, onSuccess: {})
 
         // Then
         assertEqual(analytics.receivedEvents.first, WooAnalyticsStat.simplePaymentsFlowFailed.rawValue)
@@ -424,11 +435,22 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         storage.insertSampleOrder(readOnlyOrder: .fake())
         storage.insertSamplePaymentGatewayAccount(readOnlyAccount: .fake())
 
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrderStatus(_, _, _, onCompletion):
+                onCompletion(nil)
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
         let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
         let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
         let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
         let dependencies = Dependencies(presentNoticeSubject: noticeSubject,
                                         cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+                                        stores: stores,
                                         storage: storage)
         let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00",
                                                        dependencies: dependencies)
@@ -458,9 +480,20 @@ final class SimplePaymentsMethodsViewModelTests: XCTestCase {
         storage.insertSampleOrder(readOnlyOrder: .fake())
         storage.insertSamplePaymentGatewayAccount(readOnlyAccount: .fake())
 
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrderStatus(_, _, _, onCompletion):
+                onCompletion(nil)
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
         let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
         let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
         let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+                                        stores: stores,
                                         storage: storage)
         let viewModel = SimplePaymentsMethodsViewModel(formattedTotal: "$12.00",
                                                        dependencies: dependencies)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5892 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After a merchant collects a Simple Payment successfully and goes back to the orders tab, the order status of the newly paid order remains the same as before (most often "Pending payment" unless some other plugins or configurations override the default status) because the order isn't updated until the next refresh of the order list or order details. I was able to reproduce the issue consistently, the newly collected orders still have "Pending payment" status which could be confusing to a merchant.

In Simple Payments, we already mark an order as "Completed" locally for the cash payment method. This PR just reuses this function with a new payment method parameter for analytics.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to Order List
- Tap the + button and tap "Simple payment"
- Enter an amount
- Tap Next
- Tap Take Payment
- Tap Card
- Collect the Payment --> in the console, you should see event like `🔵 Tracked simple_payments_flow_completed, properties: [AnyHashable("payment_method"): "card", AnyHashable("amount"): "$12.00", ...]`
- After the payment capture is completed, tap "Continue to Orders" --> all the modals should be dismissed, and the order list shows the order as `Completed`

#### Confidence check on affected Simple Payment flow with cash
- [x] @jaclync also tested the Cash payment method and audited the analytics


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
