### PR TITLE
[Order Details] Display date and time in the order details screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.4
 -----
-
+- [*] Orders: Order details now displays both the date and time for all orders. [https://github.com/woocommerce/woocommerce-ios/pull/6996]
 
 9.3
 -----

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -154,4 +154,15 @@ extension DateFormatter {
         formatter.setLocalizedDateFormatFromTemplate("hh:mm a")
         return formatter
     }()
+
+    /// Date formatter used for creating a **localized** date and time string.
+    ///
+    /// Example output in English: "Jan 28, 2018, 11:23 AM"
+    ///
+    public static let dateAndTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d yyyy hh:mm a")
+
+        return formatter
+    }()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -46,19 +46,10 @@ struct SummaryTableViewCellViewModel {
         }
     }
 
-    /// The date and the order number concatenated together. Example, “Jan 22, 2018 • #1587”.
-    ///
-    /// If the date is today, the time will be returned instead.
+    /// The date, time, and the order number concatenated together. Example, “Jan 22, 2018, 11:23 AM • #1587”.
     ///
     var subtitle: String {
-        let formatter: DateFormatter = {
-            if dateCreated.isSameDay(as: Date(), using: calendar) {
-                return DateFormatter.timeFormatter
-            } else {
-                return DateFormatter.mediumLengthLocalizedDateFormatter
-            }
-        }()
-
+        let formatter = DateFormatter.dateAndTimeFormatter
         return "\(formatter.string(from: dateCreated)) • #\(orderNumber)"
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellViewModelTests.swift
@@ -32,28 +32,9 @@ final class SummaryTableViewCellViewModelTests: XCTestCase {
         XCTAssertEqual(personName, "Skylar Ferry")
     }
 
-    func test_subtitle_returns_the_date_and_order_number() throws {
+    func test_subtitle_returns_the_date_and_time_and_order_number() throws {
         // Given
-        let expectedFormatter = DateFormatter.mediumLengthLocalizedDateFormatter
-        let calendar = Calendar(identifier: .gregorian, timeZone: expectedFormatter.timeZone)
-
-        let order = makeOrder(dateCreated: try XCTUnwrap(Date().adding(days: -2, using: calendar)))
-
-        let viewModel = SummaryTableViewCellViewModel(order: order,
-                                                      status: nil,
-                                                      calendar: calendar)
-
-        // When
-        let subtitle = viewModel.subtitle
-
-        // Then
-        let expectedSubtitle = expectedFormatter.string(from: order.dateCreated) + " • #\(order.number)"
-        XCTAssertEqual(subtitle, expectedSubtitle)
-    }
-
-    func test_given_an_order_created_today_then_subtitle_returns_the_time_and_order_number() {
-        // Given
-        let expectedFormatter = DateFormatter.timeFormatter
+        let expectedFormatter = DateFormatter.dateAndTimeFormatter
         let calendar = Calendar(identifier: .gregorian, timeZone: expectedFormatter.timeZone)
 
         let order = makeOrder(dateCreated: Date())


### PR DESCRIPTION
Closes: #6861

## Description

This PR updates the order details screen to display both the date and time on all orders. Previously it displayed only the time on orders from today and the date on orders from previous days.

## Changes

* Adds a new date formatter `dateAndTimeFormatter` that displays both the date and the time.
* Updates the `subtitle` in the order details `SummaryTableViewCell` to use the new formatter.
* Updates the unit tests to have a single test that checks that the expected formatter is used in this cell.

## Testing

1. Go to the Orders tab.
2. Select an order from today and confirm the top section displays both the date and time the order was created, localized according to your device settings.
3. Select an order from a previous day and confirm the top section displays both the date and time the order was created, localized according to your device settings.

## Screenshots

/|Before|After
-|-|-
Today|![OrderDetails-Today-Before](https://user-images.githubusercontent.com/8658164/170994822-f2c57c7d-05ad-4a1a-a470-235770a108ab.png)|![OrderDetails-Today-After](https://user-images.githubusercontent.com/8658164/170994849-0b337548-a40b-4727-8faf-ad415dadf322.png)
Previous day|![OrderDetails-PreviousDay-Before](https://user-images.githubusercontent.com/8658164/170994838-926b8c25-d0fb-4224-816e-2ed8ac3a2651.png)|![OrderDetails-PreviousDay-After](https://user-images.githubusercontent.com/8658164/170994869-af548ee1-58c3-40e6-9284-6835cc9b8cbf.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
