### PR TITLE
Use new localization tooling to generate base `.strings` for GlotPress and to download its translations

### DIFF
--- a/WooCommerce/Resources/ar.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/ar.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/de.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/de.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/en.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/en.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/es.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/es.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/fr.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/fr.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/he.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/he.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/id.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/id.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/it.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/it.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/ja.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/ja.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/ko.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/ko.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/nl.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/nl.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/pt-BR.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/pt-BR.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/ru.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/ru.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/sv.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/sv.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/tr.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/tr.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/zh-Hans.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/Resources/zh-Hant.lproj/InfoPlist.strings
+++ b/WooCommerce/Resources/zh-Hant.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "To take photos or videos to add to your Products, scan barcode for Product SKU, or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "To save photos from camera for Product images, or to add photos or videos to your Products or support tickets.";
+
+/* A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground. */
+NSLocationWhenInUseUsageDescription = "Location access is required in order to accept payments.";
+
+/* A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals. */
+NSBluetoothPeripheralUsageDescription = "Bluetooth access is required in order to connect to supported card readers.";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to supported card readers.";

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -656,6 +656,7 @@
 		3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */; };
 		3F58701F281B947E004F7556 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F58701E281B947E004F7556 /* Main.storyboard */; };
 		3F587021281B9494004F7556 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F587020281B9494004F7556 /* LaunchScreen.storyboard */; };
+		3F587026281B9C19004F7556 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F587028281B9C19004F7556 /* InfoPlist.strings */; };
 		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
 		3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF22489267073AE008FFA87 /* ScreenObject */; };
 		3FF314E126FC74450012E68E /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FF314E026FC74450012E68E /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2373,6 +2374,23 @@
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		3F58701E281B947E004F7556 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		3F587020281B9494004F7556 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3F587027281B9C19004F7556 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587029281B9C2D004F7556 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F58702A281B9C2E004F7556 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		3F58702B281B9C33004F7556 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		3F58702C281B9C35004F7556 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F58702D281B9C39004F7556 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F58702E281B9C41004F7556 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F58702F281B9C43004F7556 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587030281B9C44004F7556 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587031281B9C46004F7556 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587032281B9C48004F7556 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587033281B9C4A004F7556 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587034281B9C4C004F7556 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587035281B9C4D004F7556 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		3F587036281B9C4F004F7556 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587037281B9C50004F7556 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3F587038281B9C52004F7556 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3FF314D626FC55DE0012E68E /* ScreenObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScreenObject+Extension.swift"; sourceTree = "<group>"; };
 		3FF314DE26FC74450012E68E /* UITestsFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestsFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF314E026FC74450012E68E /* UITestsFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UITestsFoundation.h; sourceTree = "<group>"; };
@@ -6305,6 +6323,7 @@
 				B56DB3D32049BFAA00D4AA8E /* Assets.xcassets */,
 				B5D1AFB320BC445900DB0E8C /* Images.xcassets */,
 				B573B19D219DC2690081C78C /* Localizable.strings */,
+				3F587028281B9C19004F7556 /* InfoPlist.strings */,
 				B56DB3D82049BFAA00D4AA8E /* Info.plist */,
 				B56C721921B5F65E00E5E85B /* Woo-Debug.entitlements */,
 				03180BE72763AA9000B938A8 /* Woo-Debug-macOS.entitlements */,
@@ -8413,6 +8432,7 @@
 				B92FF9AE27FC7217005C34E3 /* OrderListViewController.xib in Resources */,
 				023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */,
 				026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */,
+				3F587026281B9C19004F7556 /* InfoPlist.strings in Resources */,
 				4515C88E25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.xib in Resources */,
 				CE27258021925AE8002B22EB /* ValueOneTableViewCell.xib in Resources */,
 				451A04F12386F7B500E368C9 /* ProductImageCollectionViewCell.xib in Resources */,
