### PR TITLE
[Mobile Payments] Add a Cancel button to the Card Reader Found modal

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -134,6 +134,15 @@ extension UIButton {
         tintColor = .accent
     }
 
+    /// By default UIButton adds an animation when changing the title. Use this method to avoid that
+    /// 
+    func setTitleWithoutAnimation(_ title: String?, for state: UIControl.State) {
+        UIView.performWithoutAnimation {
+            setTitle(title, for: .normal)
+            layoutIfNeeded()
+        }
+    }
+
     /// Supports title of multiple lines, either from longer text than allocated width or text with line breaks.
     private func enableMultipleLines() {
         titleLabel?.lineBreakMode = .byWordWrapping

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
@@ -9,8 +9,11 @@ final class CardPresentModalFoundReader: CardPresentPaymentsModalViewModel {
     /// Called when keep searching button is tapped
     private let continueSearchAction: () -> Void
 
+    /// Called when the cancel button is tapped
+    private let cancelAction: () -> Void
+
     let textMode: PaymentsModalTextMode = .noBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .twoAction
+    let actionsMode: PaymentsModalActionsMode = .twoActionAndAuxiliary
 
     var topTitle: String
 
@@ -22,7 +25,7 @@ final class CardPresentModalFoundReader: CardPresentPaymentsModalViewModel {
 
     let secondaryButtonTitle: String? = Localization.continueSearching
 
-    let auxiliaryButtonTitle: String? = nil
+    let auxiliaryButtonTitle: String? = Localization.cancel
 
     let bottomTitle: String? = nil
 
@@ -32,10 +35,11 @@ final class CardPresentModalFoundReader: CardPresentPaymentsModalViewModel {
         return Localization.connect
     }
 
-    init(name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void) {
+    init(name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void, cancel: @escaping () -> Void) {
         self.topTitle = String.localizedStringWithFormat(Localization.title, name)
         self.connectAction = connect
         self.continueSearchAction = continueSearch
+        self.cancelAction = cancel
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -46,7 +50,9 @@ final class CardPresentModalFoundReader: CardPresentPaymentsModalViewModel {
         continueSearchAction()
     }
 
-    func didTapAuxiliaryButton(in viewController: UIViewController?) {}
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        cancelAction()
+    }
 }
 
 private extension CardPresentModalFoundReader {
@@ -64,6 +70,11 @@ private extension CardPresentModalFoundReader {
         static let continueSearching = NSLocalizedString(
             "Keep Searching",
             comment: "Label for a button that when tapped, continues searching for card readers"
+        )
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Label for a button that when tapped, cancels the process of connecting to a card reader "
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -279,8 +279,8 @@ private extension CardPresentPaymentsModalViewController {
             return
         }
 
+        auxiliaryButton.setTitleWithoutAnimation(viewModel.auxiliaryButtonTitle, for: .normal)
         auxiliaryButton.isHidden = false
-        auxiliaryButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
     }
 
     func configureSpacer() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -58,7 +58,8 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         setViewModelAndPresent(from: from,
                                viewModel: foundReader(name: name,
                                                       connect: connect,
-                                                      continueSearch: continueSearch
+                                                      continueSearch: continueSearch,
+                                                      cancel: { from.dismiss(animated: true) }
                                )
         )
     }
@@ -208,8 +209,10 @@ private extension CardReaderSettingsAlerts {
         }
     }
 
-    func foundReader(name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalFoundReader(name: name, connect: connect, continueSearch: continueSearch)
+    func foundReader(name: String, connect: @escaping () -> Void,
+                     continueSearch: @escaping () -> Void,
+                     cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalFoundReader(name: name, connect: connect, continueSearch: continueSearch, cancel: cancel)
     }
 
     func setViewModelAndPresent(from: UIViewController, viewModel: CardPresentPaymentsModalViewModel) {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalFoundReaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalFoundReaderTests.swift
@@ -8,7 +8,10 @@ final class CardPresentModalFoundReaderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalFoundReader(name: Expectations.name, connect: closures.primaryAction(), continueSearch: closures.secondaryAction())
+        viewModel = CardPresentModalFoundReader(name: Expectations.name,
+                                                connect: closures.primaryAction(),
+                                                continueSearch: closures.secondaryAction(),
+                                                cancel: closures.auxiliaryAction())
     }
 
     override func tearDown() {
@@ -36,8 +39,8 @@ final class CardPresentModalFoundReaderTests: XCTestCase {
         XCTAssertNotNil(viewModel.secondaryButtonTitle)
     }
 
-    func test_auxiliary_button_title_is_nil() {
-        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    func test_auxiliary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.auxiliaryButtonTitle)
     }
 
     func test_bottom_title_is_nil() {
@@ -59,6 +62,12 @@ final class CardPresentModalFoundReaderTests: XCTestCase {
 
         XCTAssertTrue(closures.didTapContinue)
     }
+
+    func test_auxiliary_button_action_calls_closure() {
+        viewModel.didTapAuxiliaryButton(in: nil)
+
+        XCTAssertTrue(closures.didTapCancel)
+    }
 }
 
 
@@ -74,6 +83,7 @@ private extension CardPresentModalFoundReaderTests {
 private final class Closures {
     var didTapConnect = false
     var didTapContinue = false
+    var didTapCancel = false
 
     func primaryAction() -> () -> Void {
         return {[weak self] in
@@ -84,6 +94,12 @@ private final class Closures {
     func secondaryAction() -> () -> Void {
         return {[weak self] in
             self?.didTapContinue = true
+        }
+    }
+
+    func auxiliaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapCancel = true
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6904
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As explained here [p91TBi-8P0-p2#cpp-inconsistencies](https://href.li/?p91TBi-8P0-p2#cpp-inconsistencies) we align with Android by adding a tertiary auxiliary cancel button to the modal when a card reader is found. Tapping on that new button dismisses the modal.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Prerequisites
Have a pending payment order that can be collected

1. Go to Orders
2. Tap on that order
3. Tap on Collect Payment
4. Have a reader ready to be found
5. When the reader is found, you can see that there is a new cancel button at the bottom. Tapping on it dismisses the modal and goes back to the Order Details screen.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/1864060/169345886-f7ee2695-556b-45e7-9d10-ffd99da3e0a4.PNG" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->