### PR TITLE
Remove order number from the order details summary cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -14,7 +14,6 @@ struct SummaryTableViewCellViewModel {
 
     private let billingAddress: Address?
     private let dateCreated: Date
-    private let orderNumber: String
 
     fileprivate let presentation: OrderStatusPresentation
 
@@ -26,7 +25,6 @@ struct SummaryTableViewCellViewModel {
 
         billingAddress = order.billingAddress
         dateCreated = order.dateCreated
-        orderNumber = order.number
 
         presentation = OrderStatusPresentation(
             style: status?.status ?? order.status,
@@ -46,11 +44,11 @@ struct SummaryTableViewCellViewModel {
         }
     }
 
-    /// The date, time, and the order number concatenated together. Example, “Jan 22, 2018, 11:23 AM • #1587”.
+    /// The date, time, and the order number concatenated together. Example, “Jan 22, 2018, 11:23 AM”.
     ///
     var subtitle: String {
         let formatter = DateFormatter.dateAndTimeFormatter
-        return "\(formatter.string(from: dateCreated)) • #\(orderNumber)"
+        return "\(formatter.string(from: dateCreated))"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -48,7 +48,7 @@ struct SummaryTableViewCellViewModel {
     ///
     var subtitle: String {
         let formatter = DateFormatter.dateAndTimeFormatter
-        return "\(formatter.string(from: dateCreated))"
+        return formatter.string(from: dateCreated)
     }
 }
 

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -24,9 +24,6 @@ public final class SingleOrderScreen: ScreenObject {
         orderDetailTableView.assertTextVisibilityCount(textToFind: order.status, expectedCount: 1)
         orderDetailTableView.assertTextVisibilityCount(textToFind: order.total, expectedCount: 1)
 
-        // Expects 1 instance of order.number in Summary
-        orderDetailTableView.assertTextVisibilityCount(textToFind: "#\(order.number)", expectedCount: 1)
-
         // Expects 2 instances of first_name - one in Summary and one in Shipping details
         orderDetailTableView.assertTextVisibilityCount(textToFind: order.billing.first_name, expectedCount: 2)
         orderDetailTableView.assertElement(matching: "summary-table-view-cell",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellViewModelTests.swift
@@ -32,7 +32,7 @@ final class SummaryTableViewCellViewModelTests: XCTestCase {
         XCTAssertEqual(personName, "Skylar Ferry")
     }
 
-    func test_subtitle_returns_the_date_and_time_and_order_number() throws {
+    func test_subtitle_returns_the_date_and_time() throws {
         // Given
         let expectedFormatter = DateFormatter.dateAndTimeFormatter
         let calendar = Calendar(identifier: .gregorian, timeZone: expectedFormatter.timeZone)
@@ -47,7 +47,7 @@ final class SummaryTableViewCellViewModelTests: XCTestCase {
         let subtitle = viewModel.subtitle
 
         // Then
-        let expectedSubtitle = expectedFormatter.string(from: order.dateCreated) + " • #\(order.number)"
+        let expectedSubtitle = expectedFormatter.string(from: order.dateCreated)
         XCTAssertEqual(subtitle, expectedSubtitle)
     }
 }


### PR DESCRIPTION
# Why

As a continuation of https://github.com/woocommerce/woocommerce-ios/pull/6996, this PR removes the order number from the summary cell because the order number is already displayed in the navigation bar title.

# Testing instructions
- Go to an order detail screen
- See that the order number is not displayed beside the date.

### Screenshots

<img width="439" alt="Screen Shot 2022-06-01 at 4 29 43 PM" src="https://user-images.githubusercontent.com/562080/171505708-fb882814-bf03-49c0-96dd-07f82ca78ad7.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
