### PR TITLE
[Mobile Payments] Enhanced deeplinking from IPP onboarding

### DIFF
--- a/WooCommerce/Classes/Extensions/Site+PluginsURL.swift
+++ b/WooCommerce/Classes/Extensions/Site+PluginsURL.swift
@@ -12,11 +12,17 @@ private extension CardPresentPaymentsPlugin {
     }
 }
 
+/// Encapsulates the logic related to the provision of the Site URLs that point to plugins related content
+///
 extension Site {
+    /// Site's plugins section in wp-admin.
+    ///
     var pluginsURL: String {
         adminURL + "/plugins.php"
     }
 
+    /// Payment plugin settings in wp-admin. This can be helpful when the plugin needs to be setup completely.
+    /// 
     func pluginSettingsSectionURL(from plugin: CardPresentPaymentsPlugin) -> String {
         adminURL + "admin.php?page=wc-settings&tab=checkout&section=" + plugin.setupURLSectionPath
     }

--- a/WooCommerce/Classes/Extensions/Site+PluginsURL.swift
+++ b/WooCommerce/Classes/Extensions/Site+PluginsURL.swift
@@ -18,7 +18,7 @@ extension Site {
     /// Site's plugins section in wp-admin.
     ///
     var pluginsURL: String {
-        adminURL + "/plugins.php"
+        adminURL + "plugins.php"
     }
 
     /// Payment plugin settings in wp-admin. This can be helpful when the plugin needs to be setup completely.

--- a/WooCommerce/Classes/Extensions/Site+PluginsURL.swift
+++ b/WooCommerce/Classes/Extensions/Site+PluginsURL.swift
@@ -1,0 +1,23 @@
+import Yosemite
+import Foundation
+
+private extension CardPresentPaymentsPlugin {
+    var setupURLSectionPath: String {
+        switch self {
+        case .wcPay:
+            return "woocommerce_payments"
+        case .stripe:
+            return "stripe"
+        }
+    }
+}
+
+extension Site {
+    var pluginsURL: String {
+        adminURL + "/plugins.php"
+    }
+
+    func pluginSettingsSectionURL(from plugin: CardPresentPaymentsPlugin) -> String {
+        adminURL + "admin.php?page=wc-settings&tab=checkout&section=" + plugin.setupURLSectionPath
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
@@ -43,11 +43,11 @@ struct InPersonPaymentsDeactivateStripeView: View {
     }
 
     private var setupURL: URL? {
-        guard let adminURL = ServiceLocator.stores.sessionManager.defaultSite?.adminURL else {
+        guard let pluginsURL = ServiceLocator.stores.sessionManager.defaultSite?.pluginsURL else {
             return nil
         }
 
-        return URL(string: adminURL)
+        return URL(string: pluginsURL)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
@@ -48,7 +48,7 @@ struct InPersonPaymentsPluginConflictAdmin: View {
     }
 
     private var setupURL: URL? {
-        guard let adminURL = ServiceLocator.stores.sessionManager.defaultSite?.adminURL else {
+        guard let adminURL = ServiceLocator.stores.sessionManager.defaultSite?.pluginsURL else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
@@ -38,7 +38,7 @@ struct InPersonPaymentsPluginConflictShopManager: View {
     }
 
     private var setupURL: URL? {
-        guard let adminURL = ServiceLocator.stores.sessionManager.defaultSite?.adminURL else {
+        guard let adminURL = ServiceLocator.stores.sessionManager.defaultSite?.pluginsURL else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -39,11 +39,11 @@ struct InPersonPaymentsPluginNotSetup: View {
     }
 
     private var setupURL: URL? {
-        guard let adminURL = ServiceLocator.stores.sessionManager.defaultSite?.adminURL else {
+        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.pluginSettingsSectionURL(from: plugin) else {
             return nil
         }
 
-        return URL(string: adminURL)
+        return URL(string: pluginSectionURL)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1221,6 +1221,7 @@
 		B979A9B8282AB69300EBB383 /* Order+CardPresentPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B979A9B7282AB69300EBB383 /* Order+CardPresentPaymentTests.swift */; };
 		B979A9BA282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */; };
 		B9B6DEEF283F8B9F00901FB7 /* Site+PluginsURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B6DEEE283F8B9F00901FB7 /* Site+PluginsURL.swift */; };
+		B9B6DEF1283F8EB100901FB7 /* SitePluginsURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B6DEF0283F8EB100901FB7 /* SitePluginsURLTests.swift */; };
 		B9C4AB2527FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */; };
 		B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */; };
 		B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */; };
@@ -2962,6 +2963,7 @@
 		B979A9B7282AB69300EBB383 /* Order+CardPresentPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+CardPresentPaymentTests.swift"; sourceTree = "<group>"; };
 		B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsDeactivateStripeView.swift; sourceTree = "<group>"; };
 		B9B6DEEE283F8B9F00901FB7 /* Site+PluginsURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Site+PluginsURL.swift"; sourceTree = "<group>"; };
+		B9B6DEF0283F8EB100901FB7 /* SitePluginsURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsURLTests.swift; sourceTree = "<group>"; };
 		B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProvider.swift; sourceTree = "<group>"; };
 		B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminer.swift; sourceTree = "<group>"; };
 		B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminerTests.swift; sourceTree = "<group>"; };
@@ -6405,6 +6407,7 @@
 				02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */,
 				02645D8927BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift */,
 				B979A9B7282AB69300EBB383 /* Order+CardPresentPaymentTests.swift */,
+				B9B6DEF0283F8EB100901FB7 /* SitePluginsURLTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9955,6 +9958,7 @@
 				CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */,
 				CE50345A21B1F8F7007573C6 /* ZendeskManagerTests.swift in Sources */,
 				02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */,
+				B9B6DEF1283F8EB100901FB7 /* SitePluginsURLTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
 				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStorageTests.swift in Sources */,
 				262AF38A2713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1220,6 +1220,7 @@
 		B979A9B32829237A00EBB383 /* Order+CardPresentPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B979A9B22829237A00EBB383 /* Order+CardPresentPayment.swift */; };
 		B979A9B8282AB69300EBB383 /* Order+CardPresentPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B979A9B7282AB69300EBB383 /* Order+CardPresentPaymentTests.swift */; };
 		B979A9BA282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */; };
+		B9B6DEEF283F8B9F00901FB7 /* Site+PluginsURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B6DEEE283F8B9F00901FB7 /* Site+PluginsURL.swift */; };
 		B9C4AB2527FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */; };
 		B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */; };
 		B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */; };
