### PR TITLE
Shipping Labels Onboarding M1 feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -33,6 +33,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .shippingLabelsOnboardingM1:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -65,4 +65,8 @@ public enum FeatureFlag: Int {
     /// Enable optimistic updates for orders
     ///
     case updateOrderOptimistically
+
+    /// Enable Shipping Labels Onboarding M1 (display the banner in Order Detail screen for installing the WCShip plugin)
+    ///
+    case shippingLabelsOnboardingM1
 }


### PR DESCRIPTION
Part of #6914

### Description
Added the feature flag for starting the implementation of Shipping Labels Onboarding M1.

### Testing instructions
- Just CI, the feature flag is still not in use.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
