### PR TITLE
Coupons: Hide limit usage to X Items when discount type is fixed cart

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -13,8 +13,6 @@ final class AddEditCouponViewModel: ObservableObject {
     ///
     private let editingOption: EditingOption
 
-    private let discountType: Coupon.DiscountType
-
     private let onCompletion: ((Result<Coupon, Error>) -> Void)
 
     /// Defines the current notice that should be shown.
@@ -144,6 +142,7 @@ final class AddEditCouponViewModel: ObservableObject {
     @Published var isLoading: Bool = false
 
     // Fields
+    @Published var discountType: Coupon.DiscountType
     @Published var amountField: String
     @Published var codeField: String
     @Published var descriptionField: String

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -142,7 +142,11 @@ final class AddEditCouponViewModel: ObservableObject {
     @Published var isLoading: Bool = false
 
     // Fields
-    @Published var discountType: Coupon.DiscountType
+    @Published var discountType: Coupon.DiscountType {
+        didSet {
+            couponRestrictionsViewModel.onDiscountTypeChanged(discountType: discountType)
+        }
+    }
     @Published var amountField: String
     @Published var codeField: String
     @Published var descriptionField: String

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -72,7 +72,7 @@ struct CouponRestrictions: View {
                             Divider()
                                     .padding(.leading, Constants.margin)
                                     .padding(.leading, insets: geometry.safeAreaInsets)
-                        }
+                        }.renderedIf(viewModel.shouldDisplayLimitUsageToXItemsRow)
                         TitleAndValueRow(title: Localization.allowedEmails,
                                          value: viewModel.allowedEmails.isNotEmpty ?
                                             .content(viewModel.allowedEmails) :

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -62,15 +62,17 @@ struct CouponRestrictions: View {
                     .background(Color(.listForeground))
 
                     VStack(alignment: .leading, spacing: 0) {
-                        TitleAndTextFieldRow(title: Localization.limitUsageToXItems,
-                                             placeholder: Localization.allQualifyingInCart,
-                                             text: $viewModel.limitUsageToXItems,
-                                             keyboardType: .asciiCapableNumberPad,
-                                             inputFormatter: IntegerInputFormatter(defaultValue: ""))
-                            .padding(.horizontal, insets: geometry.safeAreaInsets)
-                        Divider()
-                            .padding(.leading, Constants.margin)
-                            .padding(.leading, insets: geometry.safeAreaInsets)
+                        VStack {
+                            TitleAndTextFieldRow(title: Localization.limitUsageToXItems,
+                                    placeholder: Localization.allQualifyingInCart,
+                                    text: $viewModel.limitUsageToXItems,
+                                    keyboardType: .asciiCapableNumberPad,
+                                    inputFormatter: IntegerInputFormatter(defaultValue: ""))
+                                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                            Divider()
+                                    .padding(.leading, Constants.margin)
+                                    .padding(.leading, insets: geometry.safeAreaInsets)
+                        }
                         TitleAndValueRow(title: Localization.allowedEmails,
                                          value: viewModel.allowedEmails.isNotEmpty ?
                                             .content(viewModel.allowedEmails) :

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -126,6 +126,7 @@ final class CouponRestrictionsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
+        shouldDisplayLimitUsageToXItemsRow = false
         minimumSpend = ""
         maximumSpend = ""
         usageLimitPerCoupon = ""

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -118,7 +118,7 @@ final class CouponRestrictionsViewModel: ObservableObject {
         excludedProductOrVariationIDs = coupon.excludedProductIds
         excludedCategoryIDs = coupon.excludedProductCategories
 
-        shouldDisplayLimitUsageToXItemsRow = coupon.discountType == .fixedCart
+        shouldDisplayLimitUsageToXItemsRow = coupon.discountType != .fixedCart
     }
 
     init(siteID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -9,6 +9,8 @@ final class CouponRestrictionsViewModel: ObservableObject {
 
     let currencySymbol: String
 
+    let shouldDisplayLimitUsageToXItemsRow: Bool
+
     var excludeProductsButtonIcon: UIImage {
         excludedProductOrVariationIDs.isEmpty ? .plusImage : .pencilImage
     }
@@ -115,6 +117,8 @@ final class CouponRestrictionsViewModel: ObservableObject {
         excludeSaleItems = coupon.excludeSaleItems
         excludedProductOrVariationIDs = coupon.excludedProductIds
         excludedCategoryIDs = coupon.excludedProductCategories
+
+        shouldDisplayLimitUsageToXItemsRow = coupon.discountType == .fixedCart
     }
 
     init(siteID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -9,7 +9,7 @@ final class CouponRestrictionsViewModel: ObservableObject {
 
     let currencySymbol: String
 
-    let shouldDisplayLimitUsageToXItemsRow: Bool
+    private(set) var shouldDisplayLimitUsageToXItemsRow: Bool
 
     var excludeProductsButtonIcon: UIImage {
         excludedProductOrVariationIDs.isEmpty ? .plusImage : .pencilImage
@@ -140,6 +140,10 @@ final class CouponRestrictionsViewModel: ObservableObject {
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager
+    }
+
+    func onDiscountTypeChanged(discountType: Coupon.DiscountType) {
+        shouldDisplayLimitUsageToXItemsRow = discountType != .fixedCart
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -267,7 +267,7 @@ struct CouponDetails: View {
                 Text(String.pluralize(Int(viewModel.limitUsageToXItems),
                                       singular: Localization.singularItemsInCartUsageLimit,
                                       plural: Localization.pluralItemsInCartUsageLimit))
-                .renderedIf(viewModel.limitUsageToXItems > 0)
+                .renderedIf(viewModel.shouldDisplayLimitUsageToXItems)
             }
             .renderedIf(viewModel.minimumAmount.isNotEmpty ||
                         viewModel.maximumAmount.isNotEmpty ||

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -125,6 +125,10 @@ final class CouponDetailsViewModel: ObservableObject {
         (hasErrorLoadingAmount || hasWCAnalyticsDisabled) && discountedAmount == nil
     }
 
+    var shouldDisplayLimitUsageToXItems: Bool {
+        limitUsageToXItems > 0 && coupon.discountType != .fixedCart
+    }
+
     private let stores: StoresManager
     private let currencySettings: CurrencySettings
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponDetailsViewModelTests.swift
@@ -398,4 +398,46 @@ final class CouponDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.isDeletionInProgress)
     }
+
+    func test_shouldDisplayLimitUsageToXItems_should_be_false_when_discount_type_is_fixed_cart() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(
+            siteID: 123,
+            couponID: 456,
+            discountType: .fixedCart,
+            limitUsageToXItems: 5
+        )
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItems)
+    }
+
+    func test_shouldDisplayLimitUsageToXItems_should_be_false_when_limitUsageToXItems_is_zero() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(
+            siteID: 123,
+            couponID: 456,
+            discountType: .percent,
+            limitUsageToXItems: 0
+        )
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItems)
+    }
+
+    func test_shouldDisplayLimitUsageToXItems_should_be_true() {
+        // Given
+        let sampleCoupon = Coupon.fake().copy(
+            siteID: 123,
+            couponID: 456,
+            discountType: .percent,
+            limitUsageToXItems: 5
+        )
+        let viewModel = CouponDetailsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItems)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -88,6 +88,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
     }
 
     func test_shouldDisplayLimitUsageToXItemsRow_is_false_when_discount_type_is_changed_to_fixed_cart() {
+        // Given
         let sampleCoupon = Coupon.fake().copy(discountType: .percent)
         let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -68,4 +68,12 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         let expectedTitle = String.localizedStringWithFormat(NSLocalizedString("Exclude Product Categories (%1$d)", comment: ""), 2)
         XCTAssertEqual(viewModel.excludeCategoriesButtonTitle, expectedTitle)
     }
+
+    func test_shouldDisplayLimitUsageToXItemsRow_is_false_when_fixed_cart_discount_type_is_set() {
+        let sampleCoupon = Coupon.fake().copy(discountType: .fixedCart)
+        let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItemsRow)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -76,4 +76,12 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItemsRow)
     }
+
+    func test_shouldDisplayLimitUsageToXItemsRow_is_true_when_fixed_cart_discount_type_is_NOT_set() {
+        let sampleCoupon = Coupon.fake().copy(discountType: .percent)
+        let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItemsRow)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -95,6 +95,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItemsRow)
 
+        // When
         viewModel.onDiscountTypeChanged(discountType: .fixedCart)
 
         XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItemsRow)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -79,6 +79,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
     }
 
     func test_shouldDisplayLimitUsageToXItemsRow_is_true_when_fixed_cart_discount_type_is_NOT_set() {
+        // Given
         let sampleCoupon = Coupon.fake().copy(discountType: .percent)
         let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -103,6 +103,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
     }
 
     func test_shouldDisplayLimitUsageToXItemsRow_is_true_when_discount_type_is_changed_from_fixed_cart() {
+        // Given
         let sampleCoupon = Coupon.fake().copy(discountType: .fixedCart)
         let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -84,4 +84,28 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItemsRow)
     }
