### PR TITLE
Align to leading when there is more than one line

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethod.swift
@@ -140,6 +140,7 @@ private struct MethodRow: View {
                 Text(title)
                     .bodyStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
 
                 DisclosureIndicator()
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6854
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Method rows in the Simple Payment Method screen didn't handle properly the alignment when the text is multiline, as in the case of the Share Payment Link in Spanish. With this PR we add the `multilineTextAlignment` modifier to the Text so we align it properly then.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Prerequisites
Switch the language of your device or simulator to Spanish.

#### Steps

1. Go to 'Orders', tap + and create a simple payment
2. Enter and amount and continue
3. Tap Collect Payment

The text should be properly aligned.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
-|-
<img src="https://user-images.githubusercontent.com/8739/168241120-6949804f-8f12-45a7-80d9-8e5144d43e1d.png" width="375">|<img src="https://user-images.githubusercontent.com/1864060/168848023-97202b51-7915-49c9-9cbe-f6d40ab2168b.png" width="375">
---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
