### PR TITLE
[Order Creation] Automatically confirm selected order status

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
@@ -15,9 +15,9 @@ final class OrderStatusListViewModel {
     ///
     var indexOfSelectedStatus: IndexPath? {
         didSet {
-            if initialStatus != indexOfSelectedStatus, !isSelectionAutoConfirmed {
+            if initialStatus != indexOfSelectedStatus, !autoConfirmSelection {
                 shouldEnableApplyButton = true
-            } else if initialStatus != indexOfSelectedStatus, isSelectionAutoConfirmed {
+            } else if initialStatus != indexOfSelectedStatus, autoConfirmSelection {
                 confirmSelectedStatus()
             } else {
                 shouldEnableApplyButton = false
@@ -33,7 +33,7 @@ final class OrderStatusListViewModel {
     ///
     /// Defaults to `false`.
     ///
-    let isSelectionAutoConfirmed: Bool
+    let autoConfirmSelection: Bool
 
     /// A closure to be called when the VC wants its creator to dismiss it without saving changes.
     ///
@@ -45,11 +45,11 @@ final class OrderStatusListViewModel {
 
     init(siteID: Int64,
          status: OrderStatusEnum,
-         isSelectionAutoConfirmed: Bool = false,
+         autoConfirmSelection: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.status = status
         self.dataSource = OrderStatusListDataSource(siteID: siteID, storageManager: storageManager)
-        self.isSelectionAutoConfirmed = isSelectionAutoConfirmed
+        self.autoConfirmSelection = autoConfirmSelection
 
         configureDataSource()
         configureInitialStatus()

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
@@ -15,12 +15,14 @@ final class OrderStatusListViewModel {
     ///
     var indexOfSelectedStatus: IndexPath? {
         didSet {
-            if initialStatus != indexOfSelectedStatus, !autoConfirmSelection {
-                shouldEnableApplyButton = true
-            } else if initialStatus != indexOfSelectedStatus, autoConfirmSelection {
-                confirmSelectedStatus()
-            } else {
-                shouldEnableApplyButton = false
+            let selectedNewStatus = initialStatus != indexOfSelectedStatus
+            switch (selectedNewStatus, autoConfirmSelection) {
+            case (true, false):
+                shouldEnableApplyButton = true // New status with manual confirmation
+            case (true, true):
+                confirmSelectedStatus() // New status with automatic confirmation
+            case (false, _):
+                shouldEnableApplyButton = false // No new status
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
@@ -11,12 +11,18 @@ struct OrderStatusList: UIViewControllerRepresentable {
     ///
     let status: OrderStatusEnum
 
+    /// Whether to automatically confirm the order status when it is selected.
+    ///
+    /// Defaults to `false`.
+    ///
+    let isSelectionAutoConfirmed: Bool
+
     /// Closure to be invoked when the status is updated.
     ///
     var didSelectApply: ((OrderStatusEnum) -> Void)
 
     func makeUIViewController(context: Context) -> WooNavigationController {
-        let statusList = OrderStatusListViewController(siteID: siteID, status: status)
+        let statusList = OrderStatusListViewController(siteID: siteID, status: status, isSelectionAutoConfirmed: isSelectionAutoConfirmed)
 
         statusList.didSelectCancel = { [weak statusList] in
             statusList?.dismiss(animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
@@ -13,7 +13,7 @@ struct OrderStatusList: UIViewControllerRepresentable {
 
     /// Whether to automatically confirm the order status when it is selected.
     ///
-    let isSelectionAutoConfirmed: Bool
+    let autoConfirmSelection: Bool
 
     /// Closure to be invoked when the status is updated.
     ///
@@ -22,7 +22,7 @@ struct OrderStatusList: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> WooNavigationController {
         let viewModel = OrderStatusListViewModel(siteID: siteID,
                                                  status: status,
-                                                 isSelectionAutoConfirmed: isSelectionAutoConfirmed)
+                                                 autoConfirmSelection: autoConfirmSelection)
         let statusList = OrderStatusListViewController(viewModel: viewModel)
 
         viewModel.didCancelSelection = { [weak statusList] in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
@@ -19,18 +19,14 @@ struct OrderStatusList: UIViewControllerRepresentable {
 
     /// Closure to be invoked when the status is updated.
     ///
-    var didSelectApply: ((OrderStatusEnum) -> Void)
+    var didConfirmSelection: ((OrderStatusEnum) -> Void)
 
     func makeUIViewController(context: Context) -> WooNavigationController {
         let statusList = OrderStatusListViewController(siteID: siteID, status: status, isSelectionAutoConfirmed: isSelectionAutoConfirmed)
 
-        statusList.didSelectCancel = { [weak statusList] in
-            statusList?.dismiss(animated: true, completion: nil)
-        }
-
-        statusList.didSelectApply = { [weak statusList] selectedStatus in
+        statusList.didConfirmSelection = { [weak statusList] selectedStatus in
             statusList?.dismiss(animated: true) {
-                didSelectApply(selectedStatus)
+                didConfirmSelection(selectedStatus)
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -37,7 +37,7 @@ struct OrderStatusSection: View {
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 .accessibilityIdentifier("order-status-section-edit-button")
                 .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
-                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus, isSelectionAutoConfirmed: true) { newStatus in
+                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus, autoConfirmSelection: true) { newStatus in
                         viewModel.updateOrderStatus(newStatus: newStatus)
                     }.ignoresSafeArea()
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -37,7 +37,7 @@ struct OrderStatusSection: View {
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 .accessibilityIdentifier("order-status-section-edit-button")
                 .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
-                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus) { newStatus in
+                    OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus, isSelectionAutoConfirmed: true) { newStatus in
                         viewModel.updateOrderStatus(newStatus: newStatus)
                     }.ignoresSafeArea()
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -9,12 +9,15 @@ final class OrderStatusListViewController: UIViewController {
     /// The index of the status stored in the database when list view is presented
     ///
     private var initialStatus: IndexPath?
+
     /// The index of (new) order status selected by the user tapping on a table row.
     ///
     private var indexOfSelectedStatus: IndexPath? {
         didSet {
-            if initialStatus != indexOfSelectedStatus {
+            if initialStatus != indexOfSelectedStatus, !isSelectionAutoConfirmed {
                 activateApplyButton()
+            } else if initialStatus != indexOfSelectedStatus, isSelectionAutoConfirmed {
+                confirmSelectedStatus()
             } else {
                 deActivateApplyButton()
             }
@@ -116,7 +119,7 @@ extension OrderStatusListViewController {
         let rightBarButton = UIBarButtonItem(title: applyButtonTitle,
                                              style: .done,
                                              target: self,
-                                             action: #selector(applyButtonTapped))
+                                             action: #selector(confirmSelectedStatus))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
         navigationItem.rightBarButtonItem?.accessibilityIdentifier = "order-status-list-apply-button"
         deActivateApplyButton()
@@ -134,7 +137,7 @@ extension OrderStatusListViewController {
         didSelectCancel?()
     }
 
-    @objc func applyButtonTapped() {
+    @objc func confirmSelectedStatus() {
         guard let indexOfSelectedStatus = indexOfSelectedStatus else {
             didSelectCancel?()
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -69,10 +69,6 @@ extension OrderStatusListViewController {
     }
 
     func configureLeftButton() {
-        guard !viewModel.autoConfirmSelection else {
-            return
-        }
-
         let dismissButtonTitle = NSLocalizedString("Cancel",
                                                    comment: "Change order status screen - button title for closing the view")
         let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -33,9 +33,16 @@ final class OrderStatusListViewController: UIViewController {
     ///
     var didSelectApply: ((OrderStatusEnum) -> Void)?
 
-    init(siteID: Int64, status: OrderStatusEnum) {
+    /// Whether to automatically confirm the order status when it is selected.
+    ///
+    /// Defaults to `false`.
+    ///
+    private let isSelectionAutoConfirmed: Bool
+
+    init(siteID: Int64, status: OrderStatusEnum, isSelectionAutoConfirmed: Bool = false) {
         self.viewModel = OrderStatusListViewModel(status: status,
                                                   dataSource: OrderStatusListDataSource(siteID: siteID))
+        self.isSelectionAutoConfirmed = isSelectionAutoConfirmed
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -34,7 +34,7 @@ final class OrderStatusListViewController: UIViewController {
 
     /// A closure to be  called when this VC wants its creator to change the order status to the selected status and dismiss it.
     ///
-    var didSelectApply: ((OrderStatusEnum) -> Void)?
+    var didConfirmSelection: ((OrderStatusEnum) -> Void)?
 
     /// Whether to automatically confirm the order status when it is selected.
     ///
@@ -104,6 +104,10 @@ extension OrderStatusListViewController {
     }
 
     func configureLeftButton() {
+        guard !isSelectionAutoConfirmed else {
+            return
+        }
+
         let dismissButtonTitle = NSLocalizedString("Cancel",
                                                    comment: "Change order status screen - button title for closing the view")
         let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,
@@ -114,6 +118,10 @@ extension OrderStatusListViewController {
     }
 
     func configureRightButton() {
+        guard !isSelectionAutoConfirmed else {
+            return
+        }
+
         let applyButtonTitle = NSLocalizedString("Apply",
                                                comment: "Change order status screen - button title to apply selection")
         let rightBarButton = UIBarButtonItem(title: applyButtonTitle,
@@ -146,7 +154,7 @@ extension OrderStatusListViewController {
             didSelectCancel?()
             return
         }
-        didSelectApply?(selectedStatus)
+        didConfirmSelection?(selectedStatus)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -69,7 +69,7 @@ extension OrderStatusListViewController {
     }
 
     func configureLeftButton() {
-        guard !viewModel.isSelectionAutoConfirmed else {
+        guard !viewModel.autoConfirmSelection else {
             return
         }
 
@@ -83,7 +83,7 @@ extension OrderStatusListViewController {
     }
 
     func configureRightButton() {
-        guard !viewModel.isSelectionAutoConfirmed else {
+        guard !viewModel.autoConfirmSelection else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -864,7 +864,7 @@ private extension OrderDetailsViewController {
             statusList?.dismiss(animated: true, completion: nil)
         }
 
-        statusList.didSelectApply = { [weak statusList] (selectedStatus) in
+        statusList.didConfirmSelection = { [weak statusList] (selectedStatus) in
             statusList?.dismiss(animated: true) {
                 self.setOrderStatus(to: selectedStatus)
             }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -90,7 +90,6 @@ public final class NewOrderScreen: ScreenObject {
     public func editOrderStatus() throws -> NewOrderScreen {
       return try openOrderStatusScreen()
             .selectOrderStatus(atIndex: 1)
-            .confirmSelectedOrderStatus()
     }
 
     /// Select the first product from the addProductScreen

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
@@ -3,15 +3,9 @@ import XCTest
 
 public final class OrderStatusScreen: ScreenObject {
 
-    private let applyButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["order-status-list-apply-button"]
-    }
-
     private let orderStatusTableGetter: (XCUIApplication) -> XCUIElement = {
         $0.tables["order-status-list"]
     }
-
-    private var applyButton: XCUIElement { applyButtonGetter(app) }
 
     /// Table with list of order statuses.
     ///
@@ -27,16 +21,8 @@ public final class OrderStatusScreen: ScreenObject {
     /// Selects a new order status from the list.
     /// - Returns: Order Status screen object (self).
     @discardableResult
-    public func selectOrderStatus(atIndex index: Int) throws -> Self {
+    public func selectOrderStatus(atIndex index: Int) throws -> NewOrderScreen {
         orderStatusTable.cells.element(boundBy: index).tap()
-        return self
-    }
-
-    /// Updates the order with the selected order status.
-    /// - Returns: New Order screen object.
-    @discardableResult
-    public func confirmSelectedOrderStatus() throws -> NewOrderScreen {
-        applyButton.tap()
         return try NewOrderScreen()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewModelTests.swift
@@ -31,7 +31,7 @@ class OrderStatusListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.initialStatus, IndexPath(row: expectedIndex, section: 0))
         XCTAssertFalse(viewModel.shouldEnableApplyButton)
-        XCTAssertFalse(viewModel.isSelectionAutoConfirmed)
+        XCTAssertFalse(viewModel.autoConfirmSelection)
     }
 
     func test_statusCount_returns_expected_count() {
@@ -99,11 +99,11 @@ class OrderStatusListViewModelTests: XCTestCase {
         XCTAssertTrue(didCancel)
     }
 
-    func test_selected_status_is_autoconfirmed_when_isSelectionAutoConfirmed_is_true() {
+    func test_selected_status_is_autoconfirmed_when_autoConfirmSelection_is_true() {
         // Given
         let viewModel = OrderStatusListViewModel(siteID: sampleSiteID,
                                                  status: sampleOrderStatuses[0],
-                                                 isSelectionAutoConfirmed: true, storageManager: storageManager)
+                                                 autoConfirmSelection: true, storageManager: storageManager)
         let expectedStatusIndex = 1
         var selectedStatus: OrderStatusEnum?
         viewModel.didApplySelection = {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewModelTests.swift
@@ -31,6 +31,7 @@ class OrderStatusListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.initialStatus, IndexPath(row: expectedIndex, section: 0))
         XCTAssertFalse(viewModel.shouldEnableApplyButton)
+        XCTAssertFalse(viewModel.isSelectionAutoConfirmed)
     }
 
     func test_statusCount_returns_expected_count() {
@@ -74,11 +75,12 @@ class OrderStatusListViewModelTests: XCTestCase {
             selectedStatus = $0
         }
 
-        // When
+        // When & Then
         viewModel.indexOfSelectedStatus = IndexPath(row: expectedStatusIndex, section: 0)
-        viewModel.confirmSelectedStatus()
+        XCTAssertNil(selectedStatus)
 
-        // Then
+        // When & Then
+        viewModel.confirmSelectedStatus()
         XCTAssertEqual(selectedStatus, sampleOrderStatuses[expectedStatusIndex])
     }
 
@@ -95,6 +97,24 @@ class OrderStatusListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(didCancel)
+    }
+
+    func test_selected_status_is_autoconfirmed_when_isSelectionAutoConfirmed_is_true() {
+        // Given
+        let viewModel = OrderStatusListViewModel(siteID: sampleSiteID,
+                                                 status: sampleOrderStatuses[0],
+                                                 isSelectionAutoConfirmed: true, storageManager: storageManager)
+        let expectedStatusIndex = 1
+        var selectedStatus: OrderStatusEnum?
+        viewModel.didApplySelection = {
+            selectedStatus = $0
+        }
+
+        // When
+        viewModel.indexOfSelectedStatus = IndexPath(row: expectedStatusIndex, section: 0)
+
+        // Then
+        XCTAssertEqual(selectedStatus, sampleOrderStatuses[expectedStatusIndex])
     }
 }
 


### PR DESCRIPTION
Part of: #6651

⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/7024 ⚠️ 

## Description

During Order Creation, we want to unify the list selection behavior so that making a list selection automatically confirms the selection and navigates you back to the previous screen.

This PR updates the behavior for selecting the order status during Order Creation. It removes the Cancel/Apply navigation buttons and automatically confirms your selected order status. (You can swipe to dismiss the modal.)

There are no changes to selecting the order status during Order Editing (on the Order Details screen); that change still requires confirmation using the Apply button.

## Changes

* Changes to `OrderStatusListViewController`/`OrderStatusListViewModel`:
   * Adds the property `isSelectionAutoConfirmed` to determine if the selected order status should be automatically confirmed.
   * Updates the setter for `indexOfSelectedStatus` to check `isSelectionAutoConfirmed` and act accordingly.
   * Only configures the navigation buttons on the VC if `isSelectionAutoConfirmed` is `false`.
   * Updates the closure method names for canceling/applying selections (since those are not specific to selecting the Cancel/Apply buttons).
* `OrderStatusList` (a SwiftUI wrapper for `OrderStatusListViewController`) is updated to support the above changes.
* `OrderStatusSection` (used in the New Order screen) is updated to set `isSelectionAutoConfirmed` to `true` for Order Creation.
* Updates the helpers for the order creation UI test (in `NewOrderScreen` and `OrderStatusScreen` screen objects) to remove the manual confirmation step when editing the order status.
* Updates the unit tests, including a new test for auto-confirming the selected status.

## Testing

Order Creation:

1. Go to Orders tab and create new order.
2. On the New Order screen, select "Edit" next to the order status.
3. Confirm there are no navigation buttons (Cancel/Apply) on the order status list.
4. Select a new order status and confirm the list is dismissed and the new status is selected for the order.

Order Editing:

1. Go to the Orders tab and select an existing order.
2. On the Order Details screen, select the edit icon next to the order status.
3. Confirm there is a Cancel button and a disabled Apply button at the top of the order status list.
4. Select a new order status and confirm the Apply button is enabled.
5. Tap Apply and confirm the list is dismissed and the new status is selected for the order.

## Screenshots


https://user-images.githubusercontent.com/8658164/171441509-36fedb08-ae8f-4972-b2fb-f9bdb6227b91.mp4






## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
