### PR TITLE
[Unified Order Editing] Make Addresses read only

### DIFF
--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -79,6 +79,12 @@ extension Address {
     var hasEmailAddress: Bool {
         return email?.isEmpty == false
     }
+
+    /// Indicates if an address has only empty values.
+    ///
+    var isEmpty: Bool {
+        self == .empty
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -837,6 +837,12 @@ private extension OrderDetailsDataSource {
             }
         }
 
+        // TODO: Before releasing the feature, please the delete closures assignation above.
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing) {
+            cell.onEditTapped = nil
+            cell.onAddTapped = nil
+        }
+
         cell.addButtonTitle = NSLocalizedString("Add Shipping Address", comment: "Title for the button to add the Shipping Address in Order Details")
         cell.editButtonAccessibilityLabel = NSLocalizedString(
             "Update Address",

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -4,6 +4,7 @@ import Gridicons
 import Yosemite
 import MessageUI
 import Combine
+import Experiments
 import WooFoundation
 import enum Networking.DotcomError
 
@@ -427,7 +428,8 @@ extension OrderDetailsViewModel {
             viewController.show(productListVC, sender: nil)
         case .billingDetail:
             ServiceLocator.analytics.track(.orderDetailShowBillingTapped)
-            let billingInformationViewController = BillingInformationViewController(order: order, editingEnabled: true)
+            let isUnifiedEditingEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing)
+            let billingInformationViewController = BillingInformationViewController(order: order, editingEnabled: !isUnifiedEditingEnabled)
             viewController.navigationController?.pushViewController(billingInformationViewController, animated: true)
         case .seeReceipt:
             let countryCode = configurationLoader.configuration.countryCode


### PR DESCRIPTION
Closes: #6959 

# Why

To only allow one way to edit an order, this PR makes the customer addresses (Shipping & Billing) on the order detail screen to be read-only.

In particular this:

- Hides the edit icon on the shipping address row.
- Hides the edit icon on the billing information screen.
- Removes the shipping address row when the shipping address is empty.
- Removes the billing information row when the billing address is empty.

# Testing

- Go to an order without shipping details
- See that the shipping details row is not visible
----
- Go to an order without billing details
- See that the billing details row is not visible
----
- Go to an order with shipping details
- See that the shipping details row is visible but there is no edit icon
----
- Go to an order with billing details
- See that the billing details row is visible
- Tap the billing details row
- See that the billing information screen does not have an edit icon


# Screenshots

Read-only Shipping | Read-only Billing | No Addresses
--- | --- | ---
![shipping-read-only](https://user-images.githubusercontent.com/562080/172085179-c693384b-db37-44bc-a1c2-068f59575178.png) | ![billing-read-only](https://user-images.githubusercontent.com/562080/172085176-14488a6a-dfbb-4121-86fa-40f9bf457c9d.png) | ![rows-hidden](https://user-images.githubusercontent.com/562080/172085182-343dc5d0-e8e5-4a4a-a3f8-6180fd8bd9e2.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

