### PR TITLE
Fetch order asynchronously after collecting a Simple Payment successfully

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -219,6 +219,9 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                         self?.trackFlowFailed()
                     },
                     onCompleted: { [weak self] in
+                        // Update order in case its status and/or other details are updated after a successful in-person payment
+                        self?.updateOrderAsynchronously()
+
                         // Inform success to consumer
                         onSuccess()
 
@@ -264,6 +267,11 @@ private extension SimplePaymentsMethodsViewModel {
             .removeDuplicates()
             .assign(to: &$showPayWithCardRow)
         cppStoreStateObserver.refresh()
+    }
+
+    func updateOrderAsynchronously() {
+        let action = OrderAction.retrieveOrder(siteID: siteID, orderID: orderID) { _, _  in }
+        stores.dispatch(action)
     }
 
     /// Tracks the `simplePaymentsFlowCompleted` event.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5892 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#### Why

After a merchant collects a Simple Payment successfully and goes back to the orders tab, the order status of the newly paid order remains the same as before (most often "Pending payment" unless some other plugins or configurations override the default status) because the order isn't updated until the next refresh of the order list or order details. I was able to reproduce the issue consistently, the newly collected orders still have "Pending payment" status which could be confusing to a merchant.

#### Implementation

Similar to [order details](https://github.com/woocommerce/woocommerce-ios/blob/c384062e439f246a2ed6f70de7d9b1852ec5b3bb/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/OrderDetailsViewController.swift#L731-L735), we can fetch the latest order after a successful IPP in Simple Payments. Originally, I tried moving the order fetching to `CollectOrderPaymentUseCase`, but then I decided not to because the changes were not trivial and affected IPP in order details.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to Order List
- Tap the + button and tap "Simple payment"
- Enter an amount
- Tap Next
- Tap Take Payment
- Tap Card
- Collect the Payment --> in the console, you should see event like `🔵 Tracked simple_payments_flow_completed, properties: [AnyHashable("payment_method"): "card", AnyHashable("amount"): "$12.00", ...]`
- After the payment capture is completed, tap "Continue to Orders" --> all the modals should be dismissed, and the order list shows the order as `Completed` (or whatever the backend sets to)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
