### PR TITLE
Add pull to refresh to `EmptyStateViewController`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -88,7 +88,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
 
     /// The handler to execute when the view is pulled to refresh.
     ///
-    private var pullToRefreshActionHandler: ((UIRefreshControl) -> ())?
+    private var pullToRefreshHandler: ((UIRefreshControl) -> ())?
 
     private lazy var keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: { [weak self] frame in
         self?.handleKeyboardFrameUpdate(keyboardFrame: frame)
@@ -292,7 +292,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
 
 private extension EmptyStateViewController {
     @objc func onPullToRefresh(sender: UIRefreshControl) {
-        pullToRefreshActionHandler?(sender)
+        pullToRefreshHandler?(sender)
     }
 
     /// Configures the `actionButton` based on the given `config`.
@@ -314,7 +314,7 @@ private extension EmptyStateViewController {
 
     /// Configures pull to refresh based on the given `config`
     func configurePullToRefresh(_ config: Config) {
-        pullToRefreshActionHandler = {
+        pullToRefreshHandler = {
             switch config {
             case .simple(_, _, let pullToRefreshClosure):
                 return pullToRefreshClosure
@@ -327,7 +327,7 @@ private extension EmptyStateViewController {
             }
         }()
 
-        guard pullToRefreshActionHandler != nil else {
+        guard pullToRefreshHandler != nil else {
             // Remove refresh control if config doesn't have action handler
             scrollView.refreshControl = nil
             return

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -329,8 +329,7 @@ private extension EmptyStateViewController {
 
         guard pullToRefreshHandler != nil else {
             // Remove refresh control if config doesn't have action handler
-            scrollView.refreshControl = nil
-            return
+            return scrollView.refreshControl = nil
         }
 
         // Create refresh control if needed

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -218,18 +218,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
             }
         }()
 
-        pullToRefreshActionHandler = {
-            switch config {
-            case .simple(_, _, let pullToRefreshClosure):
-                return pullToRefreshClosure
-            case .withLink(_, _, _, _, _, let pullToRefreshClosure):
-                return pullToRefreshClosure
-            case .withButton(_, _, _, _, _, let pullToRefreshClosure):
-                return pullToRefreshClosure
-            case .withSupportRequest(_, _, _, _, let pullToRefreshClosure):
-                return pullToRefreshClosure
-            }
-        }()
+        configurePullToRefresh(config)
     }
 
     /// Watch for device orientation changes and update the `imageView`'s visibility accordingly.
@@ -302,6 +291,10 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
 // MARK: - Configuration
 
 private extension EmptyStateViewController {
+    @objc func onPullToRefresh(sender: UIRefreshControl) {
+        pullToRefreshActionHandler?(sender)
+    }
+
     /// Configures the `actionButton` based on the given `config`.
     func configureActionButton(_ config: Config) {
         switch config {
@@ -317,6 +310,34 @@ private extension EmptyStateViewController {
             actionButton.contentEdgeInsets = .zero
             actionButton.setTitle(buttonTitle, for: .normal)
         }
+    }
+
+    /// Configures pull to refresh based on the given `config`
+    func configurePullToRefresh(_ config: Config) {
+        pullToRefreshActionHandler = {
+            switch config {
+            case .simple(_, _, let pullToRefreshClosure):
+                return pullToRefreshClosure
+            case .withLink(_, _, _, _, _, let pullToRefreshClosure):
+                return pullToRefreshClosure
+            case .withButton(_, _, _, _, _, let pullToRefreshClosure):
+                return pullToRefreshClosure
+            case .withSupportRequest(_, _, _, _, let pullToRefreshClosure):
+                return pullToRefreshClosure
+            }
+        }()
+
+        guard pullToRefreshActionHandler != nil else {
+            // Remove refresh control if config doesn't have action handler
+            scrollView.refreshControl = nil
+            return
+        }
+
+        // Create refresh control if needed
+        if scrollView.refreshControl == nil {
+            scrollView.refreshControl = UIRefreshControl()
+        }
+        scrollView.refreshControl?.addTarget(self, action: #selector(onPullToRefresh(sender:)), for: .valueChanged)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -185,6 +185,34 @@ final class EmptyStateViewControllerTests: XCTestCase {
         XCTAssertEqual(invocation.controller, viewController)
         XCTAssertNil(invocation.sourceTag)
     }
+
+    // MARK: - Pull to refresh
+
+    func test_given_a_simple_config_with_pull_to_refresh_handler_when_pulled_to_refresh_fires_callback() throws {
+        // Given
+        let viewController = EmptyStateViewController()
+        XCTAssertNotNil(viewController.view)
+
+        let mirror = try self.mirror(of: viewController)
+
+        let exp = expectation(description: "Pull to refresh callback executed.")
+        let completionHandler: ((UIRefreshControl) -> Void) = { _ in
+            exp.fulfill()
+        }
+        // When
+        viewController.configure(.simple(message: NSAttributedString(string: "Ola"),
+                                         image: .infoImage,
+                                         onPullToRefresh: completionHandler))
+
+        // Then
+        XCTAssertNotNil(mirror.scrollView.refreshControl)
+
+        // When
+        mirror.scrollView.refreshControl?.sendActions(for: .valueChanged)
+
+        // Then
+        waitForExpectations(timeout: Constants.expectationTimeout)
+    }
 }
 
 // MARK: - Mirroring

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -307,6 +307,29 @@ final class EmptyStateViewControllerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: Constants.expectationTimeout)
     }
+
+    func test_pull_to_refresh_control_is_removed_when_reconfigured_using_nil_onPullToRefresh_value() throws {
+        // Given
+        let viewController = EmptyStateViewController()
+        XCTAssertNotNil(viewController.view)
+
+        let mirror = try self.mirror(of: viewController)
+
+        // When
+        viewController.configure(.simple(message: NSAttributedString(string: "Ola"),
+                                         image: .infoImage,
+                                         onPullToRefresh: { _ in }))
+
+        // Then
+        XCTAssertNotNil(mirror.scrollView.refreshControl)
+
+        // When
+        viewController.configure(.simple(message: NSAttributedString(string: "Ola"),
+                                         image: .infoImage))
+
+        // Then
+        XCTAssertNil(mirror.scrollView.refreshControl)
+    }
 }
 
 // MARK: - Mirroring

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -213,6 +213,68 @@ final class EmptyStateViewControllerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: Constants.expectationTimeout)
     }
+
+    func test_given_a_link_config_with_pull_to_refresh_handler_when_pulled_to_refresh_fires_callback() throws {
+        // Given
+        let viewController = EmptyStateViewController()
+        XCTAssertNotNil(viewController.view)
+
+        let mirror = try self.mirror(of: viewController)
+
+        let exp = expectation(description: "Pull to refresh callback executed.")
+        let completionHandler: ((UIRefreshControl) -> Void) = { _ in
+            exp.fulfill()
+        }
+
+        // When
+        viewController.configure(.withLink(
+            message: NSAttributedString(string: "Ola"),
+            image: .infoImage,
+            details: "Dolores eum",
+            linkTitle: "Bakero!",
+            linkURL: WooConstants.URLs.blog.asURL(),
+            onPullToRefresh: completionHandler
+        ))
+
+        // Then
+        XCTAssertNotNil(mirror.scrollView.refreshControl)
+
+        // When
+        mirror.scrollView.refreshControl?.sendActions(for: .valueChanged)
+
+        // Then
+        waitForExpectations(timeout: Constants.expectationTimeout)
+    }
+
+    func test_given_a_withButton_config_with_pull_to_refresh_handler_when_pulled_to_refresh_fires_callback() throws {
+        // Given
+        let viewController = EmptyStateViewController()
+        XCTAssertNotNil(viewController.view)
+
+        let mirror = try self.mirror(of: viewController)
+
+        let exp = expectation(description: "Pull to refresh callback executed.")
+        let completionHandler: ((UIRefreshControl) -> Void) = { _ in
+            exp.fulfill()
+        }
+
+        // When
+        viewController.configure(.withButton(message: NSAttributedString(string: "Ola"),
+                                             image: .infoImage,
+                                             details: "Dolores eum",
+                                             buttonTitle: "Bakero!",
+                                             onTap: { _ in },
+                                             onPullToRefresh: completionHandler))
+
+        // Then
+        XCTAssertNotNil(mirror.scrollView.refreshControl)
+
+        // When
+        mirror.scrollView.refreshControl?.sendActions(for: .valueChanged)
+
+        // Then
+        waitForExpectations(timeout: Constants.expectationTimeout)
+    }
 }
 
 // MARK: - Mirroring

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -275,6 +275,38 @@ final class EmptyStateViewControllerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: Constants.expectationTimeout)
     }
