### PR TITLE
Coupons: Add validation for allowed emails

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
@@ -25,6 +25,13 @@ struct CouponAllowedEmails: View {
         }
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    // TODO: validate
+                }, label: Localization.done)
+            }
+        }
     }
 }
 
@@ -41,6 +48,7 @@ private extension CouponAllowedEmails {
             "Separate email addresses with commas. You can also use an asterisk (*) " +
             "to match parts of an email. For example \"*@gmail.com\" would match all gmail addresses.",
             comment: "Description of the allowed emails field for coupons")
+        static let done = NSLocalizedString("Done", comment: "Done button on the Allowed Emails screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
@@ -4,6 +4,7 @@ import SwiftUI
 ///
 struct CouponAllowedEmails: View {
     @ObservedObject private var viewModel: CouponAllowedEmailsViewModel
+    @Environment(\.presentationMode) var presentation
 
     init(viewModel: CouponAllowedEmailsViewModel) {
         self.viewModel = viewModel
@@ -31,11 +32,14 @@ struct CouponAllowedEmails: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    viewModel.validateEmails()
-                }, label: Localization.done)
+                Button(Localization.done) {
+                    viewModel.validateEmails {
+                        presentation.wrappedValue.dismiss()
+                    }
+                }
             }
         }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
@@ -3,12 +3,16 @@ import SwiftUI
 /// View to input allowed email formats for coupons
 ///
 struct CouponAllowedEmails: View {
-    @Binding var emailFormats: String
+    @ObservedObject private var viewModel: CouponAllowedEmailsViewModel
+
+    init(viewModel: CouponAllowedEmailsViewModel) {
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         GeometryReader { geometry in
             VStack(alignment: .leading) {
-                TextField("", text: $emailFormats)
+                TextField("", text: $viewModel.emailPatterns)
                     .labelsHidden()
                     .padding(.horizontal, Constants.margin)
                     .padding(.horizontal, insets: geometry.safeAreaInsets)
@@ -28,7 +32,7 @@ struct CouponAllowedEmails: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
-                    // TODO: validate
+                    viewModel.validateEmails()
                 }, label: Localization.done)
             }
         }
