### PR TITLE
Coupons: Enhance coupon date picker

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -381,12 +381,6 @@ private extension AddEditCoupon {
         static let addDescriptionPlaceholder = NSLocalizedString("Add the description of the coupon.",
                                                                  comment: "Placeholder text that will be shown in the view" +
                                                                  " for adding the description of a coupon.")
-        static let actionSheetEditExpirationDate = NSLocalizedString("Edit expiration date",
-                                                                     comment: "Button in the action sheet for editing the expiration date of a coupon.")
-        static let actionSheetDeleteExpirationDate = NSLocalizedString("Delete expiration date",
-                                                                     comment: "Button in the action sheet for deleting the expiration date of a coupon.")
-        static let actionSheetAddExpirationDate = NSLocalizedString("Add expiration date",
-                                                                     comment: "Button in the action sheet for adding the expiration date for a coupon.")
         static let titleEditDescriptionView = NSLocalizedString("Coupon Description",
                                                                 comment: "Title of the view for editing the coupon description.")
         static let discountTypeSheetTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -281,7 +281,7 @@ struct AddEditCoupon: View {
                             viewModel.expiryDateField = updatedExpiryDate
                         }), isActive: $showingCouponExpiryDate) {
                             EmptyView()
-                        }.navigationBarTitle(Localization.expiryDateBackButton)
+                        }
 
                         LazyNavigationLink(destination: CouponRestrictions(viewModel: viewModel.couponRestrictionsViewModel),
                                            isActive: $showingCouponRestrictions) {
@@ -378,10 +378,6 @@ private extension AddEditCoupon {
             "Usage Restrictions",
             comment: "Field in the view for adding or editing a coupon.")
         static let saveButton = NSLocalizedString("Save", comment: "Action for saving a Coupon remotely")
-        static let expiryDateBackButton = NSLocalizedString(
-                "Back",
-                comment: "Dismisses the Coupon expiry date picker"
-        )
         static let addDescriptionPlaceholder = NSLocalizedString("Add the description of the coupon.",
                                                                  comment: "Placeholder text that will be shown in the view" +
                                                                  " for adding the description of a coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -275,6 +275,7 @@ struct AddEditCoupon: View {
                         }
 
                         LazyNavigationLink(destination: CouponExpiryDateView(date: viewModel.expiryDateField ?? Date(),
+                                                                             isRemovalEnabled: viewModel.expiryDateField != nil,
                                                                              timezone: viewModel.timezone,
                                                                              onCompletion: { updatedExpiryDate in
                             viewModel.expiryDateField = updatedExpiryDate

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -274,17 +274,13 @@ struct AddEditCoupon: View {
                             EmptyView()
                         }
 
-                        LazyNavigationLink(destination: CouponExpiryDateView(
-                            date: viewModel.expiryDateField ?? Date(),
-                            timezone: viewModel.timezone,
-                            onCompletion: { updatedExpiryDate in
-                                viewModel.expiryDateField = updatedExpiryDate
-                            },
-                            onRemoval: {
-                                viewModel.expiryDateField = nil
-                            }), isActive: $showingCouponExpiryDate) {
-                                EmptyView()
-                            }
+                        LazyNavigationLink(destination: CouponExpiryDateView(date: viewModel.expiryDateField ?? Date(),
+                                                                             timezone: viewModel.timezone,
+                                                                             onCompletion: { updatedExpiryDate in
+                            viewModel.expiryDateField = updatedExpiryDate
+                        }), isActive: $showingCouponExpiryDate) {
+                            EmptyView()
+                        }
 
                         LazyNavigationLink(destination: CouponRestrictions(viewModel: viewModel.couponRestrictionsViewModel),
                                            isActive: $showingCouponRestrictions) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -66,7 +66,6 @@ struct AddEditCoupon: View {
 
     @ObservedObject private var viewModel: AddEditCouponViewModel
     @State private var showingEditDescription: Bool = false
-    @State private var showingCouponExpiryActionSheet: Bool = false
     @State private var showingCouponExpiryDate: Bool = false
     @State private var showingCouponRestrictions: Bool = false
     @State private var showingSelectProducts: Bool = false

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -381,8 +381,6 @@ private extension AddEditCoupon {
         static let addDescriptionPlaceholder = NSLocalizedString("Add the description of the coupon.",
                                                                  comment: "Placeholder text that will be shown in the view" +
                                                                  " for adding the description of a coupon.")
-        static let expiryDateActionSheetTitle = NSLocalizedString("Set an expiry date for this coupon",
-                                                                  comment: "Title of the action sheet for setting an expiry date for a coupon.")
         static let actionSheetEditExpirationDate = NSLocalizedString("Edit expiration date",
                                                                      comment: "Button in the action sheet for editing the expiration date of a coupon.")
         static let actionSheetDeleteExpirationDate = NSLocalizedString("Delete expiration date",

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -275,14 +275,17 @@ struct AddEditCoupon: View {
                             EmptyView()
                         }
 
-                        LazyNavigationLink(destination: CouponExpiryDateView(date: viewModel.expiryDateField ?? Date(),
-                                                                             timezone: viewModel.timezone,
-                                                                             completion: { updatedExpiryDate in
-                            viewModel.expiryDateField = updatedExpiryDate
-                        }),
-                                           isActive: $showingCouponExpiryDate) {
-                            EmptyView()
-                        }
+                        LazyNavigationLink(destination: CouponExpiryDateView(
+                            date: viewModel.expiryDateField ?? Date(),
+                            timezone: viewModel.timezone,
+                            onCompletion: { updatedExpiryDate in
+                                viewModel.expiryDateField = updatedExpiryDate
+                            },
+                            onRemoval: {
+                                viewModel.expiryDateField = nil
+                            }), isActive: $showingCouponExpiryDate) {
+                                EmptyView()
+                            }
 
                         LazyNavigationLink(destination: CouponRestrictions(viewModel: viewModel.couponRestrictionsViewModel),
                                            isActive: $showingCouponRestrictions) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -281,7 +281,7 @@ struct AddEditCoupon: View {
                             viewModel.expiryDateField = updatedExpiryDate
                         }), isActive: $showingCouponExpiryDate) {
                             EmptyView()
-                        }
+                        }.navigationBarTitle(Localization.expiryDateBackButton)
 
                         LazyNavigationLink(destination: CouponRestrictions(viewModel: viewModel.couponRestrictionsViewModel),
                                            isActive: $showingCouponRestrictions) {
@@ -378,6 +378,10 @@ private extension AddEditCoupon {
             "Usage Restrictions",
             comment: "Field in the view for adding or editing a coupon.")
         static let saveButton = NSLocalizedString("Save", comment: "Action for saving a Coupon remotely")
+        static let expiryDateBackButton = NSLocalizedString(
+                "Back",
+                comment: "Dismisses the Coupon expiry date picker"
+        )
         static let addDescriptionPlaceholder = NSLocalizedString("Add the description of the coupon.",
                                                                  comment: "Placeholder text that will be shown in the view" +
                                                                  " for adding the description of a coupon.")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -73,32 +73,6 @@ struct AddEditCoupon: View {
     @State private var showingSelectCategories: Bool = false
     @State private var showingDiscountType: Bool = false
 
-    private var expiryDateActionSheetButtons: [Alert.Button] {
-        var buttons: [Alert.Button] = []
-
-        if viewModel.expiryDateField != nil {
-            buttons = [
-                .default(Text(Localization.actionSheetEditExpirationDate), action: {
-                    showingCouponExpiryDate = true
-                }),
-                .destructive(Text(Localization.actionSheetDeleteExpirationDate), action: {
-                    viewModel.expiryDateField = nil
-                })
-            ]
-        }
-        else {
-            buttons = [
-                .default(Text(Localization.actionSheetAddExpirationDate), action: {
-                    showingCouponExpiryDate = true
-                })
-            ]
-        }
-
-        buttons.append(.cancel())
-
-        return buttons
-    }
-
     private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     private let viewProperties = BottomSheetListSelectorViewProperties(title: Localization.discountTypeSheetTitle)
 
@@ -201,14 +175,8 @@ struct AddEditCoupon: View {
                                 TitleAndValueRow(title: Localization.couponExpiryDate,
                                                  value: viewModel.expiryDateValue,
                                                  selectionStyle: .disclosure, action: {
-                                    showingCouponExpiryActionSheet = true
+                                    showingCouponExpiryDate = true
                                 })
-                                    .actionSheet(isPresented: $showingCouponExpiryActionSheet) {
-                                        ActionSheet(
-                                            title: Text(Localization.expiryDateActionSheetTitle),
-                                            buttons: expiryDateActionSheetButtons
-                                        )
-                                    }
                                 Divider()
                                     .padding(.leading, Constants.margin)
                             }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -7,7 +7,8 @@ struct CouponExpiryDateView: View {
 
     @State var date: Date = Date()
     var timezone: TimeZone
-    let completion: ((Date) -> Void)
+    let onCompletion: (Date) -> Void
+    let onRemoval: () -> Void
 
     var body: some View {
         GeometryReader { geometry in
@@ -17,7 +18,7 @@ struct CouponExpiryDateView: View {
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
                         .onChange(of: date) { newDate in
-                            completion(newDate)
+                            onCompletion(newDate)
                         }
                     Spacer()
                 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -36,6 +36,7 @@ struct CouponExpiryDateView: View {
                     onCompletion(date)
                     presentationMode.wrappedValue.dismiss()
                 }, label: { Text(Localization.doneButton) })
+                        .foregroundColor(Color(.accent))
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -27,7 +27,10 @@ struct CouponExpiryDateView: View {
                         Button(action: {
                             onCompletion(nil)
                             presentationMode.wrappedValue.dismiss()
-                        }, label: { Text(Localization.removeButton) })
+                        }, label: {
+                            Text(Localization.removeButton)
+                                .bold()
+                        })
                         .buttonStyle(PlainButtonStyle())
                         .padding(.vertical, Constants.margin)
                         .foregroundColor(Color(.error))

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -18,6 +18,7 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
+                        .padding(.vertical, Constants.datePickerVerticalMargin)
                         .onChange(of: date) { _ in
                             isRemovalEnabled = true
                         }
@@ -35,7 +36,7 @@ struct CouponExpiryDateView: View {
                         .foregroundColor(Color(.error))
                         Divider()
                     }
-                    .padding(.top, Constants.verticalMargin)
+                    .padding(.top, Constants.removeDateButtonVerticalMargin)
                     .renderedIf(isRemovalEnabled)
                 }
             }
@@ -60,7 +61,8 @@ struct CouponExpiryDateView: View {
 private extension CouponExpiryDateView {
     enum Constants {
         static let margin: CGFloat = 8
-        static let verticalMargin: CGFloat = 40
+        static let removeDateButtonVerticalMargin: CGFloat = 40
+        static let datePickerVerticalMargin: CGFloat = 20
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -42,6 +42,6 @@ private extension CouponExpiryDateView {
 
 struct CouponExpiryDateView_Previews: PreviewProvider {
     static var previews: some View {
-        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, completion: { _ in })
+        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, onCompletion: { _ in }, onRemoval: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -18,9 +18,9 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
-                        .onChange(of: date, perform: { newDate in
-                                isRemovalEnabled = true
-                            })
+                        .onChange(of: date) { _ in
+                            isRemovalEnabled = true
+                        }
                     Spacer()
                     VStack {
                         Divider()

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -19,16 +19,18 @@ struct CouponExpiryDateView: View {
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
                     Spacer()
-                    
-                    Divider()
-                    Button(action: {
-                        onRemoval()
-                        presentationMode.wrappedValue.dismiss()
-                    }, label: { Text(Localization.removeButton) })
-                    .buttonStyle(PlainButtonStyle())
-                    .padding(.vertical, Constants.margin)
-                    .foregroundColor(Color(.error))
-                    Divider()
+                    VStack {
+                        Divider()
+                        Button(action: {
+                            onRemoval()
+                            presentationMode.wrappedValue.dismiss()
+                        }, label: { Text(Localization.removeButton) })
+                        .buttonStyle(PlainButtonStyle())
+                        .padding(.vertical, Constants.margin)
+                        .foregroundColor(Color(.error))
+                        Divider()
+                    }
+                    .padding(.top, Constants.verticalMargin)
                 }
             }
         }
@@ -51,7 +53,8 @@ struct CouponExpiryDateView: View {
 //
 private extension CouponExpiryDateView {
     enum Constants {
-        static let margin: CGFloat = 16
+        static let margin: CGFloat = 8
+        static let verticalMargin: CGFloat = 40
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -21,7 +21,6 @@ struct CouponExpiryDateView: View {
                         .onChange(of: date) { _ in
                             isRemovalEnabled = true
                         }
-                    Spacer()
                     VStack {
                         Divider()
                         Button(action: {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -8,8 +8,7 @@ struct CouponExpiryDateView: View {
 
     @State var date: Date = Date()
     var timezone: TimeZone
-    let onCompletion: (Date) -> Void
-    let onRemoval: () -> Void
+    let onCompletion: (Date?) -> Void
 
     var body: some View {
         GeometryReader { geometry in
@@ -22,7 +21,7 @@ struct CouponExpiryDateView: View {
                     VStack {
                         Divider()
                         Button(action: {
-                            onRemoval()
+                            onCompletion(nil)
                             presentationMode.wrappedValue.dismiss()
                         }, label: { Text(Localization.removeButton) })
                         .buttonStyle(PlainButtonStyle())
@@ -67,6 +66,6 @@ private extension CouponExpiryDateView {
 
 struct CouponExpiryDateView_Previews: PreviewProvider {
     static var previews: some View {
-        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, onCompletion: { _ in }, onRemoval: {})
+        CouponExpiryDateView(date: Date(), timezone: TimeZone.siteTimezone, onCompletion: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -18,9 +18,6 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
-                        .onChange(of: date) { newDate in
-                            onCompletion(newDate)
-                        }
                     Spacer()
                     Button(action: {
                         onRemoval()
@@ -33,6 +30,14 @@ struct CouponExpiryDateView: View {
         .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(Localization.title)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Done") {
+                    onCompletion(date)
+                    presentationMode.wrappedValue.dismiss()
+                }
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -19,11 +19,13 @@ struct CouponExpiryDateView: View {
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
                     Spacer()
+                    Divider()
                     Button(action: {
                         onRemoval()
                         presentationMode.wrappedValue.dismiss()
                     }, label: { Text(Localization.removeButton) })
-                    .buttonStyle(SecondaryButtonStyle())
+                    .buttonStyle(LinkButtonStyle())
+                    Divider()
                 }
             }
         }
@@ -50,7 +52,7 @@ private extension CouponExpiryDateView {
         static let title = NSLocalizedString("Coupon expiry date",
                                              comment: "Title of the view for selecting an expiry date for a coupon.")
         static let doneButton = NSLocalizedString("Done", comment: "Button to finish selecting the Coupon expiry date in the AddEditCoupon screen")
-        static let removeButton = NSLocalizedString("Remove", comment: "Button to remove the Coupon expiry date in the AddEditCoupon screen")
+        static let removeButton = NSLocalizedString("Remove Expiry Date", comment: "Button to remove the Coupon expiry date in the AddEditCoupon screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -22,7 +22,7 @@ struct CouponExpiryDateView: View {
                     Button(action: {
                         onRemoval()
                         presentationMode.wrappedValue.dismiss()
-                    }, label: { Text("Remove") })
+                    }, label: { Text(Localization.removeButton) })
                     .buttonStyle(SecondaryButtonStyle())
                 }
             }
@@ -32,10 +32,10 @@ struct CouponExpiryDateView: View {
         .navigationTitle(Localization.title)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button("Done") {
+                Button(action: {
                     onCompletion(date)
                     presentationMode.wrappedValue.dismiss()
-                }
+                }, label: { Text(Localization.doneButton) })
             }
         }
     }
@@ -48,6 +48,8 @@ private extension CouponExpiryDateView {
     enum Localization {
         static let title = NSLocalizedString("Coupon expiry date",
                                              comment: "Title of the view for selecting an expiry date for a coupon.")
+        static let doneButton = NSLocalizedString("Done", comment: "Button to finish selecting the Coupon expiry date in the AddEditCoupon screen")
+        static let removeButton = NSLocalizedString("Remove", comment: "Button to remove the Coupon expiry date in the AddEditCoupon screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -4,6 +4,7 @@ import WordPressAuthenticator
 /// View for selecting a date in SwiftUI.
 ///
 struct CouponExpiryDateView: View {
+    @Environment(\.presentationMode) var presentationMode
 
     @State var date: Date = Date()
     var timezone: TimeZone
@@ -21,6 +22,11 @@ struct CouponExpiryDateView: View {
                             onCompletion(newDate)
                         }
                     Spacer()
+                    Button(action: {
+                        onRemoval()
+                        presentationMode.wrappedValue.dismiss()
+                    }, label: { Text("Remove") })
+                    .buttonStyle(SecondaryButtonStyle())
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -19,12 +19,15 @@ struct CouponExpiryDateView: View {
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
                     Spacer()
+                    
                     Divider()
                     Button(action: {
                         onRemoval()
                         presentationMode.wrappedValue.dismiss()
                     }, label: { Text(Localization.removeButton) })
-                    .buttonStyle(LinkButtonStyle())
+                    .buttonStyle(PlainButtonStyle())
+                    .padding(.vertical, Constants.margin)
+                    .foregroundColor(Color(.error))
                     Divider()
                 }
             }
@@ -47,6 +50,9 @@ struct CouponExpiryDateView: View {
 // MARK: - Constants
 //
 private extension CouponExpiryDateView {
+    enum Constants {
+        static let margin: CGFloat = 16
+    }
 
     enum Localization {
         static let title = NSLocalizedString("Coupon expiry date",

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -7,6 +7,7 @@ struct CouponExpiryDateView: View {
     @Environment(\.presentationMode) var presentationMode
 
     @State var date: Date = Date()
+    @State var isRemovalEnabled: Bool = false
     var timezone: TimeZone
     let onCompletion: (Date?) -> Void
 
@@ -17,6 +18,9 @@ struct CouponExpiryDateView: View {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)
                         .environment(\.timeZone, timezone)
                         .datePickerStyle(GraphicalDatePickerStyle())
+                        .onChange(of: date, perform: { newDate in
+                                isRemovalEnabled = true
+                            })
                     Spacer()
                     VStack {
                         Divider()
@@ -30,6 +34,7 @@ struct CouponExpiryDateView: View {
                         Divider()
                     }
                     .padding(.top, Constants.verticalMargin)
+                    .renderedIf(isRemovalEnabled)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -66,8 +66,8 @@ private extension CouponExpiryDateView {
     enum Localization {
         static let title = NSLocalizedString("Coupon expiry date",
                                              comment: "Title of the view for selecting an expiry date for a coupon.")
-        static let doneButton = NSLocalizedString("Done", comment: "Button to finish selecting the Coupon expiry date in the AddEditCoupon screen")
-        static let removeButton = NSLocalizedString("Remove Expiry Date", comment: "Button to remove the Coupon expiry date in the AddEditCoupon screen")
+        static let doneButton = NSLocalizedString("Done", comment: "Button to finish selecting the Coupon expiry date in the Add or Edit Coupon screen")
+        static let removeButton = NSLocalizedString("Remove Expiry Date", comment: "Button to remove the Coupon expiry date in the Add or Edit Coupon screen")
     }
 }
 


### PR DESCRIPTION
Summary
==========
Fix issue #6918 by removing the action sheet when the user presses the date expiry row, displaying the date picker view immediately.

From within the date picker view, we now present a Done button in the navigation bar for confirming the date selected and a button `Remove Expiry Date` for dismissing the view and removing the existing date if available.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-26 at 15 24 33](https://user-images.githubusercontent.com/5920403/170552153-d0075a07-3c04-47ea-9492-eac0baed22ee.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-26 at 15 22 37](https://user-images.githubusercontent.com/5920403/170552010-b4de67fe-fe9c-45c5-a3c2-92add448a8e9.png) |

How to Test
==========
1. Make sure the Coupons experimental toggle is activated
2. Go to the Coupon list, select any editable Coupon
3. Inside the Coupon details, select the Edit coupon in the action menu
4. Inside the Edit Coupon view, select the `Coupon Expiry Date` option
5. Verify that now the picker is right away displayed instead of showing an action sheet
6. Verify that the `Remove Expiry Date` only shows up when a date is selected
7. Verify that the `done` button submits the selected date

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.