### PR TITLE
Background product image upload: feature flag and initial `ProductImageUploader`

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -35,6 +35,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inPersonPaymentGatewaySelection:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .backgroundProductImageUpload:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -69,4 +69,8 @@ public enum FeatureFlag: Int {
     /// Enable selection of payment gateway to use for In-Person Payments when there is more than one available
     ///
     case inPersonPaymentGatewaySelection
+
+    /// Enable image upload after leaving the product form
+    ///
+    case backgroundProductImageUpload
 }

--- a/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
@@ -1,0 +1,6 @@
+/// Used for `ServiceLocator.productImageUploader` if `backgroundProductImageUpload` feature flag is off.
+final class LegacyProductImageUploader: ProductImageUploaderProtocol {
+    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
+        ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses)
+    }
+}

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -1,0 +1,37 @@
+import struct Yosemite.ProductImage
+import enum Yosemite.ProductAction
+import protocol Yosemite.StoresManager
+
+/// Handles product image upload to support background image upload.
+protocol ProductImageUploaderProtocol {
+    /// Called for product image upload use cases (e.g. product/variation form, downloadable product list).
+    /// - Parameters:
+    ///   - siteID: the ID of the site where images are uploaded to.
+    ///   - productID: the ID of the product where images are added to.
+    ///   - isLocalID: whether the product ID is a local ID like in product creation.
+    ///   - originalStatuses: the current image statuses of the product for initialization.
+    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler
+}
+
+/// Supports background image upload and product images update after the user leaves the product form.
+final class ProductImageUploader: ProductImageUploaderProtocol {
+    private struct ProductKey: Equatable, Hashable {
+        let siteID: Int64
+        let productID: Int64
+        let isLocalID: Bool
+    }
+
+    private var actionHandlersByProduct: [ProductKey: ProductImageActionHandler] = [:]
+
+    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
+        let key = ProductKey(siteID: siteID, productID: productID, isLocalID: isLocalID)
+        let actionHandler: ProductImageActionHandler
+        if let handler = actionHandlersByProduct[key], handler.productImageStatuses.hasPendingUpload {
+            actionHandler = handler
+        } else {
+            actionHandler = ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses)
+            actionHandlersByProduct[key] = actionHandler
+        }
+        return actionHandler
+    }
+}

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -36,6 +36,11 @@ final class ServiceLocator {
     ///
     private static var _noticePresenter: NoticePresenter = DefaultNoticePresenter()
 
+    /// Product image uploader
+    ///
+    private static var _productImageUploader: ProductImageUploaderProtocol =
+    featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload) ? ProductImageUploader(): LegacyProductImageUploader()
+
     /// Push Notifications Manager
     ///
     private static var _pushNotesManager: PushNotesManager = PushNotificationsManager()
