### PR TITLE
[Unified Order Editing] Add feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -35,6 +35,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inPersonPaymentGatewaySelection:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .unifiedOrderEditing:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -69,4 +69,8 @@ public enum FeatureFlag: Int {
     /// Enable selection of payment gateway to use for In-Person Payments when there is more than one available
     ///
     case inPersonPaymentGatewaySelection
+
+    /// Enable order editing from the order detailed screen.
+    ///
+    case unifiedOrderEditing
 }


### PR DESCRIPTION
Closes: #6957

# Why

This PR just adds the `unifiedOrderEditing` feature flag to be able to develop the **Unified Order Editing** project without breaking the current experience.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
