### PR TITLE
[Mobile Payments] Connect logic for selecting payment gateway during onboarding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -92,13 +92,13 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         state = checkOnboardingState()
     }
 
-    func selectPlugin(_ plugin: CardPresentPaymentsPlugin) {
-        precondition(state == .selectPlugin)
-        preferredPluginLocal = plugin
+    func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
+        assert(state == .selectPlugin)
+        preferredPluginLocal = selectedPlugin
         updateState()
         if case .completed(let pluginState) = state,
-           pluginState.preferred == plugin {
-            savePreferredPlugin(plugin)
+           pluginState.preferred == selectedPlugin {
+            savePreferredPlugin(selectedPlugin)
         }
     }
 }
@@ -327,12 +327,12 @@ private extension CardPresentPaymentsOnboardingUseCase {
             return nil
         }
 
-        var plugin: String?
+        var gatewayID: String?
         let action = AppSettingsAction.getPreferredInPersonPaymentGateway(siteID: siteID) {
-            plugin = $0
+            gatewayID = $0
         }
         stores.dispatch(action)
-        return plugin.flatMap(CardPresentPaymentsPlugin.with(gatewayID:))
+        return gatewayID.flatMap(CardPresentPaymentsPlugin.with(gatewayID:))
     }
 
     func savePreferredPlugin(_ plugin: CardPresentPaymentsPlugin) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -3,12 +3,12 @@ import SwiftUI
 import Yosemite
 
 final class InPersonPaymentsMenuViewController: UITableViewController {
-    private let plugin: CardPresentPaymentsPlugin
+    private let pluginState: CardPresentPaymentsPluginState
     private var rows = [Row]()
     private let configurationLoader: CardPresentConfigurationLoader
 
-    init(plugin: CardPresentPaymentsPlugin) {
-        self.plugin = plugin
+    init(pluginState: CardPresentPaymentsPluginState) {
+        self.pluginState = pluginState
         configurationLoader = CardPresentConfigurationLoader()
         super.init(style: .grouped)
     }
@@ -259,10 +259,10 @@ private enum Constants {
 /// SwiftUI wrapper for CardReaderSettingsPresentingViewController
 ///
 struct InPersonPaymentsMenu: UIViewControllerRepresentable {
-    let plugin: CardPresentPaymentsPlugin
+    let pluginState: CardPresentPaymentsPluginState
 
     func makeUIViewController(context: Context) -> some UIViewController {
-        InPersonPaymentsMenuViewController(plugin: plugin)
+        InPersonPaymentsMenuViewController(pluginState: pluginState)
     }
 
     func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPlugin.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPlugin.swift
@@ -22,9 +22,10 @@ struct InPersonPaymentsSelectPluginRow: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
-        .overlay(
+        .background(
             RoundedRectangle(cornerRadius: 8)
                 .stroke(borderColor, lineWidth: 1)
+                .background(Color(.tertiarySystemBackground))
                )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPlugin.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPlugin.swift
@@ -37,7 +37,7 @@ struct InPersonPaymentsSelectPluginRow: View {
     }
 }
 
-struct InPersonPaymentsSelectPlugin: View {
+struct InPersonPaymentsSelectPluginView: View {
     @State var selectedPlugin: CardPresentPaymentsPlugin?
     let onPluginSelected: (CardPresentPaymentsPlugin) -> Void
 
@@ -94,9 +94,9 @@ private enum Localization {
 
 struct InPersonPaymentsSelectPlugin_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsSelectPlugin(onPluginSelected: { _ in })
-        InPersonPaymentsSelectPlugin(selectedPlugin: .wcPay, onPluginSelected: { _ in })
-        InPersonPaymentsSelectPlugin(selectedPlugin: .stripe, onPluginSelected: { _ in })
+        InPersonPaymentsSelectPluginView(onPluginSelected: { _ in })
+        InPersonPaymentsSelectPluginView(selectedPlugin: .wcPay, onPluginSelected: { _ in })
+        InPersonPaymentsSelectPluginView(selectedPlugin: .stripe, onPluginSelected: { _ in })
             .preferredColorScheme(.dark)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPlugin.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPlugin.swift
@@ -39,6 +39,7 @@ struct InPersonPaymentsSelectPluginRow: View {
 
 struct InPersonPaymentsSelectPlugin: View {
     @State var selectedPlugin: CardPresentPaymentsPlugin?
+    let onPluginSelected: (CardPresentPaymentsPlugin) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -65,7 +66,9 @@ struct InPersonPaymentsSelectPlugin: View {
             Spacer()
 
             Button(Localization.confirm) {
-                // TODO
+                if let selectedPlugin = selectedPlugin {
+                    onPluginSelected(selectedPlugin)
+                }
             }
             .disabled(selectedPlugin == nil)
             .buttonStyle(PrimaryButtonStyle())
@@ -91,9 +94,9 @@ private enum Localization {
 
 struct InPersonPaymentsSelectPlugin_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsSelectPlugin()
-        InPersonPaymentsSelectPlugin(selectedPlugin: .wcPay)
-        InPersonPaymentsSelectPlugin(selectedPlugin: .stripe)
+        InPersonPaymentsSelectPlugin(onPluginSelected: { _ in })
+        InPersonPaymentsSelectPlugin(selectedPlugin: .wcPay, onPluginSelected: { _ in })
+        InPersonPaymentsSelectPlugin(selectedPlugin: .stripe, onPluginSelected: { _ in })
             .preferredColorScheme(.dark)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -66,11 +66,7 @@ struct InPersonPaymentsSelectPluginView: View {
 
             Spacer()
 
-            Button(Localization.confirm) {
-                if let selectedPlugin = selectedPlugin {
-                    onPluginSelected(selectedPlugin)
-                }
-            }
+            Button(Localization.confirm, action: confirmPluginSelection)
             .disabled(selectedPlugin == nil)
             .buttonStyle(PrimaryButtonStyle())
         }
@@ -78,6 +74,15 @@ struct InPersonPaymentsSelectPluginView: View {
         .padding(.horizontal, 16)
         .padding(.bottom, 24)
         .background(Color(.tertiarySystemBackground).ignoresSafeArea())
+    }
+
+    private func confirmPluginSelection() {
+        guard let selectedPlugin = selectedPlugin else {
+            // This should not be possible
+            assertionFailure()
+            return DDLogError("Attempt to confirm a payment gateway selection with no gateway selected")
+        }
+        onPluginSelected(selectedPlugin)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -70,9 +70,9 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsStripeAccountReview()
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected()
-            case .completed(let plugin):
+            case .completed(let pluginState):
                 if viewModel.showMenuOnCompletion {
-                    InPersonPaymentsMenu(plugin: plugin)
+                    InPersonPaymentsMenu(pluginState: pluginState)
                 } else {
                     InPersonPaymentsCompleted()
                 }
@@ -108,7 +108,7 @@ private enum Localization {
 struct InPersonPaymentsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            InPersonPaymentsView(viewModel: InPersonPaymentsViewModel(fixedState: .completed(plugin: .stripe)))
+            InPersonPaymentsView(viewModel: InPersonPaymentsViewModel(fixedState: .completed(plugin: .stripeOnly)))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -40,7 +40,11 @@ struct InPersonPaymentsView: View {
             case .loading:
                 InPersonPaymentsLoading()
             case .selectPlugin:
-                if viewModel.userIsAdministrator {
+                if viewModel.gatewaySelectionAvailable {
+                    InPersonPaymentsSelectPlugin(selectedPlugin: nil) { plugin in
+                        viewModel.selectPlugin(plugin)
+                    }
+                } else if viewModel.userIsAdministrator {
                     InPersonPaymentsPluginConflictAdmin(onRefresh: viewModel.refresh)
                 } else {
                     InPersonPaymentsPluginConflictShopManager(onRefresh: viewModel.refresh)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -41,7 +41,7 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsLoading()
             case .selectPlugin:
                 if viewModel.gatewaySelectionAvailable {
-                    InPersonPaymentsSelectPlugin(selectedPlugin: nil) { plugin in
+                    InPersonPaymentsSelectPluginView(selectedPlugin: nil) { plugin in
                         viewModel.selectPlugin(plugin)
                     }
                 } else if viewModel.userIsAdministrator {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1666,7 +1666,7 @@
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
 		E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */; };
 		E1906E9A26C4126300CA6819 /* InPersonPaymentsMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */; };
-		E1ABAEF728479E0300F40BB2 /* InPersonPaymentsSelectPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABAEF628479E0300F40BB2 /* InPersonPaymentsSelectPlugin.swift */; };
+		E1ABAEF728479E0300F40BB2 /* InPersonPaymentsSelectPluginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABAEF628479E0300F40BB2 /* InPersonPaymentsSelectPluginView.swift */; };
 		E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */; };
@@ -3442,7 +3442,7 @@
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
 		E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequiredTests.swift; sourceTree = "<group>"; };
 		E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewController.swift; sourceTree = "<group>"; };
-		E1ABAEF628479E0300F40BB2 /* InPersonPaymentsSelectPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsSelectPlugin.swift; sourceTree = "<group>"; };
+		E1ABAEF628479E0300F40BB2 /* InPersonPaymentsSelectPluginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsSelectPluginView.swift; sourceTree = "<group>"; };
 		E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingStack.swift; sourceTree = "<group>"; };
@@ -7957,7 +7957,7 @@
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
 				E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */,
 				E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */,
-				E1ABAEF628479E0300F40BB2 /* InPersonPaymentsSelectPlugin.swift */,
+				E1ABAEF628479E0300F40BB2 /* InPersonPaymentsSelectPluginView.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -9381,7 +9381,7 @@
 				DEC6C51C27477890006832D3 /* JetpackInstallStepsView.swift in Sources */,
 				E15FC74526BC213500CF83E6 /* InPersonPaymentsLearnMore.swift in Sources */,
 				D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */,
-				E1ABAEF728479E0300F40BB2 /* InPersonPaymentsSelectPlugin.swift in Sources */,
+				E1ABAEF728479E0300F40BB2 /* InPersonPaymentsSelectPluginView.swift in Sources */,
 				B9B6DEEF283F8B9F00901FB7 /* Site+PluginsURL.swift in Sources */,
 				D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */,
 				26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -8,19 +8,22 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSplitViewInOrdersTabOn: Bool
     private let isUpdateOrderOptimisticallyOn: Bool
     private let shippingLabelsOnboardingM1: Bool
+    private let inPersonPaymentGatewaySelection: Bool
 
     init(isJetpackConnectionPackageSupportOn: Bool = false,
          isHubMenuOn: Bool = false,
          isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
-         shippingLabelsOnboardingM1: Bool = false) {
+         shippingLabelsOnboardingM1: Bool = false,
+         inPersonPaymentGatewaySelection: Bool = false) {
         self.isJetpackConnectionPackageSupportOn = isJetpackConnectionPackageSupportOn
         self.isHubMenuOn = isHubMenuOn
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
+        self.inPersonPaymentGatewaySelection = inPersonPaymentGatewaySelection
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -37,6 +40,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isUpdateOrderOptimisticallyOn
         case .shippingLabelsOnboardingM1:
             return shippingLabelsOnboardingM1
+        case .inPersonPaymentGatewaySelection:
+            return inPersonPaymentGatewaySelection
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -313,7 +313,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayPreferred))
     }
 
     func test_onboarding_uses_preferred_plugin_stripe_when_both_stripe_and_wcpay_plugins_are_active_and_preferred_plugin_is_not_complete() {
@@ -346,7 +346,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .stripe))
+        XCTAssertEqual(state, .completed(plugin: .stripePreferred))
     }
     func test_onboarding_returns_wcpay_plugin_unsupported_version_when_unpatched_wcpay_outdated() {
         // Given
@@ -426,7 +426,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayOnly))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_version_has_newer_patch_release() {
@@ -440,7 +440,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayOnly))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_version_has_newer_unpatched_release() {
@@ -454,7 +454,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayOnly))
     }
 
     func test_onboarding_returns_complete_when_wcpay_active_and_stripe_plugin_installed_but_not_active() {
@@ -469,7 +469,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayOnly))
     }
 
     func test_onboarding_returns_complete_when_stripe_active_and_wcpay_plugin_installed_but_not_active() {
@@ -484,7 +484,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .stripe))
+        XCTAssertEqual(state, .completed(plugin: .stripeOnly))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_active() {
@@ -498,7 +498,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayOnly))
     }
 
     func test_onboarding_returns_complete_when_wcpay_plugin_is_network_active() {
@@ -512,7 +512,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayOnly))
     }
 
     func test_onboarding_sends_use_wcpay_account_action_when_wcpay_plugin_is_used_with_an_account_meeting_requirements() throws {
@@ -558,7 +558,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .stripe))
+        XCTAssertEqual(state, .completed(plugin: .stripeOnly))
     }
 
     func test_onboarding_sends_use_stripe_account_action_when_stripe_plugin_is_used_with_an_account_meeting_requirements() throws {
@@ -798,7 +798,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .completed(plugin: .wcPay))
+        XCTAssertEqual(state, .completed(plugin: .wcPayOnly))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -16,12 +16,27 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 1234
 
