### PR TITLE
Order Creation: Make sure remote sync uses the updated order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -56,6 +56,53 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
     ///
     private let localIDStore = LocalIDStore()
 
+    // MARK: Private publishers for significant order input
+
+    private lazy var productInput: AnyPublisher<Order, Never> = {
+        setProduct.withLatestFrom(orderPublisher)
+            .map { [weak self] productInput, order -> Order in
+                guard let self = self else { return order }
+                let localInput = self.replaceInputWithLocalIDIfNeeded(productInput)
+                let updatedOrder = ProductInputTransformer.update(input: localInput, on: order, updateZeroQuantities: true)
+                // Calculate order total locally while order is being synced
+                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
+            }
+            .share()
+            .eraseToAnyPublisher()
+    }()
+
+    private lazy var addressInput: AnyPublisher<Order, Never> = {
+        setAddresses.withLatestFrom(orderPublisher)
+            .map { addressesInput, order in
+                order.copy(billingAddress: .some(addressesInput?.billing), shippingAddress: .some(addressesInput?.shipping))
+            }
+            .share()
+            .eraseToAnyPublisher()
+    }()
+
+    private lazy var shippingInput: AnyPublisher<Order, Never> = { setShipping.withLatestFrom(orderPublisher)
+            .map { [weak self] shippingLineInput, order -> Order in
+                guard let self = self else { return order }
+                let updatedOrder = ShippingInputTransformer.update(input: shippingLineInput, on: order)
+                // Calculate order total locally while order is being synced
+                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
+            }
+            .share()
+            .eraseToAnyPublisher()
+    }()
+
+    private lazy var feeInput: AnyPublisher<Order, Never> = {
+        setFee.withLatestFrom(orderPublisher)
+            .map { [weak self] feeLineInput, order -> Order in
+                guard let self = self else { return order }
+                let updatedOrder = FeesInputTransformer.update(input: feeLineInput, on: order)
+                // Calculate order total locally while order is being synced
+                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
+            }
+            .share()
+            .eraseToAnyPublisher()
+    }()
+
     // MARK: Initializers
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
@@ -65,6 +112,7 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
 
         updateBaseSyncOrderStatus()
         bindInputs()
+        bindOrderSync()
     }
 
     // MARK: Methods
@@ -111,66 +159,28 @@ private extension RemoteOrderSynchronizer {
             }
             .assign(to: &$order)
 
-        let setProduct: AnyPublisher<Order, Never> = setProduct.withLatestFrom(orderPublisher)
-            .map { [weak self] productInput, order -> Order in
-                guard let self = self else { return order }
-                let localInput = self.replaceInputWithLocalIDIfNeeded(productInput)
-                let updatedOrder = ProductInputTransformer.update(input: localInput, on: order, updateZeroQuantities: true)
-                // Calculate order total locally while order is being synced
-                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
-            }
-            .share()
-            .eraseToAnyPublisher()
-        setProduct.assign(to: &$order)
+        productInput.assign(to: &$order)
 
-        let setAddress: AnyPublisher<Order, Never> = setAddresses.withLatestFrom(orderPublisher)
-            .map { addressesInput, order in
-                order.copy(billingAddress: .some(addressesInput?.billing), shippingAddress: .some(addressesInput?.shipping))
-            }
-            .share()
-            .eraseToAnyPublisher()
-        setAddress.assign(to: &$order)
+        addressInput.assign(to: &$order)
 
-        let setShipping: AnyPublisher<Order, Never> = setShipping.withLatestFrom(orderPublisher)
-            .map { [weak self] shippingLineInput, order -> Order in
-                guard let self = self else { return order }
-                let updatedOrder = ShippingInputTransformer.update(input: shippingLineInput, on: order)
-                // Calculate order total locally while order is being synced
-                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
-            }
-            .share()
-            .eraseToAnyPublisher()
-        setShipping.assign(to: &$order)
+        shippingInput.assign(to: &$order)
 
-        let setFee: AnyPublisher<Order, Never> = setFee.withLatestFrom(orderPublisher)
-            .map { [weak self] feeLineInput, order -> Order in
-                guard let self = self else { return order }
-                let updatedOrder = FeesInputTransformer.update(input: feeLineInput, on: order)
-                // Calculate order total locally while order is being synced
-                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
-            }
-            .share()
-            .eraseToAnyPublisher()
-        setFee.assign(to: &$order)
+        feeInput.assign(to: &$order)
 
         setNote.withLatestFrom(orderPublisher)
             .map { notes, order in
                 order.copy(customerNote: notes)
             }
             .assign(to: &$order)