@@ -110,6 +115,12 @@ final class ServiceLocator {
     /// - Returns: An implementation of the NoticePresenter protocol. It defaults to DefaultNoticePresenter
     static var noticePresenter: NoticePresenter {
         return _noticePresenter
+    }
+
+    /// Provides the access point to the ProductImageUploaderProtocol.
+    /// - Returns: An implementation of the ProductImageUploaderProtocol. It defaults to ProductImageUploader
+    static var productImageUploader: ProductImageUploaderProtocol {
+        return _productImageUploader
     }
 
     /// Provides the access point to the PushNotesManager.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -14,18 +14,28 @@ final class AddProductCoordinator: Coordinator {
     private let sourceBarButtonItem: UIBarButtonItem?
     private let sourceView: UIView?
 
-    init(siteID: Int64, sourceBarButtonItem: UIBarButtonItem, sourceNavigationController: UINavigationController) {
+    private let productImageUploader: ProductImageUploaderProtocol
+
+    init(siteID: Int64,
+         sourceBarButtonItem: UIBarButtonItem,
+         sourceNavigationController: UINavigationController,
+         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID
         self.sourceBarButtonItem = sourceBarButtonItem
         self.sourceView = nil
         self.navigationController = sourceNavigationController
+        self.productImageUploader = productImageUploader
     }
 
-    init(siteID: Int64, sourceView: UIView, sourceNavigationController: UINavigationController) {
+    init(siteID: Int64,
+         sourceView: UIView,
+         sourceNavigationController: UINavigationController,
+         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID
         self.sourceBarButtonItem = nil
         self.sourceView = sourceView
         self.navigationController = sourceNavigationController
+        self.productImageUploader = productImageUploader
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -64,8 +74,10 @@ private extension AddProductCoordinator {
 
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
-                                                                  product: model)
+        let productImageActionHandler = productImageUploader.actionHandler(siteID: product.siteID,
+                                                                           productID: model.productID,
+                                                                           isLocalID: true,
+                                                                           originalStatuses: model.imageStatuses)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -32,11 +32,16 @@ final class ProductDownloadListViewController: UIViewController {
     private let loadingView = LoadingView(waitMessage: Localization.loadingMessage,
                                           backgroundColor: UIColor.black.withAlphaComponent(0.4))
 
-    init(product: ProductFormDataModel, completion: @escaping Completion) {
+    init(product: ProductFormDataModel,
+         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+         completion: @escaping Completion) {
         self.product = product
         viewModel = ProductDownloadListViewModel(product: product)
         onCompletion = completion
-        productImageActionHandler = ProductImageActionHandler(siteID: product.siteID, product: product)
+        productImageActionHandler = productImageUploader.actionHandler(siteID: product.siteID,
+                                                                       productID: product.productID,
+                                                                       isLocalID: !product.existsRemotely,
+                                                                       originalStatuses: product.imageStatuses)
         super.init(nibName: type(of: self).nibName, bundle: nil)
 
         onDeviceMediaLibraryPickerCompletion = { [weak self] assets in

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -39,13 +39,14 @@ final class ProductImageActionHandler {
 
     /// - Parameters:
     ///   - siteID: the ID of a site/store where the product belongs to.
-    ///   - product: the product whose image statuses and actions are of concern.
+    ///   - productID: the ID of the product whose image statuses and actions are of concern.
+    ///   - imageStatuses: the current image statuses of the product.
     ///   - queue: the queue where the update callbacks are called on. Default to be the main queue.
-    init(siteID: Int64, product: ProductFormDataModel, queue: DispatchQueue = .main) {
+    init(siteID: Int64, productID: Int64, imageStatuses: [ProductImageStatus], queue: DispatchQueue = .main) {
         self.siteID = siteID
-        self.productID = product.productID
+        self.productID = productID
         self.queue = queue
-        self.allStatuses = (productImageStatuses: product.imageStatuses, error: nil)
+        self.allStatuses = (productImageStatuses: imageStatuses, error: nil)
     }
 
     /// Observes when the image statuses have been updated.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -14,11 +14,13 @@ struct ProductDetailsFactory {
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings = ServiceLocator.currencySettings,
                                forceReadOnly: Bool,
+                               productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
                                onCompletion: @escaping (UIViewController) -> Void) {
         let vc = productDetails(product: product,
                                 presentationStyle: presentationStyle,
                                 currencySettings: currencySettings,
-                                isEditProductsEnabled: forceReadOnly ? false: true)
+                                isEditProductsEnabled: forceReadOnly ? false: true,
+                                productImageUploader: productImageUploader)
         onCompletion(vc)
     }
 }
@@ -27,11 +29,14 @@ private extension ProductDetailsFactory {
     static func productDetails(product: Product,
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings,
-                               isEditProductsEnabled: Bool) -> UIViewController {
+                               isEditProductsEnabled: Bool,
+                               productImageUploader: ProductImageUploaderProtocol) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
-        let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
-                                                                  product: productModel)
+        let productImageActionHandler = productImageUploader.actionHandler(siteID: product.siteID,
+                                                                           productID: productModel.productID,
+                                                                           isLocalID: false,
+                                                                           originalStatuses: productModel.imageStatuses)
         let formType: ProductFormType = isEditProductsEnabled ? .edit: .readonly
         let viewModel = ProductFormViewModel(product: productModel,
                                              formType: formType,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -16,12 +16,14 @@ struct ProductVariationDetailsFactory {
                                         presentationStyle: ProductFormPresentationStyle,
                                         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
                                         forceReadOnly: Bool,
+                                        productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
                                         onCompletion: @escaping (UIViewController) -> Void) {
         let vc = productVariationDetails(productVariation: productVariation,
                                          parentProduct: parentProduct,
                                          presentationStyle: presentationStyle,
                                          currencySettings: currencySettings,
-                                         isEditProductsEnabled: forceReadOnly ? false: true)
+                                         isEditProductsEnabled: forceReadOnly ? false: true,
+                                         productImageUploader: productImageUploader)
         onCompletion(vc)
     }
 }
@@ -31,13 +33,16 @@ private extension ProductVariationDetailsFactory {
                                         parentProduct: Product,
                                         presentationStyle: ProductFormPresentationStyle,
                                         currencySettings: CurrencySettings,
-                                        isEditProductsEnabled: Bool) -> UIViewController {
+                                        isEditProductsEnabled: Bool,
+                                        productImageUploader: ProductImageUploaderProtocol) -> UIViewController {
         let vc: UIViewController
         let productVariationModel = EditableProductVariationModel(productVariation: productVariation,
                                                                   allAttributes: parentProduct.attributes,
                                                                   parentProductSKU: parentProduct.sku)
-        let productImageActionHandler = ProductImageActionHandler(siteID: productVariation.siteID,
-                                                                  product: productVariationModel)
+        let productImageActionHandler = productImageUploader.actionHandler(siteID: productVariation.siteID,
+                                                                           productID: productVariationModel.productID,
+                                                                           isLocalID: !productVariationModel.existsRemotely,
+                                                                           originalStatuses: productVariationModel.imageStatuses)
         let formType: ProductFormType = isEditProductsEnabled ? .edit: .readonly
         let viewModel = ProductVariationFormViewModel(productVariation: productVariationModel,
                                                       allAttributes: parentProduct.attributes,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -100,6 +100,7 @@ final class ProductVariationsViewController: UIViewController, GhostableViewCont
     }
 
     private let imageService: ImageService = ServiceLocator.imageService
+    private let productImageUploader: ProductImageUploaderProtocol
 
     private let viewModel: ProductVariationsViewModel
     private let noticePresenter: NoticePresenter
@@ -119,13 +120,15 @@ final class ProductVariationsViewController: UIViewController, GhostableViewCont
          product: Product,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          analytics: Analytics = ServiceLocator.analytics,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.initialViewController = initialViewController
         self.product = product
         self.viewModel = viewModel
         self.noticePresenter = noticePresenter
         self.analytics = analytics
         self.featureFlagService = featureFlagService
+        self.productImageUploader = productImageUploader
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -519,8 +522,10 @@ private extension ProductVariationsViewController {
 
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let productImageActionHandler = ProductImageActionHandler(siteID: productVariation.siteID,
-                                                                  product: model)
+        let productImageActionHandler = productImageUploader.actionHandler(siteID: productVariation.siteID,
+                                                                           productID: model.productID,
+                                                                           isLocalID: !model.existsRemotely,
+                                                                           originalStatuses: model.imageStatuses)
 
         let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                       allAttributes: allAttributes,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -372,6 +372,8 @@
 		02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */; };
 		02DE5CAB279F8754007CBEF3 /* Double+RoundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */; };
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
+		02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9B284743A40010B254 /* ProductImageUploader.swift */; };
+		02E19B9E284745210010B254 /* LegacyProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9D284745210010B254 /* LegacyProductImageUploader.swift */; };
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */; };
 		02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */; };
 		02E4AF7126FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */; };
@@ -2118,6 +2120,8 @@
 		02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Rounding.swift"; sourceTree = "<group>"; };
 		02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+RoundingTests.swift"; sourceTree = "<group>"; };
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
+		02E19B9B284743A40010B254 /* ProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageUploader.swift; sourceTree = "<group>"; };
+		02E19B9D284745210010B254 /* LegacyProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyProductImageUploader.swift; sourceTree = "<group>"; };
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
 		02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewFromNoteParcelFactory.swift; sourceTree = "<group>"; };
@@ -7648,6 +7652,8 @@
 				D831E2DF230E0BA7000037D0 /* Logs.swift */,
 				575472802452185300A94C3C /* PushNotification.swift */,
 				57532CAB24BFF4DA0032B84E /* MessageComposerPresenter.swift */,
+				02E19B9B284743A40010B254 /* ProductImageUploader.swift */,
+				02E19B9D284745210010B254 /* LegacyProductImageUploader.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -9036,6 +9042,7 @@
 				DE34771327F174C8009CA300 /* StatusView.swift in Sources */,
 				45DB704A26121F3C0064A6CF /* TitleAndValueRow.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
+				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSourceProtocol.swift in Sources */,
@@ -9418,6 +9425,7 @@
 				D85136B9231CED5800DD0539 /* ReviewAge.swift in Sources */,
 				5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */,
 				26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */,
+				02E19B9E284745210010B254 /* LegacyProductImageUploader.swift in Sources */,
 				DE7B479527A38B8F0018742E /* CouponDetailsViewModel.swift in Sources */,
 				DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */,
 				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -346,3 +346,9 @@ private extension ProductFormViewModel_UpdatesTests {
         return date
     }
 }
