### PR TITLE
Dashboard: only show refresh control on the syncing time range tab

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -125,13 +125,14 @@ private extension StoreStatsAndTopPerformersViewController {
 
         var syncError: Error? = nil
 
-        ensureGhostContentIsDisplayed()
-        showSpinner(shouldShowSpinner: true)
+        let viewControllerToSync = visibleChildViewController
+        ensureGhostContentIsDisplayed(for: viewControllerToSync)
+        showSpinner(for: viewControllerToSync, shouldShowSpinner: true)
 
         defer {
             group.notify(queue: .main) { [weak self] in
                 self?.isSyncing = false
-                self?.showSpinner(shouldShowSpinner: false)
+                self?.showSpinner(for: viewControllerToSync, shouldShowSpinner: false)
                 if let error = syncError {
                     DDLogError("⛔️ Error loading dashboard: \(error)")
                     self?.handleSyncError(error: error)
@@ -149,7 +150,7 @@ private extension StoreStatsAndTopPerformersViewController {
         let timezoneForStatsDates = TimeZone.siteTimezone
         let timezoneForSync = TimeZone.current
 
-        [visibleChildViewController].forEach { [weak self] vc in
+        [viewControllerToSync].forEach { [weak self] vc in
             guard let self = self else {
                 return
             }
@@ -240,13 +241,11 @@ private extension StoreStatsAndTopPerformersViewController {
         }
     }
 
-    func showSpinner(shouldShowSpinner: Bool) {
-        periodVCs.forEach { (vc) in
-            if shouldShowSpinner {
-                vc.refreshControl.beginRefreshing()
-            } else {
-                vc.refreshControl.endRefreshing()
-            }
+    func showSpinner(for periodViewController: StoreStatsAndTopPerformersPeriodViewController, shouldShowSpinner: Bool) {
+        if shouldShowSpinner {
+            periodViewController.refreshControl.beginRefreshing()
+        } else {
+            periodViewController.refreshControl.endRefreshing()
         }
     }
 }
@@ -257,13 +256,11 @@ private extension StoreStatsAndTopPerformersViewController {
 
     /// Displays the Ghost Placeholder whenever there is no visible data.
     ///
-    func ensureGhostContentIsDisplayed() {
-        periodVCs.forEach { periodVC in
-            guard periodVC.shouldDisplayStoreStatsGhostContent else {
-                return
-            }
-            periodVC.displayGhostContent()
+    func ensureGhostContentIsDisplayed(for periodViewController: StoreStatsAndTopPerformersPeriodViewController) {
+        guard periodViewController.shouldDisplayStoreStatsGhostContent else {
+            return
         }
+        periodViewController.displayGhostContent()
     }
 
     /// If the Ghost Content was previously onscreen, this method will restart the animations.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6865 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As a followup task after the main goal to only fetch stats data for the visible time range tab, we also want to only show the refresh control (spinner) on the tab which the user pulls to refresh. Before this PR, any pull-to-refresh shows a refresh control in all 4 time range tabs.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a store if needed
- Pull down to refresh any time range tab --> the refresh control should only be shown on the time range tab with the refresh

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