@@ -2960,6 +2961,7 @@
 		B979A9B22829237A00EBB383 /* Order+CardPresentPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+CardPresentPayment.swift"; sourceTree = "<group>"; };
 		B979A9B7282AB69300EBB383 /* Order+CardPresentPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+CardPresentPaymentTests.swift"; sourceTree = "<group>"; };
 		B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsDeactivateStripeView.swift; sourceTree = "<group>"; };
+		B9B6DEEE283F8B9F00901FB7 /* Site+PluginsURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Site+PluginsURL.swift"; sourceTree = "<group>"; };
 		B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProvider.swift; sourceTree = "<group>"; };
 		B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminer.swift; sourceTree = "<group>"; };
 		B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminerTests.swift; sourceTree = "<group>"; };
@@ -7048,6 +7050,7 @@
 				DEC51B05276B3F3C009F3DF4 /* Int64+Helpers.swift */,
 				02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */,
 				02645D8727BA2E820065DC68 /* NSAttributedString+Attributes.swift */,
+				B9B6DEEE283F8B9F00901FB7 /* Site+PluginsURL.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9336,6 +9339,7 @@
 				DEC6C51C27477890006832D3 /* JetpackInstallStepsView.swift in Sources */,
 				E15FC74526BC213500CF83E6 /* InPersonPaymentsLearnMore.swift in Sources */,
 				D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */,
+				B9B6DEEF283F8B9F00901FB7 /* Site+PluginsURL.swift in Sources */,
 				D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */,
 				26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */,
 				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/SitePluginsURLTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/SitePluginsURLTests.swift