+    /// Preferred payment gateways
+    ///
+    private var preferredInPersonPaymentGatewayBySite = [Int64: String]()
+
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         storageManager = MockStorageManager()
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.sessionManager.setStoreId(sampleSiteID)
         ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .setPreferredInPersonPaymentGateway(let siteID, let gateway):
+                self.preferredInPersonPaymentGatewayBySite[siteID] = gateway
+            case .getPreferredInPersonPaymentGateway(let siteID, let onCompletion):
+                onCompletion(self.preferredInPersonPaymentGatewayBySite[siteID])
+            default:
+                fatalError("Not available")
+            }
+        }
     }
 
     override func tearDownWithError() throws {
@@ -29,6 +44,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         storageManager.reset()
         storageManager = nil
         stores = nil
+        preferredInPersonPaymentGatewayBySite.removeAll()
         try super.tearDownWithError()
     }
 
@@ -82,18 +98,33 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .countryNotSupportedStripe(plugin: .stripe, countryCode: "CA"))
     }
 
-    func test_onboarding_returns_deactivate_stripe_when_stripe_and_wcPay_plugins_are_installed_in_Canada() {
+    func test_onboarding_returns_deactivate_stripe_when_stripe_and_wcPay_plugins_are_installed_in_Canada_with_inPersonPaymentGatewaySelection_false() {
         // Given
         setupCountry(country: .ca)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanada)
+
+        // When
+        let featureFlagService = MockFeatureFlagService(inPersonPaymentGatewaySelection: false)
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores, featureFlagService: featureFlagService)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginShouldBeDeactivated(plugin: .stripe))
+    }
+
+    func test_onboarding_returns_setup_not_completed_stripe_when_stripe_and_wcPay_plugins_are_installed_in_Canada() {
+        // Given
+        setupCountry(country: .ca)
+        setupStripePlugin(status: .active, version: .minimumSupportedVersion)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanada)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .pluginShouldBeDeactivated(plugin: .stripe))
+        XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .wcPay))
     }
 
     func test_onboarding_returns_wcpay_plugin_unsupported_version_for_canada_when_version_unsupported() {
@@ -205,6 +236,118 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .selectPlugin)
     }
 
