### PR TITLE
[Unified Order Editing ] Adds isEditable fallback for older stores

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		26455E2725F669EA008A1D32 /* ProductAttributeTermListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */; };
 		26455E2A25F669F0008A1D32 /* ProductAttributeTermMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */; };
 		265BCA02243056E3004E53EE /* categories-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA01243056E3004E53EE /* categories-all.json */; };
+		265EFBDC285257950033BD33 /* Order+Fallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265EFBDB285257950033BD33 /* Order+Fallbacks.swift */; };
 		26615473242D596B00A31661 /* ProductCategoriesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615472242D596B00A31661 /* ProductCategoriesRemote.swift */; };
 		26615475242D7C9500A31661 /* ProductCategoryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */; };
 		26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */; };
@@ -801,6 +802,7 @@
 		261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-list-half.json"; sourceTree = "<group>"; };
 		262E5AD4255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayListMapperTests.swift; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
+		265EFBDB285257950033BD33 /* Order+Fallbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Fallbacks.swift"; sourceTree = "<group>"; };
 		26615472242D596B00A31661 /* ProductCategoriesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoriesRemote.swift; sourceTree = "<group>"; };
 		26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListMapper.swift; sourceTree = "<group>"; };
 		26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoyListMapperTests.swift; sourceTree = "<group>"; };
@@ -2161,6 +2163,7 @@
 				02BDB83423EA98C800BCC63E /* String+HTML.swift */,
 				57E8FED2246616AC0057CD68 /* Result+Extensions.swift */,
 				24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */,
+				265EFBDB285257950033BD33 /* Order+Fallbacks.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2775,6 +2778,7 @@
 				025CA2C2238EBBAA00B05C81 /* ProductShippingClassListMapper.swift in Sources */,
 				74ABA1CD213F1B6B00FFAD30 /* TopEarnerStats.swift in Sources */,
 				CCAAD10F2683974000909664 /* ShippingLabelPackagePurchase.swift in Sources */,
+				265EFBDC285257950033BD33 /* Order+Fallbacks.swift in Sources */,
 				B557DA0220975500005962F4 /* JetpackRequest.swift in Sources */,
 				D88E229025AC990A0023F3B1 /* OrderFeeLine.swift in Sources */,
 				74046E1F217A6B70007DD7BF /* SiteSettingsMapper.swift in Sources */,

--- a/Networking/Networking/Extensions/Order+Fallbacks.swift
+++ b/Networking/Networking/Extensions/Order+Fallbacks.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Extension to provide fallbacks to new Order properties.
+///
+internal extension Order {
+
+    // MARK: WC 6.6 properties
+
+    /// Conditions copied from:
+    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1520-L1523
+    ///
+    static func inferNeedsPayment(status: OrderStatusEnum, total: String) -> Bool {
+        guard let total = Double(total) else {
+            return false
+        }
+        return total > .zero && (status == .pending || status == .failed)
+    }
+
+    /// Conditions copied from:
+    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1395-L1402
+    ///
+    static func inferIsEditable(status: OrderStatusEnum) -> Bool {
+        return status == .pending || status == .onHold || status == .autoDraft
+    }
+}

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -135,12 +135,6 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         let parentID = try container.decode(Int64.self, forKey: .parentID)
         let customerID = try container.decode(Int64.self, forKey: .customerID)
         let orderKey = try container.decode(String.self, forKey: .orderKey)
-
-        // TODO: Update with local fallback implementation https://github.com/woocommerce/woocommerce-ios/issues/6977
-        let isEditable = try container.decodeIfPresent(Bool.self, forKey: .isEditable) ?? false
-        let needsPayment = try container.decodeIfPresent(Bool.self, forKey: .needsPayment) ?? false
-        let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? false
-
         let number = try container.decode(String.self, forKey: .number)
         let status = try container.decode(OrderStatusEnum.self, forKey: .status)
 
@@ -191,6 +185,14 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         let fees = try container.decode([OrderFeeLine].self, forKey: .feeLines)
 
         let taxes = try container.decode([OrderTaxLine].self, forKey: .taxLines)
+
+        // Properties added on WC 6.6, we provide a local fallback for older stores.
+        let isEditable = try container.decodeIfPresent(Bool.self, forKey: .isEditable) ?? Self.inferIsEditable(status: status)
+        let needsPayment = try container.decodeIfPresent(Bool.self, forKey: .needsPayment) ?? Self.inferNeedsPayment(status: status, total: total)
+
+        // TODO: Update with local fallback when required.
+        // https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1561
+        let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? false
 
         self.init(siteID: siteID,
                   orderID: orderID,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -751,16 +751,3 @@ extension OrderDetailsViewModel {
         }
     }
 }
-
-private extension Order {
-    /// This check is temporary, we are working on knowing if an order needs payment directly from the API.
-    /// Conditions copied from:
-    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1520-L1523
-    ///
-    var needsPayment: Bool {
-        guard let total = Double(total) else {
-            return false
-        }
-        return total > .zero && (status == .pending || status == .failed)
-    }
-}

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -95,7 +95,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_there_should_not_be_share_link_action_if_order_is_not_pending_payment() {
         // Given
-        let order = Order.fake().copy(status: .processing, total: "10.0", paymentURL: nil)
+        let order = Order.fake().copy(needsPayment: false, status: .processing, total: "10.0", paymentURL: nil)
 
         // When
         let viewModel = OrderDetailsViewModel(order: order)
@@ -108,7 +108,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_there_should_be_share_link_action_if_order_is_pending_payment() {
         // Given
         let paymentURL = URL(string: "http://www.automattic.com")
-        let order = Order.fake().copy(status: .pending, total: "10.0", paymentURL: paymentURL)
+        let order = Order.fake().copy(needsPayment: true, status: .pending, total: "10.0", paymentURL: paymentURL)
 
         // When
         let viewModel = OrderDetailsViewModel(order: order)


### PR DESCRIPTION
Closes: #6977 

# Why 

After adding the `isEditable`, `needsPayments`, and `needsProccessing` properties which are only available on WC6.6+.

This PR adds a fallback logic for those properties older stores.

The logic has been copied from:

- [Needs Payment](https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1520-L1523)

- [Is Editable](https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1395-L1402)

Note: I decided to not add unit tests because this is legacy logic that should not be updated.
Note 2: I'm not adding a fallback for `needsProccessing` because the logic is more complex and the property is not being used right now.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
