### PR TITLE
[Unified Order Editing]  Make Customer Provided Note read only

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import Yosemite
+import Experiments
 import WooFoundation
 import protocol Storage.StorageManagerType
 
@@ -409,6 +410,12 @@ private extension OrderDetailsDataSource {
             cell.onAddTapped = { [weak self] in
                 self?.onCellAction?(.editCustomerNote, nil)
             }
+        }
+
+        // TODO: Before releasing the feature, please the delete closures assignation above.
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing) {
+            cell.onEditTapped = nil
+            cell.onAddTapped = nil
         }
 
         cell.addButtonTitle = NSLocalizedString("Add Customer Note", comment: "Title for the button to add the Customer Provided Note in Order Details")
@@ -1010,8 +1017,16 @@ extension OrderDetailsDataSource {
         let customerInformation: Section = {
             var rows: [Row] = []
 
-            /// Always visible to allow editing.
-            rows.append(.customerNote)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing) {
+                if order.customerNote?.isNotEmpty == true {
+                    /// When inside `.unifiedOrderEditing` only show the note if there is content for it.
+                    rows.append(.customerNote)
+                }
+
+            } else {
+                /// Always visible to allow editing.
+                rows.append(.customerNote)
+            }
 
             let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
                 return items.first(where: { $0.productID == product.productID}) != nil


### PR DESCRIPTION
Closes: #6958

# Why

To only allow one way to edit an order, this PR makes the customer note row on the order detail screen to be read-only.
In particular this:

- Hides the customer note edit icon.
- Removes the customer note cell when the order is empty.


### Testing instructions

- Navigate to an order with a customer note
- See that there is no edit icon(pencil) on the customer note row.

----

- Navigate to an order without a customer note
- See that there is no customer note row.

### Screenshots
No Edit | No Note
---- | ----
<img width="445" alt="no-edit" src="https://user-images.githubusercontent.com/562080/172027173-93040a65-595d-4e0a-ab5a-e5e5403bb087.png"> | <img width="438" alt="no-section" src="https://user-images.githubusercontent.com/562080/172027175-0b7dfe65-cff0-4fbc-bb36-29e31a1d7511.png">




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

