### PR TITLE
Add `ProductAction.updateProductImages` for updating images of a product

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -35,6 +35,7 @@ public protocol ProductsRemoteProtocol {
                    sku: String,
                    completion: @escaping (Result<String, Error>) -> Void)
     func updateProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void)
+    func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void)
 }
 
 extension ProductsRemoteProtocol {
@@ -279,6 +280,19 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    public func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void) {
+        do {
+            let parameters = try ([ParameterKey.images: images]).toDictionary()
+            let path = "\(Path.products)/\(productID)"
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let mapper = ProductMapper(siteID: siteID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 
@@ -320,6 +334,7 @@ public extension ProductsRemote {
         static let stockStatus: String = "stock_status"
         static let category: String   = "category"
         static let fields: String     = "_fields"
+        static let images: String = "images"
     }
 
     private enum ParameterValues {

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -503,6 +503,44 @@ final class ProductsRemoteTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Update Product Images
+
+    /// Verifies that updateProductImages properly parses the `product-update` sample response.
+    ///
+    func test_updateProductImages_properly_returns_parsed_product() throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product-update")
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductImages(siteID: self.sampleSiteID, productID: self.sampleProductID, images: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let product = try XCTUnwrap(result.get())
+        XCTAssertEqual(product.images.map { $0.imageID }, [1043, 1064])
+    }
+
+    /// Verifies that updateProductImages properly relays Networking Layer errors.
+    ///
+    func test_updateProductImages_properly_relays_networking_error() {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductImages(siteID: self.sampleSiteID, productID: self.sampleProductID, images: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
 }
 
 // MARK: - Private Helpers

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -70,6 +70,10 @@ public enum ProductAction: Action {
     ///
     case updateProduct(product: Product, onCompletion: (Result<Product, ProductUpdateError>) -> Void)
 
+    /// Updates a specified Product's images.
+    ///
+    case updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], onCompletion: (Result<Product, ProductUpdateError>) -> Void)
+
     /// Checks whether a Product SKU is valid against other Products in the store.
     ///
     case validateProductSKU(_ sku: String?, siteID: Int64, onCompletion: (Bool) -> Void)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -92,6 +92,8 @@ public class ProductStore: Store {
             requestMissingProducts(for: order, onCompletion: onCompletion)
         case .updateProduct(let product, let onCompletion):
             updateProduct(product: product, onCompletion: onCompletion)
+        case .updateProductImages(let siteID, let productID, let images, let onCompletion):
+            updateProductImages(siteID: siteID, productID: productID, images: images, onCompletion: onCompletion)
         case .validateProductSKU(let sku, let siteID, let onCompletion):
             validateProductSKU(sku, siteID: siteID, onCompletion: onCompletion)
         case let .replaceProductLocally(product, onCompletion):
@@ -321,6 +323,22 @@ private extension ProductStore {
                     guard let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: product.siteID, productID: product.productID) else {
                         onCompletion(.failure(.notFoundInStorage))
                         return
+                    }
+                    onCompletion(.success(storageProduct.toReadOnly()))
+                }
+            }
+        }
+    }
+
+    func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], onCompletion: @escaping (Result<Product, ProductUpdateError>) -> Void) {
+        remote.updateProductImages(siteID: siteID, productID: productID, images: images) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(ProductUpdateError(error: error)))
+            case .success(let product):
+                self?.upsertStoredProductsInBackground(readOnlyProducts: [product], siteID: product.siteID) { [weak self] in
+                    guard let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: product.siteID, productID: product.productID) else {
+                        return onCompletion(.failure(.notFoundInStorage))
                     }
                     onCompletion(.success(storageProduct.toReadOnly()))
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To support background image upload whether the merchant still stays in the product form or not, we want to update only the images of a product without changing other fields. This PR added `ProductAction.updateProductImages` with implementation in Yosemite and Networking layers to update a product's images remotely and persist the updated product in storage.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This action isn't used yet, just CI passing should be sufficient!


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
