### PR TITLE
Attempt to fix review details not shown after tapping a push notification

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -21,8 +21,8 @@ struct HubMenu: View {
     ///
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
-    init(siteID: Int64, navigationController: UINavigationController? = nil) {
-        viewModel = HubMenuViewModel(siteID: siteID, navigationController: navigationController)
+    init(viewModel: HubMenuViewModel) {
+        self.viewModel = viewModel
     }
 
     var body: some View {
@@ -109,10 +109,6 @@ struct HubMenu: View {
             // fall back method in case menu disabled state is not reset properly
             enableMenuItemTaps()
         }
-    }
-
-    func pushReviewDetailsView(using parcel: ProductReviewFromNoteParcel) {
-        viewModel.showReviewDetails(using: parcel)
     }
 
     /// Reset state to make the menu items tappable
@@ -213,17 +209,17 @@ struct HubMenu: View {
 
 struct HubMenu_Previews: PreviewProvider {
     static var previews: some View {
-        HubMenu(siteID: 123)
+        HubMenu(viewModel: .init(siteID: 123))
             .environment(\.colorScheme, .light)
 
-        HubMenu(siteID: 123)
+        HubMenu(viewModel: .init(siteID: 123))
             .environment(\.colorScheme, .dark)
 
-        HubMenu(siteID: 123)
+        HubMenu(viewModel: .init(siteID: 123))
             .previewLayout(.fixed(width: 312, height: 528))
             .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
 
-        HubMenu(siteID: 123)
+        HubMenu(viewModel: .init(siteID: 123))
             .previewLayout(.fixed(width: 1024, height: 768))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -4,9 +4,11 @@ import Yosemite
 
 /// Displays a grid view of all available menu in the "Menu" tab (eg. View Store, Reviews, Coupons, etc...)
 final class HubMenuViewController: UIHostingController<HubMenu> {
+    private let viewModel: HubMenuViewModel
 
     init(siteID: Int64, navigationController: UINavigationController?) {
-        super.init(rootView: HubMenu(siteID: siteID, navigationController: navigationController))
+        self.viewModel = HubMenuViewModel(siteID: siteID, navigationController: navigationController)
+        super.init(rootView: HubMenu(viewModel: viewModel))
         configureTabBarItem()
     }
 
@@ -17,7 +19,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     /// Present the specific Review Details View from a push notification
     ///
     func pushReviewDetailsViewController(using parcel: ProductReviewFromNoteParcel) {
-        rootView.pushReviewDetailsView(using: parcel)
+        viewModel.showReviewDetails(using: parcel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -481,7 +481,11 @@ private extension MainTabBarController {
     func createHubMenuTabCoordinator() -> HubMenuCoordinator {
         HubMenuCoordinator(navigationController: hubMenuNavigationController,
                            willPresentReviewDetailsFromPushNotification: { [weak self] in
-            self?.navigateTo(.hubMenu)
+            await withCheckedContinuation { [weak self] continuation in
+                self?.navigateTo(.hubMenu) {
+                    continuation.resume(returning: ())
+                }
+            }
         })
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Attempted fix for #1810 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When I was able to reproduce this issue, sometimes the app shows the Menu tab and sometimes it shows the review details. This felt like a race condition, I didn't find a way to verify but the app was navigating to the Menu tab with animation (in `willPresentReviewDetailsFromPushNotification`) and pushing the review details at the same time. It's possible the animation didn't finish while the review details is shown.

One issue I was struggling with was the navigation bar being hidden when testing in iOS 14.5. Even if I set `navigationController?.setNavigationBarHidden(false, animated: false/true)` in `ReviewDetailsViewController`'s `viewWillAppear` it seemed to get overridden by the `HubMenu` SwiftUI view's `navigationBarHidden(true)`. I couldn't reproduce this navigation bar issue anymore after upgrading to iOS 15 though, please feel free to bring up any issues you might see from testing.

I also moved the `HubMenuViewModel.showReviewDetails(using:)` call from `HubMenu` view to `HubMenuViewController` which now owns the view model so that we don't add logic to the SwiftUI view.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I used to be able to repro about 90% of the time in an iOS 14.5 test device, but I wanted to test the iOS 15 behavior and couldn't repro this consistently anymore (maybe 1 out of 20 times in `trunk`) after upgrading the device to iOS 15.5 🤦🏻‍♀️ If you still have an iOS 14.5 device, please try that for testing!

- Open the app and then background the app, make sure the app can receive remote push notifications
- On the web, write a review or resend a review push notification from MC debug tool (link in p99K0U-1qz-p2) --> the app should receive a push notification
- Tap on the push notification --> the app should switch to the target store if needed, navigate to the Menu tab, and show review details (there is a known issue where the review list isn't shown before review details https://github.com/woocommerce/woocommerce-ios/issues/6929)
- Go back to the root of the Menu tab to leave the review details
- Tap on another main tab
- On the web, write a review or resend a review push notification from MC debug tool --> an in-app notice should be shown
- Tap "View" on the in-app notice --> the app should navigate to the Menu tab, and show review details


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->