@@ -1,0 +1,46 @@
+import Yosemite
+
+@testable import WooCommerce
+
+import Foundation
+import XCTest
+
+final class Site_PluginsURLTests: XCTestCase {
+    private var adminURL: String!
+    private var site: Site!
+
+    override func setUp() {
+        super.setUp()
+
+        adminURL = "https://testshop.com/wp-admin"
+        site = Site.fake().copy(adminURL: adminURL)
+    }
+
+    override func tearDown() {
+        adminURL = nil
+        site = nil
+
+        super.tearDown()
+    }
+
+    func test_pluginsURL_then_returns_right_URL() {
+        let expectedURL = adminURL + "/plugins.php"
+
+        // Then
+        XCTAssertEqual(site.pluginsURL, expectedURL)
+    }
+
+    func test_pluginSettingsSectionURL_when_plugin_is_WCPay_then_returns_right_URL() {
+        let expectedURL = adminURL + "admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+
+        // Then
+        XCTAssertEqual(site.pluginSettingsSectionURL(from: .wcPay), expectedURL)
+    }
+
+    func test_pluginSettingsSectionURL_when_plugin_is_stripe_then_returns_right_URL() {
+        let expectedURL = adminURL + "admin.php?page=wc-settings&tab=checkout&section=stripe"
+
+        // Then
+        XCTAssertEqual(site.pluginSettingsSectionURL(from: .stripe), expectedURL)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Extensions/SitePluginsURLTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/SitePluginsURLTests.swift
@@ -12,7 +12,7 @@ final class Site_PluginsURLTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        adminURL = "https://testshop.com/wp-admin"
+        adminURL = "https://testshop.com/wp-admin/"
         site = Site.fake().copy(adminURL: adminURL)
     }
 
@@ -24,7 +24,7 @@ final class Site_PluginsURLTests: XCTestCase {
     }
 
     func test_pluginsURL_then_returns_right_URL() {
-        let expectedURL = adminURL + "/plugins.php"
+        let expectedURL = adminURL + "plugins.php"
 
         // Then
         XCTAssertEqual(site.pluginsURL, expectedURL)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6043
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we enhance the deep linking to the site wp-admin configuration from the IPP onboarding screens by linking directly to where the action can be performed instead of wp-admin (top level). Since these URLs are stable enough, we can rely on linking these directly.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Stripe should be deactivated

Prerequisites:
- Store should be in Canada
- Both Stripe and WCPay should be installed and active
---
- Go to Menu tab
- Open Settings
- Tap on In-Person Payments
- Onboading screen advising of deactivating WooCommerce Stripe Gateway should be shown
- Press on Manage Plugins
- It can be that you need to login to WordPress.com Otherwise the Plugins menu from wp-admin should be shown

<img src="https://user-images.githubusercontent.com/1864060/170474411-9da12e18-0b23-4d24-931f-331b5acd0d1e.png" width="375">

#### Plugins Conflict

Prerequisites:
- Store should be in the US
- Both Stripe and WCPay should be installed and active
---
- Go to Menu tab
- Open Settings
- Tap on In-Person Payments
- Onboading screen advising of plugins conflict is shown
- Press on Manage Plugins
- It can be that you need to login to WordPress.com Otherwise the Plugins menu from wp-admin should be shown

#### Plugin needs to be setup

Prerequisites:
- Payment plugin is installed and active, but not setup (You can force this by hardcoding the show of `InPersonPaymentsPluginNotSetup` in `InPersonPaymentsViewController`, `InPersonPaymentsView`)
---
- Go to Menu tab
- Open Settings
- Tap on In-Person Payments
- Onboading screen advising of plugins conflict is shown
- Press on Manage Plugins
- It can be that you need to login to WordPress.com Otherwise the selected plugin settings section from wp-admin should be shown

<img src="https://user-images.githubusercontent.com/1864060/170479045-f9c29c6d-9d52-4e53-8182-8b75009f902f.png" width="375"> | <img src="https://user-images.githubusercontent.com/1864060/170479056-d332f6ea-961c-4eaa-9b84-9900ac6056fc.png" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
