### PR TITLE
[Order Details] Only show issue refund when an order has been paid

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Simple payments have the `Card` option available for stores with configuration issues to resolve, and show onboarding to help resolve them [https://github.com/woocommerce/woocommerce-ios/pull/7002]
 - [*] Order & Product list: Now, we can pull to refresh from an empty view. [https://github.com/woocommerce/woocommerce-ios/pull/7023, https://github.com/woocommerce/woocommerce-ios/pull/7030]
 - [*] Collect payment button on Order Details no longer flickers when the screen loads [https://github.com/woocommerce/woocommerce-ios/pull/7043]
+- [*] Issue refund button on Order Details is shown for all paid orders [https://github.com/woocommerce/woocommerce-ios/pull/7046]
 
 9.3
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -53,7 +53,7 @@ final class OrderDetailsDataSource: NSObject {
 
     var isEligibleForRefund: Bool {
         guard !isRefundedStatus,
-              !isEligibleForCardPresentPayment,
+              order.datePaid != nil,
               refundableOrderItemsDeterminer.isAnythingToRefund(from: order, with: refunds, currencyFormatter: currencyFormatter) else {
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -98,6 +98,24 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(issueRefundRow)
     }
 
+    func test_refund_button_is_not_visible_when_there_is_no_date_paid() throws {
+        // Given
+        let order = makeOrder().copy(datePaid: .some(nil))
+        let orderRefundsOptionsDeterminer = MockOrderRefundsOptionsDeterminer(isAnythingToRefund: true)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                refundableOrderItemsDeterminer: orderRefundsOptionsDeterminer)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        let issueRefundRow = row(row: .issueRefundButton, in: paymentSection)
+        XCTAssertNil(issueRefundRow)
+    }
+
     func test_refund_button_is_not_visible_when_the_order_status_is_refunded() throws {
         // Given
         let order = MockOrders().makeOrder(status: .refunded, items: [makeOrderItem()])
@@ -217,7 +235,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_collect_payment_button_is_not_visible_if_order_is_processing_and_order_is_not_eligible_for_cash_on_delivery() throws {
         // Given
-        let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "stripe")
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cash")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
@@ -231,7 +249,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_collect_payment_button_is_not_visible_if_order_is_eligible_for_cash_on_delivery_and_total_amount_is_zero() throws {
         // Given
-        let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "cod")
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "0", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 
@@ -259,7 +277,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_collect_payment_button_is_not_visible_if_order_is_a_confirmed_booking_and_total_amount_is_zero() throws {
         // Given
-        let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "wc-booking-gateway")
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "0", paymentMethodID: "wc-booking-gateway")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.configureResultsControllers { }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6903
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, we showed Issue Refund for all orders, even if they were unpaid, unless they were eligible for CPP, in which case we would show the Collect Payment button instead.

This risked confusion for merchants, particularly over whether an order was paid or not. There was no strong reason to allow unpaid orders to be refunded, so this changes the app to only show this button when there's a `date_paid` set for the order.

This makes the dependency between Issue Refund and Collect Payment a dotted line: since Collect (card) Payment eligibility is only for orders without a `date_paid` and which are fully paid. In future, we could start showing `Collect Payment` even if an order is partially paid, to take the balance of a payment, potentially using cash or payment links.

### Testing instructions

Open order details for orders with the following statuses:

Order status | Payment status | Expected button state on CPP store | Expected button state on non-CPP store
---|---|---|---
Complete | Paid | Issue Refund | Issue Refund
On hold | Paid | Issue Refund | Issue Refund
Processing | Paid | Issue Refund | Issue Refund
On hold | Unpaid | Collect Payment | No button*
Processing | Unpaid | Collect Payment | No button*
Pending payment | Unpaid | Collect Payment | No button*
Complete | Unpaid | No button | No button
Refunded | Paid | No button | No button
Complete | Paid and part refunded | Issue Refund | Issue Refund
Complete | Paid and fully refunded | No button | No button

*In #7003, we will start showing `Collect Payment` for these

N.B. this is not determined using the statuses above, rather the presence of a `date_paid`. In normal use, these should correlate, and it seemed best to test all these scenarios rather than just manipulating the `date_paid` which isn't an easily user-changeable field.

Don't feel you need to test all of these: I have, and some are pretty silly and unlikely!

We do not support partial payments in the app at the moment. I've tested with a couple of plugins, and the changes required to support them for showing the refund or collect payment button correctly are out of scope of this ticket, and a pre-existing issue.

### Screenshots

https://user-images.githubusercontent.com/2472348/172373002-182b58df-9474-4d23-a1b1-49054787690f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