-
-        // Combine inputs that should trigger an order sync operation.
-        let syncTrigger: AnyPublisher<Order, Never> = setProduct
-            .merge(with: setAddress, setShipping, setFee)
-            .merge(with: retryTrigger.compactMap { [weak self] in self?.order })
-            .eraseToAnyPublisher()
-        bindOrderSync(trigger: syncTrigger)
     }
 
     /// Creates or updates the order when a significant order input occurs.
     ///
-    func bindOrderSync(trigger: AnyPublisher<Order, Never>) {
-        let syncTrigger: AnyPublisher<Order, Never> = trigger
+    func bindOrderSync() {
+        // Combine inputs that should trigger an order sync operation.
+        let syncTrigger: AnyPublisher<Order, Never> = productInput
+            .merge(with: addressInput, shippingInput, feeInput)
+            .merge(with: retryTrigger.compactMap { [weak self] in self?.order })
             .debounce(for: 0.5, scheduler: DispatchQueue.main) // Group & wait for 0.5 since the last signal was emitted.
             .compactMap { [weak self] order in
                 guard let self = self else { return nil }


### PR DESCRIPTION
Part of: #6339

## Description

This is the first of two PRs to immediately respond to additive changes to an order (e.g. adding a new product to the order) during Order Creation. This will avoid scenarios where the user is able to open new screens to then be blocked while the network requests completes.

This PR prepares the synchronizer to be able to respond immediately to additive changes:

Previously in the `RemoteOrderSynchronizer`, we were using the `PassthroughSubject` inputs (`setStatus`, `setProduct`, etc.) in two places separately/simultaneously:

* In `bindInputs()` to update the underlying order.
* In `bindOrderSync()` to trigger a remote sync (using the underlying order `self.order`).

![Remote Sync - Before](https://user-images.githubusercontent.com/8658164/170299429-df735d4d-575b-41ae-a9d4-14a36e162479.png)

This worked because we debounced the sync triggers in `bindOrderSync()` before getting the underlying order. That gave `bindInputs()` time to update the underlying order before `bindOrderSync()` used it. However, if we want to make immediate changes based on additive changes to the order, we need to change this flow to avoid a race condition.

This PR updates the flow in `RemoteOrderSynchronizer` to ensure the updated order is always used for remote sync:

1. The synchronizer receives an input event from a `PassthroughSubject`.
2. Significant inputs (products, addresses, shipping, fee) have private publishers. Those publishers transform the input, publishing an updated order with that input to multiple subscribers.
3. `bindInputs()` subscribes to those publishers and updates the underlying order.
4. `bindOrderSync()` subscribes to those publishers (and the `retryTrigger` subject), debounces the trigger events as before, and uses order received from the publishers (instead of the underlying order from `self.order`) to sync remotely.

![Remote Sync - After](https://user-images.githubusercontent.com/8658164/170299469-957d2068-4c82-40c7-be7e-f373bfdc2d2e.png)

Because we are still debouncing before syncing the order, there should be no noticeable changes in behavior for Order Creation yet. (In a followup PR I'll introduce changes to make the UI respond immediately to additive changes to the order.)

## Changes

* Introduces four private publishers for significant inputs: `productInput`, `addressInput`, `shippingInput`, and `feeInput`. These publishers do the same transformations previously done in `bindInputs()`, and then make the resulting updated order available to multiple subscribers.
* `bindInputs()` no longer needs to do any work for those four significant inputs. Instead, it subscribes to the new publishers and assigns the updated order directly to the underlying order.
* `bindOrderSync()` relies on the same input as before, but it now subscribes to the new publishers (instead of the `PassthroughSubject` for each input) and uses the updated order from those publishers for the remote sync. The only exception is `retryTrigger`, which takes events directly from the `PassthroughSubject` and uses `self.order` because in that case there are no changes to the underlying order to handle first.

## Testing

1. Go to the Orders tab and create a new order.
2. Add, change, and remove items from the order and confirm it behaves as before.
3. Make sure that when the order syncs remotely, there are no unexpected changes to the order.
4. Disable your internet connection while the order syncs remotely.
5. Reconnect and retry the remote sync; confirm the order syncs with no unexpected changes to the order.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
