### PR TITLE
[Order Editing] Make notes in order details selectable/copiable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.3
 -----
-
+- [*] Orders: Now it's possible to select and copy text from the notes on an order. [https://github.com/woocommerce/woocommerce-ios/pull/6894]
 
 9.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
@@ -4,7 +4,7 @@ final class CustomerNoteTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var headlineLabel: UILabel!
 
-    @IBOutlet private weak var bodyLabel: UILabel!
+    @IBOutlet private weak var bodyTextView: UITextView!
 
     @IBOutlet private weak var editButton: UIButton!
 
@@ -25,10 +25,10 @@ final class CustomerNoteTableViewCell: UITableViewCell {
     ///
     var body: String? {
         get {
-            return bodyLabel.text
+            return bodyTextView.text
         }
         set {
-            bodyLabel.text = newValue
+            bodyTextView.text = newValue
         }
     }
 
@@ -77,7 +77,8 @@ final class CustomerNoteTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
-        configureLabels()
+        configureHeadlineLabel()
+        configureBodyTextView()
         configureEditButton()
         configureAddButton()
     }
@@ -85,7 +86,7 @@ final class CustomerNoteTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         headlineLabel.text = nil
-        bodyLabel.text = nil
+        bodyTextView.text = nil
         onEditTapped = nil
         onAddTapped = nil
         editButton.accessibilityLabel = nil
@@ -100,9 +101,20 @@ private extension CustomerNoteTableViewCell {
         applyDefaultBackgroundStyle()
     }
 