@@ -10121,6 +10141,30 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		3F587028281B9C19004F7556 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3F587027281B9C19004F7556 /* en */,
+				3F587029281B9C2D004F7556 /* ar */,
+				3F58702A281B9C2E004F7556 /* zh-Hans */,
+				3F58702B281B9C33004F7556 /* zh-Hant */,
+				3F58702C281B9C35004F7556 /* tr */,
+				3F58702D281B9C39004F7556 /* nl */,
+				3F58702E281B9C41004F7556 /* fr */,
+				3F58702F281B9C43004F7556 /* de */,
+				3F587030281B9C44004F7556 /* he */,
+				3F587031281B9C46004F7556 /* id */,
+				3F587032281B9C48004F7556 /* it */,
+				3F587033281B9C4A004F7556 /* ja */,
+				3F587034281B9C4C004F7556 /* ko */,
+				3F587035281B9C4D004F7556 /* pt-BR */,
+				3F587036281B9C4F004F7556 /* ru */,
+				3F587037281B9C50004F7556 /* es */,
+				3F587038281B9C52004F7556 /* sv */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		B573B19D219DC2690081C78C /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -972,14 +972,14 @@ platform :ios do
       ],
       exclude: [
         '*Vendor*',
-        'WooCommerce/WooCommerceTests/**', # Some unit tests include localized strings
+        'WooCommerce/WooCommerceTests/**', # Some unit tests include localized strings, but we don't want to crowd GlotPress with them
       ],
       output_dir: en_lproj_path
     )
 
     # Merge various manually-maintained `.strings` files into the previously generated `Localizable.strings` so their extra keys are also imported in GlotPress.
     #
-    # Note: We will re-extract the translations back during `TODO` (via a call to `ios_extract_keys_from_strings_files`)
+    # Note: We will re-extract the translations back during `download_localized_strings_from_glotpress` (via a call to `ios_extract_keys_from_strings_files`)
     ios_merge_strings_files(
       paths_to_merge: MANUALLY_MAINTAINED_STRINGS_FILES,
       destination: File.join(en_lproj_path, 'Localizable.strings')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,7 +182,7 @@ platform :ios do
   desc 'Creates a new release branch from the current trunk'
   lane :complete_code_freeze do |options|
     ios_completecodefreeze_prechecks(options)
-    update_localization
+    generate_strings_file_for_glotpress
     version = ios_get_app_version
     trigger_beta_build(branch_to_build: "release/#{version}")
   end
@@ -958,7 +958,7 @@ platform :ios do
   end
 
   desc 'Run localization only'
-  lane :update_localization do
+  lane :generate_strings_file_for_glotpress do
     cocoapods
 
     en_lproj_path = File.join(RESOURCES_FOLDER, 'en.lproj')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -822,7 +822,7 @@ platform :ios do
       'app_store_keywords' => { desc: 'keywords.txt' },
       'app_store_subtitle' => { desc: 'subtitle.txt' },
       'app_store_promo_text' => { desc: 'promotional_text.txt' },
-      'whats_new' => { desc: 'whats_new.txt' },
+      "v#{ios_get_app_version}-whats-new" => { desc: 'whats_new.txt' },
 
       # Screenshots
       'app_store_screenshot-1' => { desc: 'app_store_screenshot_1.txt' },

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -840,9 +840,8 @@ platform :ios do
                         source_locale: 'en-US',
                         download_path: './fastlane/metadata')
 
-    # Copy source files into `en-US`
+    # Copy appstoreres (screenshot-related) txt files into `en-US`
     enUS_path = File.join(Dir.pwd, 'metadata', 'en-US')
