### PR TITLE
Update PriceInputFormatter to support Arabic numerals

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.3
 -----
-
+- [*] Support Arabic numerals on amount fields. [https://github.com/woocommerce/woocommerce-ios/pull/6891]
 
 9.2
 -----

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -44,7 +44,9 @@ struct PriceInputFormatter: UnitInputFormatter {
             return ""
         }
 
-        let formattedText = text
+        let latinText = text.applyingTransform(StringTransform.toLatin, reverse: false) ?? text
+
+        let formattedText = latinText
             // Replace any characters not in the set of 0-9 with the current decimal separator configured on website
             .replacingOccurrences(of: "[^0-9]", with: currencySettings.decimalSeparator, options: .regularExpression)
             // Remove any initial zero number in the string. Es. 00224.30 will be 2224.30

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -149,4 +149,12 @@ final class PriceInputFormatterTests: XCTestCase {
         // Then
         XCTAssertEqual(formatter.value(from: emptyValue), NSNumber(value: 0))
     }
+
+    func test_arabic_numerals_are_transformed_correctly() {
+        // When
+        let value = "٤٥,٤١"
+
+        // Then
+        XCTAssertEqual(formatter.value(from: value), NSNumber(value: 45.41))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6842 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR makes sure that Arabic numerals can be input for fields that use `PriceInputFormatter`.
The solution is to use String's `applyingTransform` method to transform Arabic numerals into Latin ones.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Add Arabic keyboard to your device
- In Product Form or Coupon Edit flow, switch to the Arabic keyboard when entering the price for a product or amount for a coupon.
- Notice that the Arabic characters are transformed automatically to Latin ones.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/169022954-25c2870d-0af9-442e-b24e-a2ee76294bee.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
