### PR TITLE
Dashboard: fix syncing behavior when selecting a time range tab that is not next to the current tab

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -79,20 +79,14 @@ final class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripView
         }
     }
 
-    override func updateIndicator(for viewController: PagerTabStripViewController,
-                                  fromIndex: Int,
-                                  toIndex: Int,
-                                  withProgressPercentage progressPercentage: CGFloat,
-                                  indexWasChanged: Bool) {
-        super.updateIndicator(for: viewController,
-                              fromIndex: fromIndex,
-                              toIndex: toIndex,
-                              withProgressPercentage: progressPercentage,
-                              indexWasChanged: indexWasChanged)
-        guard fromIndex != toIndex, toIndex < periodVCs.count else {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        super.collectionView(collectionView, didSelectItemAt: indexPath)
+        let timeRangeTabIndex = indexPath.item
+        guard let periodViewController = viewControllers[timeRangeTabIndex] as? StoreStatsAndTopPerformersPeriodViewController,
+              timeRangeTabIndex != currentIndex else {
             return
         }
-        syncAllStats(forced: false)
+        syncStats(forced: false, viewControllerToSync: periodViewController)
     }
 }
 
@@ -115,6 +109,10 @@ extension StoreStatsAndTopPerformersViewController: DashboardUI {
 //
 private extension StoreStatsAndTopPerformersViewController {
     func syncAllStats(forced: Bool, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        syncStats(forced: forced, viewControllerToSync: visibleChildViewController, onCompletion: onCompletion)
+    }
+
+    func syncStats(forced: Bool, viewControllerToSync: StoreStatsAndTopPerformersPeriodViewController, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         guard !isSyncing else {
             return
         }
@@ -125,7 +123,6 @@ private extension StoreStatsAndTopPerformersViewController {
 
         var syncError: Error? = nil
 
-        let viewControllerToSync = visibleChildViewController
         ensureGhostContentIsDisplayed(for: viewControllerToSync)
         showSpinner(for: viewControllerToSync, shouldShowSpinner: true)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6865 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After more testing on the main change for #6865 (only fetching stats data only for the visible/selected time range tab), I noticed that the stats data often showed `-` while the placeholder (ghost animation) wasn't shown which indicates the sync was done. The cause was from how the app is notified by the time range tab selection.

Before this PR, the app is notified when the user selects a different time range tab with this delegate function:

https://github.com/woocommerce/woocommerce-ios/blob/a69f6ba83c56ff9dc709c70a1bec6f681bd74053/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersViewController.swift#L82-L95

At the time of https://github.com/woocommerce/woocommerce-ios/pull/6890, I didn't find a better delegate function and only tested tapping on the next time range tab 😓 . The issue occurs when tapping on a time range tab that is not the next tab. The reason is that the delegate function above is triggered by `scrollViewDidScroll(_:)` in `XLPageTabStrip.PagerTabStripViewController`, and the `(fromIndex, toIndex)` tuple could change from `(1, 2)` then `(2, 3)` when changing the time range tab from Today to This Year tab for example. Since the app used to sync stats data always with `visibleChildViewController`, the tab change first triggers the delegate function when the scroll view content offset changes and the `visibleChildViewController` used to sync data isn't the final selected tab.

To fix this issue, I found a better delegate function `collectionView(_:, didSelectItemAt:)` that is triggered by the tap action instead of `scrollViewDidScroll(_:)`. The selected tab index is the `didSelectItemAt` index path item. With this change, the stats data are now fetched for the correctly selected tab once (if data was last fetched before [the minimum interval](https://github.com/woocommerce/woocommerce-ios/blob/a69f6ba83c56ff9dc709c70a1bec6f681bd74053/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersPeriodViewController.swift#L45-L55)).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Log in to a store if needed
- Tap "This Year" tab --> the stats data should be shown after the API sync completes. before this PR, `-` data is shown
- Feel free to try tapping any other time range tab, or switching to a different store

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before:

https://user-images.githubusercontent.com/1945542/170211974-b3e3ca7e-b69e-4002-8eed-319ce37139fa.mov

after:

https://user-images.githubusercontent.com/1945542/170212128-46e2d88a-d9ac-4e0d-b8ca-733720b36200.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
