### PR TITLE
[Order Details] Fix products duplicated in products and refund items lists

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
@@ -55,7 +55,6 @@ extension AggregateOrderItem: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(productID)
         hasher.combine(variationID)
-        hasher.combine(attributes)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6902
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix an edge-case bug that caused some items appear twice in the order details, once in the product list, and another in the refund items. As @joe-keenan mentioned in the issue, if the item is refunded it shouldn't appear in the product list on the order details screen. And it is mostly like that, except when the refunded item is a variable product.

In that case, since the `OrderItemRefund` doesn't have any `attributes` property  as in `OrderItem`, there is an inconsistency when converting to `AggregateOrderItem` depending if the item came from a refund (no attributes) or from the product itself (it has attributes).
In `AggregateDataHelper.combineOrderItems` we group the items into a dictionary using the hash function of `AggregateOrderItem`. But because that function uses the `attributes` property to hash among others, **it cannot group the same variable product**, thus creating two different groups for the same item (refunded-original order item). Because of that, we end up displaying the item in products and refunded.

To fix it, I remove the `attributes` property from the `AggregateOrderItem` hasher function. I think this is safe because:

- It is only used in `AggregateDataHelper` where hashing only depending on `productID` and `variationID` works fine.
- In general, I think it is enough and acceptable to use `productID` and `variationID` to uniquely identify an `AggregateOrderItem` instance. Please let me know if you think this is not correct.
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites
- Create an order that contains at least one variable product. Do not mark the order as complete.
- Refund that variable product.
Before: the refunded variable product appears in "Products" and "Refunded Products" sections in Order Details:

https://user-images.githubusercontent.com/95003933/170157984-03502594-333b-44db-a0cc-22ad649d5573.mp4

After: The refunded product does not appear in "Products", only in "Refunded Products" sections in Order Details:


https://user-images.githubusercontent.com/1864060/171039155-03390c13-b9aa-40f1-810a-1d9e10716b9d.mp4




### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
