### PR TITLE
GET updated data for a Refund immediately after it has been created

### DIFF
--- a/Networking/Networking/Model/Refund/Refund.swift
+++ b/Networking/Networking/Model/Refund/Refund.swift
@@ -71,7 +71,7 @@ public struct Refund: Codable, GeneratedFakeable, GeneratedCopiable {
         let amount = try container.decode(String.self, forKey: .amount)
         let reason = try container.decode(String.self, forKey: .reason)
         let refundedByUserID = try container.decode(Int64.self, forKey: .refundedByUserID)
-        let isAutomated = try container.decodeIfPresent(Bool.self, forKey: .automatedRefund) ?? false
+        let isAutomated = try container.decodeIfPresent(Bool.self, forKey: .automatedRefund)
         let items = try container.decode([OrderItemRefund].self, forKey: .items)
         let shippingLines = try container.decodeIfPresent([ShippingLine].self, forKey: .shippingLines)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -385,7 +385,7 @@ private extension RefundSubmissionUseCase {
 
             if let refundData = refundData {
                 // Workaround for https://github.com/woocommerce/woocommerce-ios/issues/6704. It can be removed when the API issue is fixed (Link TBD)
-                self.getLatestRefundData(refund: refundData){ [weak self] _ in }
+                self.getLatestRefundData(refund: refundData) { [weak self] _ in }
             }
             if let error = error {
                 DDLogError("Error creating refund: \(refund)\nWith Error: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -384,8 +384,8 @@ private extension RefundSubmissionUseCase {
             guard let self = self else { return }
 
             if let refundData = refundData {
-                // Workaround for https://github.com/woocommerce/woocommerce-ios/issues/6704. It can be removed when the API issue is fixed (Link TBD)
-                self.getLatestRefundData(refund: refundData) { [weak self] _ in }
+                // Workaround for https://github.com/woocommerce/woocommerce/issues/33389. This can be removed when the related API issue is fixed
+                self.retrieveUpdatedRefundData(refund: refundData)
             }
             if let error = error {
                 DDLogError("Error creating refund: \(refund)\nWith Error: \(error)")
@@ -402,16 +402,13 @@ private extension RefundSubmissionUseCase {
     /// Retrieves the up-to-date refund data
     /// - Parameters:
     ///   - refund: the refund to retrieve details from.
-    ///   - onCompletion: called when the submission completes.
-    func getLatestRefundData(refund: Refund, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let action = RefundAction.retrieveRefund(siteID: details.order.siteID, orderID: details.order.orderID, refundID: refund.refundID) {
-                (refundDataFromGETreq, error) in
-            if let error = error {
-                DDLogError("Error retrieving refund data: \(String(describing: refundDataFromGETreq))\nWith Error: \(error)")
-                return onCompletion(.failure(error))
+    private func retrieveUpdatedRefundData(refund: Refund) {
+        let action = RefundAction.retrieveRefund(siteID: details.order.siteID, orderID: details.order.orderID, refundID: refund.refundID) { (_, error) in
+                if let error = error {
+                    DDLogError("Error retrieving refund: \(String(describing: refund))\nWith Error: \(error)")
+                }
             }
-        }
-        stores.dispatch(action)
+            stores.dispatch(action)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6704


### Description
When we create a refund via the app, the process involves submitting a POST request to `/wc/v3/orders/$ORDER_ID/refunds&_method=post`. This data is used to map the refund model before we can dispatch it to the store.

One of the properties that we expect from this POST request is [refunded_payment](https://woocommerce.github.io/woocommerce-rest-api-docs/#order-refund-properties). This defines if the payment gateway API is used to generate the refund (or, on the contrary, it is a manual refund), however, the POST response doesn't seem to return this property at the moment, which seems to be a bug with the API as the usage of `refunded_payment` can be seen in the [documentation and examples](https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-refund).

If we perform a GET request to `/wc/v3/orders/$ORDER_ID/refunds&_method=get ` in order to retrieve an existing refund data, the parameter `refunded_payment` can be found in the response.

This causes that when we create a refund via the app, the [refund summary](https://github.com/woocommerce/woocommerce-ios/blob/46196e64c17beaeac9388ea509c068917d168e8c/WooCommerce/Classes/ViewModels/Order%20Details/OrderPaymentDetailsViewModel.swift#L122) always defaults to "manual payment", and the data doesn't update until we perform a GET request (for example, by refreshing the View). This means the user is seeing wrong information on-screen unless they refresh the View.

This PR attempts to resolve this problem by adding a GET request via the existing action [RefundAction.retrieveRefund()](https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/Yosemite/Yosemite/Actions/RefundAction.swift#L9) immediately after the refund has been submitted to be created, on its completion handler.

### Testing instructions
1 - Go to an order that has been paid via a payment gateway that supports automatic refunds (e.g. Stripe, WCPay, ...)
2 - Tap Issue Refund, and refund the payment to the original payment method
3 - On the order details, see that now correctly shows the refund payment method

### Screenshots
![Kapture 2022-06-09 at 21 08 08](https://user-images.githubusercontent.com/3812076/172987664-9b7a0050-675a-43a0-9f96-9f6f5019e2fa.gif)

TODO:
- [x] Open the GH issue with the API and add the link to the code comment
- [ ] Unit Tests?
- [x] Question: Is there a different way to write [this](https://github.com/woocommerce/woocommerce-ios/pull/7069/files#diff-427d3b9e04aaa71070d08f4a840f9c40fa106c8e2247f1799e3098efdd3a3afdR388)? I'm not using the completion handler here, just need to write it because the original method deals with the error at that point.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