+
+    func test_shouldDisplayLimitUsageToXItemsRow_is_false_when_discount_type_is_changed_to_fixed_cart() {
+        let sampleCoupon = Coupon.fake().copy(discountType: .percent)
+        let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItemsRow)
+
+        viewModel.onDiscountTypeChanged(discountType: .fixedCart)
+
+        XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItemsRow)
+    }
+
+    func test_shouldDisplayLimitUsageToXItemsRow_is_true_when_discount_type_is_changed_from_fixed_cart() {
+        let sampleCoupon = Coupon.fake().copy(discountType: .fixedCart)
+        let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItemsRow)
+
+        viewModel.onDiscountTypeChanged(discountType: .percent)
+
+        XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItemsRow)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -70,6 +70,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
     }
 
     func test_shouldDisplayLimitUsageToXItemsRow_is_false_when_fixed_cart_discount_type_is_set() {
+        // Given
         let sampleCoupon = Coupon.fake().copy(discountType: .fixedCart)
         let viewModel = CouponRestrictionsViewModel(coupon: sampleCoupon)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -110,6 +110,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItemsRow)
 
+        // When
         viewModel.onDiscountTypeChanged(discountType: .percent)
 
         XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItemsRow)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -98,6 +98,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         // When
         viewModel.onDiscountTypeChanged(discountType: .fixedCart)
 