+
+extension ProductImageActionHandler {
+    convenience init(siteID: Int64, product: ProductFormDataModel) {
+        self.init(siteID: siteID, productID: product.productID, imageStatuses: product.imageStatuses)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To make it easier for development while keeping the feature hidden for production users, this PR added a feature flag `backgroundProductImageUpload`. The initialization of `ProductImageActionHandler` is now moved to the legacy implementation of `ProductImageUploaderProtocol` when the feature flag is off, and a barebone `ProductImageUploader` when the feature flag is on. `productImageUploader: ProductImageUploaderProtocol` was added to `ServiceLocator` as a global dependency now that it handles image upload for multiple products/stores.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Feature flag on

- Launch the app
- In product editing/creation form, add a few images
- Save the product while the images are still being uploaded --> the product is still saved after all images are uploaded (production behavior)
- In product editing/creation form, add a few images
- Leave the product form and quickly come back while the images are still being uploaded --> if the images are still pending upload, they show up in the product images in loading state but aren't saved to the product by default

#### Feature flag off

- In code, return `false` for `backgroundProductImageUpload` feature flag in `DefaultFeatureFlagService`
- Launch the app
- In product editing/creation form, add a few images
- Save the product while the images are still being uploaded --> the product is still saved after all images are uploaded (production behavior)
- In product editing/creation form, add a few images
- Leave the product form and quickly come back while the images are still being uploaded --> no pending images are shown

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