-
     FileUtils.mkdir_p(enUS_path)
 
     [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -987,7 +987,7 @@ platform :ios do
 
     git_commit(
       path: en_lproj_path,
-      message: 'Update strings for localization',
+      message: 'Freeze strings for localization',
       allow_nothing_to_commit: true
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -840,25 +840,6 @@ platform :ios do
                         source_locale: 'en-US',
                         download_path: './fastlane/metadata')
 
-    # Ensure that localizations are present in the right places (some locale codes aren't correct)
-    {
-      'ar' => 'ar-SA',
-      'de' => 'de-DE',
-      'es' => 'es-ES',
-      'fr' => 'fr-FR',
-      'nl' => 'nl-NL',
-      'zh-cn' => 'zh-Hans',
-      'zh-tw' => 'zh-Hant'
-    }.each do |source, destination|
-      source_dir = File.join(Dir.pwd, 'metadata', source)
-      Dir.children(source_dir).each do |file|
-        source_file = File.join(source_dir, file)
-        destination_file = File.join(Dir.pwd, 'metadata', destination, file)
-        FileUtils.mv(source_file, destination_file)
-      end
-      FileUtils.remove_dir(source_dir)
-    end
-
     # Copy source files into `en-US`
     enUS_path = File.join(Dir.pwd, 'metadata', 'en-US')
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce].freeze # Registe
 #
 # See calls to `ios_merge_strings_files` and `ios_extract_keys_from_strings_files` for usage.
 #
-# Note that, yes, we currently have only one file, but it's still worth defining this constant because it's used across more than one lane, as describe above.
+# Note that, yes, we currently have only one file, but it's still worth defining this constant because it's used across more than one lane, as described above.
 #
 MANUALLY_MAINTAINED_STRINGS_FILES = {
   File.join(RESOURCES_FOLDER, 'en.lproj', 'InfoPlist.strings') => 'infoplist.'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,7 +31,7 @@ ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce].freeze # Registe
 # List of `.strings` files manually maintained by developers (as opposed to being automatically extracted from the code)
 # which we will merge into the main `Localizable.strings` file imported by GlotPress, then extract back once we download the translations.
 #
-# Each `.strings` file to be merged/extracted is associated with a prefix to add the the keys being used to avoid conflicts and differentiate.
+# Each `.strings` file to be merged/extracted is associated with a prefix to add to the keys, used to avoid conflicts and differentiate the source of the copies.
 #
 # See calls to `ios_merge_strings_files` and `ios_extract_keys_from_strings_files` for usage.
 #

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -857,11 +857,6 @@ platform :ios do
       FileUtils.cp(source, destination)
     end
 
-    # Replace the `default` directory with the contents of `en-US`
-    default_path = File.join(Dir.pwd, 'metadata', 'default')
-    FileUtils.remove_dir(default_path) if File.directory?(default_path)
-    FileUtils.copy_entry(enUS_path, default_path)
-
     # Never store review information (it contains passwords and PII)
     review_info_path = File.join(Dir.pwd, 'metadata', 'review_information')
     FileUtils.remove_dir(review_info_path) if File.directory?(review_info_path)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,6 @@ FASTLANE_DIR = __dir__
 DERIVED_DATA_DIR = File.join(FASTLANE_DIR, 'DerivedData')
 SCREENSHOTS_DIR =  File.join(FASTLANE_DIR, 'screenshots')
 IOS_LOCALES = %w[ar de-DE en-US es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant].freeze
