### PR TITLE
[Simple Payments] Change wording when dismissing the Simple Payments creation flow to match the action behind.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -210,7 +210,8 @@ private extension SimplePaymentsAmount {
         static let created = NSLocalizedString("🎉 Order created", comment: "Notice text after creating a simple payment order")
         static let completed = NSLocalizedString("🎉 Order completed", comment: "Notice text after completing a simple payment order")
         static let buttonTitle = NSLocalizedString("Next", comment: "Title for the button to confirm the amount in the simple payments screen")
-        static let dismissOrder = NSLocalizedString("Dismiss Order", comment: "Title for dismiss the action when dragging the screen down.")
+        static let dismissOrder = NSLocalizedString("Dismiss", comment: "Title for dismiss the action of a" +
+                                                    "simple payment creation when dragging the screen down.")
     }
 
     enum Layout {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6850
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we change the wording of the flow dismissal action from "Dismiss Order" to just "Dismiss". The reason behind that is that, as explained in the issue above when past a point of the flow (Take Payment action) we were not dismissing the order, but instead, we were persisting. It is confusing then to press on "Dismiss Order", just to see it again on the Orders list in the next step.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to 'Orders'
2. Tap +, Simple Payment
3. Enter a payment amount and tap Next
4. Tap Take Payment
5. Drag down the view from the top

You see now "Dismiss" instead of "Dismiss Order"

We discuss here pdfdoF-Ot-p2 other options to fix this issue (e.g delete the order after the dismissal) but since we do not know how this really affects the userbase, we go for this easy solution before we get more feedback.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1864060/168835647-f0100fb1-1fb5-4dd5-9eb5-44c23a232f0d.png" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->