### PR TITLE
Download missing App Store screenshot copy localizations

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -731,6 +731,11 @@ platform :ios do
       app_store_subtitle: { desc: "subtitle.txt", max_size: 30 },
       app_store_desc: { desc: "description.txt", max_size: 4000 },
       app_store_keywords: { desc: "keywords.txt", max_size: 100 },
+      'app_store_screenshot-1' => { desc: 'app_store_screenshot_1.txt' },
+      'app_store_screenshot-2' => { desc: 'app_store_screenshot_2.txt' },
+      'app_store_screenshot-3' => { desc: 'app_store_screenshot_3.txt' },
+      'app_store_screenshot-4' => { desc: 'app_store_screenshot_4.txt' },
+      'app_store_screenshot-5' => { desc: 'app_store_screenshot_5.txt' }
     }
 
     gp_downloadmetadata(


### PR DESCRIPTION
I forgot about these when updating the logic that downloads localized App Store metadata from GlotPress, see c991e2a.

If the action doesn't have those files in the `target_files` parameter, it won't download them. But it won't download them either, so this issue wasn't noticed.

### Testing instructions

I created #6938  to test this. In it you can see [four commits](https://github.com/woocommerce/woocommerce-ios/pull/6938/commits)

1. Prep work: Run the metadata download lane to avoid noise later on
2. `rm fastlane/metadata/it/app_*` to delete existing `it` screenshots localizations

At this point, I run the automation again and reproduced the issue: the screenshots localization were not downloaded

<img width="1432" alt="Screen Shot 2022-05-25 at 4 08 37 pm" src="https://user-images.githubusercontent.com/1218433/170192247-bd98e5fa-5085-4fbb-8ea2-d6cbb35ae758.png">

Since no change was made to the codebase, there's no commit to show that 😅

4. Apply this fix
5. Run the `bundle exec fastlane download_localized_metadata_from_glotpress` and verify the deleted `.txt` files were re-downloaded:

<img width="1592" alt="image" src="https://user-images.githubusercontent.com/1218433/170190803-6b11e006-4b44-4fa8-9dfb-78e82ba64a29.png">

FYI @oguzkocer – I'm not opening this against `release/19.2` because the existing `app_store_screenshot_*.txt` files won't be deleted by the automation and, as far as I'm aware, we don't need new screenshots localization in 9.2

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
