### PR TITLE
[Order Creation] Ensure correct variation list is opened for selected variation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Orders: Order details now displays both the date and time for all orders. [https://github.com/woocommerce/woocommerce-ios/pull/6996]
 - [*] Simple payments have the `Card` option available for stores with configuration issues to resolve, and show onboarding to help resolve them [https://github.com/woocommerce/woocommerce-ios/pull/7002]
 - [*] Order & Product list: Now, we can pull to refresh from an empty view. [https://github.com/woocommerce/woocommerce-ios/pull/7023, https://github.com/woocommerce/woocommerce-ios/pull/7030]
+- [*] Order Creation: Fixes a bug where selecting a variable product to add to a new order would sometimes open the wrong list of product variations. [https://github.com/woocommerce/woocommerce-ios/pull/7042]
 
 9.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -31,7 +31,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     /// The ID of the parent variable product
     ///
-    private let productID: Int64
+    let productID: Int64
 
     /// The name of the parent variable product
     ///


### PR DESCRIPTION
Closes: #7026

## Description

This fixes a bug in the `ProductSelector` (used for displaying the product list in Order Creation and in the Coupons feature) where selecting a variable product from the product list could open the wrong list of product variations.

## Changes

The problem was caused by using an `isActive` state property in the `LazyNavigationLink` within the `ForEach` loop (the product list). This activated all of the navigation links in the list, instead of just the link for the selected variable product.

This PR moves the `LazyNavigationLink` outside the `ForEach` loop so there's only a single navigation link in the view. To make that work, there's a new state property `variationListViewModel`: it is set when a variable product is tapped and is used in the `LazyNavigationLink` to set the selected variation list view model. (The `productID` in that view model is also now publicly accessible so it can be used in the `LazyNavigationLink` in the `onMultipleSelections` closure.)

## Testing

1. Go to the Orders tab and create a new order.
2. Select "Add Product" to open the product list.
3. Select several different variable products and confirm that each time, the expected variation list is opened.
4. You can also search the product list for variable products. Then, select one of the variable products in the search results and confirm the expected variation list is opened.

Bonus: Enable the experimental Coupons feature and confirm the product selector works as expected there:

1. Go to Menu > Settings > Experimental Features > Enable Coupon Management.
2. On the Menu tab, select Coupons.
3. Select a coupon from the list.
4. Tap the ellipsis menu in the top right and select "Edit Coupon."
5. Under "Apply This Coupon To" select "All Products."
6. Confirm you can select all or some of the variations for a variable product in the product list there.

## Screenshots

Before:

https://user-images.githubusercontent.com/8658164/172176978-4dc023d6-d2e3-4096-be63-48eb24b3ce34.mp4

After:


https://user-images.githubusercontent.com/8658164/172176992-aea260f8-8bdb-4c53-8596-e235dcfb2c36.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