@@ -54,6 +58,7 @@ private extension CouponAllowedEmails {
 
 struct CouponAllowedEmails_Previews: PreviewProvider {
     static var previews: some View {
-        CouponAllowedEmails(emailFormats: .constant("*gmail.com, *@me.com"))
+        let viewModel = CouponAllowedEmailsViewModel(allowedEmails: "*gmail.com, *@me.com") { _ in }
+        CouponAllowedEmails(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmails.swift
@@ -39,6 +39,7 @@ struct CouponAllowedEmails: View {
                 }
             }
         }
+        .notice($viewModel.notice)
         .wooNavigationBarStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
@@ -4,17 +4,20 @@ import Foundation
 ///
 final class CouponAllowedEmailsViewModel: ObservableObject {
 
-    @Published var allowedEmails: String
+    @Published var emailPatterns: String
+    @Published var foundInvalidPatterns: Bool = false
 
-    @Published private(set) var foundInvalidPatterns: Bool = false
+    private let onCompletion: (String) -> Void
 
-    init(allowedEmails: String) {
-        self.allowedEmails = allowedEmails
+    init(allowedEmails: String, onCompletion: @escaping (String) -> Void) {
+        self.emailPatterns = allowedEmails
+        self.onCompletion = onCompletion
     }
 
     /// Validate the input
     ///
-    func validateEmails() {
-        
+    func validateEmails() -> Bool {
+        // TODO: implement this
+        return true
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// View model for `CouponAllowedEmails` view.
+///
+final class CouponAllowedEmailsViewModel: ObservableObject {
+
+    @Published var allowedEmails: String
+
+    @Published private(set) var foundInvalidPatterns: Bool = false
+
+    init(allowedEmails: String) {
+        self.allowedEmails = allowedEmails
+    }
+
+    /// Validate the input
+    ///
+    func validateEmails() {
+        
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
@@ -6,7 +6,11 @@ import WordPressShared
 final class CouponAllowedEmailsViewModel: ObservableObject {
 
     @Published var emailPatterns: String
-    @Published var foundInvalidPatterns: Bool = false
+
+    /// Defines the current notice that should be shown.
+    /// Defaults to `nil`.
+    ///
+    @Published var notice: Notice?
 
     private let onCompletion: (String) -> Void
 
@@ -19,10 +23,21 @@ final class CouponAllowedEmailsViewModel: ObservableObject {
     ///
     func validateEmails(dismissHandler: @escaping () -> Void) {
         let emails = emailPatterns.components(separatedBy: ", ")
-        foundInvalidPatterns = emails.contains(where: { !EmailFormatValidator.validate(string: $0) })
+        let foundInvalidPatterns = emails.contains(where: { !EmailFormatValidator.validate(string: $0) })
         if !foundInvalidPatterns {
             onCompletion(emailPatterns)
             dismissHandler()
+        } else {
+            notice = Notice(title: Localization.failedEmailValidation, feedbackType: .error)
         }
+    }
+}
+
+private extension CouponAllowedEmailsViewModel {
+    enum Localization {
+        static let failedEmailValidation = NSLocalizedString(
+            "Some email address is not valid.",
+            comment: "Error message when at least an address on the Coupon Allowed Emails screen is not valid."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// View model for `CouponAllowedEmails` view.
 ///
@@ -16,8 +17,12 @@ final class CouponAllowedEmailsViewModel: ObservableObject {
 
     /// Validate the input
     ///
-    func validateEmails() -> Bool {
-        // TODO: implement this
-        return true
+    func validateEmails(dismissHandler: @escaping () -> Void) {
+        let emails = emailPatterns.components(separatedBy: ", ")
+        foundInvalidPatterns = emails.contains(where: { !EmailFormatValidator.validate(string: $0) })
+        if !foundInvalidPatterns {
+            onCompletion(emailPatterns)
+            dismissHandler()
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -167,7 +167,7 @@ struct CouponRestrictions: View {
                                         categoryListConfig: categoryListConfig,
                                         viewModel: viewModel.categorySelectorViewModel)
             }
-            LazyNavigationLink(destination: CouponAllowedEmails(emailFormats: $viewModel.allowedEmails), isActive: $showingAllowedEmails) {
+            LazyNavigationLink(destination: CouponAllowedEmails(viewModel: viewModel.allowedEmailsViewModel), isActive: $showingAllowedEmails) {
                 EmptyView()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -75,6 +75,12 @@ final class CouponRestrictionsViewModel: ObservableObject {
         }
     }()
 
+    lazy var allowedEmailsViewModel = {
+        CouponAllowedEmailsViewModel(allowedEmails: allowedEmails) { [weak self] updatedEmails in
+            self?.allowedEmails = updatedEmails
+        }
+    }()
+
     private let siteID: Int64
     private let stores: StoresManager
     private let storageManager: StorageManagerType

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1627,6 +1627,7 @@
 		DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */; };
 		DECE13FC27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */; };
 		DECE1400279A595200816ECD /* Coupon+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13FF279A595200816ECD /* Coupon+Woo.swift */; };
+		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
 		DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
@@ -3378,6 +3379,7 @@
 		DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndStatusTableViewCell.swift; sourceTree = "<group>"; };
 		DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndSubtitleAndStatusTableViewCell.xib; sourceTree = "<group>"; };
 		DECE13FF279A595200816ECD /* Coupon+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+Woo.swift"; sourceTree = "<group>"; };
+		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
 		DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageAttributes.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
@@ -7757,6 +7759,7 @@
 				DE69C54C27BB719A000BB888 /* CouponRestrictions.swift */,
 				DE69C54927BB715D000BB888 /* CouponRestrictionsViewModel.swift */,
 				DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */,
+				DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */,
 			);
 			path = UsageDetails;
 			sourceTree = "<group>";
@@ -9475,6 +9478,7 @@
 				DE26B52C277DA11800A2EA0A /* CouponListView.swift in Sources */,
 				AEA622B2274669D3002A9B57 /* AddOrderCoordinator.swift in Sources */,
 				4535EE7A281ADD56004212B4 /* CouponCodeInputFormatter.swift in Sources */,
+				DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
 				2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1568,6 +1568,7 @@
 		DE279BAD26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */; };
 		DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */; };
 		DE279BB126EA184A002BA963 /* ShippingLabelPackageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */; };
+		DE2BF4FD2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2BF4FC2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
@@ -3320,6 +3321,7 @@
 		DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesFormViewModelTests.swift; sourceTree = "<group>"; };
 		DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSinglePackageViewModelTests.swift; sourceTree = "<group>"; };
 		DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageListViewModel.swift; sourceTree = "<group>"; };
+		DE2BF4FC2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
@@ -4514,6 +4516,7 @@
 				4535EE7F281BE4E0004212B4 /* CouponAmountInputFormatterTests.swift */,
 				4535EE81281BE726004212B4 /* CouponCodeInputFormatterTests.swift */,
 				DE3877E3283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift */,
+				DE2BF4FC2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift */,
 			);
 			path = Coupons;
 			sourceTree = "<group>";
@@ -9698,6 +9701,7 @@
 				E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */,
 				269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
+				DE2BF4FD2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift in Sources */,
 				FEEB2F6E268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift in Sources */,
 				31E906A326CC91A70099A985 /* CardReaderConnectionControllerTests.swift in Sources */,
 				02AB40822784297C00929CF3 /* ProductTableViewCellViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponAllowedEmailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponAllowedEmailsViewModelTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import WooCommerce
+
+final class CouponAllowedEmailsViewModelTests: XCTestCase {
+
+    func test_completion_block_is_triggered_when_address_validation_succeeds() {
+        // Given
+        var savedAddresses: String?
+        let completionBlock: (String) -> Void = { email in
+            savedAddresses = email
+        }
+        let viewModel = CouponAllowedEmailsViewModel(allowedEmails: "", onCompletion: completionBlock)
+
+        // When
+        viewModel.emailPatterns = "*@mail.com"
+        viewModel.validateEmails {}
+
+        // Then
+        XCTAssertEqual(savedAddresses, "*@mail.com")
+        XCTAssertNil(viewModel.notice)
+    }
+
+    func test_completion_block_is_not_triggered_and_notice_is_not_nil_when_address_validation_fails() {
+        var savedAddresses: String?
+        let completionBlock: (String) -> Void = { email in
+            savedAddresses = email
+        }
+        let viewModel = CouponAllowedEmailsViewModel(allowedEmails: "", onCompletion: completionBlock)
+
+        // When
+        viewModel.emailPatterns = "*@mail"
+        viewModel.validateEmails {}
+
+        // Then
+        XCTAssertNil(savedAddresses)
+        XCTAssertNotNil(viewModel.notice)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #6845 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds validation to the Allowed Emails screen to make sure only valid addresses are entered.

Changes include:
- Add a view model to `CouponAllowedEmails` view.
- Add a Done button on the `CouponAllowedEmails` view to trigger validation.
- Handle the validation.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that Coupon Management is enabled in Settings > Experimental Features.
- Navigate to Menu > Coupons > select a coupon > select the ellipsis button > Edit Coupon.
- Select Usage Restrictions at the bottom of the edit form, then select Allowed Emails.
- Try entering an invalid address then tap Done, and notice that there's a notice indicating failed validation.
- Correct the address to a valid form - notice that tapping Done dismisses the view saves the address to the list.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/171142839-e5708fcd-3562-4953-baa9-f5388c0f8497.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
