### PR TITLE
[Mobile Payments] Use currency formatter in Yosemite

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -73,7 +73,7 @@ public extension ReceiptRenderer {
                         <h1>\(receiptTitle)</h1>
                         <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
                         <p>
-                            \(content.parameters.formattedAmount) \(content.parameters.currency.uppercased())
+                            \(content.parameters.formattedAmount)
                         </p>
                         <h3>\(Localization.datePaidSectionTitle.uppercased())</h3>
                         <p>
@@ -126,7 +126,7 @@ private extension ReceiptRenderer {
                 title.append(". \(variations.trimmingCharacters(in: .whitespaces))")
             }
             let stripedTitle = title.htmlStripped()
-            summaryContent += "<tr><td>\(stripedTitle) × \(line.quantity)</td><td>\(line.amount) \(content.parameters.currency.uppercased())</td></tr>"
+            summaryContent += "<tr><td>\(stripedTitle) × \(line.quantity)</td><td>\(line.amount)</td></tr>"
         }
         summaryContent += totalRows()
         summaryContent += "</table>"
@@ -149,7 +149,7 @@ private extension ReceiptRenderer {
                     \(title)
                 </td>
                 <td>
-                    \(amount) \(content.parameters.currency.uppercased())
+                    \(amount)
                 </td>
             </tr>
         """

--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -6,7 +6,7 @@ import CryptoKit
 
 final class ReceiptRendererTest: XCTestCase {
     func test_TextWithoutHtmlSymbols() {
-        let expectedResultWithoutHtmlSymbolsMd5Description = "MD5 digest: aaf7e9f13e65797745b27b35deb87d5e"
+        let expectedResultWithoutHtmlSymbolsMd5Description = "MD5 digest: dcf62ae7ac29fc305c280193887350b6"
         let content = generateReceiptContent()
 
         let renderer = ReceiptRenderer(content: content)
@@ -18,7 +18,7 @@ final class ReceiptRendererTest: XCTestCase {
     }
 
     func test_TextWithHtmlSymbols() {
-        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: 3c24eae234431b76f371f6198858c90f"
+        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: 40083b7f6ef076c8d84f8fca79611823"
         let stringWithHtml = "<tt><table></table></footer>"
         let content = generateReceiptContent(stringToAppend: stringWithHtml)
 
@@ -31,7 +31,7 @@ final class ReceiptRendererTest: XCTestCase {
     }
 
     func test_TextWithVariationsSymbols() {
-        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: b28ce45f9b2be604b22ef68378529874"
+        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: a30f786359ebb6197b58fe1eaddbb04f"
         let attributeOne = ReceiptLineAttribute(name: "name_attr_1", value: "value_attr_1")
         let attributeTwo = ReceiptLineAttribute(name: "name_attr_2", value: "value_attr_2")
         let content = generateReceiptContent(attributes: [attributeOne, attributeTwo])
@@ -52,7 +52,7 @@ private extension ReceiptRendererTest {
         ReceiptContent(
             parameters: CardPresentReceiptParameters(
                 amount: 1,
-                formattedAmount: "1",
+                formattedAmount: "$1",
                 currency: "USD",
                 date: .init(timeIntervalSince1970: 1636970486),
                 storeName: "Test Store",
@@ -79,9 +79,9 @@ private extension ReceiptRendererTest {
             lineItems: [ReceiptLineItem(
                 title: "Sample product #1\(stringToAppend)",
                 quantity: "2",
-                amount: "25",
+                amount: "$25",
                 attributes: attributes)],
-            cartTotals: [ReceiptTotalLine(description: "description", amount: "13")],
+            cartTotals: [ReceiptTotalLine(description: "description", amount: "$13")],
             orderNote: nil
         )
     }

--- a/WooCommerce/Classes/Extensions/Order+CardPresentPayment.swift
+++ b/WooCommerce/Classes/Extensions/Order+CardPresentPayment.swift
@@ -28,7 +28,7 @@ extension Order {
         }
 
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        guard let totalAmount = currencyFormatter.convertToDecimal(from: total), totalAmount.decimalValue > 0 else {
+        guard let totalAmount = currencyFormatter.convertToDecimal(total), totalAmount.decimalValue > 0 else {
             return false
         }
 

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -46,7 +46,7 @@ final class AggregateDataHelper {
             let totalQuantity = items.sum(\.quantity)
             // Sum the refunded product amount
             let total = items
-                .compactMap { currency.convertToDecimal(from: $0.total) }
+                .compactMap { currency.convertToDecimal($0.total) }
                 .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
             return AggregateOrderItem(
@@ -77,7 +77,7 @@ final class AggregateDataHelper {
         let currency = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         // Convert the order items into a mutable type
         let convertedItems = items.map { item -> AggregateOrderItem in
-            let total = currency.convertToDecimal(from: item.total) ?? NSDecimalNumber.zero
+            let total = currency.convertToDecimal(item.total) ?? NSDecimalNumber.zero
             return AggregateOrderItem(
                 productID: item.productID,
                 variationID: item.variationID,

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -88,12 +88,12 @@ extension CurrencySettings {
                 self.currencyPosition = currencyPosition
             }
         case Constants.thousandSeparatorKey:
-            self.thousandSeparator = value
+            self.groupingSeparator = value
         case Constants.decimalSeparatorKey:
             self.decimalSeparator = value
         case Constants.numberOfDecimalsKey:
             if let numberOfDecimals = Int(value) {
-                self.numberOfDecimals = numberOfDecimals
+                self.fractionDigits = numberOfDecimals
             }
         default:
             break

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -30,7 +30,7 @@ final class OrderPaymentDetailsViewModel {
     }
 
     var discountValue: String? {
-        guard let discount = currencyFormatter.convertToDecimal(from: order.discountTotal), discount.isZero() == false else {
+        guard let discount = currencyFormatter.convertToDecimal(order.discountTotal), discount.isZero() == false else {
             return nil
         }
 
@@ -208,7 +208,7 @@ final class OrderPaymentDetailsViewModel {
     /// Calculate the net amount after refunds
     ///
     private func calculateNetAmount() -> NSDecimalNumber? {
-        guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
+        guard let orderTotal = currencyFormatter.convertToDecimal(order.total) else {
             return .zero
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
@@ -74,7 +74,7 @@ private extension RefundDetailsViewModel {
     /// Calculate the subtotal for each returned item
     ///
     func calculateItemSubtotal() -> NSDecimalNumber {
-        let itemSubtotals = refund.items.map { currencyFormatter.convertToDecimal(from: $0.subtotal) }
+        let itemSubtotals = refund.items.map { currencyFormatter.convertToDecimal($0.subtotal) }
 
         var subtotal = NSDecimalNumber.zero
         for itemSubtotal in itemSubtotals {
@@ -93,7 +93,7 @@ private extension RefundDetailsViewModel {
     /// Calculate the subtotal tax for each returned item
     ///
     func calculateSubtotalTax() -> NSDecimalNumber {
-        let itemSubtotalTaxes = refund.items.map { currencyFormatter.convertToDecimal(from: $0.subtotalTax) }
+        let itemSubtotalTaxes = refund.items.map { currencyFormatter.convertToDecimal($0.subtotalTax) }
 
         var subtotalTax = NSDecimalNumber.zero
         for itemSubtotalTax in itemSubtotalTaxes {

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
@@ -113,7 +113,7 @@ private extension AggregatedShippingLabelOrderItems {
         case .product(let product, let orderItem, let name):
             let productName = orderItem?.name ?? name
             let price = orderItem?.price ??
-                currencyFormatter.convertToDecimal(from: product.price) ?? 0
+                currencyFormatter.convertToDecimal(product.price) ?? 0
             let totalPrice = price.multiplying(by: .init(decimal: Decimal(quantity)))
             let imageURL: URL?
             if let encodedImageURLString = product.images.first?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
@@ -133,7 +133,7 @@ private extension AggregatedShippingLabelOrderItems {
         case .productVariation(let variation, let orderItem, let name):
             let productName = orderItem?.name ?? name
             let price = orderItem?.price ??
-                currencyFormatter.convertToDecimal(from: variation.price) ?? 0
+                currencyFormatter.convertToDecimal(variation.price) ?? 0
             let totalPrice = price.multiplying(by: .init(decimal: Decimal(quantity)))
             let imageURL: URL?
             if let encodedImageURLString = variation.image?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -131,7 +131,7 @@ struct ProductDetailsCellViewModel {
                   imageURL: product?.imageURL,
                   name: item.name,
                   positiveQuantity: abs(item.quantity),
-                  total: formatter.convertToDecimal(from: item.total) ?? NSDecimalNumber.zero,
+                  total: formatter.convertToDecimal(item.total) ?? NSDecimalNumber.zero,
                   price: item.price,
                   skuText: item.sku,
                   attributes: item.attributes.map { VariationAttributeViewModel(orderItemAttribute: $0) },
@@ -168,7 +168,7 @@ struct ProductDetailsCellViewModel {
                   imageURL: product?.imageURL,
                   name: refundedItem.name,
                   positiveQuantity: abs(refundedItem.quantity),
-                  total: formatter.convertToDecimal(from: refundedItem.total) ?? NSDecimalNumber.zero,
+                  total: formatter.convertToDecimal(refundedItem.total) ?? NSDecimalNumber.zero,
                   price: refundedItem.price,
                   skuText: refundedItem.sku,
                   attributes: [], // Attributes are not supported for a refund item yet.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -507,8 +507,8 @@ extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
             } else {
                 return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
                     .formatCurrency(using: value.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true),
-                                    at: ServiceLocator.currencySettings.currencyPosition,
-                                    with: currencySymbol,
+                                    currencyPosition: ServiceLocator.currencySettings.currencyPosition,
+                                    currencySymbol: currencySymbol,
                                     isNegative: value.sign == .minus)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -42,7 +42,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     /// fired and disposed, not reused for multiple payment flows).
     ///
     private lazy var orderTotal: NSDecimalNumber? = {
-        currencyFormatter.convertToDecimal(from: order.total)
+        currencyFormatter.convertToDecimal(order.total)
     }()
 
     /// Formatted amount to collect.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetailsViewModel.swift
@@ -34,7 +34,7 @@ class FeeLineDetailsViewModel: ObservableObject {
     ///
     private var finalAmountDecimal: Decimal {
         let inputString = feeType == .fixed ? amount : percentage
-        guard let decimalInput = currencyFormatter.convertToDecimal(from: inputString) else {
+        guard let decimalInput = currencyFormatter.convertToDecimal(inputString) else {
             return .zero
         }
 
@@ -125,7 +125,7 @@ class FeeLineDetailsViewModel: ObservableObject {
         self.isExistingFeeLine = isExistingFeeLine
         self.baseAmountForPercentage = baseAmountForPercentage
 
-        if let initialAmount = currencyFormatter.convertToDecimal(from: feesTotal) {
+        if let initialAmount = currencyFormatter.convertToDecimal(feesTotal) {
             self.initialAmount = initialAmount as Decimal
         } else {
             self.initialAmount = .zero

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetailsViewModel.swift
@@ -78,7 +78,7 @@ class ShippingLineDetailsViewModel: ObservableObject {
         self.methodTitle = initialMethodTitle
 
         let currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
-        if isExistingShippingLine, let initialAmount = currencyFormatter.convertToDecimal(from: shippingTotal) {
+        if isExistingShippingLine, let initialAmount = currencyFormatter.convertToDecimal(shippingTotal) {
             self.initialAmount = initialAmount as Decimal
         } else {
             self.initialAmount = nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
@@ -14,13 +14,13 @@ final class OrderTotalsCalculator {
     /// Total shipping amount on an order.
     ///
     private var shippingTotal: NSDecimalNumber {
-        currencyFormatter.convertToDecimal(from: order.shippingTotal) ?? .zero
+        currencyFormatter.convertToDecimal(order.shippingTotal) ?? .zero
     }
 
     /// Total taxes amount on an order.
     ///
     private var taxesTotal: NSDecimalNumber {
-        currencyFormatter.convertToDecimal(from: order.totalTax) ?? .zero
+        currencyFormatter.convertToDecimal(order.totalTax) ?? .zero
     }
 
     // MARK: Calculated totals
@@ -30,7 +30,7 @@ final class OrderTotalsCalculator {
     var itemsTotal: NSDecimalNumber {
         order.items
             .map { $0.subtotal }
-            .compactMap { currencyFormatter.convertToDecimal(from: $0) }
+            .compactMap { currencyFormatter.convertToDecimal($0) }
             .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
     }
 
@@ -45,7 +45,7 @@ final class OrderTotalsCalculator {
     var feesTotal: NSDecimalNumber {
         order.fees
             .map { $0.total }
-            .compactMap { currencyFormatter.convertToDecimal(from: $0) }
+            .compactMap { currencyFormatter.convertToDecimal($0) }
             .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/OrderRefundsOptionsDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/OrderRefundsOptionsDeterminer.swift
@@ -31,11 +31,11 @@ final class OrderRefundsOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol
     func isAnythingToRefund(from order: Order, with refunds: [Refund], currencyFormatter: CurrencyFormatter) -> Bool {
         let alreadyRefundedTotal = refunds
             .map {
-                (currencyFormatter.convertToDecimal(from: $0.amount) ?? 0) as Decimal
+                (currencyFormatter.convertToDecimal($0.amount) ?? 0) as Decimal
             }
             .reduce(Decimal(0), +)
 
-        let orderTotal = (currencyFormatter.convertToDecimal(from: order.total) ?? 0) as Decimal
+        let orderTotal = (currencyFormatter.convertToDecimal(order.total) ?? 0) as Decimal
 
         let thereIsSomeAmountToRefund = orderTotal - alreadyRefundedTotal > 0
         let thereAreItemsToRefund = determineRefundableOrderItems(from: order, with: refunds).count > 0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
@@ -148,7 +148,7 @@ struct RefundCreationUseCase {
     /// Calculates the refundable tax from a tax line by diving its total tax value by the purchased quantity and mutiplying it by the refunded quantity.
     ///
     private func calculateTax(of taxLine: OrderItemTax, purchasedQuantity: Decimal, refundQuantity: Decimal) -> String {
-        let totalTax = currencyFormatter.convertToDecimal(from: taxLine.total) ?? 0
+        let totalTax = currencyFormatter.convertToDecimal(taxLine.total) ?? 0
         let itemTax = (totalTax as Decimal) / purchasedQuantity
         let refundableTax = itemTax * refundQuantity
         return "\(refundableTax)"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundFeesCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundFeesCalculationUseCase.swift
@@ -17,11 +17,11 @@ struct RefundFeesCalculationUseCase {
     ///
     func calculateRefundValues() -> RefundValues {
         let totalTaxes = fees.compactMap {
-            currencyFormatter.convertToDecimal(from: $0.totalTax) as Decimal?
+            currencyFormatter.convertToDecimal($0.totalTax) as Decimal?
         }.reduce(0, +)
 
         let subtotal = fees.compactMap {
-            currencyFormatter.convertToDecimal(from: $0.total) as Decimal?
+            currencyFormatter.convertToDecimal($0.total) as Decimal?
         }.reduce(0, +)
 
         return RefundValues(subtotal: subtotal, tax: totalTaxes)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundItemsValuesCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundItemsValuesCalculationUseCase.swift
@@ -24,13 +24,13 @@ struct RefundItemsValuesCalculationUseCase {
             // Using price is not safe right now.
             // See: https://github.com/woocommerce/woocommerce-ios/issues/6885
             let itemTotal: Decimal = {
-                let refundItemTotal = currencyFormatter.convertToDecimal(from: refundItem.item.total) ?? 0
+                let refundItemTotal = currencyFormatter.convertToDecimal(refundItem.item.total) ?? 0
                 return (refundItemTotal as Decimal) / refundItem.item.quantity
             }()
 
             // Figure out `itemTax` by dividing `totalTax` by the purchased `quantity`.
             let itemTax: Decimal = {
-                let totalTax = currencyFormatter.convertToDecimal(from: refundItem.item.totalTax) ?? 0
+                let totalTax = currencyFormatter.convertToDecimal(refundItem.item.totalTax) ?? 0
                 return (totalTax as Decimal) / refundItem.item.quantity
             }()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundShippingCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundShippingCalculationUseCase.swift
@@ -17,8 +17,8 @@ struct RefundShippingCalculationUseCase {
     /// Calculates the total value(cost + tax) to be refunded.
     ///
     func calculateRefundValue() -> Decimal {
-        guard let cost = currencyFormatter.convertToDecimal(from: shippingLine.total) as Decimal?,
-            let tax = currencyFormatter.convertToDecimal(from: shippingLine.totalTax) as Decimal? else {
+        guard let cost = currencyFormatter.convertToDecimal(shippingLine.total) as Decimal?,
+            let tax = currencyFormatter.convertToDecimal(shippingLine.totalTax) as Decimal? else {
                 return .zero
         }
         return cost + tax

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/TotalRefundedCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/TotalRefundedCalculationUseCase.swift
@@ -20,7 +20,7 @@ struct TotalRefundedCalculationUseCase {
     /// **negative** number because that's how the API returns them as.
     func totalRefunded() -> NSDecimalNumber {
         order.refunds.reduce(NSDecimalNumber.zero) { result, refundCondensed -> NSDecimalNumber in
-            let totalAsDecimal = currencyFormatter.convertToDecimal(from: refundCondensed.total, locale: locale) ?? .zero
+            let totalAsDecimal = currencyFormatter.convertToDecimal(refundCondensed.total, locale: locale) ?? .zero
 
             /// Even though the API returns refunds as negative, there is one case
             /// where the refund is a positive number: right between issuing the refund

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -158,7 +158,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
             cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
                 from: rootViewController) { [weak self] in
                 guard let self = self else { return }
-                guard let refundAmount = self.currencyFormatter.convertToDecimal(from: self.details.amount) else {
+                guard let refundAmount = self.currencyFormatter.convertToDecimal(self.details.amount) else {
                     DDLogError("Error: attempted to refund an order without a valid amount.")
                     return onCompletion(.failure(RefundSubmissionError.invalidRefundAmount))
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/PriceFieldFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/PriceFieldFormatter.swift
@@ -15,7 +15,7 @@ class PriceFieldFormatter {
     /// Current amount converted to Decimal.
     ///
     var amountDecimal: Decimal? {
-        guard let amountDecimal = currencyFormatter.convertToDecimal(from: amount) else {
+        guard let amountDecimal = currencyFormatter.convertToDecimal(amount) else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/PriceFieldFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/PriceFieldFormatter.swift
@@ -87,7 +87,7 @@ private extension PriceFieldFormatter {
 
         let deviceDecimalSeparator = userLocale.decimalSeparator ?? "."
         let storeDecimalSeparator = storeCurrencySettings.decimalSeparator
-        let storeNumberOfDecimals = storeCurrencySettings.numberOfDecimals
+        let storeNumberOfDecimals = storeCurrencySettings.fractionDigits
 
         // Removes any unwanted character & makes sure to use the store decimal separator
         let sanitized = amount
@@ -115,8 +115,8 @@ private extension PriceFieldFormatter {
     ///
     func setCurrencySymbol(to amount: String) -> String {
         currencyFormatter.formatCurrency(using: amount,
-                                         at: storeCurrencySettings.currencyPosition,
-                                         with: storeCurrencySymbol,
+                                         currencyPosition: storeCurrencySettings.currencyPosition,
+                                         currencySymbol: storeCurrencySymbol,
                                          isNegative: allowNegativeNumber && amount.hasPrefix(minusSign))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/UnitInputViewModel+BulkUpdatePrice.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/UnitInputViewModel+BulkUpdatePrice.swift
@@ -13,9 +13,9 @@ extension UnitInputViewModel {
         let unit = currencySettings.symbol(from: currencyCode)
         /// Depending on the currency settings we might have different decimal seperator or number of digits
         let formattedPlaceholder = currencyFormatter.localize(Decimal.zero,
-                                                              with: currencySettings.decimalSeparator,
-                                                              in: currencySettings.numberOfDecimals,
-                                                              including: currencySettings.thousandSeparator)
+                                                              decimalSeparator: currencySettings.decimalSeparator,
+                                                              fractionDigits: currencySettings.fractionDigits,
+                                                              groupingSeparator: currencySettings.groupingSeparator)
         return UnitInputViewModel(title: "",
                                   unit: unit,
                                   value: nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsValidator.swift
@@ -25,7 +25,7 @@ final class ProductPriceSettingsValidator {
         guard let price = price else {
             return nil
         }
-        return currencyFormatter.convertToDecimal(from: price)
+        return currencyFormatter.convertToDecimal(price)
     }
 
     /// Validates a selection for price settings.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -73,7 +73,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         guard let price = price else {
             return nil
         }
-        let productSubtotal = quantity * (currencyFormatter.convertToDecimal(from: price)?.decimalValue ?? Decimal.zero)
+        let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
         return currencyFormatter.formatAmount(productSubtotal)
     }
 

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -136,20 +136,20 @@ private extension AggregateDataHelperTests {
         let item0 = AggregateOrderItem(productID: 16,
                                        variationID: 0,
                                        name: "Woo Logo",
-                                       price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
+                                       price: currencyFormatter.convertToDecimal("31.5") ?? NSDecimalNumber.zero,
                                        quantity: -2,
                                        sku: "HOODIE-WOO-LOGO",
-                                       total: currencyFormatter.convertToDecimal(from: "-63.00") ?? NSDecimalNumber.zero,
+                                       total: currencyFormatter.convertToDecimal("-63.00") ?? NSDecimalNumber.zero,
                                        attributes: [])
         expectedArray.append(item0)
         let item1 = AggregateOrderItem(
             productID: 21,
             variationID: 70,
             name: "Ship Your Idea - Blue, XL",
-            price: currencyFormatter.convertToDecimal(from: "27") ?? NSDecimalNumber.zero,
+            price: currencyFormatter.convertToDecimal("27") ?? NSDecimalNumber.zero,
             quantity: -3,
             sku: "HOODIE-SHIP-YOUR-IDEA-BLUE-XL",
-            total: currencyFormatter.convertToDecimal(from: "-81.00") ?? NSDecimalNumber.zero,
+            total: currencyFormatter.convertToDecimal("-81.00") ?? NSDecimalNumber.zero,
             attributes: []
         )
         expectedArray.append(item1)
@@ -158,10 +158,10 @@ private extension AggregateDataHelperTests {
             productID: 21,
             variationID: 71,
             name: "Ship Your Idea - Black, L",
-            price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
+            price: currencyFormatter.convertToDecimal("31.5") ?? NSDecimalNumber.zero,
             quantity: -1,
             sku: "HOODIE-SHIP-YOUR-IDEA-BLACK-L",
-            total: currencyFormatter.convertToDecimal(from: "-31.50") ?? NSDecimalNumber.zero,
+            total: currencyFormatter.convertToDecimal("-31.50") ?? NSDecimalNumber.zero,
             attributes: []
         )
         expectedArray.append(item2)
@@ -170,10 +170,10 @@ private extension AggregateDataHelperTests {
             productID: 22,
             variationID: 0,
             name: "Ninja Silhouette",
-            price: currencyFormatter.convertToDecimal(from: "18") ?? NSDecimalNumber.zero,
+            price: currencyFormatter.convertToDecimal("18") ?? NSDecimalNumber.zero,
             quantity: -1,
             sku: "T-SHIRT-NINJA-SILHOUETTE",
-            total: currencyFormatter.convertToDecimal(from: "-18.00") ?? NSDecimalNumber.zero,
+            total: currencyFormatter.convertToDecimal("-18.00") ?? NSDecimalNumber.zero,
             attributes: []
         )
         expectedArray.append(item3)
@@ -182,10 +182,10 @@ private extension AggregateDataHelperTests {
             productID: 24,
             variationID: 0,
             name: "Happy Ninja",
-            price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
+            price: currencyFormatter.convertToDecimal("31.5") ?? NSDecimalNumber.zero,
             quantity: -1,
             sku: "HOODIE-HAPPY-NINJA",
-            total: currencyFormatter.convertToDecimal(from: "-31.50") ?? NSDecimalNumber.zero,
+            total: currencyFormatter.convertToDecimal("-31.50") ?? NSDecimalNumber.zero,
             attributes: []
         )
         expectedArray.append(item4)

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -76,7 +76,7 @@ class CurrencyFormatterTests: XCTestCase {
             return
         }
 
-        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(convertedDecimal, with: separator)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(convertedDecimal, decimalSeparator: separator)
 
         XCTAssertEqual(expectedResult, actualResult)
     }
@@ -118,7 +118,7 @@ class CurrencyFormatterTests: XCTestCase {
             return
         }
 
-        let formattedString = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimal, including: comma)
+        let formattedString = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimal, groupingSeparator: comma)
         guard let actualResult = formattedString else {
             XCTFail()
             return
@@ -142,8 +142,8 @@ class CurrencyFormatterTests: XCTestCase {
         }
 
         let localizedAmount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimal,
-                                                           with: decimalSeparator,
-                                                           including: thousandSeparator)
+                                                                                                   decimalSeparator: decimalSeparator,
+                                                                                                   groupingSeparator: thousandSeparator)
 
         guard let actualResult = localizedAmount else {
             XCTFail()
@@ -168,9 +168,9 @@ class CurrencyFormatterTests: XCTestCase {
 
         let position = 2
         let localizedAmount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(convertedDecimal,
-                                                           with: separator,
-                                                           in: position,
-                                                           including: separator)
+                                                                                                   decimalSeparator: separator,
+                                                                                                   fractionDigits: position,
+                                                                                                   groupingSeparator: separator)
         guard let actualResult = localizedAmount else {
             XCTFail()
             return
@@ -194,9 +194,9 @@ class CurrencyFormatterTests: XCTestCase {
         }
 
         let formattedAmount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(convertedDecimal,
-                                                           with: separator,
-                                                           in: position,
-                                                           including: separator)
+                                                                                                   decimalSeparator: separator,
+                                                                                                   fractionDigits: position,
+                                                                                                   groupingSeparator: separator)
 
         guard let actualResult = formattedAmount else {
             XCTFail()
@@ -230,9 +230,9 @@ class CurrencyFormatterTests: XCTestCase {
 
         let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
             .localize(decimalAmount,
-                      with: decimalSeparator,
-                      in: decimalPosition,
-                      including: thousandSeparator)
+                      decimalSeparator: decimalSeparator,
+                      fractionDigits: decimalPosition,
+                      groupingSeparator: thousandSeparator)
 
         guard let localizedAmount = amount else {
             XCTFail()
@@ -243,8 +243,8 @@ class CurrencyFormatterTests: XCTestCase {
         let isNegative = decimalAmount.isNegative()
         let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings)
             .formatCurrency(using: localizedAmount,
-                            at: currencyPosition,
-                            with: symbol,
+                            currencyPosition: currencyPosition,
+                            currencySymbol: symbol,
                             isNegative: isNegative,
                             locale: locale)
 
@@ -264,9 +264,9 @@ class CurrencyFormatterTests: XCTestCase {
 
         let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
             .localize(decimalAmount,
-                      with: decimalSeparator,
-                      in: decimalPosition,
-                      including: thousandSeparator)
+                      decimalSeparator: decimalSeparator,
+                      fractionDigits: decimalPosition,
+                      groupingSeparator: thousandSeparator)
 
         guard let localizedAmount = amount else {
             XCTFail()
@@ -278,8 +278,8 @@ class CurrencyFormatterTests: XCTestCase {
         let locale = sampleLocale
         let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings)
             .formatCurrency(using: localizedAmount,
-                            at: currencyPosition,
-                            with: symbol,
+                            currencyPosition: currencyPosition,
+                            currencySymbol: symbol,
                             isNegative: isNegative,
                             locale: locale)
 
@@ -298,8 +298,8 @@ class CurrencyFormatterTests: XCTestCase {
         let isNegative = true
         let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings)
             .formatCurrency(using: stringAmount,
-                            at: currencyPosition,
-                            with: symbol,
+                            currencyPosition: currencyPosition,
+                            currencySymbol: symbol,
                             isNegative: isNegative,
                             locale: sampleLocale)
 

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -32,7 +32,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "9.99"
         let expectedResult = NSDecimalNumber(string: stringValue)
 
-        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringValue)
 
         // check the formatted decimal exists
         guard let actualResult = converted else {
@@ -59,7 +59,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "9.9999"
         let expectedResult = NSDecimalNumber(string: stringValue)
 
-        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringValue)
         XCTAssertEqual(expectedResult, actualResult)
     }
 
@@ -69,7 +69,7 @@ class CurrencyFormatterTests: XCTestCase {
         let separator = ","
         let stringValue = "1.17"
         let expectedResult = "1,17"
-        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringValue)
 
         guard let convertedDecimal = converted else {
             XCTFail()
@@ -85,7 +85,7 @@ class CurrencyFormatterTests: XCTestCase {
     ///
     func testBadDataInStringDoesNotConvertToDecimal() {
         let badInput = "~HUKh*(&Y3HkJ8"
-        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: badInput)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(badInput)
 
         XCTAssertNil(actualResult)
     }
@@ -95,7 +95,7 @@ class CurrencyFormatterTests: XCTestCase {
     func testNegativeNumbersSuccessfullyConvertToDecimal() {
         let negativeNumber = "-81346.45"
         let expectedResult = NSDecimalNumber(string: negativeNumber)
-        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: negativeNumber)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(negativeNumber)
 
         XCTAssertEqual(expectedResult, actualResult)
     }
@@ -111,7 +111,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "1204.67"
         let expectedResult = "1,204.67"
 
-        let convertedDecimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
+        let convertedDecimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringValue)
 
         guard let decimal = convertedDecimal else {
             XCTFail()
@@ -135,7 +135,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "1204.67"
         let expectedResult = "1204.67"
 
-        let convertedDecimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
+        let convertedDecimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringValue)
         guard let decimal = convertedDecimal else {
             XCTFail()
             return
@@ -160,7 +160,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "45958320.97"
         let expectedResult = "45,958,320,97"
 
-        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringValue)
         guard let convertedDecimal = converted else {
             XCTFail()
             return
@@ -187,7 +187,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "45958320.97"
         let expectedResult = "45,958,320,970"
 
-        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringValue)
         guard let convertedDecimal = converted else {
             XCTFail()
             return
@@ -222,7 +222,7 @@ class CurrencyFormatterTests: XCTestCase {
         let expectedResult = "-7.867.818.684,640 £"
 
         let locale = sampleLocale
-        let decimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringAmount, locale: locale)
+        let decimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(stringAmount, locale: locale)
         guard let decimalAmount = decimal else {
             XCTFail("Error: invalid string amount. Cannot convert to decimal.")
             return

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -26,8 +26,8 @@ final class CurrencySettingsTests: XCTestCase {
         XCTAssertEqual(.USD, moneyFormat?.currencyCode)
         XCTAssertEqual(.left, moneyFormat?.currencyPosition)
         XCTAssertEqual(".", moneyFormat?.decimalSeparator)
-        XCTAssertEqual(2, moneyFormat?.numberOfDecimals)
-        XCTAssertEqual(",", moneyFormat?.thousandSeparator)
+        XCTAssertEqual(2, moneyFormat?.fractionDigits)
+        XCTAssertEqual(",", moneyFormat?.groupingSeparator)
     }
 
     func testInitWithIndividualParameters() {
@@ -40,8 +40,8 @@ final class CurrencySettingsTests: XCTestCase {
         XCTAssertEqual(.USD, moneyFormat?.currencyCode)
         XCTAssertEqual(.right, moneyFormat?.currencyPosition)
         XCTAssertEqual("X", moneyFormat?.decimalSeparator)
-        XCTAssertEqual(10, moneyFormat?.numberOfDecimals)
-        XCTAssertEqual("M", moneyFormat?.thousandSeparator)
+        XCTAssertEqual(10, moneyFormat?.fractionDigits)
+        XCTAssertEqual("M", moneyFormat?.groupingSeparator)
     }
 
     func testInitWithSiteSettingsEmptyArray() {
@@ -51,8 +51,8 @@ final class CurrencySettingsTests: XCTestCase {
         XCTAssertEqual(.USD, moneyFormat?.currencyCode)
         XCTAssertEqual(.left, moneyFormat?.currencyPosition)
         XCTAssertEqual(".", moneyFormat?.decimalSeparator)
-        XCTAssertEqual(2, moneyFormat?.numberOfDecimals)
-        XCTAssertEqual(",", moneyFormat?.thousandSeparator)
+        XCTAssertEqual(2, moneyFormat?.fractionDigits)
+        XCTAssertEqual(",", moneyFormat?.groupingSeparator)
     }
 
     func testInitWithSiteSettings() {
@@ -102,8 +102,8 @@ final class CurrencySettingsTests: XCTestCase {
         XCTAssertEqual(.SHP, moneyFormat?.currencyCode)
         XCTAssertEqual(.right, moneyFormat?.currencyPosition)
         XCTAssertEqual("Y", moneyFormat?.decimalSeparator)
-        XCTAssertEqual(3, moneyFormat?.numberOfDecimals)
-        XCTAssertEqual("X", moneyFormat?.thousandSeparator)
+        XCTAssertEqual(3, moneyFormat?.fractionDigits)
+        XCTAssertEqual("X", moneyFormat?.groupingSeparator)
     }
 
     func testInitWithIncompleteSiteSettings() {
@@ -147,8 +147,8 @@ final class CurrencySettingsTests: XCTestCase {
         XCTAssertEqual(.SHP, moneyFormat?.currencyCode)
         XCTAssertEqual(.right, moneyFormat?.currencyPosition)
         XCTAssertEqual("Y", moneyFormat?.decimalSeparator)
-        XCTAssertEqual(2, moneyFormat?.numberOfDecimals)
-        XCTAssertEqual("X", moneyFormat?.thousandSeparator)
+        XCTAssertEqual(2, moneyFormat?.fractionDigits)
+        XCTAssertEqual("X", moneyFormat?.groupingSeparator)
     }
 
     /// Test currency symbol lookup returns correctly encoded symbol.

--- a/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
@@ -14,7 +14,7 @@ public class CurrencyFormatter {
     ///   - stringValue: the string received from the API
     ///   - locale: the locale that the currency string is based on.
     ///
-    public func convertToDecimal(from stringValue: String, locale: Locale = .current) -> NSDecimalNumber? {
+    public func convertToDecimal(_ stringValue: String, locale: Locale = .current) -> NSDecimalNumber? {
 
         // NSDecimalNumber use by default the local decimal separator to evaluate a decimal amount.
         // We substitute the current decimal separator with the locale decimal separator.
@@ -150,7 +150,7 @@ public class CurrencyFormatter {
     ///     - locale: the locale that is used to format the currency amount string.
     ///
     public func formatAmount(_ amount: String, with currency: String? = nil, locale: Locale = .current) -> String? {
-        guard let decimalAmount = convertToDecimal(from: amount, locale: locale) else {
+        guard let decimalAmount = convertToDecimal(amount, locale: locale) else {
             return nil
         }
 
@@ -193,7 +193,7 @@ public class CurrencyFormatter {
                                    with currency: String? = nil,
                                    roundSmallNumbers: Bool = true,
                                    locale: Locale = .current) -> String? {
-        guard let amount = convertToDecimal(from: stringAmount, locale: locale) else {
+        guard let amount = convertToDecimal(stringAmount, locale: locale) else {
             assertionFailure("Cannot convert the amount \"\(stringAmount)\" to decimal value with locale \(locale.identifier)")
             return nil
         }

--- a/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
@@ -41,15 +41,15 @@ public class CurrencyFormatter {
     /// - Parameters:
     ///     - decimal: a valid NSDecimalNumber, preferably converted using `convertToDecimal()`
     ///     - decimalSeparator: a string representing the user's preferred decimal symbol
-    ///     - decimalPosition: an int for positioning the decimal symbol
-    ///     - thousandSeparator: a string representing the user's preferred thousand symbol*
+    ///     - fractionDigits: how many fraction digits do we want to show
+    ///     - groupingSeparator: a string representing the user's preferred thousand symbol*
     ///       *Assumes thousands grouped by 3, because a user can't indicate a preference and it's a majority default.
     ///       Note this assumption will be wrong for India.
     ///
     public func localize(_ decimalAmount: NSDecimalNumber,
-                  with decimalSeparator: String? = ".",
-                  in decimalPosition: Int = 2,
-                  including thousandSeparator: String? = ",") -> String? {
+                         decimalSeparator: String? = ".",
+                         fractionDigits: Int = 2,
+                         groupingSeparator: String? = ",") -> String? {
 
         // If the decimal amount is negative, change it to a positive.
         // We'll add our own custom negative sign in `formatAmount(with:)`
@@ -57,14 +57,14 @@ public class CurrencyFormatter {
 
         let numberFormatter = NumberFormatter()
         numberFormatter.usesGroupingSeparator = true
-        numberFormatter.groupingSeparator = thousandSeparator
+        numberFormatter.groupingSeparator = groupingSeparator
         numberFormatter.decimalSeparator = decimalSeparator
         numberFormatter.groupingSize = 3
         numberFormatter.formatterBehavior = .behavior10_4
         numberFormatter.numberStyle = .decimal
         numberFormatter.generatesDecimalNumbers = true
-        numberFormatter.minimumFractionDigits = decimalPosition
-        numberFormatter.maximumFractionDigits = decimalPosition
+        numberFormatter.minimumFractionDigits = fractionDigits
+        numberFormatter.maximumFractionDigits = fractionDigits
         numberFormatter.roundingMode = .halfUp
 
         return numberFormatter.string(from: absoluteAmount)
@@ -74,31 +74,31 @@ public class CurrencyFormatter {
     /// - Parameters:
     ///     - decimal: a valid Decimal number
     ///     - decimalSeparator: a string representing the user's preferred decimal symbol
-    ///     - decimalPosition: an int for positioning the decimal symbol
-    ///     - thousandSeparator: a string representing the user's preferred thousand symbol*
+    ///     - fractionDigits: how many fraction digits do we want to show
+    ///     - groupingSeparator: a string representing the user's preferred thousand symbol*
     ///       *Assumes thousands grouped by 3, because a user can't indicate a preference and it's a majority default.
     ///       Note this assumption will be wrong for India.
     ///
     public func localize(_ decimalAmount: Decimal,
-                  with decimalSeparator: String? = ".",
-                  in decimalPosition: Int = 2,
-                  including thousandSeparator: String? = ",") -> String? {
-        localize(decimalAmount as NSDecimalNumber, with: decimalSeparator, in: decimalPosition, including: thousandSeparator)
+                         decimalSeparator: String? = ".",
+                         fractionDigits: Int = 2,
+                         groupingSeparator: String? = ",") -> String? {
+        localize(decimalAmount as NSDecimalNumber, decimalSeparator: decimalSeparator, fractionDigits: fractionDigits, groupingSeparator: groupingSeparator)
     }
 
     /// Returns a string that displays the amount using all of the specified currency settings
     /// - Parameters:
     ///     - stringValue: a formatted string, preferably converted using `localize(_:in:with:including:)`.
-    ///     - position: the currency position enum, either right, left, right_space, or left_space.
-    ///     - symbol: the currency symbol as a string, to be used with the amount.
+    ///     - currencyPosition: the currency position enum, either right, left, right_space, or left_space.
+    ///     - currencySymbol: the currency symbol as a string, to be used with the amount.
     ///     - isNegative: whether the value is negative or not.
     ///     - locale: the locale that is used to format the currency amount string.
     ///
     public func formatCurrency(using amount: String,
-                        at position: CurrencySettings.CurrencyPosition,
-                        with symbol: String,
-                        isNegative: Bool,
-                        locale: Locale = .current) -> String {
+                               currencyPosition position: CurrencySettings.CurrencyPosition,
+                               currencySymbol symbol: String,
+                               isNegative: Bool,
+                               locale: Locale = .current) -> String {
         let space = "\u{00a0}" // unicode equivalent of &nbsp;
         let negative = isNegative ? "-" : ""
 
@@ -215,8 +215,8 @@ public class CurrencyFormatter {
         let isNegative = amount.isNegative()
 
         return formatCurrency(using: humanReadableAmount,
-                              at: position,
-                              with: symbol,
+                              currencyPosition: position,
+                              currencySymbol: symbol,
                               isNegative: isNegative,
                               locale: locale)
     }
@@ -235,16 +235,16 @@ public class CurrencyFormatter {
         // Grab the read-only currency options. These are set by the user in Site > Settings.
         let symbol = currencySettings.symbol(from: code)
         let separator = currencySettings.decimalSeparator
-        let numberOfDecimals = numberOfDecimals ?? currencySettings.numberOfDecimals
+        let numberOfDecimals = numberOfDecimals ?? currencySettings.fractionDigits
         let position = currencySettings.currencyPosition
-        let thousandSeparator = currencySettings.thousandSeparator
+        let thousandSeparator = currencySettings.groupingSeparator
 
         // Put all the pieces of user preferences on currency formatting together
         // and spit out a string that has the formatted amount.
         let localized = localize(amount,
-                                 with: separator,
-                                 in: numberOfDecimals,
-                                 including: thousandSeparator)
+                                 decimalSeparator: separator,
+                                 fractionDigits: numberOfDecimals,
+                                 groupingSeparator: thousandSeparator)
 
         guard let localizedAmount = localized else {
             return nil
@@ -253,8 +253,8 @@ public class CurrencyFormatter {
         // Now take the formatted amount and piece it together with
         // the currency symbol, negative sign, and any requisite spaces.
         let formattedAmount = formatCurrency(using: localizedAmount,
-                                             at: position,
-                                             with: symbol,
+                                             currencyPosition: position,
+                                             currencySymbol: symbol,
                                              isNegative: amount.isNegative(),
                                              locale: locale)
 

--- a/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
@@ -31,9 +31,9 @@ public class CurrencySettings {
     ///
     @Published public var currencyCode: CurrencyCode
     public var currencyPosition: CurrencyPosition
-    public var thousandSeparator: String
+    public var groupingSeparator: String
     public var decimalSeparator: String
-    public var numberOfDecimals: Int
+    public var fractionDigits: Int
 
     // MARK: - Initializers & Methods
 
@@ -43,9 +43,9 @@ public class CurrencySettings {
     public init(currencyCode: CurrencyCode, currencyPosition: CurrencyPosition, thousandSeparator: String, decimalSeparator: String, numberOfDecimals: Int) {
         self.currencyCode = currencyCode
         self.currencyPosition = currencyPosition
-        self.thousandSeparator = thousandSeparator
+        self.groupingSeparator = thousandSeparator
         self.decimalSeparator = decimalSeparator
-        self.numberOfDecimals = numberOfDecimals
+        self.fractionDigits = numberOfDecimals
     }
 
 

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -14,7 +14,7 @@ public extension PaymentIntent {
             .flatMap { Int64($0) }
 
         return CardPresentReceiptParameters(amount: amount,
-                                            formattedAmount: formattedAmount(amount),
+                                            formattedAmount: formattedAmount(amount, currency: currency),
                                             currency: currency,
                                             date: created,
                                             storeName: metadata?[CardPresentReceiptParameters.MetadataKeys.store],
@@ -22,13 +22,13 @@ public extension PaymentIntent {
                                             orderID: orderID)
     }
 
-    private func formattedAmount(_ amount: UInt) -> String {
+    private func formattedAmount(_ amount: UInt, currency: String) -> String {
         let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let decimalPosition = 2 // TODO - support non cent currencies like JPY - see #3948
 
         var amount: Decimal = Decimal(amount)
         amount = amount / pow(10, decimalPosition)
 
-        return formatter.localize(amount, in: decimalPosition) ?? ""
+        return formatter.formatAmount(amount, with: currency) ?? ""
     }
 }

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -24,7 +24,7 @@ public extension PaymentIntent {
 
     private func formattedAmount(_ amount: UInt) -> String {
         let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        let decimalPosition = 2
+        let decimalPosition = 2 // TODO - support non cent currencies like JPY - see #3948
 
         var amount: Decimal = Decimal(amount)
         amount = amount / pow(10, decimalPosition)

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -1,4 +1,5 @@
 import Hardware
+import WooFoundation
 
 public extension PaymentIntent {
     /// Maps a PaymentIntent into an struct that contains only the data we need to
@@ -22,16 +23,12 @@ public extension PaymentIntent {
     }
 
     private func formattedAmount(_ amount: UInt) -> String {
-        // We should use CurrencyFormatter instead for consistency
-        let formatter = NumberFormatter()
-
-        let fractionDigits = 2 // TODO - support non cent currencies like JPY - see #3948
-        formatter.minimumFractionDigits = fractionDigits
-        formatter.maximumFractionDigits = fractionDigits
+        let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let decimalPosition = 2
 
         var amount: Decimal = Decimal(amount)
-        amount = amount / pow(10, fractionDigits)
+        amount = amount / pow(10, decimalPosition)
 
-        return formatter.string(for: amount) ?? ""
+        return formatter.localize(amount, in: decimalPosition) ?? ""
     }
 }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -1,6 +1,7 @@
 import Storage
 import Networking
 import Hardware
+import WooFoundation
 
 
 // MARK: - ReceiptStore
@@ -13,14 +14,8 @@ public class ReceiptStore: Store {
         storageManager.writerDerivedStorage
     }()
 
-    private lazy var receiptNumberFormatter: NumberFormatter = {
-        // We should use CurrencyFormatter instead for consistency
-        let formatter = NumberFormatter()
-
-        let fractionDigits = 2 // TODO - support non cent currencies like JPY - see #3948
-        formatter.minimumFractionDigits = fractionDigits
-        formatter.maximumFractionDigits = fractionDigits
-        return formatter
+    private lazy var currencyFormatter: CurrencyFormatter = {
+        CurrencyFormatter(currencySettings: CurrencySettings())
     }()
 
     public init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, receiptPrinterService: PrinterService, fileStorage: FileStorage) {
@@ -122,7 +117,7 @@ private extension ReceiptStore {
             result += NSDecimalNumber(apiAmount: item.subtotal).decimalValue
         }
         return ReceiptTotalLine(description: ReceiptContent.Localization.productTotalLineDescription,
-                                amount: receiptNumberFormatter.string(from: lineItemsTotal as NSNumber) ?? "")
+                                amount: currencyFormatter.localize(lineItemsTotal) ?? "")
     }
 
     func discountLine(order: Order) -> ReceiptTotalLine? {
@@ -158,7 +153,7 @@ private extension ReceiptStore {
         let feeTotal = fees.reduce(into: Decimal(0)) { result, fee in
             result += NSDecimalNumber(apiAmount: fee.total).decimalValue
         }
-        return receiptNumberFormatter.string(from: feeTotal as NSNumber) ?? ""
+        return currencyFormatter.localize(feeTotal) ?? ""
     }
 
     func lineIfNonZero(description: String, amount: String) -> ReceiptTotalLine? {

--- a/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
@@ -1,5 +1,6 @@
 import Hardware
 import XCTest
+import WooFoundation
 @testable import Yosemite
 
 final class PaymentIntent_ReceiptParametersTests: XCTestCase {
@@ -41,10 +42,10 @@ final class PaymentIntent_ReceiptParametersTests: XCTestCase {
 
     func test_receiptParameters_Includes_formattedAmount_WithDecimalFormatting() {
         // Given
-        let intent = PaymentIntent.fake().copy(amount: 10000, charges: [Mocks.cardPresentCharge])
+        let intent = PaymentIntent.fake().copy(amount: 10000, currency: "usd", charges: [Mocks.cardPresentCharge])
 
         // Then
-        XCTAssertEqual(intent.receiptParameters()?.formattedAmount, "100.00")
+        XCTAssertEqual(intent.receiptParameters()?.formattedAmount, "$100.00")
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -87,7 +87,7 @@ final class ReceiptStoreTests: XCTestCase {
 
         XCTAssertEqual(mockParameters.amount, parametersProvided?.parameters.amount)
         XCTAssertEqual(mockOrder.currency, parametersProvided?.parameters.currency)
-        XCTAssertEqual("100.00", parametersProvided?.parameters.formattedAmount)
+        XCTAssertEqual("$100.00", parametersProvided?.parameters.formattedAmount)
     }
 
     func test_print_callsPrint_passing_TotalAmountPaid() throws {
@@ -111,12 +111,12 @@ final class ReceiptStoreTests: XCTestCase {
         let amountPaidLine = receiptPrinterService.contentProvided?.cartTotals.first {
             $0.description == ReceiptContent.Localization.amountPaidLineDescription
         }
-        XCTAssertEqual("100.00", amountPaidLine?.amount)
+        XCTAssertEqual("$100.00", amountPaidLine?.amount)
     }
 
     func test_print_callsPrint_passing_TotalTaxes() throws {
         // Given
-        let mockIntent = PaymentIntent.fake().copy(charges: [Mocks.cardPresentCharge])
+        let mockIntent = PaymentIntent.fake().copy(currency: "USD", charges: [Mocks.cardPresentCharge])
         let mockParameters = try XCTUnwrap(mockIntent.receiptParameters())
         let mockOrder = makeOrder(discountTax: "1.21", shippingTax: "0.50", totalTax: "10.71")
 
@@ -135,7 +135,8 @@ final class ReceiptStoreTests: XCTestCase {
         let actualTaxLine = receiptPrinterService.contentProvided?.cartTotals.first {
             $0.description == ReceiptContent.Localization.totalTaxLineDescription
         }
-        XCTAssertEqual(mockOrder.totalTax, actualTaxLine?.amount)
+        let expectedValue = "$\(mockOrder.totalTax)"
+        XCTAssertEqual(expectedValue, actualTaxLine?.amount)
     }
 
     func test_print_OrderWithoutTaxes_DoesNotIncludeTaxesInReceiptContent() throws {
@@ -164,7 +165,7 @@ final class ReceiptStoreTests: XCTestCase {
 
     func test_print_callsPrint_passing_Shipping() throws {
         // Given
-        let mockIntent = PaymentIntent.fake().copy(charges: [Mocks.cardPresentCharge])
+        let mockIntent = PaymentIntent.fake().copy(currency: "USD", charges: [Mocks.cardPresentCharge])
         let mockParameters = try XCTUnwrap(mockIntent.receiptParameters())
         let mockOrder = makeOrder(shippingTotal: "5.50")
 
@@ -183,7 +184,9 @@ final class ReceiptStoreTests: XCTestCase {
         let actualShippingLine = receiptPrinterService.contentProvided?.cartTotals.first {
             $0.description == ReceiptContent.Localization.shippingLineDescription
         }
-        XCTAssertEqual(mockOrder.shippingTotal, actualShippingLine?.amount)
+        let expectedValue = "$\(mockOrder.shippingTotal)"
+
+        XCTAssertEqual(expectedValue, actualShippingLine?.amount)
     }
 
     func test_print_OrderWithoutShipping_DoesNotIncludeShippingInReceiptContent() throws {
@@ -335,7 +338,7 @@ final class ReceiptStoreTests: XCTestCase {
         let actualFeesLine = receiptPrinterService.contentProvided?.cartTotals.first {
             $0.description == ReceiptContent.Localization.feesLineDescription
         }
-        XCTAssertEqual(actualFeesLine?.amount, "20.50")
+        XCTAssertEqual(actualFeesLine?.amount, "$20.50")
     }
 
     func test_print_OrderWithoutFees_DoesNotIncludeFeesInReceiptContent() throws {
@@ -408,7 +411,7 @@ final class ReceiptStoreTests: XCTestCase {
         let lineItemsTotalLine = receiptPrinterService.contentProvided?.cartTotals.first {
             $0.description == ReceiptContent.Localization.productTotalLineDescription
         }
-        XCTAssertEqual("30.00", lineItemsTotalLine?.amount)
+        XCTAssertEqual("$30.00", lineItemsTotalLine?.amount)
     }
 
     func test_generateContent_callsGenerate_passingUnmodified_customerNote() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #5108 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we use `WooFoundation.CurrencyFormatter` in `Yosemite` when amount formatting is necessary (receipts), making it consistent with the rest of the codebase. Furthermore, since the logic of `CurrencyFormatter` is more sophisticated, we ensure that the receipt amounts formatting will handle all cases.
Since the receipt formatting logic was already covered by unit tests, it wasn't necessary to add any here. As they pass successfully, we can be sure that adding `CurrencyFormatter` didn't cause any format changes.
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Create an order

1. Go to Orders tab
2. Tap on + to create an order
3. After the order is created, collect the payment
4. When the payment collection process finishes, tap on print the receipt
5. On the Print Options receipt preview, make sure that the amount formatting is correct


![Simulator Screen Shot - iPhone 13 - 2022-06-07 at 18 14 49](https://user-images.githubusercontent.com/1864060/172430830-04979918-ee2f-4103-bca2-47a05a0e8fa7.png)

#### Completed Order

1. Go to Orders tab
2. Go to a completed Order
3. Tap on See receipt
4. On the receipt detail view, the amounts should be formatted properly

![Simulator Screen Shot - iPhone 13 - 2022-06-07 at 18 13 44](https://user-images.githubusercontent.com/1864060/172430922-1fe1a427-5ba0-4369-b716-c5862c21085e.png)

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
