### PR TITLE
[Unified Order Editing] Redactor Order Details Syncing

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -8,6 +8,7 @@ import WooFoundation
 import enum Networking.DotcomError
 
 final class OrderDetailsViewModel {
+
     /// Retains the use-case so it can perform all of its async tasks.
     ///
     private var collectPaymentsUseCase: CollectOrderPaymentUseCase?
@@ -15,6 +16,10 @@ final class OrderDetailsViewModel {
     private let stores: StoresManager
 
     private(set) var order: Order
+
+    /// Defines the current sync states of the view model data.
+    ///
+    private var syncState: SyncState = .notSynced
 
     private let cardPresentPaymentsOnboardingPresenter = CardPresentPaymentsOnboardingPresenter()
 
@@ -566,5 +571,16 @@ extension OrderDetailsViewModel {
                     self?.collectPaymentsUseCase = nil
                 })
         }
+    }
+}
+
+// MARK: Definitions
+private extension OrderDetailsViewModel {
+    /// Defines the possible sync states of the view model data.
+    ///
+    enum SyncState {
+        case notSynced
+        case syncing
+        case synced
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -198,6 +198,10 @@ extension OrderDetailsViewModel {
     func syncEverything(onReloadSections: (() -> ())? = nil, onCompletion: (() -> ())? = nil) {
         let group = DispatchGroup()
 
+        /// Update state to syncing
+        ///
+        syncState = .syncing
+
         group.enter()
         syncOrder { _ in
             group.leave()
@@ -258,7 +262,12 @@ extension OrderDetailsViewModel {
             group.leave()
         }
 
-        group.notify(queue: .main) {
+        group.notify(queue: .main) { [weak self] in
+
+            /// Update state to synced
+            ///
+            self?.syncState = .synced
+
             onCompletion?()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -361,8 +361,6 @@ private extension OrderDetailsViewController {
             self?.reloadSections()
         }
     }
-
-    
 }
 
 // MARK: - Actions

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -81,6 +81,7 @@ final class OrderDetailsViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         syncEverything { [weak self] in
+
             self?.topLoaderView.isHidden = true
 
             /// We add the refresh control to the tableview just after the `topLoaderView` disappear for the first time.
@@ -340,140 +341,13 @@ private extension OrderDetailsViewController {
 // MARK: - Sync'ing Helpers
 //
 private extension OrderDetailsViewController {
+
+    /// Syncs all data related to the current order.
+    ///
     func syncEverything(onCompletion: (() -> ())? = nil) {
-        let group = DispatchGroup()
-
-        group.enter()
-        syncOrder { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncProducts { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncProductVariations { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncRefunds() { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncShippingLabels() { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncNotes { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncTrackingsEnablingAddButtonIfReachable {
-            group.leave()
-        }
-
-        group.enter()
-        checkShippingLabelCreationEligibility {
-            group.leave()
-        }
-
-        group.enter()
-        refreshCardPresentPaymentEligibility()
-        group.leave()
-
-        group.enter()
-        viewModel.refreshCardPresentPaymentOnboarding()
-        group.leave()
-
-        group.enter()
-        syncSavedReceipts {_ in
-            group.leave()
-        }
-
-        group.enter()
-        checkOrderAddOnFeatureSwitchState {
-            group.leave()
-        }
-
-        group.notify(queue: .main) {
-            onCompletion?()
-        }
-    }
-
-    func syncOrder(onCompletion: ((Error?) -> ())? = nil) {
-        viewModel.syncOrder { [weak self] (order, error) in
-            guard let self = self, let order = order else {
-                onCompletion?(error)
-                return
-            }
-
-            self.viewModel.update(order: order)
-
-            onCompletion?(nil)
-        }
-    }
-
-    func syncTracking(onCompletion: ((Error?) -> Void)? = nil) {
-        viewModel.syncTracking(onCompletion: onCompletion)
-    }
-
-    func syncNotes(onCompletion: ((Error?) -> ())? = nil) {
-        viewModel.syncNotes(onCompletion: onCompletion)
-    }
-
-    func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
-        viewModel.syncProducts(onCompletion: onCompletion)
-    }
-
-    func syncProductVariations(onCompletion: ((Error?) -> ())? = nil) {
-        viewModel.syncProductVariations(onCompletion: onCompletion)
-    }
-
-    func syncRefunds(onCompletion: ((Error?) -> ())? = nil) {
-        viewModel.syncRefunds(onCompletion: onCompletion)
-    }
-
-    func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
-        viewModel.syncShippingLabels(onCompletion: onCompletion)
-    }
-
-    func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
-        viewModel.syncSavedReceipts(onCompletion: onCompletion)
-    }
-
-    func syncTrackingsEnablingAddButtonIfReachable(onCompletion: (() -> Void)? = nil) {
-        syncTracking { [weak self] error in
-            if error == nil {
-                self?.viewModel.trackingIsReachable = true
-            }
-
+        viewModel.syncEverything(onReloadSections: { [weak self] in
             self?.reloadTableViewSectionsAndData()
-            onCompletion?()
-        }
-    }
-
-    func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {
-        viewModel.checkShippingLabelCreationEligibility { [weak self] in
-            self?.reloadTableViewSectionsAndData()
-            onCompletion?()
-        }
-    }
-
-    func refreshCardPresentPaymentEligibility() {
-        viewModel.refreshCardPresentPaymentEligibility()
-    }
-
-    func checkOrderAddOnFeatureSwitchState(onCompletion: (() -> Void)? = nil) {
-        viewModel.checkOrderAddOnFeatureSwitchState { [weak self] in
-            self?.reloadTableViewSectionsAndData()
-            onCompletion?()
-        }
+        }, onCompletion: onCompletion)
     }
 
     func deleteTracking(_ tracking: ShipmentTracking) {
@@ -488,31 +362,8 @@ private extension OrderDetailsViewController {
         }
     }
 
-    func syncOrderAfterPaymentCollection(onCompletion: @escaping ()-> Void) {
-        let group = DispatchGroup()
-
-        group.enter()
-        syncOrder { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncNotes { _ in
-            group.leave()
-        }
-
-        group.enter()
-        syncSavedReceipts { _ in
-            group.leave()
-        }
-
-        group.notify(queue: .main) {
-            NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
-            onCompletion()
-        }
-    }
+    
 }
-
 
 // MARK: - Actions
 //
@@ -730,8 +581,8 @@ private extension OrderDetailsViewController {
             guard let self = self else { return }
             // Refresh date & view once payment has been collected.
             if result.isSuccess {
-                self.syncOrderAfterPaymentCollection {
-                    self.refreshCardPresentPaymentEligibility()
+                self.viewModel.syncOrderAfterPaymentCollection {
+                    self.viewModel.refreshCardPresentPaymentEligibility()
                 }
             }
         }
@@ -896,7 +747,7 @@ private extension OrderDetailsViewController {
         return OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: status, onCompletion: { [weak self] error in
             guard let error = error else {
                 NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
-                self?.syncNotes()
+                self?.viewModel.syncNotes()
                 ServiceLocator.analytics.track(.orderStatusChangeSuccess)
                 return
             }


### PR DESCRIPTION
Part of #6960

# Why

In order to enable the edit button in the order details screen, we need to know when the order data is successfully loaded.

Previously the loading was being orchestrated by the View Controller with no clear way of knowing when the data has been synced.

# How

This refactor moves the syncing logic from the view controller into the view model and adds a private property `syncedState` that is mutated as the order data is synced.

The next PR will make use of that `syncedState` to know when to display the done button.

# Demo

**Note** there are some weird jumps when refreshing the screen but I corroborated that those exist prior to the refactor.

https://user-images.githubusercontent.com/562080/171498215-b8dee71b-46b0-42f5-8298-299dc15a6574.mov


https://user-images.githubusercontent.com/562080/171498760-87145a1b-1381-4be9-9c5e-ac02d09ff018.mov

# Testing

- Make sure the order loads its data correctly.
- If you have time, re-test buying a shipping label or collecting payment.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