+    func test_onboarding_returns_select_plugin_when_both_stripe_and_wcpay_plugins_are_active_ignoring_preference_if_inPersonPaymentGatewaySelection_false() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPreferredPaymentGateway(.stripe)
+
+        // When
+        let featureFlagService = MockFeatureFlagService(inPersonPaymentGatewaySelection: false)
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores, featureFlagService: featureFlagService)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .selectPlugin)
+    }
+
+    func test_onboarding_uses_selected_plugin_wcpay_when_both_stripe_and_wcpay_plugins_are_active() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        XCTAssertEqual(useCase.state, .selectPlugin)
+        useCase.selectPlugin(.wcPay)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .wcPay))
+    }
+
+    func test_onboarding_uses_selected_plugin_stripe_when_both_stripe_and_wcpay_plugins_are_active() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        XCTAssertEqual(useCase.state, .selectPlugin)
+        useCase.selectPlugin(.stripe)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .stripe))
+    }
+    func test_onboarding_uses_preferred_plugin_wcpay_when_both_stripe_and_wcpay_plugins_are_active_and_preferred_plugin_is_not_complete() {
+        // Given
+        setupCountry(country: .us)
+        // Stripe is fully set up and WCPay isn't but there's a stored preference to use WCPay
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: StripeAccount.self, status: .complete)
+        setupPreferredPaymentGateway(.wcPay)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .wcPay))
+    }
+
+    func test_onboarding_returns_complete_with_wcpay_when_both_stripe_and_wcpay_plugins_are_active_and_has_stored_preference() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupPreferredPaymentGateway(.wcPay)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed(plugin: .wcPay))
+    }
+
+    func test_onboarding_uses_preferred_plugin_stripe_when_both_stripe_and_wcpay_plugins_are_active_and_preferred_plugin_is_not_complete() {
+        // Given
+        setupCountry(country: .us)
+        // WCPay is fully set up and Stripe isn't but there's a stored preference to use Stripe
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPreferredPaymentGateway(.stripe)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .stripe))
+    }
+
+    func test_onboarding_returns_complete_with_stripe_when_both_stripe_and_wcpay_plugins_are_active_and_has_stored_preference() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: StripeAccount.self, status: .complete)
+        setupPreferredPaymentGateway(.stripe)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed(plugin: .stripe))
+    }
     func test_onboarding_returns_wcpay_plugin_unsupported_version_when_unpatched_wcpay_outdated() {
         // Given
         setupCountry(country: .us)
@@ -656,6 +799,14 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertEqual(state, .completed(plugin: .wcPay))
+    }
+}
+
+// MARK: - Settings helpers
+private extension CardPresentPaymentsOnboardingUseCaseTests {
+    func setupPreferredPaymentGateway(_ gateway: CardPresentPaymentsPlugin) {
+        let action = AppSettingsAction.setPreferredInPersonPaymentGateway(siteID: sampleSiteID, gateway: gateway.gatewayID)
+        stores.dispatch(action)
     }
 }
 

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
+		E109876C284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E109876B284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift */; };
 		E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */; };
 		E1BD4D0027ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */; };
 		E1F54D0427AD4DAF00012983 /* CardPresentConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F54D0327AD4DAF00012983 /* CardPresentConfigurationTests.swift */; };
