### PR TITLE
[Refunds] Refunds is not possible with certain configurations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundItemsValuesCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundItemsValuesCalculationUseCase.swift
@@ -19,8 +19,13 @@ struct RefundItemsValuesCalculationUseCase {
         let zero = RefundValues(subtotal: 0, tax: 0)
         return refundItems.reduce(zero) { previousValues, refundItem -> RefundValues in
 
-            let itemPrice = refundItem.item.price as Decimal
-            let quantityToRefund = Decimal(refundItem.quantity)
+            // Figure out `itemTax` by dividing `totalTax` by the purchased `quantity`.
+            // Using price is buggy at the moment.
+            // See: https://github.com/woocommerce/woocommerce-ios/issues/6885
+            let itemTotal: Decimal = {
+                let refundItemTotal = currencyFormatter.convertToDecimal(from: refundItem.item.total) ?? 0
+                return (refundItemTotal as Decimal) / refundItem.item.quantity
+            }()
 
             // Figure out `itemTax` by dividing `totalTax` by the purchased `quantity`.
             let itemTax: Decimal = {
@@ -28,8 +33,10 @@ struct RefundItemsValuesCalculationUseCase {
                 return (totalTax as Decimal) / refundItem.item.quantity
             }()
 
+            let quantityToRefund = Decimal(refundItem.quantity)
+
             // Accumulate the evaluated item values
-            let subtotal = previousValues.subtotal + (itemPrice * quantityToRefund)
+            let subtotal = previousValues.subtotal + (itemTotal * quantityToRefund)
             let tax = previousValues.tax + (itemTax * quantityToRefund)
 
             return RefundValues(subtotal: subtotal, tax: tax)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundItemsValuesCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundItemsValuesCalculationUseCase.swift
@@ -19,8 +19,8 @@ struct RefundItemsValuesCalculationUseCase {
         let zero = RefundValues(subtotal: 0, tax: 0)
         return refundItems.reduce(zero) { previousValues, refundItem -> RefundValues in
 
-            // Figure out `itemTax` by dividing `totalTax` by the purchased `quantity`.
-            // Using price is buggy at the moment.
+            // Figure out `itemTotal` by dividing `item.total` by the purchased `quantity`.
+            // Using price is not safe right now.
             // See: https://github.com/woocommerce/woocommerce-ios/issues/6885
             let itemTotal: Decimal = {
                 let refundItemTotal = currencyFormatter.convertToDecimal(from: refundItem.item.total) ?? 0

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -256,22 +256,21 @@ final class IssueRefundViewModelTests: XCTestCase {
 
     func test_viewModel_correctly_adds_item_selections_to_title() {
         // Given
-        let item1Price: Decimal = 11.50
+        let item1Price: NSDecimalNumber = 11.50
         let item1Quantity: Decimal  = 3
 
-        let item2Price: Decimal = 12.50
+        let item2Price: NSDecimalNumber = 12.50
         let item2Quantity: Decimal  = 2
 
-        let item3Price: Decimal  = 13.50
+        let item3Price: NSDecimalNumber  = 13.50
         let item3Quantity: Decimal  = 1
 
 
         let currencySettings = CurrencySettings()
-        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, total: currencyFormatter.localize(item1Price * item1Quantity) ?? "0"),
-            MockOrderItem.sampleItem(itemID: 2, quantity: 2, total: currencyFormatter.localize(item2Price * item2Quantity) ?? "0"),
-            MockOrderItem.sampleItem(itemID: 3, quantity: 1, total: currencyFormatter.localize(item3Price * item3Quantity) ?? "0"),
+            MockOrderItem.sampleItemWithCalculatedTotal(itemID: 1, quantity: item1Quantity, price: item1Price),
+            MockOrderItem.sampleItemWithCalculatedTotal(itemID: 2, quantity: item2Quantity, price: item2Price),
+            MockOrderItem.sampleItemWithCalculatedTotal(itemID: 2, quantity: item3Quantity, price: item3Price),
         ]
         let order = MockOrders().makeOrder(items: items)
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
@@ -289,21 +288,20 @@ final class IssueRefundViewModelTests: XCTestCase {
 
     func test_viewModel_correctly_adds_shipping_selection_to_title() {
         // Given
-        let item1Price: Decimal = 11.50
+        let item1Price: NSDecimalNumber = 11.50
         let item1Quantity: Decimal  = 3
 
-        let item2Price: Decimal = 12.50
+        let item2Price: NSDecimalNumber = 12.50
         let item2Quantity: Decimal  = 2
 
-        let item3Price: Decimal  = 13.50
+        let item3Price: NSDecimalNumber  = 13.50
         let item3Quantity: Decimal  = 1
 
         let currencySettings = CurrencySettings()
-        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: item1Quantity, total: currencyFormatter.localize(item1Price * item1Quantity) ?? "0"),
-            MockOrderItem.sampleItem(itemID: 2, quantity: item2Quantity, total: currencyFormatter.localize(item2Price * item2Quantity) ?? "0"),
-            MockOrderItem.sampleItem(itemID: 3, quantity: item3Quantity, total: currencyFormatter.localize(item3Price * item3Quantity) ?? "0"),
+            MockOrderItem.sampleItemWithCalculatedTotal(itemID: 1, quantity: item1Quantity, price: item1Price),
+            MockOrderItem.sampleItemWithCalculatedTotal(itemID: 2, quantity: item2Quantity, price: item2Price),
+            MockOrderItem.sampleItemWithCalculatedTotal(itemID: 2, quantity: item3Quantity, price: item3Price),
         ]
         let shippingLines = MockOrders.sampleShippingLines(cost: "7.00", tax: "0.62")
         let order = MockOrders().makeOrder(items: items, shippingLines: shippingLines)
@@ -772,5 +770,19 @@ private extension IssueRefundViewModelTests {
         storageManager.reset()
         let newAccount = storageManager.viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
         newAccount.update(with: paymentGatewayAccount)
+    }
+}
+
+private extension MockOrderItem {
+    static func sampleItemWithCalculatedTotal(itemID: Int64,
+                                    quantity: Decimal,
+                                    price: NSDecimalNumber) -> OrderItem {
+        let currencySettings = CurrencySettings()
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+
+        return MockOrderItem.sampleItem(itemID: itemID,
+                                        quantity: quantity,
+                                        price: price,
+                                        total: currencyFormatter.localize((price as Decimal) * quantity) ?? "0")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -235,9 +235,9 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, productID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, productID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3),
+            MockOrderItem.sampleItem(itemID: 2, productID: 2, quantity: 2),
+            MockOrderItem.sampleItem(itemID: 3, productID: 3, quantity: 1),
         ]
         let order = MockOrders().makeOrder(items: items)
         let refund = MockRefunds.sampleRefund(items: [
@@ -256,11 +256,22 @@ final class IssueRefundViewModelTests: XCTestCase {
 
     func test_viewModel_correctly_adds_item_selections_to_title() {
         // Given
+        let item1Price: Decimal = 11.50
+        let item1Quantity: Decimal  = 3
+
+        let item2Price: Decimal = 12.50
+        let item2Quantity: Decimal  = 2
+
+        let item3Price: Decimal  = 13.50
+        let item3Quantity: Decimal  = 1
+
+
         let currencySettings = CurrencySettings()
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, total: currencyFormatter.localize(item1Price * item1Quantity) ?? "0"),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2, total: currencyFormatter.localize(item2Price * item2Quantity) ?? "0"),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1, total: currencyFormatter.localize(item3Price * item3Quantity) ?? "0"),
         ]
         let order = MockOrders().makeOrder(items: items)
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
@@ -278,11 +289,21 @@ final class IssueRefundViewModelTests: XCTestCase {
 
     func test_viewModel_correctly_adds_shipping_selection_to_title() {
         // Given
+        let item1Price: Decimal = 11.50
+        let item1Quantity: Decimal  = 3
+
+        let item2Price: Decimal = 12.50
+        let item2Quantity: Decimal  = 2
+
+        let item3Price: Decimal  = 13.50
+        let item3Quantity: Decimal  = 1
+
         let currencySettings = CurrencySettings()
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: item1Quantity, total: currencyFormatter.localize(item1Price * item1Quantity) ?? "0"),
+            MockOrderItem.sampleItem(itemID: 2, quantity: item2Quantity, total: currencyFormatter.localize(item2Price * item2Quantity) ?? "0"),
+            MockOrderItem.sampleItem(itemID: 3, quantity: item3Quantity, total: currencyFormatter.localize(item3Price * item3Quantity) ?? "0"),
         ]
         let shippingLines = MockOrders.sampleShippingLines(cost: "7.00", tax: "0.62")
         let order = MockOrders().makeOrder(items: items, shippingLines: shippingLines)
@@ -304,9 +325,9 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1),
         ]
         let order = MockOrders().makeOrder(items: items)
 
@@ -322,9 +343,9 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1),
         ]
         let order = MockOrders().makeOrder(items: items)
 
@@ -341,9 +362,9 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1),
         ]
         let order = MockOrders().makeOrder(items: items)
 
