### PR TITLE
Fix warnings in xcode 13.3.1

### DIFF
--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -24,12 +24,15 @@ extension UIViewController {
 
     /// Show the X close button or a custom close button with title on the left bar button item position
     ///
-    func addCloseNavigationBarButton(title: String? = nil, target: Any? = self, action: Selector? = #selector(dismissVC)) {
+    func addCloseNavigationBarButton(title: String? = nil, target: Any? = nil, action: Selector? = #selector(dismissVC)) {
+        /// We can't make self the default value for the `target` parameter without a warning being added.
+        /// The compiler-recommended fix for the warning causes a crash when the button is tapped.
+        let targetOrSelf = target ?? self
         if let title = title {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(title: title, style: .plain, target: target, action: action)
+            navigationItem.leftBarButtonItem = UIBarButtonItem(title: title, style: .plain, target: targetOrSelf, action: action)
         }
         else {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: target, action: action)
+            navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: targetOrSelf, action: action)
             navigationItem.leftBarButtonItem?.accessibilityLabel = Localization.close
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -56,7 +56,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     // MARK: Subviews
 
-    var refreshControl: UIRefreshControl = {
+    lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl(frame: .zero)
         refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
         return refreshControl

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
@@ -27,12 +27,11 @@ final class ProductDownloadFileViewController: UIViewController {
         self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
     }
 
-    private let updateBarButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: nil,
-                                     style: .done,
-                                     target: self,
-                                     action: #selector(completeUpdating))
-        return button
+    private lazy var updateBarButton: UIBarButtonItem = {
+        UIBarButtonItem(title: nil,
+                        style: .done,
+                        target: self,
+                        action: #selector(completeUpdating))
     }()
 
     /// Init

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SegmentedView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SegmentedView.swift
@@ -24,7 +24,7 @@ struct SegmentedView<Content: View>: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(0..<views.count) { (index) in
+            ForEach(0..<views.count, id: \.self) { (index) in
                 VStack(spacing: 0) {
                     getContentView(index)
                     if index == selection {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

# Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since updating to Xcode 13.3.1 on CI and in local environments, some new warnings have shown up in the project.

This PR removes the warnings, some of which are dangerous because the suggested fixes add crashes in the app.

## 1. 'self' refers to the method 'UIViewController.self', which may be unexpected
The `addCloseNavigationBarButton` helper function used `self` as a default value for the `target` parameter.

From Xcode 13.3, this produced a warning:

> `'self' refers to the method 'UIViewController.self', which may be unexpected`

That was due to the function signature being available before `init` is complete, at which time `self` does not refer to self. The compiler-suggested fix (expressly specifying `UIViewController.self`) causes a crash when the close button is tapped on any view controller which uses this helper.

## 2. self refers to the method ‘ClassName.self', which may be unexpected
> StoreStatsAndTopPerformersPeriodViewController.swift:61:34: 'self' refers to the method 'StoreStatsAndTopPerformersPeriodViewController.self', which may be unexpected

> ProductDownloadFileViewController.swift:33:46: 'self' refers to the method 'ProductDownloadFileViewController.self', which may be unexpected

For properties which are created before `init()` completes, references to `self` had the warning

> `self refers to the method ‘ClassName.self', which may be unexpected`

This is due to self referring to a method in objc when init is not complete.

Changing these properties to lazy var resolves this warning without adding a runtime crash, as the Xcode suggestion will do.

## 3. Non-constant range (in SwiftUI ForEach)
> SegmentedView.swift:27:31: Non-constant range: argument must be an integer literal

SwiftUI expects a constant range for non-identified ForEach loops. I have added the ID to fix this.

See https://forums.swift.org/t/how-for-swiftui-foreach-init-data-range-int-viewbuilder-content-escaping-int-content-compiler-is-able-to-warn-if-range-is-not-constant/55233/3 for more info.

## 4. Conversion to Swift 5 available
The warning `Conversion to Swift 5 available` seems to be a [known issue at the moment](https://developer.apple.com/forums/thread/697832), and I wasn't able to remove it.

# Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## 1. 'self' refers to the method 'UIViewController.self', which may be unexpected

1. Navigate to `Products > + > Simple Physical Product > Add more details > Categories > Add Category`
2. Tap `Cancel`
3. Observe that cancel works as expected and the app does not crash

## 2. self refers to the method ‘ClassName.self', which may be unexpected

`StoreStatsAndTopPerformersPeriodViewController.swift`
1. Open the app to the dashboard
2. Pull-to-refresh
3. Observe that refresh works and the app does not crash

`ProductDownloadFileViewController.swift`
1. Navigate to `Products > A downloadable product > Downloadable files > Any download`
2. Change the file name
3. Tap `Update`
4. Observe that the update works and the app does not crash

## 3. Non-constant range (in SwiftUI ForEach)
1. Navigate to a completed order
2. Tap `Create Shipping Label`
3. Complete the form through to Package Details
4. Tap `Continue`
5. Tap `Package Selected` row
6. Tap `Create new package`
7. Observe that the segmented control for `Custom Package` and `Service Package` works.


# Screenshots
Before | After
---|---
![warnings-before](https://user-images.githubusercontent.com/2472348/170297520-dc8f83fe-8430-410b-bb15-e98ba6955ec3.jpg) | ![warnings-after](https://user-images.githubusercontent.com/2472348/170297531-500b4441-01ee-4924-92ec-e503707f3cc9.jpg)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
