### PR TITLE
[Mobile Payments] Refactor CardPresentPaymentsOnboardingUseCase to handle both plugins installed better

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -218,7 +218,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func accountChecks(plugin: CardPresentPaymentsPlugin) -> CardPresentPaymentOnboardingState {
-        guard let account = getPaymentGatewayAccount() else {
+        guard let account = getPaymentGatewayAccount(plugin: plugin) else {
             /// Active plugin but unable to fetch an account? Prompt the merchant to finish setting it up.
             return .pluginSetupNotCompleted(plugin: plugin)
         }
@@ -272,13 +272,13 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
     // Note: This counts on synchronizeStoreCountryAndPlugins having been called to get
     // the appropriate account for the site, be that Stripe or WCPay
-    func getPaymentGatewayAccount() -> PaymentGatewayAccount? {
+    func getPaymentGatewayAccount(plugin: CardPresentPaymentsPlugin) -> PaymentGatewayAccount? {
         guard let siteID = siteID else {
             return nil
         }
         return storageManager.viewStorage
             .loadPaymentGatewayAccounts(siteID: siteID)
-            .first(where: \.isCardPresentEligible)?
+            .first(where: { $0.isCardPresentEligible && $0.gatewayID == plugin.gatewayID })?
             .toReadOnly()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -177,6 +177,20 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .pluginNotActivated(plugin: .stripe))
     }
 
+    func test_onboarding_returns_select_wcpay_plugin_not_activated_when_both_stripe_and_wcpay_plugins_are_installed_but_not_active() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .inactive, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .inactive, version: StripePluginVersion.minimumSupportedVersion)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginNotActivated(plugin: .wcPay))
+    }
+
     func test_onboarding_returns_select_plugin_when_both_stripe_and_wcpay_plugins_are_active() {
         // Given
         setupCountry(country: .us)
@@ -290,6 +304,21 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .networkActive, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
+    }
+
+    func test_onboarding_returns_complete_when_wcpay_active_and_stripe_plugin_installed_but_not_active() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .inactive, version: StripePluginVersion.minimumSupportedVersion)
         setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -235,7 +235,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(accountType: StripeAccount.self, status: .complete, isLive: true, isInTestMode: true)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete, isLive: true, isInTestMode: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -334,7 +334,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         setupCountry(country: .us)
         setupWCPayPlugin(status: .inactive, version: WCPayPluginVersion.minimumSupportedVersion)
         setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
-        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupPaymentGatewayAccount(accountType: StripeAccount.self, status: .complete)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
@@ -12,6 +12,19 @@ public enum CardPresentPaymentsPlugin: Equatable, CaseIterable {
             return "WooCommerce Stripe Gateway"
         }
     }
+
+    public var gatewayID: String {
+        switch self {
+        case .wcPay:
+            return WCPayAccount.gatewayID
+        case .stripe:
+            return StripeAccount.gatewayID
+        }
+    }
+
+    public static func with(gatewayID: String) -> Self? {
+        allCases.first(where: { $0.gatewayID == gatewayID })
+    }
 }
 
 public struct PaymentPluginVersionSupport {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6992 #6993 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Before changing the onboarding logic to allow for payment gateway selection, I'm doing a separate PR laying the groundwork to make it easier. This PR just rearranges the checks so it's easier to add the logic related to having both plugins enabled. This should make the future PR easier to review, as it will only include changes relevant to both plugins being active. See upcoming [CardPresentPaymentsOnboardingUseCase changes](https://github.com/woocommerce/woocommerce-ios/pull/7059/files#diff-d1ffc35566672b9da71e945b7c98603eb6c930cf0bdf7a5c35d329984b4832e7) in #7059 

This includes a small fix in 890423f900577e4b03ea7bbd8b704e7b0e99820e, where I realized we were not filtering accounts correctly in our checks, and it wasn't checking that the account was for the plugin we were checking. I'm not sure this scenario was possible before being able to have two active plugins, but it's an easy thing to check.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Unit tests should pass. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