@@ -360,9 +381,9 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, productID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, productID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3),
+            MockOrderItem.sampleItem(itemID: 2, productID: 2, quantity: 2),
+            MockOrderItem.sampleItem(itemID: 3, productID: 3, quantity: 1),
         ]
         let order = MockOrders().makeOrder(items: items)
         let refund = MockRefunds.sampleRefund(items: [
@@ -383,9 +404,9 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50),
-            MockOrderItem.sampleItem(itemID: 2, productID: 2, quantity: 2, price: 12.50),
-            MockOrderItem.sampleItem(itemID: 3, productID: 3, quantity: 1, price: 13.50),
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3),
+            MockOrderItem.sampleItem(itemID: 2, productID: 2, quantity: 2),
+            MockOrderItem.sampleItem(itemID: 3, productID: 3, quantity: 1),
         ]
         let order = MockOrders().makeOrder(items: items)
         let refund = MockRefunds.sampleRefund(items: [
@@ -404,9 +425,13 @@ final class IssueRefundViewModelTests: XCTestCase {
 
     func test_viewModel_total_is_correctly_calculated_while_having_previous_refunds() {
         // Given
+        let item1Price: Decimal = 11.50
+        let item1Quantity: Decimal  = 3
+
         let currencySettings = CurrencySettings()
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50, totalTax: "2.97"),
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: item1Quantity, total: currencyFormatter.localize(item1Price * item1Quantity) ?? "0", totalTax: "2.97"),
         ]
         let order = MockOrders().makeOrder(items: items)
         let refund = MockRefunds.sampleRefund(items: [
@@ -426,7 +451,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items)
 
@@ -441,7 +466,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items)
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
@@ -457,7 +482,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items)
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
@@ -474,7 +499,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items)
 
