### PR TITLE
Orders: Use same color for "Create order" and "Simple payment" icons in orders bottom sheet

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -689,7 +689,7 @@ extension UIImage {
     /// Simple Payments Icon
     ///
     static var simplePaymentsImage: UIImage {
-        return UIImage(named: "icon-simple-payments")!
+        return UIImage(named: "icon-simple-payments")!.withRenderingMode(.alwaysTemplate)
     }
 
     /// Work In Progress banner icon on the Products Tab


### PR DESCRIPTION
Closes: #6628

## Description

When creating a new order from the Orders tab, the icons for the two order creation actions used slightly different grays. This updates the simple payments icon so it can use a provided tint color, allowing it to match the "Create order" icon.

## Changes

Adds `.withRenderingMode(.alwaysTemplate)` to the simple payments icon, so it can use the tint color provided in `BottomSheetOrderType`.

## Testing

1. Go to the Orders tab.
2. Tap the `+` icon and confirm the icons in the bottom sheet for "Create order" and "Simple payment" have the same color.

## Screenshots

Before|After
-|-
![OrderBottomSheet-Light-Before](https://user-images.githubusercontent.com/8658164/171019962-0966eb2f-2585-4b88-b905-140c51a113b4.png)|![OrderBottomSheet-Light-After](https://user-images.githubusercontent.com/8658164/171019992-ac745216-1db0-4aa2-bb07-09c7a7128736.png)
![OrderBottomSheet-Dark-Before](https://user-images.githubusercontent.com/8658164/171019974-adc83258-6ea8-4879-9b98-1db7f4a4abb4.png)|![OrderBottomSheet-Dark-After](https://user-images.githubusercontent.com/8658164/171019985-7cf9ba30-a8b3-4a56-be69-bd616a2ad44b.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
