### PR TITLE
Coupons: Fix text color on coupon status label 

### DIFF
--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import UIKit
 
 extension Coupon.DiscountType {
     /// Localized name to be displayed for the discount type.
@@ -190,6 +191,12 @@ extension Coupon {
             case .expired:
                 return Localization.expired
             }
+        }
+
+        /// Text color for the expiry status label
+        ///
+        var statusForegroundColor: UIColor {
+            .black
         }
 
         /// Background color for the expiry status label

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -121,6 +121,7 @@ struct CouponDetails: View {
                             .font(.title2)
                             .bold()
                         StatusView(label: viewModel.expiryStatus,
+                                   foregroundColor: viewModel.expiryStatusForegroundColor,
                                    backgroundColor: viewModel.expiryStatusBackgroundColor)
                     }
                     .padding(.horizontal, insets: geometry.safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -15,6 +15,10 @@ final class CouponDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var expiryStatus: String = ""
 
+    /// Text color for the expiry status view
+    ///
+    @Published private(set) var expiryStatusForegroundColor: UIColor = .clear
+
     /// Background color for the expiry status view
     ///
     @Published private(set) var expiryStatusBackgroundColor: UIColor = .clear
@@ -250,6 +254,7 @@ private extension CouponDetailsViewModel {
         let status = coupon.expiryStatus()
         expiryStatus = status.localizedName
         expiryStatusBackgroundColor = status.statusBackgroundColor
+        expiryStatusForegroundColor = status.statusForegroundColor
     }
 
     func formatStringAmount(_ amount: String) -> String {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/StatusView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/StatusView.swift
@@ -6,17 +6,22 @@ struct StatusView: View {
     /// The label on the status view
     private let label: String
 
+    /// Text color for the view
+    private let foregroundColor: UIColor
+
     /// The background color of the view
     private let backgroundColor: UIColor
 
-    init(label: String, backgroundColor: UIColor) {
+    init(label: String, foregroundColor: UIColor, backgroundColor: UIColor) {
         self.label = label
+        self.foregroundColor = foregroundColor
         self.backgroundColor = backgroundColor
     }
 
     var body: some View {
         Text(label)
             .font(.caption)
+            .foregroundColor(Color(foregroundColor))
             .padding(.vertical, Constants.verticalMargin)
             .padding(.horizontal, Constants.horizontalMargin)
             .background(Color(backgroundColor))
@@ -34,6 +39,6 @@ private extension StatusView {
 
 struct StatusView_Previews: PreviewProvider {
     static var previews: some View {
-        StatusView(label: "Active", backgroundColor: .withColorStudio(.celadon, shade: .shade5))
+        StatusView(label: "Active", foregroundColor: .black, backgroundColor: .withColorStudio(.celadon, shade: .shade5))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6896 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously we were not explicitly setting the foreground color to the text on the status view on the Coupon Details screen, so this color changes based on the device's dark/light mode.

This PR fixes that by adding a new config to the `StatusView` to customize its color. The color is passed from a coupon status' configuration to the coupon details view model to the status view on the coupon details screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable coupons in experimental features.
- Navigate to Menu > Coupons > select a coupon.
- Notice that the text color on the status label is readable in both dark mode and light mode.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/1945542/169069217-002d8e58-2694-4e5e-9fe3-7406e4e5f55d.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/169243874-587e88f1-c67e-4b90-96d0-465f8818a778.png" width=320 /> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