@@ -763,6 +764,7 @@
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		E109876B284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsPluginState.swift; sourceTree = "<group>"; };
 		E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingState.swift; sourceTree = "<group>"; };
 		E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsConfiguration.swift; sourceTree = "<group>"; };
 		E1F54D0327AD4DAF00012983 /* CardPresentConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationTests.swift; sourceTree = "<group>"; };
@@ -889,6 +891,7 @@
 				0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */,
 				E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */,
 				03F3AFE628097D6400E328BE /* CardPresentPaymentsPlugin.swift */,
+				E109876B284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2021,6 +2024,7 @@
 				02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */,
 				749737672141CC8C0008C490 /* TopEarnerStats+ReadOnlyType.swift in Sources */,
 				7493751222498B2C007D85D1 /* ProductTag+ReadOnlyConvertible.swift in Sources */,
+				E109876C284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift in Sources */,
 				03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */,
 				7499936420EFBC1B00CF01CD /* OrderNoteAction.swift in Sources */,
 				7455D4692141B59E00FA8C1F /* TopEarnerStatsItem+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -6,7 +6,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// All the requirements are met and the feature is ready to use
     ///
-    case completed(plugin: CardPresentPaymentsPlugin)
+    case completed(plugin: CardPresentPaymentsPluginState)
 
     /// There is more than one plugin installed and activated. The user must deactivate one.
     /// 

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPluginState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPluginState.swift
@@ -18,7 +18,7 @@ public struct CardPresentPaymentsPluginState: Equatable {
     /// - Important: The available parameter must also contain the preferred plugin
     ///
     public init(preferred: CardPresentPaymentsPlugin, available: [CardPresentPaymentsPlugin]) {
-        precondition(available.contains(preferred))
+        assert(available.contains(preferred))
         self.preferred = preferred
         self.available = available
     }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPluginState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPluginState.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Contains the state related to active plugins when Card-Present Payments onboarding is complete
+///
+public struct CardPresentPaymentsPluginState: Equatable {
+    /// The plugin to use for Card-Present Payments
+    ///
+    public let preferred: CardPresentPaymentsPlugin
+
+    /// The list of plugins available for Card-Present Payments
+    ///
+    /// When this list contains more than one plugin, the user will be able to select their preferred payment gateway
+    ///
+    public let available: [CardPresentPaymentsPlugin]
+
+    /// Initializes the state with the preferred plugin and the list of all available plugins
+    ///
+    /// - Important: The available parameter must also contain the preferred plugin
+    ///
+    public init(preferred: CardPresentPaymentsPlugin, available: [CardPresentPaymentsPlugin]) {
+        precondition(available.contains(preferred))
+        self.preferred = preferred
+        self.available = available
+    }
+
+    /// Convenience initializer to use when a single plugin is available
+    ///
+    public init(plugin: CardPresentPaymentsPlugin) {
+        self.preferred = plugin
+        self.available = [plugin]
+    }
+}
+
+// MARK: - Shorthand helpers for testing/previes
+public extension CardPresentPaymentsPluginState {
+    /// Returns a state where only WCPay is available
+    ///
+    static var wcPayOnly: Self {
+        .init(plugin: .wcPay)
+    }
+
+    /// Returns a state where only Stripe is available
+    ///
+    static var stripeOnly: Self {
+        .init(plugin: .stripe)
+    }
+
+    /// Returns a state where both plugins are available but WCPay is the preferred one
+    ///
+    static var wcPayPreferred: Self {
+        .init(preferred: .wcPay, available: [.wcPay, .stripe])
+    }
+
+    /// Returns a state where both plugins are available but Stripe is the preferred one
+    ///
+    static var stripePreferred: Self {
+        .init(preferred: .stripe, available: [.wcPay, .stripe])
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6993 
Part of: #6992 
To be merged after #7058 

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This makes the Payment Gateway selection screen introduced in #7058 work during onboarding checks. It's still not available from In-Person Payments settings (coming up in #6992).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With feature flag disabled (edit `DefaultFeatureFlagService` to return false for `inPersonPaymentGatewaySelection`):

- [x] When you go to Settings > In-Person Payments on a US store that has both WCPay and Stripe enabled, it should prompt you to disable one of the plugins.
- [x] When you go to Settings > In-Person Payments on a Canadian store that has both WCPay and Stripe enabled, it should prompt you to disable Stripe.

With feature flag enabled (default)

- [x] When you go to Settings > In-Person Payments on a US store that has both WCPay and Stripe enabled, it should prompt you to select which plugin to use
- [x] When you go to Settings > In-Person Payments on a Canadian store that has both WCPay and Stripe enabled, it should use WCPay without asking
- [x] Once you confirm the selection, it should not ask again during onboarding checks.

If you want to clear the stored preference while testing, I've done that by calling `resetGeneralStoreSettings()` at the end of the `AppSettingsStore.init` method.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->