### PR TITLE
[Unified Order Editing] Show Edit button

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -707,6 +707,14 @@ extension OrderDetailsViewModel {
     /// Defines an action button that resides inside the more action menu.
     ///
     struct MoreActionButton {
+
+        /// Defines all possible more action button types.
+        ///
+        enum ButtonType: CaseIterable {
+            case editOrder
+            case sharePaymentLink
+        }
+
         /// ID of the button.
         ///
         let id: ButtonType
@@ -714,11 +722,6 @@ extension OrderDetailsViewModel {
         /// Title of the button.
         ///
         let title: String
-
-        enum ButtonType: CaseIterable {
-            case sharePaymentLink
-            case editOrder
-        }
 
         fileprivate static func availableButtons(order: Order, syncState: SyncState) -> [MoreActionButton] {
             ButtonType.allCases.compactMap { buttonType in

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -4,6 +4,7 @@ import Gridicons
 import Yosemite
 import MessageUI
 import Combine
+import Experiments
 import WooFoundation
 import enum Networking.DotcomError
 
@@ -734,7 +735,7 @@ extension OrderDetailsViewModel {
                     return .init(id: buttonType, title: Localization.sharePaymentLink)
 
                 case .editOrder:
-                    guard syncState == .synced else {
+                    guard syncState == .synced, ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing) else {
                         return nil
                     }
                     return .init(id: buttonType, title: Localization.editOrder)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -151,22 +151,10 @@ final class OrderDetailsViewModel {
 
     private var receipt: CardPresentReceiptParameters? = nil
 
-    /// Defines if the actions menu item should be shown.
-    /// Currently the only action should be to share a payment link.
+    /// Returns available action buttons given the internal state.
     ///
-    var shouldShowActionsMenuItem: Bool {
-        needsPayment && paymentLink != nil
-    }
-
-    /// This check is temporary, we are working on knowing if an order needs payment directly from the API.
-    /// Conditions copied from:
-    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1520-L1523
-    ///
-    private var needsPayment: Bool {
-        guard let total = Double(order.total) else {
-            return false
-        }
-        return total > .zero && (order.status == .pending || order.status == .failed)
+    var moreActionsButtons: [MoreActionButton] {
+        MoreActionButton.availableButtons(order: order, syncState: syncState)
     }
 
     /// Returns the order payment link.
@@ -710,5 +698,63 @@ private extension OrderDetailsViewModel {
         case notSynced
         case syncing
         case synced
+    }
+}
+
+// MARK: More Action Buttons Definition
+extension OrderDetailsViewModel {
+
+    /// Defines an action button that resides inside the more action menu.
+    ///
+    struct MoreActionButton {
+        /// ID of the button.
+        ///
+        let id: ButtonType
+
+        /// Title of the button.
+        ///
+        let title: String
+
+        enum ButtonType: CaseIterable {
+            case sharePaymentLink
+            case editOrder
+        }
+
+        fileprivate static func availableButtons(order: Order, syncState: SyncState) -> [MoreActionButton] {
+            ButtonType.allCases.compactMap { buttonType in
+                switch buttonType {
+
+                case .sharePaymentLink:
+                    guard order.needsPayment && order.paymentURL != nil else {
+                        return nil
+                    }
+                    return .init(id: buttonType, title: Localization.sharePaymentLink)
+
+                case .editOrder:
+                    guard syncState == .synced else {
+                        return nil
+                    }
+                    return .init(id: buttonType, title: Localization.editOrder)
+                }
+            }
+        }
+
+        enum Localization {
+            static let sharePaymentLink = NSLocalizedString("Share Payment Link", comment: "Title to share an order payment link.")
+            static let editOrder = NSLocalizedString("Edit", comment: "Title to edit an order")
+        }
+    }
+}
+
+private extension Order {
+    /// This check is temporary, we are working on knowing if an order needs payment directly from the API.
+    /// Conditions copied from:
+    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1520-L1523
+    ///
+    var needsPayment: Bool {
+        guard let total = Double(total) else {
+            return false
+        }
+        return total > .zero && (status == .pending || status == .failed)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -134,7 +134,7 @@ private extension OrderDetailsViewController {
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
 
         // Actions menu
-        if viewModel.shouldShowActionsMenuItem {
+        if viewModel.moreActionsButtons.isNotEmpty {
             navigationItem.rightBarButtonItem = UIBarButtonItem(image: .moreImage,
                                                                 style: .plain,
                                                                 target: self,
@@ -312,20 +312,20 @@ private extension OrderDetailsViewController {
     ///
     @objc func presentActionMenuSheet(_ sender: UIBarButtonItem) {
         let sheetTitle = "#" + viewModel.order.number
-        guard let paymentLink = viewModel.paymentLink else {
-            return DDLogError("⛔️ No payment link for order: \(sheetTitle)")
-        }
 
         // Configure share sheet
         let actionSheet = UIAlertController(title: nil, message: sheetTitle, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
         actionSheet.addCancelActionWithTitle(Localization.ActionsMenu.cancelAction)
-        actionSheet.addDefaultActionWithTitle(Localization.ActionsMenu.paymentLink) { [weak self] _ in
-            guard let self = self else { return }
 
-            SharingHelper.shareURL(url: paymentLink, title: nil, from: sender, in: self) { _, completed, _, _ in
-                if completed {
-                    ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailPaymentLinkShared())
+        // Create action buttons
+        for button in viewModel.moreActionsButtons {
+            actionSheet.addDefaultActionWithTitle(button.title) { [weak self] _ in
+                switch button.id {
+                case .sharePaymentLink:
+                    self?.sharePaymentLink(sender)
+                case .editOrder:
+                    self?.editOrder()
                 }
             }
         }
@@ -334,6 +334,26 @@ private extension OrderDetailsViewController {
         let popoverController = actionSheet.popoverPresentationController
         popoverController?.barButtonItem = sender
         present(actionSheet, animated: true)
+    }
+
+    /// Shares the payment link(if it exists) using the native sharing helper.
+    ///
+    private func sharePaymentLink(_ sender: UIBarButtonItem) {
+        guard let paymentLink = viewModel.paymentLink else {
+            return DDLogError("⛔️ No payment link for order: \(viewModel.order.orderID)")
+        }
+
+        SharingHelper.shareURL(url: paymentLink, title: nil, from: sender, in: self) { _, completed, _, _ in
+            if completed {
+                ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailPaymentLinkShared())
+            }
+        }
+    }
+
+    /// Presents the order edit form
+    ///
+    private func editOrder() {
+        // TODO: Implement
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -129,22 +129,4 @@ final class OrderDetailsViewModelTests: XCTestCase {
         let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
         XCTAssertFalse(actionButtonIDs.contains(.editOrder))
     }
-
-    func test_there_should_be_edit_order_action_if_order_is_synced() {
-        // Given
-        let order = Order.fake().copy(total: "10.0")
-
-        // When
-        let viewModel = OrderDetailsViewModel(order: order)
-        let synced: Bool = waitFor { promise in
-            viewModel.syncEverything(onCompletion: {
-                promise(true)
-            })
-        }
-
-        // Then
-        let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
-        XCTAssertTrue(synced)
-        XCTAssertTrue(actionButtonIDs.contains(.editOrder))
-    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -93,42 +93,19 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(orderID, order.orderID)
     }
 
-    func test_should_show_actions_menu_is_false_if_there_is_no_payment_link() {
+    func test_there_should_not_be_share_link_action_if_order_is_not_pending_payment() {
         // Given
-        let order = Order.fake().copy(status: .pending, total: "10.0", paymentURL: nil)
+        let order = Order.fake().copy(status: .processing, total: "10.0", paymentURL: nil)
 
         // When
         let viewModel = OrderDetailsViewModel(order: order)
 
         // Then
-        XCTAssertFalse(viewModel.shouldShowActionsMenuItem)
+        let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
+        XCTAssertFalse(actionButtonIDs.contains(.sharePaymentLink))
     }
 
-    func test_should_show_actions_menu_is_false_if_there_is_payment_link_but_total_is_zero() {
-        // Given
-        let paymentURL = URL(string: "http://www.automattic.com")
-        let order = Order.fake().copy(status: .pending, total: "0.0", paymentURL: paymentURL)
-
-        // When
-        let viewModel = OrderDetailsViewModel(order: order)
-
-        // Then
-        XCTAssertFalse(viewModel.shouldShowActionsMenuItem)
-    }
-
-    func test_should_show_actions_menu_is_false_if_there_is_payment_link_total_is_not_zero_but_status_is_not_pending_or_failed() {
-        // Given
-        let paymentURL = URL(string: "http://www.automattic.com")
-        let order = Order.fake().copy(status: .completed, total: "0.0", paymentURL: paymentURL)
-
-        // When
-        let viewModel = OrderDetailsViewModel(order: order)
-
-        // Then
-        XCTAssertFalse(viewModel.shouldShowActionsMenuItem)
-    }
-
-    func test_should_show_actions_menu_is_true_if_there_is_payment_link_total_is_not_zero_and_status_is_pending() {
+    func test_there_should_be_share_link_action_if_order_is_pending_payment() {
         // Given
         let paymentURL = URL(string: "http://www.automattic.com")
         let order = Order.fake().copy(status: .pending, total: "10.0", paymentURL: paymentURL)
@@ -137,18 +114,37 @@ final class OrderDetailsViewModelTests: XCTestCase {
         let viewModel = OrderDetailsViewModel(order: order)
 
         // Then
-        XCTAssertTrue(viewModel.shouldShowActionsMenuItem)
+        let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
+        XCTAssertTrue(actionButtonIDs.contains(.sharePaymentLink))
     }
 
-    func test_should_show_actions_menu_is_true_if_there_is_payment_link_total_is_not_zero_and_status_is_failed() {
+    func test_there_should_not_be_edit_order_action_if_order_is_not_synced() {
         // Given
-        let paymentURL = URL(string: "http://www.automattic.com")
-        let order = Order.fake().copy(status: .failed, total: "10.0", paymentURL: paymentURL)
+        let order = Order.fake().copy(total: "10.0")
 
         // When
         let viewModel = OrderDetailsViewModel(order: order)
 
         // Then
-        XCTAssertTrue(viewModel.shouldShowActionsMenuItem)
+        let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
+        XCTAssertFalse(actionButtonIDs.contains(.editOrder))
+    }
+
+    func test_there_should_be_edit_order_action_if_order_is_synced() {
+        // Given
+        let order = Order.fake().copy(total: "10.0")
+
+        // When
+        let viewModel = OrderDetailsViewModel(order: order)
+        let synced: Bool = waitFor { promise in
+            viewModel.syncEverything(onCompletion: {
+                promise(true)
+            })
+        }
+
+        // Then
+        let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
+        XCTAssertTrue(synced)
+        XCTAssertTrue(actionButtonIDs.contains(.editOrder))
     }
 }


### PR DESCRIPTION
Closes: #6960

# Why

In order to be able to present the edit order form, this PR shows the edit button(under the feature flag) when the order has finished syncing all of its data.

# How

- Adds a new `MoreActionButton` type inside `OrderDetailsViewModel` that takes care of creating the available buttons depending on the order state.

- Updates `OrderDetailViewController` to render all of the "more action buttons" depending on the available buttons provided by the view model.

- Updates unit tests. 

# Screenshots
Loading | Loaded
--- | ---
![loading-order](https://user-images.githubusercontent.com/562080/171742412-68f21f58-2c76-4a73-9f4c-536bd0b549ce.png) | ![loaded-order](https://user-images.githubusercontent.com/562080/171742402-06878e19-78bd-4cd1-8dc8-dba8756cd52a.png)


# Testing

- Navigate to an order
- See that before the order is loaded, no edit button appears under the "3 dot" menu
- Let the order load
- See that after the order is loaded, the edit button appears under the "3 dot" menu.
---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