-GLOTPRESS_LOCALES = %w[ar de es fr he id it ja ko nl pt-br ru sv tr zh-cn zh-tw].freeze
 SIMULATOR_VERSION = '14.3' # For screenshots
 SCREENSHOT_DEVICES = [
   'iPhone 11 Pro Max',
@@ -29,8 +28,45 @@ SCREENSHOT_DEVICES = [
 MAIN_BUNDLE_IDENTIFIERS = %w[com.automattic.woocommerce].freeze        # Registered in our main account, for development and AppStore
 ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce].freeze # Registered in our Enterprise account, for App Center / Installable Builds
 
+# List of `.strings` files manually maintained by developers (as opposed to being automatically extracted from the code)
+# which we will merge into the main `Localizable.strings` file imported by GlotPress, then extract back once we download the translations.
+#
+# Each `.strings` file to be merged/extracted is associated with a prefix to add the the keys being used to avoid conflicts and differentiate.
+#
+# See calls to `ios_merge_strings_files` and `ios_extract_keys_from_strings_files` for usage.
+#
+# Note that, yes, we currently have only one file, but it's still worth defining this constant because it's used across more than one lane, as describe above.
+#
+MANUALLY_MAINTAINED_STRINGS_FILES = {
+  File.join(RESOURCES_FOLDER, 'en.lproj', 'InfoPlist.strings') => 'infoplist.'
+}.freeze
+
+# URL of the GlotPress project containing the strings used in the app
+GLOTPRESS_APP_STRINGS_URL = 'https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/'
 # URL of the GlotPress project containing App Store Connect metadata
 GLOTPRESS_METADATA_PROJECT_URL = 'https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/release-notes/'
+
+# List of locales used for the app strings (GlotPress code => `*.lproj` folder name`)
+#
+# TODO: Replace with `LocaleHelper` once provided by release toolkit (https://github.com/wordpress-mobile/release-toolkit/pull/296)
+GLOTPRESS_TO_LPROJ_APP_LOCALE_CODES = {
+  'ar' => 'ar',         # Arabic
+  'de' => 'de',         # German
+  'es' => 'es',         # Spanish
+  'fr' => 'fr',         # French
+  'he' => 'he',         # Hebrew
+  'id' => 'id',         # Indonesian
+  'it' => 'it',         # Italian
+  'ja' => 'ja',         # Japanese
+  'ko' => 'ko',         # Korean
+  'nl' => 'nl',         # Dutch
+  'pt-br' => 'pt-BR',   # Portuguese (Brazil)
+  'ru' => 'ru',         # Russian
+  'sv' => 'sv',         # Swedish
+  'tr' => 'tr',         # Turkish
+  'zh-cn' => 'zh-Hans', # Chinese (China)
+  'zh-tw' => 'zh-Hant'  # Chinese (Taiwan)
+}.freeze
 
 # Mapping of all locales which can be used for AppStore metadata (Glotpress code => AppStore Connect code)
 #
@@ -699,15 +735,26 @@ platform :ios do
 
   desc 'Downloads localized `.strings` from GlotPress'
   lane :download_localized_strings_from_glotpress do
-    # FIXME: This is a copy of what the release toolkit `ios_update_metadata` action does.
-    # We'll soon replace this with the new `ios_download_strings_files_from_glotpress`-based workflow.
-    sh("cd #{PROJECT_ROOT_FOLDER} && ./Scripts/update-translations.rb")
-
-    files_to_commit = Dir.glob(File.join(RESOURCES_FOLDER, '**', '*.strings'))
-    git_add(path: files_to_commit, shell_escape: false)
+    ios_download_strings_files_from_glotpress(
+      project_url: GLOTPRESS_APP_STRINGS_URL,
+      locales: GLOTPRESS_TO_LPROJ_APP_LOCALE_CODES,
+      download_dir: RESOURCES_FOLDER
+    )
     git_commit(
-      path: files_to_commit,
-      message: 'Update translations',
+      path: File.join(RESOURCES_FOLDER, '*.lproj', 'Localizable.strings'),
+      message: 'Update app translations – `Localizable.strings`',
+      allow_nothing_to_commit: true
+    )
+
+    # Redispatch the appropriate subset of translations back to the manually-maintained `.strings`
+    # files that we merged at the `complete_code_freeze` time via `ios_merge_strings_files`
+    modified_files = ios_extract_keys_from_strings_files(
+      source_parent_dir: RESOURCES_FOLDER,
+      target_original_files: MANUALLY_MAINTAINED_STRINGS_FILES
+    )
+    git_commit(
+      path: modified_files,
+      message: 'Update app translations – Other `.strings`',
       allow_nothing_to_commit: true
     )
   end
@@ -785,7 +832,7 @@ platform :ios do
       'app_store_screenshot-5' => { desc: 'app_store_screenshot_5.txt' }
     }
 