@@ -489,7 +514,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items)
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
@@ -564,7 +589,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50, totalTax: "2.97"),
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, totalTax: "2.97"),
         ]
         let order = MockOrders().makeOrder(items: items)
 
@@ -579,7 +604,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50, totalTax: "2.97"),
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, totalTax: "2.97"),
         ]
         let order = MockOrders().makeOrder(items: items)
         let refund = MockRefunds.sampleRefund(items: [
@@ -622,7 +647,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Given
         // The order has a chargeID
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items).copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
@@ -647,7 +672,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         var showFetchChargeErrorNotice = false
         // The order has a chargeID
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items).copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -431,7 +431,11 @@ final class IssueRefundViewModelTests: XCTestCase {
         let currencySettings = CurrencySettings()
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let items = [
-            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: item1Quantity, total: currencyFormatter.localize(item1Price * item1Quantity) ?? "0", totalTax: "2.97"),
+            MockOrderItem.sampleItem(itemID: 1,
+                                     productID: 1,
+                                     quantity: item1Quantity,
+                                     total: currencyFormatter.localize(item1Price * item1Quantity) ?? "0",
+                                     totalTax: "2.97")
         ]
         let order = MockOrders().makeOrder(items: items)
         let refund = MockRefunds.sampleRefund(items: [

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemsValuesCalculationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemsValuesCalculationUseCaseTests.swift
@@ -8,11 +8,31 @@ import Yosemite
 final class RefundItemsValuesCalculationUseCaseTests: XCTestCase {
     func test_useCase_correctly_calculates_values_from_regular_items() {
         // Given
+        let item1Price: Decimal = 10.50
+        let item1Quantity: Decimal  = 1
+
+        let item2Price: Decimal = 15.00
+        let item2Quantity: Decimal  = 2
+
+        let item3Price: Decimal  = 7.99
+        let item3Quantity: Decimal  = 3
+
+
         let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
         let refundItems: [RefundableOrderItem] = [
-            .init(item: MockOrderItem.sampleItem(quantity: 1, price: 10.50, totalTax: "1.20"), quantity: 1),
-            .init(item: MockOrderItem.sampleItem(quantity: 2, price: 15.00, totalTax: "4.20"), quantity: 2),
-            .init(item: MockOrderItem.sampleItem(quantity: 3, price: 7.99, totalTax: "3.30"), quantity: 2),
+            .init(item: MockOrderItem.sampleItem(quantity: item1Quantity,
+                                                 total: formatter.localize(item1Price * item1Quantity) ?? "0",
+                                                 totalTax: "1.20"),
+                  quantity: 1),
+            .init(item: MockOrderItem.sampleItem(quantity: item2Quantity,
+                                                 total: formatter.localize(item2Price * item2Quantity) ?? "0",
+                                                 totalTax: "4.20"),
+                  quantity: 2),
+            .init(item: MockOrderItem.sampleItem(quantity: item3Quantity,
+                                                 total: formatter.localize(item3Price * item3Quantity) ?? "0",
+                                                 totalTax: "3.30"),
+                  quantity: 2),
         ]
 
         // When
@@ -29,12 +49,33 @@ final class RefundItemsValuesCalculationUseCaseTests: XCTestCase {
 
     func test_useCase_correctly_ignores_0_quantity_values() {
         // Given
+        let item1Price: Decimal = 10.50
+        let item1Quantity: Decimal  = 1
+
+        let item2Price: Decimal = 15.00
+        let item2Quantity: Decimal  = 2
+
+        let item3Price: Decimal  = 7.99
+        let item3Quantity: Decimal  = 3
+
+
         let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
         let refundItems: [RefundableOrderItem] = [
-            .init(item: MockOrderItem.sampleItem(quantity: 1, price: 10.50, totalTax: "1.20"), quantity: 1),
-            .init(item: MockOrderItem.sampleItem(quantity: 2, price: 15.00, totalTax: "4.20"), quantity: 0),
-            .init(item: MockOrderItem.sampleItem(quantity: 3, price: 7.99, totalTax: "3.30"), quantity: 0),
+            .init(item: MockOrderItem.sampleItem(quantity: item1Quantity,
+                                                 total: formatter.localize(item1Price * item1Quantity) ?? "0",
+                                                 totalTax: "1.20"),
+                  quantity: 1),
+            .init(item: MockOrderItem.sampleItem(quantity: item2Quantity,
+                                                 total: formatter.localize(item2Price * item2Quantity) ?? "0",
+                                                 totalTax: "4.20"),
+                  quantity: 0),
+            .init(item: MockOrderItem.sampleItem(quantity: item3Quantity,
+                                                 total: formatter.localize(item3Price * item3Quantity) ?? "0",
+                                                 totalTax: "3.30"),
+                  quantity: 0),
         ]
+
 
         // When
         let useCase = RefundItemsValuesCalculationUseCase(refundItems: refundItems, currencyFormatter: formatter)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundProductsTotalViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundProductsTotalViewModelTests.swift
@@ -8,14 +8,37 @@ import Yosemite
 final class RefundProductsTotalViewModelTests: XCTestCase {
     func test_viewModel_is_created_with_correct_initial_values() {
         // Given
+        let item1Price: Decimal = 10.50
+        let item1Quantity: Decimal  = 1
+
+        let item2Price: Decimal = 15.00
+        let item2Quantity: Decimal  = 2
+
+        let item3Price: Decimal  = 7.99
+        let item3Quantity: Decimal  = 3
+
+
+        let currencySettings = CurrencySettings()
+        let formatter = CurrencyFormatter(currencySettings: currencySettings)
+
         let refundItems: [RefundableOrderItem] = [
-            .init(item: MockOrderItem.sampleItem(quantity: 1, price: 10.50, totalTax: "1.20"), quantity: 1),
-            .init(item: MockOrderItem.sampleItem(quantity: 2, price: 15.00, totalTax: "4.20"), quantity: 2),
-            .init(item: MockOrderItem.sampleItem(quantity: 3, price: 7.99, totalTax: "3.30"), quantity: 2),
+            .init(item: MockOrderItem.sampleItem(quantity: item1Quantity,
+                                                 total: formatter.localize(item1Price * item1Quantity) ?? "0",
+                                                 totalTax: "1.20"),
+                  quantity: 1),
+            .init(item: MockOrderItem.sampleItem(quantity: item2Quantity,
+                                                 total: formatter.localize(item2Price * item2Quantity) ?? "0",
+                                                 totalTax: "4.20"),
+                  quantity: 2),
+            .init(item: MockOrderItem.sampleItem(quantity: item3Quantity,
+                                                 total: formatter.localize(item3Price * item3Quantity) ?? "0",
+                                                 totalTax: "3.30"),
+                  quantity: 2),
         ]
 
+
         // When
-        let viewModel = RefundProductsTotalViewModel(refundItems: refundItems, currency: "USD", currencySettings: CurrencySettings())
+        let viewModel = RefundProductsTotalViewModel(refundItems: refundItems, currency: "USD", currencySettings: currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.productsSubtotal, "$56.48")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6885
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Up until now, we used `line_items.price`, provided by the API as a number, to calculate the amount to be refunded for each item. This however is not reliable for some order configurations with tax and coupons, because the number, which usually has two decimal places, can get much longer. This messes up our refund calculation because the total to be refunded gets bigger than the order total. When we trigger such a request to the backend, (i.e a refund for a value bigger (even if very slightly) than the order total, the API returns an error and the operation cannot finish.
With this PR we change the approach used to calculate the refund value: instead of using the price we use the `line_items.total`, which remains constant along the way. In a similar fashion to how we calculate the tax, we divide that by the item quantity, obtaining that way the value per item.
We could also keep using the price and round it precisely so the amount is not bigger than the original one. This however seems less safe to me because we keep relying on the value from the backend that proved "incorrect".

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This bug is only reproducible in certain configurations. One of these is:
- A product with a price of $18
- A Fixed cart discount coupon for $0.20
- non-automated catch-all tax rate, 2%.

#### Steps

1. Place an order on your website for that product. Use the discount coupon
2. Collect the payment
3. Refund the order in full using the apps, including any shipping or fees added.

Before: It fails because the backend returns an error
Now: It should refund the order for the right value

---

Try other refunds to make sure that the new approach is totally safe: multiple/different items, just a few items out of multiple ones ...
### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
