### PR TITLE
Update Charts from 3.6.0 to 4.0.3 and migrate to SPM

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -64,7 +64,7 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack', '~> 3.7.4'
   pod 'CocoaLumberjack/Swift', '~> 3.7.4'
   pod 'XLPagerTabStrip', '~> 9.0'
-  pod 'Charts', '~> 3.6.0'
+  pod 'Charts', '~> 4.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
   pod 'StripeTerminal', '~> 2.7'
   pod 'Kingfisher', '~> 7.2.2'

--- a/Podfile
+++ b/Podfile
@@ -64,7 +64,6 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack', '~> 3.7.4'
   pod 'CocoaLumberjack/Swift', '~> 3.7.4'
   pod 'XLPagerTabStrip', '~> 9.0'
-  pod 'Charts', '~> 4.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
   pod 'StripeTerminal', '~> 2.7'
   pod 'Kingfisher', '~> 7.2.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,9 +10,10 @@ PODS:
     - Sentry (~> 6)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
-  - Charts (3.6.0):
-    - Charts/Core (= 3.6.0)
-  - Charts/Core (3.6.0)
+  - Charts (4.0.3):
+    - Charts/Core (= 4.0.3)
+  - Charts/Core (4.0.3):
+    - SwiftAlgorithms (~> 1.0)
   - CocoaLumberjack (3.7.4):
     - CocoaLumberjack/Core (= 3.7.4)
   - CocoaLumberjack/Core (3.7.4)
@@ -41,6 +42,7 @@ PODS:
   - Sourcery (1.0.3)
   - StripeTerminal (2.7.0)
   - SVProgressHUD (2.2.5)
+  - SwiftAlgorithms (1.0.0)
   - UIDeviceIdentifier (2.0.0)
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
@@ -87,7 +89,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.8)
   - Automattic-Tracks-iOS (~> 0.11.1)
-  - Charts (~> 3.6.0)
+  - Charts (~> 4.0)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -128,6 +130,7 @@ SPEC REPOS:
     - Sourcery
     - StripeTerminal
     - SVProgressHUD
+    - SwiftAlgorithms
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
@@ -150,7 +153,7 @@ SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
   Automattic-Tracks-iOS: 5cd49d3acf76c26b92b4094d34ba84e6b55e5425
-  Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
+  Charts: d959d6723c8eedfdd0735dfc28cb0a71762ac4d9
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
@@ -166,6 +169,7 @@ SPEC CHECKSUMS:
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 237b759168a00c7f55b97c743cd8a4921866c46b
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
+  SwiftAlgorithms: 38dda4731d19027fdeee1125f973111bf3386b53
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
@@ -185,6 +189,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 5159eb591fc5a50785fa061b8be01bc1bca1938b
+PODFILE CHECKSUM: 663aea2da9c51e9d79910b4fe455dd587df6324b
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,10 +10,6 @@ PODS:
     - Sentry (~> 6)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
-  - Charts (4.0.3):
-    - Charts/Core (= 4.0.3)
-  - Charts/Core (4.0.3):
-    - SwiftAlgorithms (~> 1.0)
   - CocoaLumberjack (3.7.4):
     - CocoaLumberjack/Core (= 3.7.4)
   - CocoaLumberjack/Core (3.7.4)
@@ -42,7 +38,6 @@ PODS:
   - Sourcery (1.0.3)
   - StripeTerminal (2.7.0)
   - SVProgressHUD (2.2.5)
-  - SwiftAlgorithms (1.0.0)
   - UIDeviceIdentifier (2.0.0)
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
@@ -89,7 +84,6 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.8)
   - Automattic-Tracks-iOS (~> 0.11.1)
-  - Charts (~> 4.0)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -114,7 +108,6 @@ SPEC REPOS:
     - Alamofire
     - AppAuth
     - Automattic-Tracks-iOS
-    - Charts
     - CocoaLumberjack
     - FormatterKit
     - GoogleSignIn
@@ -130,7 +123,6 @@ SPEC REPOS:
     - Sourcery
     - StripeTerminal
     - SVProgressHUD
-    - SwiftAlgorithms
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
@@ -153,7 +145,6 @@ SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
   Automattic-Tracks-iOS: 5cd49d3acf76c26b92b4094d34ba84e6b55e5425
