### PR TITLE
Order Creation: Display and adjust quantity for order items as expected in Products section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Order Creation: Fixes a bug where selecting a variable product to add to a new order would sometimes open the wrong list of product variations. [https://github.com/woocommerce/woocommerce-ios/pull/7042]
 - [*] Collect payment button on Order Details no longer flickers when the screen loads [https://github.com/woocommerce/woocommerce-ios/pull/7043]
 - [*] Issue refund button on Order Details is shown for all paid orders [https://github.com/woocommerce/woocommerce-ios/pull/7046]
+- [*] Order Creation: Fixes several bugs with the Products section not showing the correct order items or not correctly updating the item quantity. [https://github.com/woocommerce/woocommerce-ios/pull/7067]
 
 9.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/NewOrderViewModel.swift
@@ -95,9 +95,7 @@ final class NewOrderViewModel: ObservableObject {
 
     /// Products list
     ///
-    private var allProducts: [Product] {
-        productsResultsController.fetchedObjects
-    }
+    private var allProducts: [Product] = []
 
     /// Product Variations Results Controller.
     ///
@@ -109,9 +107,7 @@ final class NewOrderViewModel: ObservableObject {
 
     /// Product Variations list
     ///
-    private var allProductVariations: [ProductVariation] {
-        productVariationsResultsController.fetchedObjects
-    }
+    private var allProductVariations: [ProductVariation] = []
 
     /// View model for the product list
     ///
@@ -549,6 +545,10 @@ private extension NewOrderViewModel {
     /// Adds a selected product (from the product list) to the order.
     ///
     func addProductToOrder(_ product: Product) {
+        if !allProducts.contains(product) {
+            allProducts.append(product)
+        }
+
         let input = OrderSyncProductInput(product: .product(product), quantity: 1)
         orderSynchronizer.setProduct.send(input)
 
@@ -558,6 +558,10 @@ private extension NewOrderViewModel {
     /// Adds a selected product variation (from the product list) to the order.
     ///
     func addProductVariationToOrder(_ variation: ProductVariation) {
+        if !allProductVariations.contains(variation) {
+            allProductVariations.append(variation)
+        }
+
         let input = OrderSyncProductInput(product: .variation(variation), quantity: 1)
         orderSynchronizer.setProduct.send(input)
 
@@ -777,6 +781,7 @@ private extension NewOrderViewModel {
     func updateProductsResultsController() {
         do {
             try productsResultsController.performFetch()
+            allProducts = productsResultsController.fetchedObjects
         } catch {
             DDLogError("⛔️ Error fetching products for new order: \(error)")
         }
@@ -787,6 +792,7 @@ private extension NewOrderViewModel {
     func updateProductVariationsResultsController() {
         do {
             try productVariationsResultsController.performFetch()
+            allProductVariations = productVariationsResultsController.fetchedObjects
         } catch {
             DDLogError("⛔️ Error fetching product variations for new order: \(error)")
         }


### PR DESCRIPTION
Closes: #7027

## Description

There were a few bugs introduced to the Products section on the New Order section (during Order Creation):

1. After adding a product variation to the order, the wrong details could appear in the Products section (the variable product details instead of the product variation). This most reliably happened if you changed the quantity after adding the variation to the order.
2. After adding a product to the order that wasn't part of the first synced page of products, you couldn't change the quantity. (It would look like the quantity was changing, but the Payments section didn't change and the order ended up with a quantity of 1.)
3. Order items could disappear from the Products section (from the UI, but not from the underlying Order).

These bugs all had a common underlying cause, and this PR fixes that so the order items look and work as expected in the Products section.

### Cause

The problem appeared in the 9.1 release with changes to `ProductSelector` (used for the Add Product screen) and how search/filters are cleared. When that screen is closed, it clears searches and filters, which triggers a resync of the product list. This removes everything except the first page of products from storage.

Because `NewOrderViewModel` used a computed property for the product and product variations lists (`allProducts` and `allProductVariations`), the New Order screen was losing its references to almost all products and product variations when the resync happened. This caused the bugs noted above, because it couldn't match the product or variation IDs in the order to their corresponding products and variations.

## Changes

This PR changes the way the product and product variation lists are handled, so the products and variations in the order are retained on the New Order screen:

* Instead of being computed properties, `allProducts` and `allProductVariations` are set only when their respective results controllers fetch those objects from storage.
* When a product or product variation is added to the order, it is also added to `allProducts` or `allProductVariations` (if it wasn't there already). This ensures that any new items synced on the Add Product screen are available for reference.

## Testing

1. Go to the Orders tab and create a new order.
2. Select "Add Product" to open the product list.
3. Search for and select a product that isn't in the first page of synced products.
4. Increase the product quantity and confirm you see the totals update in the Payment section.
5. Select "Add Product" again.
6. Select a variable product.
7. Select a product variation to add it to the order.
9. Increase the product variation quantity and confirm that the expected variation details remain visible in the Products section.
10. Tap "Create" to finish creating the order, and confirm the correct product/variation and quantities appear in the created order.

## Screenshots

Before:

https://user-images.githubusercontent.com/8658164/172912587-81ea42f3-24d0-4471-9eaa-39328dfdbf18.mp4

After:


https://user-images.githubusercontent.com/8658164/172913807-7ccf6caf-99ef-426c-8ac3-9d7f11de1bb4.mp4

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