-    metadata_locales = GLOTPRESS_LOCALES
+    metadata_locales = GLOTPRESS_TO_ASC_METADATA_LOCALE_CODES
 
     gp_downloadmetadata(project_url: 'https://translate.wordpress.com/projects/woocommerce%2Fwoocommerce-ios%2Frelease-notes/',
                         target_files: files,
@@ -912,7 +959,37 @@ platform :ios do
 
   desc 'Run localization only'
   lane :update_localization do
-    ios_localize_project
+    cocoapods
+
+    en_lproj_path = File.join(RESOURCES_FOLDER, 'en.lproj')
+    ios_generate_strings_file_from_code(
+      paths: [
+        'WooCommerce/',
+        'Pods/WordPress*/',
+        'Storage/Storage/',
+        'Networking/Networking/',
+        'Hardware/Hardware/',
+      ],
+      exclude: [
+        '*Vendor*',
+        'WooCommerce/WooCommerceTests/**', # Some unit tests include localized strings
+      ],
+      output_dir: en_lproj_path
+    )
+
+    # Merge various manually-maintained `.strings` files into the previously generated `Localizable.strings` so their extra keys are also imported in GlotPress.
+    #
+    # Note: We will re-extract the translations back during `TODO` (via a call to `ios_extract_keys_from_strings_files`)
+    ios_merge_strings_files(
+      paths_to_merge: MANUALLY_MAINTAINED_STRINGS_FILES,
+      destination: File.join(en_lproj_path, 'Localizable.strings')
+    )
+
+    git_commit(
+      path: en_lproj_path,
+      message: 'Update strings for localization',
+      allow_nothing_to_commit: true
+    )
   end
 
   def write_file(path, contents)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -932,7 +932,7 @@ platform :ios do
     configure_validate
   end
 
-  desc 'Run localization only'
+  desc 'Updates the main `Localizable.strings` file — that will be imported by GlotPress — from code and `Info.plist` files'
   lane :generate_strings_file_for_glotpress do
     cocoapods
 

--- a/fastlane/metadata/default/promo_screenshot_1.txt
+++ b/fastlane/metadata/default/promo_screenshot_1.txt
@@ -1,2 +1,0 @@
-Track sales and high
-performing products

--- a/fastlane/metadata/default/promo_screenshot_2.txt
+++ b/fastlane/metadata/default/promo_screenshot_2.txt
@@ -1,2 +1,0 @@
-View and manage
-orders on the go

--- a/fastlane/metadata/default/promo_screenshot_3.txt
+++ b/fastlane/metadata/default/promo_screenshot_3.txt
@@ -1,2 +1,0 @@
-Review order details
-and payments

--- a/fastlane/metadata/default/promo_screenshot_4.txt
+++ b/fastlane/metadata/default/promo_screenshot_4.txt
@@ -1,2 +1,0 @@
-View products and
-check inventory

--- a/fastlane/metadata/default/promo_screenshot_5.txt
+++ b/fastlane/metadata/default/promo_screenshot_5.txt
@@ -1,2 +1,0 @@
-Get notified about
-new reviews


### PR DESCRIPTION
### Description

Update the Fastlane automation to generated the `.strings` file that gets uploaded to GlotPress and the related logic to download the localized `.strings` to use the new tooling.

It made sense to me to do both sides in one go because of the introduction of the `InfoPlist.strings` files which the `.strings` generation process appends to the base file, and the download process dispatches to the appropriate `.strings` for the app to read a runtime.

Continues the work from #6879. See also [WordPress iOS counterpart](https://github.com/wordpress-mobile/WordPress-iOS/pull/18061).

cc @oguzkocer always appreciate your review, but mostly wanted to flag this to keep an eye out on the `.strings` that will be generated during the next code freeze. I'll also try to check that PR when it's time for it.

### Testing instructions

Manually testing these changes is cumbersome. I don't expect reviewers to do it.

The steps I took to verify these changes were:

1. Create a test branch on top of this, https://github.com/woocommerce/woocommerce-ios/pull/6928, and run both automations on it
2. Create a test branch on top of `trunk` and run both legacy automation steps on it, https://github.com/woocommerce/woocommerce-ios/commit/ac0e8fce93a21181224eb4457856f69a6d2a7750 and https://github.com/woocommerce/woocommerce-ios/commit/188f913a5287f37d8129666bc8dd76e7dcd13a45
3. Ensure that all the changes in the generated `.strings` that the legacy automation produced are present in the new output
4. Compare the `de` `.strings` downloaded by both automations to make sure they are the same. _They weren't_, the new automation correctly removed a key the old one had missed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
