### PR TITLE
[Mobile Payments] Change text after card payment

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -26,7 +26,7 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     let secondaryButtonTitle: String? = Localization.emailReceipt
 
-    let auxiliaryButtonTitle: String?
+    let auxiliaryButtonTitle: String? = Localization.saveReceiptAndContinue
 
     let bottomTitle: String? = nil
 
@@ -38,12 +38,10 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     init(printReceipt: @escaping () -> Void,
          emailReceipt: @escaping () -> Void,
-         noReceiptTitle: String,
          noReceiptAction: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
         self.emailReceiptAction = emailReceipt
         self.noReceiptAction = noReceiptAction
-        self.auxiliaryButtonTitle = noReceiptTitle
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -80,6 +78,11 @@ private extension CardPresentModalSuccess {
         static let emailReceipt = NSLocalizedString(
             "Email receipt",
             comment: "Button to email receipts. Presented to users after a payment has been successfully collected"
+        )
+
+        static let saveReceiptAndContinue = NSLocalizedString(
+            "Save receipt and continue",
+            comment: "Button when the user does not want to print or email receipt. Presented to users after a payment has been successfully collected"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -67,7 +67,7 @@ private extension CardPresentModalSuccessWithoutEmail {
 
         static let saveReceiptAndContinue = NSLocalizedString(
             "Save receipt and continue",
-            comment: "Button when the user does not want to print or email receipt. Presented to users after a payment has been successfully collected"
+            comment: "Button when the user does not want to print the receipt. Presented to users after a payment has been successfully collected"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -20,7 +20,7 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
 
     let primaryButtonTitle: String? = Localization.printReceipt
 
-    let secondaryButtonTitle: String?
+    let secondaryButtonTitle: String? = Localization.saveReceiptAndContinue
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -33,11 +33,9 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
     }
 
     init(printReceipt: @escaping () -> Void,
-         noReceiptTitle: String,
          noReceiptAction: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
         self.noReceiptAction = noReceiptAction
-        self.secondaryButtonTitle = noReceiptTitle
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -65,6 +63,11 @@ private extension CardPresentModalSuccessWithoutEmail {
         static let printReceipt = NSLocalizedString(
             "Print receipt",
             comment: "Button to print receipts. Presented to users after a payment has been successfully collected"
+        )
+
+        static let saveReceiptAndContinue = NSLocalizedString(
+            "Save receipt and continue",
+            comment: "Button when the user does not want to print or email receipt. Presented to users after a payment has been successfully collected"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -69,10 +69,9 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
         presentViewModel(viewModel: viewModel)
     }
 
-    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptTitle: String, noReceiptAction: @escaping () -> Void) {
+    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
         let viewModel = successViewModel(printReceipt: printReceipt,
                                          emailReceipt: emailReceipt,
-                                         noReceiptTitle: noReceiptTitle,
                                          noReceiptAction: noReceiptAction)
         presentViewModel(viewModel: viewModel)
     }
@@ -115,15 +114,13 @@ private extension OrderDetailsPaymentAlerts {
 
     func successViewModel(printReceipt: @escaping () -> Void,
                           emailReceipt: @escaping () -> Void,
-                          noReceiptTitle: String,
                           noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         if MFMailComposeViewController.canSendMail() {
             return CardPresentModalSuccess(printReceipt: printReceipt,
                                            emailReceipt: emailReceipt,
-                                           noReceiptTitle: noReceiptTitle,
                                            noReceiptAction: noReceiptAction)
         } else {
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptTitle: noReceiptTitle, noReceiptAction: noReceiptAction)
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlertsProtocol.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlertsProtocol.swift
@@ -12,7 +12,7 @@ protocol OrderDetailsPaymentAlertsProtocol {
 
     func processingPayment()
 
-    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptTitle: String, noReceiptAction: @escaping () -> Void)
+    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void)
 
     func error(error: Error, tryAgain: @escaping () -> Void, dismissCompletion: @escaping () -> Void)
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -534,7 +534,7 @@ extension OrderDetailsViewModel {
     /// Checks onboarding status before connecting to a reader.
     /// Handles receipt sharing.
     ///
-    func collectPayment(rootViewController: UIViewController, backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> Void) {
+    func collectPayment(rootViewController: UIViewController, onCollect: @escaping (Result<Void, Error>) -> Void) {
         cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(from: rootViewController) { [weak self] in
             guard let self = self else { return }
             guard let paymentGateway = self.cardPresentPaymentGatewayAccounts.first else {
@@ -559,7 +559,6 @@ extension OrderDetailsViewModel {
                 configuration: self.configurationLoader.configuration)
 
             self.collectPaymentsUseCase?.collectPayment(
-                backButtonTitle: backButtonTitle,
                 onCollect: onCollect,
                 onCompleted: { [weak self] in
                     // Make sure we free all the resources

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -725,7 +725,7 @@ private extension OrderDetailsViewController {
     }
 
     @objc private func collectPaymentTapped() {
-        viewModel.collectPayment(rootViewController: self, backButtonTitle: Localization.Payments.backToOrder) { [weak self] result in
+        viewModel.collectPayment(rootViewController: self) { [weak self] result in
             guard let self = self else { return }
             // Refresh date & view once payment has been collected.
             if result.isSuccess {
@@ -978,11 +978,6 @@ private extension OrderDetailsViewController {
             static let trackShipmentAction =
                 NSLocalizedString("Track shipment",
                                   comment: "Track shipment of a shipping label from the shipping label tracking more menu action sheet")
-        }
-
-        enum Payments {
-            static let backToOrder = NSLocalizedString("Back to Order",
-                                                       comment: "Button to dismiss modal overlay and go back to the order after a sucessful payment")
         }
 
         enum ActionsMenu {

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -209,7 +209,6 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                     configuration: CardPresentConfigurationLoader().configuration)
 
                 self.collectPaymentsUseCase?.collectPayment(
-                    backButtonTitle: Localization.continueToOrders,
                     onCollect: { [weak self] result in
                         guard case let .failure(error) = result else { return }
 
@@ -299,8 +298,6 @@ private extension SimplePaymentsMethodsViewModel {
                                                        comment: "Text when there is an error while marking the order as paid for simple payments.")
         static let genericCollectError = NSLocalizedString("There was an error while trying to collect the payment.",
                                                        comment: "Text when there is an unknown error while trying to collect payments")
-        static let continueToOrders = NSLocalizedString("Continue To Orders",
-                                                        comment: "Button to dismiss modal overlay and go back to the orders list after a sucessful payment")
 
         static let title = NSLocalizedString("Take Payment (%1$@)",
                                              comment: "Navigation bar title for the Simple Payments Methods screens. " +

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
@@ -39,7 +39,7 @@ extension MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
         // no-op
     }
 
-    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptTitle: String, noReceiptAction: @escaping () -> Void) {
+    func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
         printReceiptFromSuccessAlert = printReceipt
         emailReceiptFromSuccessAlert = emailReceipt
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -10,7 +10,6 @@ final class CardPresentModalSuccessTests: XCTestCase {
         closures = Closures()
         viewModel = CardPresentModalSuccess(printReceipt: closures.printReceipt(),
                                             emailReceipt: closures.emailReceipt(),
-                                            noReceiptTitle: "Back",
                                             noReceiptAction: closures.noReceiptAction())
     }
 
@@ -42,7 +41,6 @@ final class CardPresentModalSuccessTests: XCTestCase {
 
     func test_auxiliary_button_title_is_not_nil() {
         XCTAssertNotNil(viewModel.auxiliaryButtonTitle)
-        XCTAssertEqual(viewModel.auxiliaryButtonTitle, "Back")
     }
 
     func test_bottom_title_is_nil() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
@@ -9,7 +9,6 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
         super.setUp()
         closures = Closures()
         viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt(),
-                                                        noReceiptTitle: "Back",
                                                         noReceiptAction: closures.noReceiptAction())
     }
 
@@ -37,7 +36,6 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
 
     func test_secondary_button_title_is_not_nil() {
         XCTAssertNotNil(viewModel.secondaryButtonTitle)
-        XCTAssertEqual(viewModel.secondaryButtonTitle, "Back")
     }
 
     func test_auxiliary_button_title_is_nil() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -45,7 +45,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
     func test_collectPayment_without_reader_connection_does_not_track_collectPaymentTapped_event() {
         // When
-        useCase.collectPayment(backButtonTitle: "", onCollect: { _ in }, onCompleted: {})
+        useCase.collectPayment(onCollect: { _ in }, onCompleted: {})
 
         // Then
         XCTAssertFalse(analyticsProvider.receivedEvents.contains("card_present_collect_payment_tapped"))
@@ -54,7 +54,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
     func test_collectPayment_tracks_collectPaymentTapped_event() throws {
         // When
         mockCardPresentPaymentActions()
-        useCase.collectPayment(backButtonTitle: "", onCollect: { _ in }, onCompleted: {})
+        useCase.collectPayment(onCollect: { _ in }, onCompleted: {})
 
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "card_present_collect_payment_tapped"}))
@@ -71,7 +71,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         // When
         mockCardPresentPaymentActions()
         let _: Void = waitFor { promise in
-            self.useCase.collectPayment(backButtonTitle: "", onCollect: { _ in }, onCompleted: {
+            self.useCase.collectPayment(onCollect: { _ in }, onCompleted: {
                 promise(())
             })
             self.alerts.cancelReaderIsReadyAlert?()
@@ -100,7 +100,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            self.useCase.collectPayment(backButtonTitle: "", onCollect: { _ in
+            self.useCase.collectPayment(onCollect: { _ in
                 promise(())
             }, onCompleted: {})
         }
@@ -120,7 +120,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            self.useCase.collectPayment(backButtonTitle: "", onCollect: { _ in
+            self.useCase.collectPayment(onCollect: { _ in
                 promise(())
             }, onCompleted: {})
         }
@@ -138,7 +138,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            self.useCase.collectPayment(backButtonTitle: "", onCollect: { _ in
+            self.useCase.collectPayment(onCollect: { _ in
                 promise(())
             }, onCompleted: {})
         }
@@ -158,7 +158,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            self.useCase.collectPayment(backButtonTitle: "", onCollect: { _ in
+            self.useCase.collectPayment(onCollect: { _ in
                 promise(())
             }, onCompleted: {})
         }
@@ -190,7 +190,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         mockCardPresentPaymentActions()
         var result: Result<Void, Error>? = nil
         let _: Void = waitFor { [weak self] promise in
-            useCase.collectPayment(backButtonTitle: "", onCollect: { collectPaymentResult in
+            useCase.collectPayment(onCollect: { collectPaymentResult in
                 result = collectPaymentResult
             }, onCompleted: {
                 promise(())
@@ -221,7 +221,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            self.useCase.collectPayment(backButtonTitle: "", onCollect: { _ in
+            self.useCase.collectPayment(onCollect: { _ in
                 promise(())
             }, onCompleted: {})
         }
@@ -245,7 +245,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            self.useCase.collectPayment(backButtonTitle: "", onCollect: { _ in
+            self.useCase.collectPayment(onCollect: { _ in
                 promise(())
             }, onCompleted: {})
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/MockCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/MockCollectOrderPaymentUseCase.swift
@@ -11,7 +11,7 @@ struct MockCollectOrderPaymentUseCase: CollectOrderPaymentProtocol {
 
     /// Calls `onCollect` and `onCompleted` secuencially.
     ///
-    func collectPayment(backButtonTitle: String, onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
+    func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
         onCollect(onCollectResult)
         if onCollectResult.isSuccess {
             onCompleted()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6905
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we change the wording for the dismiss action on the alert after a payment was successfully collected from "Back to Order" (Orders) / "Continue to Orders" (Simple Payment) to "Save receipt and continue", to align it with Android and make it more meaningful.
Furthermore, we refactor this logic so instead of setting the string on `OrderDetailsViewModel`/`SimplePaymentsMethodsViewModel` we do it in the alert view model logic itself, in a similar fashion as we do for the rest of the alert strings. That way we decouple these classes to make this case unique, localized, and more consistent with the other cases.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### New Simple Payment

- Go to Orders
- Create a Simple Payment and collect it with Card
- On the success alert:
   - If the user has email on the phone, the tertiary button displays the title "Save receipt and continue"   
   - Else, the secondary button displays the title "Save receipt and continue" (See screenshots)
   
#### New Order

- Go to Orders
- Create a new order and collect it with Card
- On the success alert:
   - If the user has email on the phone, the tertiary button displays the title "Save receipt and continue"   
   - Else, the secondary button displays the title "Save receipt and continue" (See screenshots)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### New order, with email
<img src="https://user-images.githubusercontent.com/1864060/169838130-c2fd371d-36d1-49b9-9013-e9b1dfd852f5.PNG" width="375">

#### Simple payment, with email
<img src="https://user-images.githubusercontent.com/1864060/169838148-a4188e41-5875-4119-b9e8-738f5bfa4444.PNG" width="375">

#### No email account on device, new string appears on secondary button
<img src="https://user-images.githubusercontent.com/1864060/169838203-0160b827-ffb0-4971-9d8e-209a99965eb3.png" width="375">
---

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
