### PR TITLE
Product Selector: Enable selecting all varations for variable product rows

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 9.3
 -----
 - [*] Support Arabic numerals on amount fields. [https://github.com/woocommerce/woocommerce-ios/pull/6891]
+- [*] Product Selector: Enabled selecting all variations on variable product rows. [https://github.com/woocommerce/woocommerce-ios/pull/6899]
 
 9.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -8,6 +8,8 @@ struct ProductRow: View {
     ///
     private let multipleSelectionsEnabled: Bool
 
+    private let onCheckboxSelected: () -> Void
+
     /// View model to drive the view.
     ///
     @ObservedObject var viewModel: ProductRowViewModel
@@ -30,10 +32,12 @@ struct ProductRow: View {
 
     init(multipleSelectionsEnabled: Bool = false,
          viewModel: ProductRowViewModel,
-         accessibilityHint: String = "") {
+         accessibilityHint: String = "",
+         onCheckboxSelected: @escaping () -> Void = {}) {
         self.multipleSelectionsEnabled = multipleSelectionsEnabled
         self.viewModel = viewModel
         self.accessibilityHint = accessibilityHint
+        self.onCheckboxSelected = onCheckboxSelected
     }
 
     var body: some View {
@@ -44,6 +48,9 @@ struct ProductRow: View {
                         Image(uiImage: viewModel.selectedState.image)
                             .frame(width: Layout.checkImageSize * scale, height: Layout.checkImageSize * scale)
                             .foregroundColor(.init(UIColor.brand))
+                            .onTapGesture {
+                                onCheckboxSelected()
+                            }
                     }
 
                     // Product image

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -8,7 +8,7 @@ struct ProductRow: View {
     ///
     private let multipleSelectionsEnabled: Bool
 
-    private let onCheckboxSelected: () -> Void
+    private let onCheckboxSelected: (() -> Void)?
 
     /// View model to drive the view.
     ///
@@ -33,7 +33,7 @@ struct ProductRow: View {
     init(multipleSelectionsEnabled: Bool = false,
          viewModel: ProductRowViewModel,
          accessibilityHint: String = "",
-         onCheckboxSelected: @escaping () -> Void = {}) {
+         onCheckboxSelected: (() -> Void)? = nil) {
         self.multipleSelectionsEnabled = multipleSelectionsEnabled
         self.viewModel = viewModel
         self.accessibilityHint = accessibilityHint
@@ -45,12 +45,13 @@ struct ProductRow: View {
             AdaptiveStack(horizontalAlignment: .leading) {
                 HStack(alignment: .center) {
                     if multipleSelectionsEnabled {
-                        Image(uiImage: viewModel.selectedState.image)
-                            .frame(width: Layout.checkImageSize * scale, height: Layout.checkImageSize * scale)
-                            .foregroundColor(.init(UIColor.brand))
-                            .onTapGesture {
-                                onCheckboxSelected()
+                        if let selectionHandler = onCheckboxSelected {
+                            checkbox.onTapGesture {
+                                selectionHandler()
                             }
+                        } else {
+                            checkbox
+                        }
                     }
 
                     // Product image
@@ -88,6 +89,12 @@ struct ProductRow: View {
                     .renderedIf(viewModel.canChangeQuantity)
             }
         }
+    }
+
+    private var checkbox: some View {
+        Image(uiImage: viewModel.selectedState.image)
+            .frame(width: Layout.checkImageSize * scale, height: Layout.checkImageSize * scale)
+            .foregroundColor(.init(UIColor.brand))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelector.swift
@@ -139,8 +139,10 @@ struct ProductSelector: View {
                 })) {
                 HStack {
                     ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
-                               viewModel: rowViewModel)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                               viewModel: rowViewModel) {
+                        viewModel.toggleSelectionForVariations(of: rowViewModel.productOrVariationID)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                     DisclosureIndicator()
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelector.swift
@@ -10,6 +10,10 @@ struct ProductSelector: View {
     ///
     @Binding var isPresented: Bool
 
+    /// Defines whether a variation list is shown.
+    ///
+    @State var isShowingVariationList: Bool = false
+
     /// View model to drive the view.
     ///
     @ObservedObject var viewModel: ProductSelectorViewModel
@@ -130,21 +134,26 @@ struct ProductSelector: View {
     ///
     @ViewBuilder private func createProductRow(rowViewModel: ProductRowViewModel) -> some View {
         if let addVariationToOrderVM = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
-            LazyNavigationLink(destination: ProductVariationSelector(
-                isPresented: $isPresented,
-                viewModel: addVariationToOrderVM,
-                multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
-                onMultipleSelections: { selectedIDs in
-                    viewModel.updateSelectedVariations(productID: rowViewModel.productOrVariationID, selectedVariationIDs: selectedIDs)
-                })) {
-                HStack {
-                    ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
-                               viewModel: rowViewModel) {
-                        viewModel.toggleSelectionForVariations(of: rowViewModel.productOrVariationID)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            HStack {
+                ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
+                           viewModel: rowViewModel) {
+                    viewModel.toggleSelectionForVariations(of: rowViewModel.productOrVariationID)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .onTapGesture {
+                    isShowingVariationList.toggle()
+                }
 
-                    DisclosureIndicator()
+                DisclosureIndicator()
+
+                LazyNavigationLink(destination: ProductVariationSelector(
+                    isPresented: $isPresented,
+                    viewModel: addVariationToOrderVM,
+                    multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
+                    onMultipleSelections: { selectedIDs in
+                        viewModel.updateSelectedVariations(productID: rowViewModel.productOrVariationID, selectedVariationIDs: selectedIDs)
+                    }), isActive: $isShowingVariationList) {
+                    EmptyView()
                 }
             }
             .accessibilityHint(configuration.variableProductRowAccessibilityHint)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -233,6 +233,26 @@ final class ProductSelectorViewModel: ObservableObject {
         selectedProductVariationIDs.append(contentsOf: selectedVariationIDs)
     }
 
+    /// Select all variations for a given product
+    ///
+    func toggleSelectionForVariations(of productID: Int64) {
+        guard let variableProduct = products.first(where: { $0.productID == productID }),
+              variableProduct.variations.isNotEmpty else {
+            return
+        }
+        let selectedIDs: [Int64]
+        let intersection = Set(variableProduct.variations).intersection(Set(selectedProductVariationIDs))
+        if intersection.count == variableProduct.variations.count {
+            // if all variation is currently selected, deselect them all
+            selectedIDs = []
+        } else {
+            // otherwise select all variations for the product
+            selectedIDs = variableProduct.variations
+        }
+
+        updateSelectedVariations(productID: productID, selectedVariationIDs: selectedIDs)
+    }
+
     /// Triggers completion closure when the multiple selection completes.
     ///
     func completeMultipleSelection() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -380,6 +380,56 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(productRow?.selectedState, .partiallySelected)
     }
 
+    func test_toggleSelectionForVariations_set_its_product_row_to_selected_if_no_variation_was_selected() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true, variations: [1, 2])
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager)
+
+        // When
+        viewModel.toggleSelectionForVariations(of: product.productID)
+
+        // Then
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .selected)
+    }
+
+    func test_toggleSelectionForVariations_set_its_product_row_to_selected_if_some_variations_were_selected_earlier() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true, variations: [1, 2])
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager)
+
+        // When
+        viewModel.updateSelectedVariations(productID: product.productID, selectedVariationIDs: [2])
+        viewModel.toggleSelectionForVariations(of: product.productID)
+
+        // Then
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .selected)
+    }
+
+    func test_toggleSelectionForVariations_set_its_product_row_to_notSelected_if_all_variations_were_selected_earlier() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true, variations: [1, 2])
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager)
+
+        // When
+        viewModel.updateSelectedVariations(productID: product.productID, selectedVariationIDs: [1, 2])
+        viewModel.toggleSelectionForVariations(of: product.productID)
+
+        // Then
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .notSelected)
+    }
+
     func test_initialSelectedItems_are_reflected_in_selected_rows() {
         // Given
         let simpleProduct = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6897 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As discussed in p91TBi-8Ig-p2#comment-10116, we should enable selecting the checkboxes on variable product rows to select all variations for that product. This PR handles that along with toggling selection for variations following these rules:
- If **not all** variations of a product are selected, tapping the checkbox should **select all** the items.
- If **all** variations of a product are selected, tapping the checkbox should **deselect all** the items.

There's also a small change to move the variable product row outside of the navigation link to avoid the blinking effect when tapping on the row, making it consistent with regular product rows.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable coupons in experimental features
- Navigate to Menu > Coupons > select a coupon > select the ellipsis button > Edit Coupon.
- Select Add/Edit products
- Find a variable product in the product list, and notice that tapping on the checkbox toggles the selection for the variations of that product. Tapping on the row (outside of the checkbox) should navigate to the navigation list.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/169237640-2e9b390f-31bf-4561-8474-afd4067c858c.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->