-    func configureLabels() {
+    func configureHeadlineLabel() {
         headlineLabel.applyHeadlineStyle()
-        bodyLabel.applyBodyStyle()
+    }
+
+    func configureBodyTextView() {
+        bodyTextView.font = .body
+        bodyTextView.textColor = .text
+        bodyTextView.backgroundColor = .listForeground
+        bodyTextView.adjustsFontForContentSizeCategory = true
+
+        // Remove padding from inside text view
+        bodyTextView.contentInset = .zero
+        bodyTextView.textContainerInset = .zero
+        bodyTextView.textContainer.lineFragmentPadding = .zero
     }
 
     func configureEditButton() {
@@ -136,8 +148,8 @@ extension CustomerNoteTableViewCell {
         return headlineLabel
     }
 
-    func getBodyLabel() -> UILabel {
-        return bodyLabel
+    func getBodyTextView() -> UITextView {
+        return bodyTextView
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,12 +30,13 @@
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="KMy-GB-2vj">
                                 <rect key="frame" x="0.0" y="20.5" width="288" height="47.5"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Body Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z0H-LC-lIr">
-                                        <rect key="frame" x="0.0" y="13.5" width="288" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" text="Lorem ipsum" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="eZu-5u-2sA">
+                                        <rect key="frame" x="0.0" y="7.5" width="288" height="33"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="textColor" systemColor="labelColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
                                     <button hidden="YES" opaque="NO" contentMode="center" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AEi-vO-v71">
                                         <rect key="frame" x="288" y="2" width="44" height="44"/>
                                         <constraints>
@@ -69,11 +72,19 @@
             <viewLayoutGuide key="safeArea" id="U1C-V1-Or8"/>
             <connections>
                 <outlet property="addButton" destination="8sO-TX-YXZ" id="69l-hj-M3Q"/>
-                <outlet property="bodyLabel" destination="z0H-LC-lIr" id="eha-ch-GUr"/>
+                <outlet property="bodyTextView" destination="eZu-5u-2sA" id="yIJ-nY-tub"/>
                 <outlet property="editButton" destination="AEi-vO-v71" id="kDj-Jd-NCM"/>
                 <outlet property="headlineLabel" destination="T3S-nL-Xv3" id="ogO-Et-oBd"/>
             </connections>
             <point key="canvasLocation" x="47.826086956521742" y="131.91964285714286"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/OrderNoteTableViewCell.swift
@@ -14,9 +14,9 @@ class OrderNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var statusLabel: UILabel!
 
-    /// Bottom Label
+    /// Bottom Text View
     ///
-    @IBOutlet private var noteLabel: UILabel!
+    @IBOutlet private var noteTextView: UITextView!
 
 
     // MARK: - View Lifecycle
@@ -25,7 +25,8 @@ class OrderNoteTableViewCell: UITableViewCell {
         super.awakeFromNib()
 
         configureBackground()
-        configureLabels()
+        configureStatusLabel()
+        configureNoteTextView()
         configureIconButton()
     }
 
@@ -61,10 +62,10 @@ class OrderNoteTableViewCell: UITableViewCell {
     ///
     var contents: String? {
         get {
-            return noteLabel.text
+            return noteTextView.text
         }
         set {
-            noteLabel.text = newValue
+            noteTextView.text = newValue
         }
     }
 }
@@ -104,12 +105,25 @@ private extension OrderNoteTableViewCell {
         applyDefaultBackgroundStyle()
     }
 
-    /// Setup: Labels
+    /// Setup: Status Label
     ///
-    func configureLabels() {
+    func configureStatusLabel() {
         statusLabel.applyBodyStyle()
         statusLabel.textColor = .textSubtle
-        noteLabel.applyBodyStyle()
+    }
+
+    /// Setup: Note Content Text View
+    ///
+    func configureNoteTextView() {
+        noteTextView.font = .body
+        noteTextView.textColor = .text
+        noteTextView.backgroundColor = .listForeground
+        noteTextView.adjustsFontForContentSizeCategory = true
+
+        // Remove padding from inside text view
+        noteTextView.contentInset = .zero
+        noteTextView.textContainerInset = .zero
+        noteTextView.textContainer.lineFragmentPadding = .zero
     }
 
     /// Setup: Icon Button

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/OrderNoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/OrderNoteTableViewCell.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,10 +15,10 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="148"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="147.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="148"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YMK-WG-vE9">
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YMK-WG-vE9">
                         <rect key="frame" x="16" y="19" width="26" height="26"/>
                         <accessibility key="accessibilityConfiguration">
                             <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -37,32 +36,41 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7py-ye-y1B">
-                        <rect key="frame" x="54" y="43.5" width="250" height="20.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" text="Lorem ipsum" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="A65-oy-42L">
+                        <rect key="frame" x="54" y="43.5" width="250" height="88.5"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="textColor" systemColor="labelColor"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                    </textView>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailingMargin" secondItem="h9D-sT-W5S" secondAttribute="trailing" id="10O-OD-hx6"/>
-                    <constraint firstItem="7py-ye-y1B" firstAttribute="top" secondItem="h9D-sT-W5S" secondAttribute="bottom" constant="4" id="MrP-2V-xgC"/>
+                    <constraint firstAttribute="trailing" secondItem="A65-oy-42L" secondAttribute="trailing" constant="16" id="DQv-l3-8qR"/>
                     <constraint firstItem="YMK-WG-vE9" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Qsi-AX-gpI"/>
-                    <constraint firstAttribute="trailing" secondItem="7py-ye-y1B" secondAttribute="trailing" constant="16" id="TJ8-k4-vEO"/>
+                    <constraint firstItem="A65-oy-42L" firstAttribute="leading" secondItem="h9D-sT-W5S" secondAttribute="leading" id="ZuR-7w-a6c"/>
                     <constraint firstItem="h9D-sT-W5S" firstAttribute="top" secondItem="YMK-WG-vE9" secondAttribute="top" id="cvF-lP-ns4"/>
                     <constraint firstItem="YMK-WG-vE9" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="dQ0-UK-1FW"/>
                     <constraint firstItem="h9D-sT-W5S" firstAttribute="leading" secondItem="YMK-WG-vE9" secondAttribute="trailing" constant="12" id="g4p-lY-o8h"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="7py-ye-y1B" secondAttribute="bottom" priority="250" constant="8" id="r4x-c9-yPW"/>
-                    <constraint firstItem="7py-ye-y1B" firstAttribute="leading" secondItem="h9D-sT-W5S" secondAttribute="leading" id="vTe-SY-gaS"/>
+                    <constraint firstAttribute="bottom" secondItem="A65-oy-42L" secondAttribute="bottom" constant="16" id="pCa-Uw-PWe"/>
+                    <constraint firstItem="A65-oy-42L" firstAttribute="top" secondItem="h9D-sT-W5S" secondAttribute="bottom" constant="4" id="tIJ-dH-Rvt"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="iconButton" destination="YMK-WG-vE9" id="B9f-Mv-uD8"/>
-                <outlet property="noteLabel" destination="7py-ye-y1B" id="KnD-L8-UjD"/>
+                <outlet property="noteTextView" destination="A65-oy-42L" id="36P-Sa-jvH"/>
                 <outlet property="statusLabel" destination="h9D-sT-W5S" id="T4j-Su-yEa"/>
             </connections>
             <point key="canvasLocation" x="33.600000000000001" y="100.74962518740631"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/WooCommerceTests/ViewRelated/CustomerNoteTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CustomerNoteTableViewCellTests.swift
@@ -34,8 +34,8 @@ final class CustomerNoteTableViewCellTests: XCTestCase {
         let mockLabel = UILabel()
         mockLabel.applyBodyStyle()
 
-        XCTAssertEqual(cell?.getBodyLabel().font, mockLabel.font)
-        XCTAssertEqual(cell?.getBodyLabel().textColor, mockLabel.textColor)
+        XCTAssertEqual(cell?.getBodyTextView().font, mockLabel.font)
+        XCTAssertEqual(cell?.getBodyTextView().textColor, mockLabel.textColor)
     }
 
     func testHeadlineLabelValues() {
@@ -43,7 +43,7 @@ final class CustomerNoteTableViewCellTests: XCTestCase {
     }
 
     func testBodyLabelValues() {
-        XCTAssertEqual(cell?.getBodyLabel().text, bodyMock)
+        XCTAssertEqual(cell?.getBodyTextView().text, bodyMock)
     }
 
 }


### PR DESCRIPTION
Closes: #6729

## Description

Merchants want to be able to copy text from notes on an order, for example to select and copy a tracking number to share with their customer. This changes the Customer-Provided Note and Order Notes in the Order Details screen to use a `UITextView` instead of a `UILabel` so the text can be selected and copied.

## Changes

* Updates the note content view in `OrderNoteTableViewCell` (and its corresponding `.xib`) to use a non-editable `UITextView` instead of a `UILabel`.
* Updates the note content view in `CustomerNoteTableViewCell.swift` (and its corresponding `.xib`) to use a non-editable `UITextView` instead of a `UILabel`.

## Testing

1. Go to the Orders tab and select an order.
2. Go to the Customer-Provided Note section for the order, and add a note if there isn't one already.
3. Select some or all of the text in the note and confirm you can copy or share it.
4. Go to the Order Notes section for the order, and add a note if there isn't one already.
5. Select some or all of the text in the note and confirm you can copy or share it.

## Screenshots

Before|After - Customer-Provided Note|After - Order Notes
-|-|-
![Notes-Before-Light](https://user-images.githubusercontent.com/8658164/169153586-7740ffdd-a0d3-4f94-9669-0404ff4d06c8.png)|![CustomerNote-After-Light](https://user-images.githubusercontent.com/8658164/169153624-6840a8c2-0c06-40d3-9543-f7be775baac2.png)|![OrderNote-After-Light](https://user-images.githubusercontent.com/8658164/169153657-350ea9f1-2bcf-4d8e-81ef-e44b1c87679a.png)
![Notes-Before-Dark](https://user-images.githubusercontent.com/8658164/169153603-3d800901-f612-497c-bb1f-c461c08ca0f7.png)|![CustomerNote-After-Dark](https://user-images.githubusercontent.com/8658164/169153644-f5a45138-5096-4b3a-9f15-bd8dde50f80b.png)|![OrderNote-After-Dark](https://user-images.githubusercontent.com/8658164/169153669-c8dde156-bf5f-4018-94d6-732c8ff66dac.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
