### PR TITLE
[Order Creation] Refactor Order Status List VC/VM for testability

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
@@ -1,23 +1,52 @@
 import Foundation
 import Yosemite
 import class AutomatticTracks.CrashLogging
+import protocol Storage.StorageManagerType
 
 final class OrderStatusListViewModel {
-    private var status: OrderStatusEnum?
+    private let status: OrderStatusEnum?
     private var dataSource: OrderStatusListDataSource
 
-    init(status: OrderStatusEnum, dataSource: OrderStatusListDataSource) {
+    /// The index of the status stored in the database when list view is presented
+    ///
+    private(set) var initialStatus: IndexPath?
+
+    /// The index of (new) order status selected by the user tapping on a table row.
+    ///
+    var indexOfSelectedStatus: IndexPath? {
+        didSet {
+            if initialStatus != indexOfSelectedStatus {
+                shouldEnableApplyButton = true
+            } else {
+                shouldEnableApplyButton = false
+            }
+        }
+    }
+
+    /// Whether the Apply button should be enabled.
+    ///
+    private(set) var shouldEnableApplyButton: Bool = false
+
+    /// A closure to be called when the VC wants its creator to dismiss it without saving changes.
+    ///
+    var didSelectCancel: (() -> Void)?
+
+    /// A closure to be called when the VC wants its creator to change the order status to the selected status and dismiss it.
+    ///
+    var didSelectApply: ((OrderStatusEnum) -> Void)?
+
+    init(siteID: Int64,
+         status: OrderStatusEnum,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.status = status
-        self.dataSource = dataSource
+        self.dataSource = OrderStatusListDataSource(siteID: siteID, storageManager: storageManager)
+
+        configureDataSource()
+        configureInitialStatus()
     }
 
     func configureResultsController(tableView: UITableView) {
         dataSource.startForwardingEvents(to: tableView)
-        do {
-            try dataSource.performFetch()
-        } catch {
-            ServiceLocator.crashLogging.logError(error)
-        }
         tableView.reloadData()
     }
 
@@ -63,5 +92,35 @@ final class OrderStatusListViewModel {
         }
         let status = dataSource.statuses()[indexPath.row]
         return status.name
+    }
+
+    func confirmSelectedStatus() {
+        guard let indexOfSelectedStatus = indexOfSelectedStatus else {
+            didSelectCancel?()
+            return
+        }
+        guard let selectedStatus = status(at: indexOfSelectedStatus) else {
+            didSelectCancel?()
+            return
+        }
+        didSelectApply?(selectedStatus)
+    }
+}
+
+private extension OrderStatusListViewModel {
+    /// Fetches the list of order statuses.
+    ///
+    func configureDataSource() {
+        do {
+            try dataSource.performFetch()
+        } catch {
+            ServiceLocator.crashLogging.logError(error)
+        }
+    }
+
+    /// Sets the index of the initial order status.
+    ///
+    func configureInitialStatus() {
+        initialStatus = indexOfCurrentOrderStatus()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusList.swift
@@ -16,13 +16,15 @@ struct OrderStatusList: UIViewControllerRepresentable {
     var didSelectApply: ((OrderStatusEnum) -> Void)
 
     func makeUIViewController(context: Context) -> WooNavigationController {
-        let statusList = OrderStatusListViewController(siteID: siteID, status: status)
+        let viewModel = OrderStatusListViewModel(siteID: siteID,
+                                                 status: status)
+        let statusList = OrderStatusListViewController(viewModel: viewModel)
 
-        statusList.didSelectCancel = { [weak statusList] in
+        viewModel.didSelectCancel = { [weak statusList] in
             statusList?.dismiss(animated: true, completion: nil)
         }
 
-        statusList.didSelectApply = { [weak statusList] selectedStatus in
+        viewModel.didSelectApply = { [weak statusList] selectedStatus in
             statusList?.dismiss(animated: true) {
                 didSelectApply(selectedStatus)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -6,36 +6,12 @@ final class OrderStatusListViewController: UIViewController {
     ///
     @IBOutlet private var tableView: UITableView!
 
-    /// The index of the status stored in the database when list view is presented
-    ///
-    private var initialStatus: IndexPath?
-    /// The index of (new) order status selected by the user tapping on a table row.
-    ///
-    private var indexOfSelectedStatus: IndexPath? {
-        didSet {
-            if initialStatus != indexOfSelectedStatus {
-                activateApplyButton()
-            } else {
-                deActivateApplyButton()
-            }
-        }
-    }
-
-    /// A cview model containing all possible order statuses and the selected one.
+    /// A view model containing all possible order statuses and the selected one.
     ///
     private let viewModel: OrderStatusListViewModel
 
-    /// A closure to be called when this VC wants its creator to dismiss it without saving changes.
-    ///
-    var didSelectCancel: (() -> Void)?
-
-    /// A closure to be  called when this VC wants its creator to change the order status to the selected status and dismiss it.
-    ///
-    var didSelectApply: ((OrderStatusEnum) -> Void)?
-
-    init(siteID: Int64, status: OrderStatusEnum) {
-        self.viewModel = OrderStatusListViewModel(status: status,
-                                                  dataSource: OrderStatusListDataSource(siteID: siteID))
+    init(viewModel: OrderStatusListViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -60,7 +36,6 @@ final class OrderStatusListViewController: UIViewController {
             return
         }
         tableView.selectRow(at: selectedStatusIndex, animated: false, scrollPosition: .none)
-        initialStatus = selectedStatusIndex
     }
 
     /// Registers all of the available TableViewCells
@@ -112,31 +87,19 @@ extension OrderStatusListViewController {
                                              action: #selector(applyButtonTapped))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
         navigationItem.rightBarButtonItem?.accessibilityIdentifier = "order-status-list-apply-button"
-        deActivateApplyButton()
+        enableApplyButton(viewModel.shouldEnableApplyButton)
     }
 
-    func activateApplyButton() {
-        navigationItem.rightBarButtonItem?.isEnabled = true
-    }
-
-    func deActivateApplyButton() {
-        navigationItem.rightBarButtonItem?.isEnabled = false
+    func enableApplyButton(_ enabled: Bool) {
+        navigationItem.rightBarButtonItem?.isEnabled = enabled
     }
 
     @objc func dismissButtonTapped() {
-        didSelectCancel?()
+        viewModel.didSelectCancel?()
     }
 
     @objc func applyButtonTapped() {
-        guard let indexOfSelectedStatus = indexOfSelectedStatus else {
-            didSelectCancel?()
-            return
-        }
-        guard let selectedStatus = viewModel.status(at: indexOfSelectedStatus) else {
-            didSelectCancel?()
-            return
-        }
-        didSelectApply?(selectedStatus)
+        viewModel.confirmSelectedStatus()
     }
 }
 
@@ -171,6 +134,7 @@ extension OrderStatusListViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        indexOfSelectedStatus = indexPath
+        viewModel.indexOfSelectedStatus = indexPath
+        enableApplyButton(viewModel.shouldEnableApplyButton)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -857,14 +857,15 @@ private extension OrderDetailsViewController {
         ServiceLocator.analytics.track(.orderDetailOrderStatusEditButtonTapped,
                                        withProperties: ["status": viewModel.order.status.rawValue])
 
-        let statusList = OrderStatusListViewController(siteID: viewModel.order.siteID,
-                                                       status: viewModel.order.status)
+        let statusListViewModel = OrderStatusListViewModel(siteID: viewModel.order.siteID,
+                                                           status: viewModel.order.status)
+        let statusList = OrderStatusListViewController(viewModel: statusListViewModel)
 
-        statusList.didSelectCancel = { [weak statusList] in
+        statusListViewModel.didSelectCancel = { [weak statusList] in
             statusList?.dismiss(animated: true, completion: nil)
         }
 
-        statusList.didSelectApply = { [weak statusList] (selectedStatus) in
+        statusListViewModel.didSelectApply = { [weak statusList] (selectedStatus) in
             statusList?.dismiss(animated: true) {
                 self.setOrderStatus(to: selectedStatus)
             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1278,6 +1278,7 @@
 		CC77488E2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
+		CC923A1D2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */; };
 		CCB366AF274518EC007D437A /* NewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */; };
 		CCC284112768C18500F6CC8B /* ProductInOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC284102768C18500F6CC8B /* ProductInOrder.swift */; };
 		CCCC29DD25E5757C0046B96F /* RenameAttributesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */; };
@@ -3017,6 +3018,7 @@
 		CC72BB6327BD842500837876 /* DisclosureIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclosureIndicator.swift; sourceTree = "<group>"; };
 		CC770C8927B1497700CE6ABC /* SearchHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHeader.swift; sourceTree = "<group>"; };
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
+		CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModelTests.swift; sourceTree = "<group>"; };
 		CCB366AE274518EC007D437A /* NewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderViewModelTests.swift; sourceTree = "<group>"; };
 		CCC284102768C18500F6CC8B /* ProductInOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrder.swift; sourceTree = "<group>"; };
 		CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RenameAttributesViewController.xib; sourceTree = "<group>"; };
@@ -4519,6 +4521,7 @@
 		098FFA1527AD7F40002EBEE4 /* Edit Order Status */ = {
 			isa = PBXGroup;
 			children = (
+				CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */,
 				098FFA1627AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift */,
 			);
 			path = "Edit Order Status";
@@ -10034,6 +10037,7 @@
 				D85136DD231E613900DD0539 /* ReviewsViewModelTests.swift in Sources */,
 				DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */,
 				02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */,
+				CC923A1D2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,
 				02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewModelTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+import Yosemite
+import protocol Storage.StorageManagerType
+import protocol Storage.StorageType
+@testable import WooCommerce
+
+/// Tests for `OrderStatusListViewModel`
+///
+class OrderStatusListViewModelTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 12345
+    private let sampleOrderStatuses: [OrderStatusEnum] = [.pending, .processing, .onHold, .completed]
+    private var storageManager: MockOrderStatusesStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockOrderStatusesStoresManager()
+        storageManager.insert(sampleOrderStatuses, on: sampleSiteID)
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_view_model_inits_with_expected_values() {
+        // Given
+        let expectedIndex = 0
+        let viewModel = OrderStatusListViewModel(siteID: sampleSiteID, status: sampleOrderStatuses[expectedIndex], storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.initialStatus, IndexPath(row: expectedIndex, section: 0))
+        XCTAssertFalse(viewModel.shouldEnableApplyButton)
+    }
+
+    func test_statusCount_returns_expected_count() {
+        // Given
+        let viewModel = OrderStatusListViewModel(siteID: sampleSiteID, status: sampleOrderStatuses[0], storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.statusCount(), sampleOrderStatuses.count)
+    }
+
+    func test_apply_button_enabled_when_order_status_is_changed() {
+        // Given
+        let viewModel = OrderStatusListViewModel(siteID: sampleSiteID, status: sampleOrderStatuses[0], storageManager: storageManager)
+
+        // When
+        viewModel.indexOfSelectedStatus = IndexPath(row: 1, section: 0)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldEnableApplyButton)
+    }
+
+    func test_apply_button_disabled_when_order_status_is_changed_to_initial_status() {
+        // Given
+        let initialStatusIndex = 0
+        let viewModel = OrderStatusListViewModel(siteID: sampleSiteID, status: sampleOrderStatuses[initialStatusIndex], storageManager: storageManager)
+
+        // When
+        viewModel.indexOfSelectedStatus = IndexPath(row: 1, section: 0)
+        viewModel.indexOfSelectedStatus = IndexPath(row: initialStatusIndex, section: 0)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldEnableApplyButton)
+    }
+
+    func test_confirmSelectedStatus_sends_selected_status_to_expected_closure() {
+        // Given
+        let viewModel = OrderStatusListViewModel(siteID: sampleSiteID, status: sampleOrderStatuses[0], storageManager: storageManager)
+        let expectedStatusIndex = 1
+        var selectedStatus: OrderStatusEnum?
+        viewModel.didSelectApply = {
+            selectedStatus = $0
+        }
+
+        // When
+        viewModel.indexOfSelectedStatus = IndexPath(row: expectedStatusIndex, section: 0)
+        viewModel.confirmSelectedStatus()
+
+        // Then
+        XCTAssertEqual(selectedStatus, sampleOrderStatuses[expectedStatusIndex])
+    }
+
+    func test_confirmSelectedStatus_calls_expected_closure_when_no_status_is_selected() {
+        // Given
+        let viewModel = OrderStatusListViewModel(siteID: sampleSiteID, status: sampleOrderStatuses[0], storageManager: storageManager)
+        var didCancel = false
+        viewModel.didSelectCancel = {
+            didCancel = true
+        }
+
+        // When
+        viewModel.confirmSelectedStatus()
+
+        // Then
+        XCTAssertTrue(didCancel)
+    }
+}
+
+/// Mock Order Statuses Store Manager
+///
+private final class MockOrderStatusesStoresManager: MockStorageManager {
+    /// Insert an array of order statuses into storage.
+    ///
+    func insert(_ statuses: [OrderStatusEnum], on siteID: Int64) {
+        for status in statuses {
+            insert(status, on: siteID)
+        }
+    }
+
+    /// Inserts an order status into storage.
+    ///
+    func insert(_ status: OrderStatusEnum, on siteID: Int64) {
+        let orderStatus = viewStorage.insertNewObject(ofType: StorageOrderStatus.self)
+        orderStatus.name = status.rawValue
+        orderStatus.slug = status.rawValue
+        orderStatus.siteID = siteID
+    }
+}


### PR DESCRIPTION
Part of: #6651

## Description

During Order Creation, we want to unify the list selection behavior so that making a list selection automatically confirms the selection and navigates you back to the previous screen. This means changing the order status during Order Creation should automatically confirm the new selection. However, for now we don't want to change the behavior when changing the order status on the Order Details screen.

Both Order Creation and Order Details use `OrderStatusListViewController`, so the plan is for that VC to handle either auto-confirming the selection or using the Apply button to confirm it. While working on that change in behavior in https://github.com/woocommerce/woocommerce-ios/pull/7018 I realized this Order Status List view isn't very unit testable.

This PR doesn't change any of the Order Status List behavior; it only refactors the VC and VM to support adding unit tests for the current behavior. This will allow us to use (and add to) those unit tests when we change that behavior in https://github.com/woocommerce/woocommerce-ios/pull/7018.

## Changes

* Changes to `OrderStatusListViewController`/`OrderStatusListViewModel`:
   * Moves the following properties into the view model: `initialStatus`, `indexOfSelectedStatus`, `didSelectCancel`, `didSelectApply`.
   * Adds a property `shouldEnableApplyButton`, which is updated when `indexOfSelectedStatus` is set. This property is used by the new method `enableApplyButton(_ enabled: Bool)` in the VC, which sets the enabled status for the Apply button.
   * Adds the method `configureDataSource()` and `configureInitialStatus()` to the view model, and calls them in the view model `init()`, to ensure the data source and initial status are ready to use when the view model is initialized.
   * Adds `confirmSelectedStatus()` to the view model, and calls that method from `applyButtonTapped()` in the VC.
* Updates `OrderStatusList` (a SwiftUI wrapper for `OrderStatusListViewController`) and `OrderDetailsViewController` according to the changes to the VC/VM.
* Adds unit tests for the view model init, changes to `indexOfSelectedStatus`, and `confirmSelectedStatus()`.

## Testing

Edit an existing order:

1. Go to the Orders tab and select an existing order.
2. On the Order Details screen, select the edit icon next to the order status.
3. Confirm the Apply button in the top right is disabled.
4. Select a new order status and confirm the Apply button is enabled.
5. Select the initial order status and confirm the Apply button is disabled again.
6. Choose a new status, tap Apply, and confirm the list is dismissed and the new status is selected for the order.

Create a new order:

1. Go to the Orders tab and create a new order.
2. On the New Order screen, select "Edit" next to the order status.
3. Confirm the Apply button in the top right is disabled.
4. Select a new order status and confirm the Apply button is enabled.
5. Select the initial order status and confirm the Apply button is disabled again.
6. Choose a new status, tap Apply, and confirm the list is dismissed and the new status is selected for the order.

## Screenshots


https://user-images.githubusercontent.com/8658164/171412687-10314074-b4d5-408f-aa45-a25e2b1a512e.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
