### PR TITLE
Disable duplicated `.strings` keys linting

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -917,7 +917,11 @@ platform :ios do
 
   desc 'Lint the `.strings` files'
   lane :lint_localizations do
-    ios_lint_localizations(input_dir: RESOURCES_FOLDER, allow_retry: true)
+    ios_lint_localizations(
+      input_dir: RESOURCES_FOLDER,
+      allow_retry: true,
+      check_duplicate_keys: false # skip for 9.3, which has an issue in the en file
+    )
   end
 
   def write_file(path, contents)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -207,7 +207,7 @@ platform :ios do
   lane :new_beta_release do |options|
     ios_betabuild_prechecks(options)
     download_localized_strings_and_metadata_from_glotpress
-    ios_lint_localizations(input_dir: 'WooCommerce/Resources', allow_retry: true)
+    lint_localizations
     ios_bump_version_beta
     version = ios_get_app_version
     trigger_beta_build(branch_to_build: "release/#{version}")
@@ -283,7 +283,7 @@ platform :ios do
     )
 
     download_localized_strings_and_metadata_from_glotpress
-    ios_lint_localizations(input_dir: 'WooCommerce/Resources', allow_retry: true)
+    lint_localizations
     ios_bump_version_beta
 
     # Wrap up
@@ -913,6 +913,11 @@ platform :ios do
   desc 'Run localization only'
   lane :update_localization do
     ios_localize_project
+  end
+
+  desc 'Lint the `.strings` files'
+  lane :lint_localizations do
+    ios_lint_localizations(input_dir: RESOURCES_FOLDER, allow_retry: true)
   end
 
   def write_file(path, contents)


### PR DESCRIPTION
Parsing the `en.lproj/Localizable.strings` file when looking for duplicated keys raises an error.

We haven't been able to identify the error's source, but it could be an UTF-encoding related issue.

The new localization tooling, 62d1c5e (#6936), ensures localization files are always UTF-8. I run the linting
on the `en.lproj/Localizable.strings` that the new tooling would generate on `trunk` and didn't experience the crash.

Side note: The new tooling was introduce after the 9.3 code freeze, so it's available on `trunk` but hasn't run to generate a new `.strings` file there yet.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.

