### PR TITLE
Coupons: Fix weird animation on Edit Coupon screen when tapping Save button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -225,7 +225,7 @@ struct AddEditCoupon: View {
 
                         LazyNavigationLink(destination: CouponExpiryDateView(date: viewModel.expiryDateField ?? Date(),
                                                                              timezone: viewModel.timezone,
-                                                                             completion: { updatedExpiryDate in
+                                                                             onSelection: { updatedExpiryDate in
                             viewModel.expiryDateField = updatedExpiryDate
                         }),
                                            isActive: $showingCouponExpiryDate) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -225,7 +225,7 @@ struct AddEditCoupon: View {
 
                         LazyNavigationLink(destination: CouponExpiryDateView(date: viewModel.expiryDateField ?? Date(),
                                                                              timezone: viewModel.timezone,
-                                                                             onSelection: { updatedExpiryDate in
+                                                                             completion: { updatedExpiryDate in
                             viewModel.expiryDateField = updatedExpiryDate
                         }),
                                            isActive: $showingCouponExpiryDate) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -205,6 +205,8 @@ struct AddEditCoupon: View {
                         .padding(.bottom, Constants.verticalSpacing)
 
                         Button {
+                            // This should be replaced with `@FocusState` when we drop support for iOS 14
+                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                             viewModel.updateCoupon(coupon: viewModel.populatedCoupon)
                         } label: {
                             Text(Localization.saveButton)

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -7,7 +7,7 @@ struct CouponExpiryDateView: View {
 
     @State var date: Date = Date()
     var timezone: TimeZone
-    let completion: ((Date) -> Void)
+    let onSelection: ((Date) -> Void)
 
     var body: some View {
         GeometryReader { geometry in
@@ -16,6 +16,9 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
+                        .onChange(of: date) { newDate in
+                            onSelection(newDate)
+                        }
                     Spacer()
                 }
             }
@@ -23,8 +26,8 @@ struct CouponExpiryDateView: View {
         .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(Localization.title)
-        .onDisappear {
-            completion(date)
+        .onAppear {
+            onSelection(date)
         }
     }
 }
@@ -41,6 +44,6 @@ private extension CouponExpiryDateView {
 
 struct CouponExpiryDateView_Previews: PreviewProvider {
     static var previews: some View {
-        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, completion: { _ in })
+        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, onSelection: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -7,7 +7,7 @@ struct CouponExpiryDateView: View {
 
     @State var date: Date = Date()
     var timezone: TimeZone
-    let onSelection: ((Date) -> Void)
+    let completion: ((Date) -> Void)
 
     var body: some View {
         GeometryReader { geometry in
@@ -16,9 +16,6 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
-                        .onChange(of: date) { newDate in
-                            onSelection(newDate)
-                        }
                     Spacer()
                 }
             }
@@ -26,8 +23,8 @@ struct CouponExpiryDateView: View {
         .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(Localization.title)
-        .onAppear {
-            onSelection(date)
+        .onDisappear {
+            completion(date)
         }
     }
 }
@@ -44,6 +41,6 @@ private extension CouponExpiryDateView {
 
 struct CouponExpiryDateView_Previews: PreviewProvider {
     static var previews: some View {
-        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, onSelection: { _ in })
+        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, completion: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -16,6 +16,9 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
+                        .onChange(of: date) { newDate in
+                            completion(newDate)
+                        }
                     Spacer()
                 }
             }
@@ -23,9 +26,6 @@ struct CouponExpiryDateView: View {
         .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(Localization.title)
-        .onDisappear {
-            completion(date)
-        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -16,9 +16,6 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
-                        .onChange(of: date) { newDate in
-                            completion(newDate)
-                        }
                     Spacer()
                 }
             }
@@ -26,6 +23,9 @@ struct CouponExpiryDateView: View {
         .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(Localization.title)
+        .onDisappear {
+            completion(date)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6868 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the animation on the Edit Coupon screen when tapping Save by dismissing the keyboard when the Save button is tapped to avoid weird animation.

Previously this PR also included a fix for #6851 - but I reverted the change since we need the enhancement mentioned in #6918 instead.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu > Coupons > select a coupon without an expiry date (or you can remove an existing one and save the coupon).
- Select the ellipsis button on the coupon details screen and select Edit Coupon.
- Select a text field and edit the content and proceed to tap Save.
- Notice that the keyboard is dismissed immediately and there's no weird animation happening afterward.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/169733210-c8d7772f-73e8-4615-9851-5d24139fc419.mp4





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
