### PR TITLE
Change CouponCodeInputFormatter to use lowercase

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/Coupon Text Validators/CouponCodeInputFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/Coupon Text Validators/CouponCodeInputFormatter.swift
@@ -9,6 +9,6 @@ struct CouponCodeInputFormatter: UnitInputFormatter {
     }
 
     func format(input text: String?) -> String {
-        text?.uppercased() ?? ""
+        text?.lowercased() ?? ""
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponCodeInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponCodeInputFormatterTests.swift
@@ -7,13 +7,13 @@ final class CouponCodeInputFormatterTests: XCTestCase {
 
     // MARK: test cases for `isValid(input:)`
     func test_a_string_is_a_valid_coupon() {
-        let input = "ejfdklmda,349292!òàèù"
+        let input = "eJfDkLmDa,349292!òàèù"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
     // MARK: test cases for `format(input:)`
     func test_a_coupon_code_will_be_formatted_uppercased() {
-        let input = "abcdefd"
-        XCTAssertEqual(formatter.format(input: input), "ABCDEFD")
+        let input = "AbCdEfD"
+        XCTAssertEqual(formatter.format(input: input), "abcdefd")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponCodeInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponCodeInputFormatterTests.swift
@@ -12,7 +12,7 @@ final class CouponCodeInputFormatterTests: XCTestCase {
     }
 
     // MARK: test cases for `format(input:)`
-    func test_a_coupon_code_will_be_formatted_uppercased() {
+    func test_a_coupon_code_will_be_formatted_lowercased() {
         let input = "AbCdEfD"
         XCTAssertEqual(formatter.format(input: input), "abcdefd")
     }


### PR DESCRIPTION
Summary
==========
Fix issue #6834 by adjusting the CouponCodeInputFormatter inside the `AddEditCoupon` view to set the coupon code inputs as lowercase text instead of uppercase, making the formatting of the text be synced with all other Coupon views, but also making clear that the Coupon code is not case sensitive, as discussed here: https://github.com/woocommerce/woocommerce-ios/issues/6834#issuecomment-1135459067.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-24 at 17 39 04](https://user-images.githubusercontent.com/5920403/170127998-05a8ffb2-feb6-458f-bab3-c82c8689c91e.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-24 at 17 38 10](https://user-images.githubusercontent.com/5920403/170128028-36befe5f-73c9-45f0-892e-45d3fd7bc8ad.png) |

How to Test
==========
1. Make sure the Coupons experimental toggle is activated
2. Go to the Coupon list, select any coupon in the list
3. Inside the Coupon details, select the Edit coupon in the action menu
4. Inside the Edit Coupon view, verify that the Coupon code field is fully lowercased
5. Edit the Coupon code, verify that only lowercase inputs enter successfully

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.