-  Charts: d959d6723c8eedfdd0735dfc28cb0a71762ac4d9
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
@@ -169,7 +160,6 @@ SPEC CHECKSUMS:
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 237b759168a00c7f55b97c743cd8a4921866c46b
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  SwiftAlgorithms: 38dda4731d19027fdeee1125f973111bf3386b53
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
@@ -189,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 663aea2da9c51e9d79910b4fe455dd587df6324b
+PODFILE CHECKSUM: e506e3ebc3f66ec52e6682f8369507354b022d4d
 
 COCOAPODS: 1.11.2

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Charts",
+        "repositoryURL": "https://github.com/danielgindi/Charts",
+        "state": {
+          "branch": null,
+          "revision": "b38b8d45a8cbda9f0f2a3566778ed114f06056b7",
+          "version": "4.0.3"
+        }
+      },
+      {
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
@@ -35,6 +44,24 @@
           "branch": null,
           "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
           "version": "0.2.0"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
         }
       },
       {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Charts
-
+import UIKit
 
 /// This class is a custom view which is displayed over a chart element (e.g. a Bar) when it is highlighted.
 ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -374,7 +374,7 @@ private extension StoreStatsV4PeriodViewController {
 
     func configureChart() {
         lineChartView.marker = StoreStatsChartCircleMarker()
-        lineChartView.chartDescription?.enabled = false
+        lineChartView.chartDescription.enabled = false
         lineChartView.dragXEnabled = true
         lineChartView.dragYEnabled = false
         lineChartView.setScaleEnabled(false)
@@ -482,9 +482,9 @@ private extension StoreStatsV4PeriodViewController {
     }
 }
 
-// MARK: - IAxisValueFormatter Conformance (Charts)
+// MARK: - AxisValueFormatter Conformance (Charts)
 //
-extension StoreStatsV4PeriodViewController: IAxisValueFormatter {
+extension StoreStatsV4PeriodViewController: AxisValueFormatter {
     func stringForValue(_ value: Double, axis: AxisBase?) -> String {
         guard let axis = axis else {
             return ""
@@ -669,7 +669,7 @@ private extension StoreStatsV4PeriodViewController {
             let gradientColorSpace = CGColorSpaceCreateDeviceRGB()
             let locations: [CGFloat] = [0.0, 1.0]
             if let gradient = CGGradient(colorsSpace: gradientColorSpace, colors: gradientColors, locations: locations) {
-                dataSet.fill = .init(linearGradient: gradient, angle: 90.0)
+                dataSet.fill = LinearGradientFill(gradient: gradient, angle: 90.0)
                 dataSet.fillAlpha = 1.0
                 dataSet.drawFilledEnabled = true
             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 		3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
 		3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
 		3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
+		3FFC5EAC2851942F00563C48 /* Charts in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFC5EAB2851942F00563C48 /* Charts */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -3511,6 +3512,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FFC5EAC2851942F00563C48 /* Charts in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
 				263E37E12641AD8300260D3B /* Codegen in Frameworks */,
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
@@ -8141,6 +8143,7 @@
 				263E37E02641AD8300260D3B /* Codegen */,
 				45455E312657C3F300BBB0C4 /* Shimmer */,
 				174CA86927D90A6200126524 /* AutomatticAbout */,
+				3FFC5EAB2851942F00563C48 /* Charts */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -8302,6 +8305,7 @@
 				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
+				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -10946,6 +10950,14 @@
 				minimumVersion = 0.2.0;
 			};
 		};
+		3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/danielgindi/Charts";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.3;
+			};
+		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/markiv/SwiftUI-Shimmer";
@@ -11004,6 +11016,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
 			productName = XCUITestHelpers;
+		};
+		3FFC5EAB2851942F00563C48 /* Charts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */;
+			productName = Charts;
 		};
 		45455E312657C3F300BBB0C4 /* Shimmer */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
### Description

For a reason unknown to me, Xcode 14.0 beta 1 can't compile Charts when installed via CocoaPods. That's not a big deal for us, since we plan to slowly move away from CocoaPods in favor of Swift Package Manager. 

This PR does exactly that for Charts, feeding two birds with one spoon.

### Testing instructions

A green CI should be enough to ensure the migration process was successful, but there could be unexpected regression as a result of bugs in the library. ~~I'm waiting for the installable build to verify that, but~~ I'd appreciate other eyes on that, too.

### Screenshots

I don't have a store linked to my account with lots of activity. This is the only graph I could use to verify the upgrade:


<img alt="IMG_2468" src="https://user-images.githubusercontent.com/1218433/172756368-9ad88c2f-9391-43ed-b095-ad159f145281.PNG" width=300/>


---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
