### PR TITLE
Extract ASC key path definition in constant for later reuse

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -549,7 +549,8 @@ platform :ios do
       register_device(
         name: device_name,
         udid: device_id,
-        team_id: get_required_env('EXT_EXPORT_TEAM_ID')
+        team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
+        api_key_path: ASC_KEY_PATH
       )
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,6 +54,8 @@ GLOTPRESS_TO_ASC_METADATA_LOCALE_CODES = {
   'zh-tw' => 'zh-Hant',
 }.freeze
 
+ASC_KEY_PATH = File.join(SECRETS_DIR, 'app_store_connect_fastlane_api_key.json')
+
 # Use this instead of getting values from ENV directly
 # It will throw an error if the requested value is missing
 def get_required_env(key)
@@ -398,7 +400,7 @@ platform :ios do
 
     testflight(
       skip_waiting_for_build_processing: true,
-      api_key_path: File.join(SECRETS_DIR, 'app_store_connect_fastlane_api_key.json')
+      api_key_path: ASC_KEY_PATH
     )
     sh('cd .. && rm WooCommerce.ipa')
 


### PR DESCRIPTION
### Description

I recently addressed a platform request to add a device to the WooCommerce iOS profiles and thought I'd upgrade the setup just a little. 

Unfortunately, even with this change, we still need to provide some credentials to the lane because of the subsequent steps to `add_development_certificates_to_provisioning_profiles` and `add_all_devices_to_provisioning_profiles`. Those are actions defined in our release toolkit and they interface [with the developer portal](https://github.com/wordpress-mobile/release-toolkit/blob/bead08d00c2cf7bdf96eaa909362c89cd2339e23/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb#L7). The portal doesn't support API keys yet, and Fastlane/Spaceship only connects to it [via username and password](https://rdoc.info/gems/fastlane/Spaceship.login).

Incidentally, this is the same as https://github.com/wordpress-mobile/WordPress-iOS/pull/18768. I didn't intentionally port the changes between repos, it just so happened that two requests to add a device were opened close to eachother.

### Testing instructions

Is it okay to say: "trust me, it worked?"

<img width="830" alt="image" src="https://user-images.githubusercontent.com/1218433/170899586-8f13578d-b0bf-4ade-af49-2940f8e17ec1.png">

Otherwise, I think it should be okay to try and run the lane with one of your iOS test devices, even if already registered.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
