### PR TITLE
[Order Details] Paid By Customer section should be hidden if no date_paid returned

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1028,7 +1028,14 @@ extension OrderDetailsDataSource {
         }()
 
         let payment: Section = {
-            var rows: [Row] = [.payment, .customerPaid]
+            var rows: [Row] = [.payment]
+
+            let shouldShowCustomerPaidRow = order.datePaid != nil
+
+            if shouldShowCustomerPaidRow {
+                rows.append(.customerPaid)
+            }
+
             if condensedRefunds.isNotEmpty {
                 let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
                 rows.append(contentsOf: refunds)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -56,6 +56,34 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertEqual(actualTitles, expectedTitles)
     }
 
+    func test_reloadSections_when_there_is_no_paid_date_then_customer_paid_row_is_hidden() throws {
+        // Given
+        let order = Order.fake()
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        let customerPaidRow = row(row: .customerPaid, in: paymentSection)
+        XCTAssertNil(customerPaidRow)
+    }
+
+    func test_reloadSections_when_there_is_a_paid_date_then_customer_paid_row_is_visible() throws {
+        // Given
+        let order = Order.fake().copy(datePaid: Date())
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        let customerPaidRow = row(row: .customerPaid, in: paymentSection)
+        XCTAssertNotNil(customerPaidRow)
+    }
+
     func test_refund_button_is_visible() throws {
         // Given
         let order = makeOrder()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #1827
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we hide the "paid" if the order was not paid yet. That way we declutter the already crowded order details screen by removing an unnecessary element.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Not paid order

1. Go to orders
2. Create an order, but do not collect the payment yet
3. The Paid row should not be visible

#### Paid order

1. Go to orders
2. Create an order, and collect the payment yet
3. The Paid row should be visible


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
On this video we can see how the Paid row is hidden for a "Pending Payment" order, while for a "Completed" order it is shown with the paid amount and information.

https://user-images.githubusercontent.com/1864060/170270577-09c354aa-8d1b-449d-9ab8-b655769f359a.mp4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
