### PR TITLE
[Unified Order Editing] Hide customer section conditionally

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1090,7 +1090,7 @@ extension OrderDetailsDataSource {
             return sections
         }()
 
-        let customerInformation: Section = {
+        let customerInformation: Section? = {
             var rows: [Row] = []
 
             let isUnifiedEditingEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing)
@@ -1137,6 +1137,11 @@ extension OrderDetailsDataSource {
             } else {
                 /// Always visible to allow editing.
                 rows.append(.billingDetail)
+            }
+
+            /// Return `nil` if there is no rows to display.
+            guard rows.isNotEmpty else {
+                return nil
             }
 
             return Section(category: .customerInformation, title: Title.information, rows: rows)


### PR DESCRIPTION
Closes: #7040

# Why 

With #6959 we are hiding all rows from the customer section when there is no data to display.
This PR makes sure that when that happens we also hide the customer section header.


# Testing instructions

- Navigate to an order with no shipping address, billing address, and shipping methods. Like a simple payment order.
- Make sure the customer section is not visible.

# Screenshots

![no-customer-section](https://user-images.githubusercontent.com/562080/172204986-b223d605-0a2e-4664-acbe-b02d955c4fbc.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
