### PR TITLE
[Mobile Payments] Enable Moose on the Loose for all merchants

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -19,8 +19,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productSKUInputScanner:
             return true
-        case .canadaInPersonPayments:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .bulkEditProductVariations:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -38,10 +38,6 @@ public enum FeatureFlag: Int {
     ///
     case productSKUInputScanner
 
-    /// Support for In-Person Payments in Canada
-    ///
-    case canadaInPersonPayments
-
     /// Displays the Inbox option under the Hub Menu.
     ///
     case inbox

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 9.3
 -----
+- [***] In-Person Payments is now available for merchants using WooCommerce Payments in Canada. [https://github.com/woocommerce/woocommerce-ios/pull/6954]
 - [*] In-Person Payments: Accessibility improvement [https://github.com/woocommerce/woocommerce-ios/pull/6869, https://github.com/woocommerce/woocommerce-ios/pull/6886, https://github.com/woocommerce/woocommerce-ios/pull/6906]
 - [*] Orders: Now it's possible to select and copy text from the notes on an order. [https://github.com/woocommerce/woocommerce-ios/pull/6894]
 - [*] Support Arabic numerals on amount fields. [https://github.com/woocommerce/woocommerce-ios/pull/6891]

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -9,7 +9,6 @@ extension GeneralAppSettings {
         installationDate: NullableCopiableProp<Date> = .copy,
         feedbacks: CopiableProp<[FeedbackType: FeedbackSettings]> = .copy,
         isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy,
-        isCanadaInPersonPaymentsSwitchEnabled: CopiableProp<Bool> = .copy,
         isProductSKUInputScannerSwitchEnabled: CopiableProp<Bool> = .copy,
         isCouponManagementSwitchEnabled: CopiableProp<Bool> = .copy,
         knownCardReaders: CopiableProp<[String]> = .copy,
@@ -19,7 +18,6 @@ extension GeneralAppSettings {
         let installationDate = installationDate ?? self.installationDate
         let feedbacks = feedbacks ?? self.feedbacks
         let isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled ?? self.isViewAddOnsSwitchEnabled
-        let isCanadaInPersonPaymentsSwitchEnabled = isCanadaInPersonPaymentsSwitchEnabled ?? self.isCanadaInPersonPaymentsSwitchEnabled
         let isProductSKUInputScannerSwitchEnabled = isProductSKUInputScannerSwitchEnabled ?? self.isProductSKUInputScannerSwitchEnabled
         let isCouponManagementSwitchEnabled = isCouponManagementSwitchEnabled ?? self.isCouponManagementSwitchEnabled
         let knownCardReaders = knownCardReaders ?? self.knownCardReaders
@@ -30,7 +28,6 @@ extension GeneralAppSettings {
             installationDate: installationDate,
             feedbacks: feedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
-            isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
             isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
             isCouponManagementSwitchEnabled: isCouponManagementSwitchEnabled,
             knownCardReaders: knownCardReaders,

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -24,10 +24,6 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isViewAddOnsSwitchEnabled: Bool
 
-    /// The state for the In-Person Payments in Canada feature switch
-    ///
-    public let isCanadaInPersonPaymentsSwitchEnabled: Bool
-
     /// The state(`true` or `false`) for the Product SKU Input Scanner feature switch.
     ///
     public let isProductSKUInputScannerSwitchEnabled: Bool
@@ -51,7 +47,6 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     public init(installationDate: Date?,
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
-                isCanadaInPersonPaymentsSwitchEnabled: Bool,
                 isProductSKUInputScannerSwitchEnabled: Bool,
                 isCouponManagementSwitchEnabled: Bool,
                 knownCardReaders: [String],
@@ -60,7 +55,6 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
-        self.isCanadaInPersonPaymentsSwitchEnabled = isCanadaInPersonPaymentsSwitchEnabled
         self.isProductSKUInputScannerSwitchEnabled = isProductSKUInputScannerSwitchEnabled
         self.isCouponManagementSwitchEnabled = isCouponManagementSwitchEnabled
         self.knownCardReaders = knownCardReaders
@@ -89,7 +83,6 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             installationDate: installationDate,
             feedbacks: updatedFeedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
-            isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
             isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
             isCouponManagementSwitchEnabled: isCouponManagementSwitchEnabled,
             knownCardReaders: knownCardReaders,
@@ -108,7 +101,6 @@ extension GeneralAppSettings {
         self.installationDate = try container.decodeIfPresent(Date.self, forKey: .installationDate)
         self.feedbacks = try container.decodeIfPresent([FeedbackType: FeedbackSettings].self, forKey: .feedbacks) ?? [:]
         self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
-        self.isCanadaInPersonPaymentsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isCanadaInPersonPaymentsSwitchEnabled) ?? false
         self.isProductSKUInputScannerSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isProductSKUInputScannerSwitchEnabled) ?? false
         self.isCouponManagementSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isCouponManagementSwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -61,7 +61,6 @@ final class GeneralAppSettingsTests: XCTestCase {
         let previousSettings = GeneralAppSettings(installationDate: installationDate,
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
-                                                  isCanadaInPersonPaymentsSwitchEnabled: true,
                                                   isProductSKUInputScannerSwitchEnabled: true,
                                                   isCouponManagementSwitchEnabled: true,
                                                   knownCardReaders: readers,
@@ -82,7 +81,6 @@ final class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.knownCardReaders, readers)
         assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
-        assertEqual(newSettings.isCanadaInPersonPaymentsSwitchEnabled, true)
         assertEqual(newSettings.isProductSKUInputScannerSwitchEnabled, true)
         assertEqual(newSettings.isCouponManagementSwitchEnabled, true)
         assertEqual(newSettings.lastJetpackBenefitsBannerDismissedTime, jetpackBannerDismissedDate)
@@ -93,7 +91,6 @@ private extension GeneralAppSettingsTests {
     func createGeneralAppSettings(installationDate: Date? = nil,
                                   feedbacks: [FeedbackType: FeedbackSettings] = [:],
                                   isViewAddOnsSwitchEnabled: Bool = false,
-                                  isCanadaInPersonPaymentsSwitchEnabled: Bool = false,
                                   isProductSKUInputScannerSwitchEnabled: Bool = false,
                                   isCouponManagementSwitchEnabled: Bool = false,
                                   knownCardReaders: [String] = [],
@@ -102,7 +99,6 @@ private extension GeneralAppSettingsTests {
         GeneralAppSettings(installationDate: installationDate,
                            feedbacks: feedbacks,
                            isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
-                           isCanadaInPersonPaymentsSwitchEnabled: isCanadaInPersonPaymentsSwitchEnabled,
                            isProductSKUInputScannerSwitchEnabled: isProductSKUInputScannerSwitchEnabled,
                            isCouponManagementSwitchEnabled: isCouponManagementSwitchEnabled,
                            knownCardReaders: knownCardReaders,

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -2,21 +2,15 @@ import Foundation
 import Yosemite
 
 final class CardPresentConfigurationLoader {
-    private var canadaIPPEnabled: Bool = false
-
     init(stores: StoresManager = ServiceLocator.stores) {
-        let canadaAction = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState(onCompletion: { [weak self]  result in
-            if case .success(let canadaIPPEnabled) = result {
-                self?.canadaIPPEnabled = canadaIPPEnabled
-            }
-        })
-        stores.dispatch(canadaAction)
+        // This initialized is kept since this is where we'd check for
+        // feature flags while developing support for a new country
+        // See https://github.com/woocommerce/woocommerce-ios/pull/6954
     }
 
     var configuration: CardPresentPaymentsConfiguration {
         .init(
-            country: SiteAddress().countryCode,
-            canadaEnabled: canadaIPPEnabled
+            country: SiteAddress().countryCode
         )
     }
 }

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 final class CardPresentConfigurationLoader {
     init(stores: StoresManager = ServiceLocator.stores) {
-        // This initialized is kept since this is where we'd check for
+        // This initializer is kept since this is where we'd check for
         // feature flags while developing support for a new country
         // See https://github.com/woocommerce/woocommerce-ios/pull/6954
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -74,7 +74,6 @@ private extension BetaFeaturesViewController {
     func configureSections() {
         self.sections = [
             productsSection(),
-            inPersonPaymentsSection(),
             productSKUInputScannerSection(),
             couponManagementSection()
         ].compactMap { $0 }
@@ -83,16 +82,6 @@ private extension BetaFeaturesViewController {
     func productsSection() -> Section {
         return Section(rows: [.orderAddOns,
                               .orderAddOnsDescription])
-    }
-
-    func inPersonPaymentsSection() -> Section? {
-        var rows: [Row] = []
-
-        guard rows.isNotEmpty else {
-            return nil
-        }
-
-        return Section(rows: rows)
     }
 
     func productSKUInputScannerSection() -> Section? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -88,10 +88,6 @@ private extension BetaFeaturesViewController {
     func inPersonPaymentsSection() -> Section? {
         var rows: [Row] = []
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.canadaInPersonPayments) {
-            rows += [.canadaInPersonPayments, .canadaInPersonPaymentsDescription]
-        }
-
         guard rows.isNotEmpty else {
             return nil
         }
@@ -138,11 +134,6 @@ private extension BetaFeaturesViewController {
             configureOrderAddOnsSwitch(cell: cell)
         case let cell as BasicTableViewCell where row == .orderAddOnsDescription:
             configureOrderAddOnsDescription(cell: cell)
-        // In-Person Payments in Canada
-        case let cell as SwitchTableViewCell where row == .canadaInPersonPayments:
-            configureCanadaInPersonPaymentsSwitch(cell: cell)
-        case let cell as BasicTableViewCell where row == .canadaInPersonPaymentsDescription:
-            configureCanadaInPersonPaymentsDescription(cell: cell)
         // Product SKU Input Scanner
         case let cell as SwitchTableViewCell where row == .productSKUInputScanner:
             configureProductSKUInputScannerSwitch(cell: cell)
@@ -190,37 +181,6 @@ private extension BetaFeaturesViewController {
     func configureOrderAddOnsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
         cell.textLabel?.text = Localization.orderAddOnsDescription
-    }
-
-    func configureCanadaInPersonPaymentsSwitch(cell: SwitchTableViewCell) {
-        configureCommonStylesForSwitchCell(cell)
-        cell.title = Localization.canadaExtensionInPersonPaymentsTitle
-
-        // Fetch switch's state stored value.
-        let action = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState { result in
-            guard let isEnabled = try? result.get() else {
-                return cell.isOn = false
-            }
-            cell.isOn = isEnabled
-        }
-        ServiceLocator.stores.dispatch(action)
-
-        // Change switch's state stored value
-        cell.onChange = { isSwitchOn in
-            let action = AppSettingsAction.setCanadaInPersonPaymentsSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
-                // Roll back toggle if an error occurred
-                if result.isFailure {
-                    cell.isOn.toggle()
-                }
-            })
-            ServiceLocator.stores.dispatch(action)
-        }
-        cell.accessibilityIdentifier = "beta-features-canada-in-person-payments-cell"
-    }
-
-    func configureCanadaInPersonPaymentsDescription(cell: BasicTableViewCell) {
-        configureCommonStylesForDescriptionCell(cell)
-        cell.textLabel?.text = Localization.canadaExtensionInPersonPaymentsDescription
     }
 
     func configureProductSKUInputScannerSwitch(cell: SwitchTableViewCell) {
@@ -348,10 +308,6 @@ private enum Row: CaseIterable {
     case orderAddOns
     case orderAddOnsDescription
 
-    // In-Person Payments in Canada
-    case canadaInPersonPayments
-    case canadaInPersonPaymentsDescription
-
     // Product SKU Input Scanner
     case productSKUInputScanner
     case productSKUInputScannerDescription
@@ -362,10 +318,9 @@ private enum Row: CaseIterable {
 
     var type: UITableViewCell.Type {
         switch self {
-        case .orderAddOns, .canadaInPersonPayments, .productSKUInputScanner, .couponManagement:
+        case .orderAddOns, .productSKUInputScanner, .couponManagement:
             return SwitchTableViewCell.self
-        case .orderAddOnsDescription, .canadaInPersonPaymentsDescription,
-                .productSKUInputScannerDescription, .couponManagementDescription:
+        case .orderAddOnsDescription, .productSKUInputScannerDescription, .couponManagementDescription:
             return BasicTableViewCell.self
         }
     }
@@ -383,13 +338,6 @@ private extension BetaFeaturesViewController {
         static let orderAddOnsDescription = NSLocalizedString(
             "Test out viewing Order Add-Ons as we get ready to launch",
             comment: "Cell description on the beta features screen to enable the order add-ons feature")
-
-        static let canadaExtensionInPersonPaymentsTitle = NSLocalizedString(
-            "In-Person Payments in Canada",
-            comment: "Cell title on beta features screen to enable accepting in-person payments for stores in Canada ")
-        static let canadaExtensionInPersonPaymentsDescription = NSLocalizedString(
-            "Test out In-Person Payments in Canada",
-            comment: "Cell description on beta features screen to enable accepting in-person payments for stores in Canada")
 
         static let productSKUInputScannerTitle = NSLocalizedString(
             "Product SKU Scanner",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -48,10 +48,6 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         self.configurationLoader = .init(stores: stores)
         self.cardPresentPluginsDataProvider = .init(storageManager: storageManager, stores: stores, configuration: configurationLoader.configuration)
 
-
-        // At the time of writing, actions are dispatched and processed synchronously, so the completion blocks for
-        // loadStripeInPersonPaymentsSwitchState and loadCanadaInPersonPaymentsSwitchState should have been called already.
-        // We defer updating the state until all settings are read to prevent unnecessary checks.
         updateState()
     }
 

--- a/WooCommerce/WooCommerceTests/Extensions/Order+CardPresentPaymentTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Order+CardPresentPaymentTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class Order_CardPresentPaymentTests: XCTestCase {
     private static let currency = "US"
-    private let configuration = CardPresentPaymentsConfiguration(country: Order_CardPresentPaymentTests.currency, canadaEnabled: true)
+    private let configuration = CardPresentPaymentsConfiguration(country: Order_CardPresentPaymentTests.currency)
     private let eligibleOrder = Order.fake().copy(status: .pending,
                                                currency: Order_CardPresentPaymentTests.currency,
                                                datePaid: nil,

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -19,14 +19,6 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         try super.setUpWithError()
         storageManager = MockStorageManager()
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case .loadCanadaInPersonPaymentsSwitchState(let completion):
-                completion(.success(true))
-            default:
-                break
-            }
-        }
         stores.sessionManager.setStoreId(sampleSiteID)
         ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
     }
@@ -39,9 +31,8 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func test_configuration_for_US_with_stripe_enabled_and_canada_enabled() {
+    func test_configuration_for_US() {
         // Given
-        setupFeatures(stripe: true, canada: true)
         setupCountry(country: .us)
 
         // When
@@ -52,9 +43,8 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         XCTAssertTrue(configuration.isSupportedCountry)
     }
 
-    func test_configuration_for_Canada_with_stripe_enabled_and_canada_enabled() {
+    func test_configuration_for_Canada() {
         // Given
-        setupFeatures(stripe: true, canada: true)
         setupCountry(country: .ca)
 
         // When
@@ -65,9 +55,8 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         XCTAssertTrue(configuration.isSupportedCountry)
     }
 
-    func test_configuration_for_Spain_with_stripe_enabled_and_canada_enabled() {
+    func test_configuration_for_Spain() {
         // Given
-        setupFeatures(stripe: true, canada: true)
         setupCountry(country: .es)
 
         // When
@@ -96,16 +85,5 @@ private extension CardPresentConfigurationLoaderTests {
         case us = "US:CA"
         case ca = "CA:NS"
         case es = "ES"
-    }
-
-    func setupFeatures(stripe: Bool, canada: Bool) {
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case .loadCanadaInPersonPaymentsSwitchState(onCompletion: let completion):
-                completion(.success(canada))
-            default:
-                break
-            }
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -284,7 +284,7 @@ private extension CollectOrderPaymentUseCaseTests {
 
 private extension CollectOrderPaymentUseCaseTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
+        static let configuration = CardPresentPaymentsConfiguration(country: "US")
         static let cardReaderModel: String = "WISEPAD_3"
         static let paymentGatewayAccount: String = "woocommerce-payments"
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -517,7 +517,7 @@ private extension RefundSubmissionUseCaseTests {
 
 private extension RefundSubmissionUseCaseTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
+        static let configuration = CardPresentPaymentsConfiguration(country: "US")
         static let cardReaderModel: String = "WISEPAD_3"
         static let paymentGatewayID: String = "woocommerce-payments"
         static let siteID: Int64 = 322

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -20,14 +20,6 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         try super.setUpWithError()
         storageManager = MockStorageManager()
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case .loadCanadaInPersonPaymentsSwitchState(let completion):
-                completion(.success(true))
-            default:
-                break
-            }
-        }
         stores.sessionManager.setStoreId(sampleSiteID)
         ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -419,6 +419,6 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
 private extension CardReaderConnectionControllerTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
+        static let configuration = CardPresentPaymentsConfiguration(country: "US")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -491,6 +491,6 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
 private extension CardReaderSettingsConnectedViewModelTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
+        static let configuration = CardPresentPaymentsConfiguration(country: "US")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 private struct TestConstants {
     static let mockReaderID = "CHB204909005931"
-    static let mockConfiguration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
+    static let mockConfiguration = CardPresentPaymentsConfiguration(country: "US")
 }
 
 final class CardReaderSettingsSearchingViewModelTests: XCTestCase {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -422,7 +422,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: true)
+        let configuration = CardPresentPaymentsConfiguration(country: "CA")
         let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: configuration)
         dataSource.configureResultsControllers { }
@@ -445,30 +445,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
-        let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: configuration)
-        dataSource.configureResultsControllers { }
-
-        // When
-        dataSource.reloadSections()
-
-        // Then
-        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
-        XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
-
-        // Clean up
-        storageManager.viewStorage.deleteObject(account)
-        storageManager.viewStorage.saveIfNeeded()
-    }
-
-    func test_collect_payment_button_is_not_visible_if_order_currency_would_be_in_configuration_but_not_enabled() throws {
-        // Setup
-        let account = storageManager.insertCardPresentEligibleAccount()
-        storageManager.viewStorage.saveIfNeeded()
-
-        // Given
-        let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: false)
+        let configuration = CardPresentPaymentsConfiguration(country: "US")
         let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: configuration)
         dataSource.configureResultsControllers { }
@@ -810,6 +787,6 @@ private final class MockPaymentGatewayAccountStoresManager: MockStorageManager {
 
 private extension OrderDetailsDataSourceTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
+        static let configuration = CardPresentPaymentsConfiguration(country: "US")
     }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -96,14 +96,6 @@ public enum AppSettingsAction: Action {
     ///
     case loadOrderAddOnsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
 
-    /// Loads the most recent state for the In-Person Payments in Canada beta feature switch
-    ///
-    case loadCanadaInPersonPaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
-
-    /// Sets the state for the In-Person Payments in Canada beta feature switch
-    ///
-    case setCanadaInPersonPaymentsSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
-
     /// Sets the state for the Product SKU Input Scanner beta feature switch.
     ///
     case setProductSKUInputScannerFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -25,7 +25,6 @@ struct MockAppSettingsActionHandler: MockActionHandler {
                 .setTelemetryAvailability,
                 .loadOrdersSettings,
                 .upsertProductsSettings,
-                .loadCanadaInPersonPaymentsSwitchState,
                 .loadCouponManagementFeatureSwitchState:
             break
         default: unimplementedAction(action: action)

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 public struct CardPresentPaymentsConfiguration {
-    private let stripeTerminalforCanadaEnabled: Bool
-
     public let countryCode: String
     public let paymentMethods: [WCPayPaymentMethodType]
     public let currencies: [CurrencyCode]
@@ -13,7 +11,6 @@ public struct CardPresentPaymentsConfiguration {
     public let stripeSmallestCurrencyUnitMultiplier: Decimal
 
     init(countryCode: String,
-         stripeTerminalforCanadaEnabled: Bool,
          paymentMethods: [WCPayPaymentMethodType],
          currencies: [CurrencyCode],
          paymentGateways: [String],
@@ -22,7 +19,6 @@ public struct CardPresentPaymentsConfiguration {
          minimumAllowedChargeAmount: NSDecimalNumber,
          stripeSmallestCurrencyUnitMultiplier: Decimal) {
         self.countryCode = countryCode
-        self.stripeTerminalforCanadaEnabled = stripeTerminalforCanadaEnabled
         self.paymentMethods = paymentMethods
         self.currencies = currencies
         self.paymentGateways = paymentGateways
@@ -38,7 +34,6 @@ public struct CardPresentPaymentsConfiguration {
         case "US":
             self.init(
                 countryCode: country,
-                stripeTerminalforCanadaEnabled: canadaEnabled,
                 paymentMethods: [.cardPresent],
                 currencies: [.USD],
                 paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
@@ -53,7 +48,6 @@ public struct CardPresentPaymentsConfiguration {
         case "CA" where canadaEnabled == true:
             self.init(
                 countryCode: country,
-                stripeTerminalforCanadaEnabled: true,
                 paymentMethods: [.cardPresent, .interacPresent],
                 currencies: [.CAD],
                 paymentGateways: [WCPayAccount.gatewayID],
@@ -65,7 +59,6 @@ public struct CardPresentPaymentsConfiguration {
         default:
             self.init(
                 countryCode: country,
-                stripeTerminalforCanadaEnabled: canadaEnabled,
                 paymentMethods: [],
                 currencies: [],
                 paymentGateways: [],

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -28,7 +28,7 @@ public struct CardPresentPaymentsConfiguration {
         self.stripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
     }
 
-    public init(country: String, canadaEnabled: Bool) {
+    public init(country: String) {
         /// Changing `minimumVersion` values here? You'll need to also update `CardPresentPaymentsOnboardingUseCaseTests`
         switch country {
         case "US":
@@ -45,7 +45,7 @@ public struct CardPresentPaymentsConfiguration {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
-        case "CA" where canadaEnabled == true:
+        case "CA":
             self.init(
                 countryCode: country,
                 paymentMethods: [.cardPresent, .interacPresent],

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -165,10 +165,6 @@ public class AppSettingsStore: Store {
             getSimplePaymentsTaxesToggleState(siteID: siteID, onCompletion: onCompletion)
         case .resetGeneralStoreSettings:
             resetGeneralStoreSettings()
-        case .loadCanadaInPersonPaymentsSwitchState(onCompletion: let onCompletion):
-            loadCanadaInPersonPaymentsSwitchState(onCompletion: onCompletion)
-        case .setCanadaInPersonPaymentsSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
-            setCanadaInPersonPaymentsSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .setProductSKUInputScannerFeatureSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
             setProductSKUInputScannerFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .loadProductSKUInputScannerFeatureSwitchState(onCompletion: let onCompletion):
@@ -250,25 +246,6 @@ private extension AppSettingsStore {
     func loadOrderAddOnsSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
         let settings = loadOrCreateGeneralAppSettings()
         onCompletion(.success(settings.isViewAddOnsSwitchEnabled))
-    }
-
-    /// Loads the current In-Person Payments in Canada beta feature switch state from `GeneralAppSettings`
-    ///
-    func loadCanadaInPersonPaymentsSwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
-        let settings = loadOrCreateGeneralAppSettings()
-        onCompletion(.success(settings.isCanadaInPersonPaymentsSwitchEnabled))
-    }
-
-    /// Sets the provided In-Person Payments in Canada beta feature switch state into `GeneralAppSettings`
-    ///
-    func setCanadaInPersonPaymentsSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
-        do {
-            let settings = loadOrCreateGeneralAppSettings().copy(isCanadaInPersonPaymentsSwitchEnabled: isEnabled)
-            try saveGeneralAppSettings(settings)
-            onCompletion(.success(()))
-        } catch {
-            onCompletion(.failure(error))
-        }
     }
 
     /// Sets the state for the Product SKU Input Scanner beta feature switch into `GeneralAppSettings`.

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -342,7 +342,6 @@ private extension AppSettingsStore {
             return GeneralAppSettings(installationDate: nil,
                                       feedbacks: [:],
                                       isViewAddOnsSwitchEnabled: false,
-                                      isCanadaInPersonPaymentsSwitchEnabled: false,
                                       isProductSKUInputScannerSwitchEnabled: false,
                                       isCouponManagementSwitchEnabled: false,
                                       knownCardReaders: [],

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -4,17 +4,8 @@ import XCTest
 
 class CardPresentConfigurationTests: XCTestCase {
     // MARK: - US Tests
-    func test_configuration_for_US_with_Canada_enabled() throws {
-        let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: true)
-        XCTAssertTrue(configuration.isSupportedCountry)
-        XCTAssertEqual(configuration.currencies, [.USD])
-        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
-        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl().absoluteString, Constants.PurchaseURL.us)
-    }
-
-    func test_configuration_for_US_with_Canada_disabled() throws {
-        let configuration = CardPresentPaymentsConfiguration(country: "US", canadaEnabled: false)
+    func test_configuration_for_US() throws {
+        let configuration = CardPresentPaymentsConfiguration(country: "US")
         XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [.USD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
@@ -23,18 +14,12 @@ class CardPresentConfigurationTests: XCTestCase {
     }
 
     // MARK: - Canada Tests
-    func test_configuration_for_Canada_with_Canada_enabled() throws {
-        let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: true)
+    func test_configuration_for_Canada() throws {
+        let configuration = CardPresentPaymentsConfiguration(country: "CA")
         XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [.CAD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent, .interacPresent])
-        XCTAssertEqual(configuration.purchaseCardReaderUrl().absoluteString, Constants.PurchaseURL.ca)
-    }
-
-    func test_configuration_for_Canada_with_Canada_disabled() {
-        let configuration = CardPresentPaymentsConfiguration(country: "CA", canadaEnabled: false)
-        XCTAssertFalse(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.purchaseCardReaderUrl().absoluteString, Constants.PurchaseURL.ca)
     }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -159,7 +159,6 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         // Given
         let settings = GeneralAppSettings(installationDate: nil,
                                           feedbacks: [:], isViewAddOnsSwitchEnabled: false,
-                                          isCanadaInPersonPaymentsSwitchEnabled: false,
                                           isProductSKUInputScannerSwitchEnabled: false,
                                           isCouponManagementSwitchEnabled: false,
                                           knownCardReaders: [])
@@ -226,7 +225,6 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             installationDate: installationDate,
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
-            isCanadaInPersonPaymentsSwitchEnabled: false,
             isProductSKUInputScannerSwitchEnabled: false,
             isCouponManagementSwitchEnabled: false,
             knownCardReaders: []

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -801,7 +801,6 @@ private extension AppSettingsStoreTests {
             installationDate: installationDate,
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
-            isCanadaInPersonPaymentsSwitchEnabled: false,
             isProductSKUInputScannerSwitchEnabled: false,
             isCouponManagementSwitchEnabled: false,
             knownCardReaders: []

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -571,42 +571,6 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertFalse(isVisible)
     }
 
-    func test_loadCanadaInPersonPaymentsSwitchState_returns_false_on_new_generalAppSettings() throws {
-        // Given
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-
-        // When
-        let result: Result<Bool, Error> = waitFor { promise in
-            let action = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState { result in
-                promise(result)
-            }
-            self.subject?.onAction(action)
-        }
-
-        // Then
-        let isEnabled = try result.get()
-        XCTAssertFalse(isEnabled)
-    }
-
-    func test_loadCanadaInPersonPaymentsSwitchState_returns_true_after_updating_switch_state_to_true() throws {
-        // Given
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.setCanadaInPersonPaymentsSwitchState(isEnabled: true, onCompletion: { _ in })
-        subject?.onAction(updateAction)
-
-        // When
-        let result: Result<Bool, Error> = waitFor { promise in
-            let action = AppSettingsAction.loadCanadaInPersonPaymentsSwitchState { result in
-                promise(result)
-            }
-            self.subject?.onAction(action)
-        }
-
-        // Then
-        let isEnabled = try result.get()
-        XCTAssertTrue(isEnabled)
-    }
-
     func test_loadCouponManagementFeatureSwitchState_returns_false_on_new_generalAppSettings() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6952 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Removes both the feature flag and experimental toggle for In-Person Payments in Canada, enabling the feature for everyone.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Go to Settings -> In-Person Payments and verify the onboarding shows the right state:

- US: available for both WCPay and Stripe extension
- Canada: available for WCPay but not Stripe
- Other countries: unavailable

You can also edit the scheme in Xcode to test on a `Release` build, which should match the configuration in the App Store:
![Screen Shot 2022-05-26 at 11 59 30](https://user-images.githubusercontent.com/8739/170465794-6b96a494-7b9a-4402-bb63-99c847a7deb7.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
