### PR TITLE
Display more than 2 error lines when needed on Login errors

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -86,7 +86,8 @@ private extension ULErrorViewController {
         extraInfoButton.applyLinkButtonStyle()
         extraInfoButton.contentEdgeInsets = Constants.extraInfoCustomInsets
         extraInfoButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
-        extraInfoButton.titleLabel?.numberOfLines = 2
+        extraInfoButton.titleLabel?.numberOfLines = 0
+        extraInfoButton.titleLabel?.lineBreakMode = .byWordWrapping
         extraInfoButton.titleLabel?.textAlignment = .center
         extraInfoButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapAuxiliaryButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -48,6 +48,8 @@ final class ULErrorViewController: UIViewController {
         configurePrimaryButton()
         configureSecondaryButton()
 
+        configureButtonLabels()
+
         setUnifiedMargins(forWidth: view.frame.width)
 
         viewModel.viewDidLoad()
@@ -86,8 +88,6 @@ private extension ULErrorViewController {
         extraInfoButton.applyLinkButtonStyle()
         extraInfoButton.contentEdgeInsets = Constants.extraInfoCustomInsets
         extraInfoButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
-        extraInfoButton.titleLabel?.numberOfLines = 0
-        extraInfoButton.titleLabel?.lineBreakMode = .byWordWrapping
         extraInfoButton.titleLabel?.textAlignment = .center
         extraInfoButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapAuxiliaryButton()
@@ -106,6 +106,14 @@ private extension ULErrorViewController {
         secondaryButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
         secondaryButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapSecondaryButton()
+        }
+    }
+
+    func configureButtonLabels() {
+        let buttons = [extraInfoButton, primaryButton, secondaryButton]
+        for button in buttons {
+            button?.titleLabel?.numberOfLines = 0
+            button?.titleLabel?.lineBreakMode = .byWordWrapping
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3331
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removes the two line limit on the button text in the login error screen, so that languages with longer sentences in the translations do not have a truncated string.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. switch your phone to German
2. try to login, but using a wrong account
3. see error 

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After
---|---
![german-error-truncation-before](https://user-images.githubusercontent.com/2472348/170262811-28afb582-27c8-46c3-8d23-7ac8308c3932.jpg) | ![german-error-truncation-after](https://user-images.githubusercontent.com/2472348/170262832-6371b68e-8782-46ab-8bab-6fea423d1a6d.jpg)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