+        // Then
         XCTAssertFalse(viewModel.shouldDisplayLimitUsageToXItemsRow)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponRestrictionsViewModelTests.swift
@@ -113,6 +113,7 @@ final class CouponRestrictionsViewModelTests: XCTestCase {
         // When
         viewModel.onDiscountTypeChanged(discountType: .percent)
 
+        // Then
         XCTAssertTrue(viewModel.shouldDisplayLimitUsageToXItemsRow)
     }
 }


### PR DESCRIPTION
Summary
==========
Fix issue #6863 by setting a rule inside the `CouponRestriction` view and viewModel to only display the `limit usage to X items` row when the Coupon discount type is different from `fixed cart`.

Screenshots
==========
### Before
https://user-images.githubusercontent.com/5920403/170117633-d1a45346-2f4d-4230-9df8-b984ac7d49ce.mp4

### After
https://user-images.githubusercontent.com/5920403/170117670-c85a7417-645d-4db7-a535-36299fd63068.mp4

How to Test
==========
### Scenario 1
1. Make sure the Coupons experimental toggle is activated
2. Go to the Coupon list, select a Coupon configured with the fixed cart discount type
3. Inside the Coupon details, select the Edit coupon in the action menu
4. Inside the Edit Coupon view, select the `usage restrictions` option
5. Verify that the `limit usage to X items` is **NOT** displayed

### Scenario 2
1. Make sure the Coupons experimental toggle is activated
2. Go to the Coupon list, select a Coupon configured with **any discount type different from fixed cart**
3. Inside the Coupon details, select the Edit coupon in the action menu
4. Inside the Edit Coupon view, select the `usage restrictions` option
5. Verify that the `limit usage to X items` is displayed

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.