+
+    func test_given_a_supportRequest_config_with_pull_to_refresh_handler_when_pulled_to_refresh_fires_callback() throws {
+        // Given
+        let zendeskManager = MockZendeskManager()
+        let viewController = EmptyStateViewController(style: .basic, zendeskManager: zendeskManager)
+        XCTAssertNotNil(viewController.view)
+
+        let mirror = try self.mirror(of: viewController)
+
+        let exp = expectation(description: "Pull to refresh callback executed.")
+        let completionHandler: ((UIRefreshControl) -> Void) = { _ in
+            exp.fulfill()
+        }
+
+        // When
+        viewController.configure(.withSupportRequest(
+            message: NSAttributedString(string: ""),
+            image: .infoImage,
+            details: "",
+            buttonTitle: "Dolores",
+            onPullToRefresh: completionHandler
+        ))
+
+        // Then
+        XCTAssertNotNil(mirror.scrollView.refreshControl)
+
+        // When
+        mirror.scrollView.refreshControl?.sendActions(for: .valueChanged)
+
+        // Then
+        waitForExpectations(timeout: Constants.expectationTimeout)
+    }
 }
 
 // MARK: - Mirroring

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -195,6 +195,7 @@ private extension EmptyStateViewControllerTests {
         let imageView: UIImageView
         let detailsLabel: UILabel
         let actionButton: UIButton
+        let scrollView: UIScrollView
     }
 
     func mirror(of viewController: EmptyStateViewController) throws -> EmptyStateViewControllerMirror {
@@ -204,7 +205,8 @@ private extension EmptyStateViewControllerTests {
             messageLabel: try XCTUnwrap(mirror.descendant("messageLabel") as? UILabel),
             imageView: try XCTUnwrap(mirror.descendant("imageView") as? UIImageView),
             detailsLabel: try XCTUnwrap(mirror.descendant("detailsLabel") as? UILabel),
-            actionButton: try XCTUnwrap(mirror.descendant("actionButton") as? UIButton)
+            actionButton: try XCTUnwrap(mirror.descendant("actionButton") as? UIButton),
+            scrollView: try XCTUnwrap(mirror.descendant("scrollView") as? UIScrollView)
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6356
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds pull to refresh ability to `EmptyStateViewController`. 

We will be using this `PullToRequestActionHandler` callback in Orders and Products screens in future PRs to add pull to request to the empty state child view controllers.

Breadown details [here](https://github.com/woocommerce/woocommerce-ios/issues/6356#issuecomment-1141800065).

### Testing instructions
- Successful CI should be enough. 

### Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
