### PR TITLE
Add dateFromString helper function to TestKit

### DIFF
--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -51,14 +51,14 @@ private extension ProductVariationMapperTests {
                                 productVariationID: id,
                                 attributes: sampleProductVariationAttributes(),
                                 image: ProductImage(imageID: 2432,
-                                                    dateCreated: dateFromGMT("2020-03-13T03:13:57"),
-                                                    dateModified: dateFromGMT("2020-07-21T08:29:16"),
+                                                    dateCreated: DateFormatter.dateFromString(with: "2020-03-13T03:13:57"),
+                                                    dateModified: DateFormatter.dateFromString(with: "2020-07-21T08:29:16"),
                                                     src: imageSource,
                                                     name: "DSC_0010",
                                                     alt: ""),
                                 permalink: "https://chocolate.com/marble",
-                                dateCreated: dateFromGMT("2020-06-12T14:36:02"),
-                                dateModified: dateFromGMT("2020-07-21T08:35:47"),
+                                dateCreated: DateFormatter.dateFromString(with: "2020-06-12T14:36:02"),
+                                dateModified: DateFormatter.dateFromString(with: "2020-07-21T08:35:47"),
                                 dateOnSaleStart: nil,
                                 dateOnSaleEnd: nil,
                                 status: .published,
@@ -97,10 +97,5 @@ private extension ProductVariationMapperTests {
             ProductVariationAttribute(id: 0, name: "Flavor", option: "strawberry"),
             ProductVariationAttribute(id: 0, name: "Shape", option: "marble")
         ]
-    }
-
-    func dateFromGMT(_ dateStringInGMT: String) -> Date {
-        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-        return dateFormatter.date(from: dateStringInGMT)!
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -405,11 +405,11 @@ private extension CouponsRemoteTests {
                couponID: 720,
                code: "free shipping",
                amount: "10.00",
-               dateCreated: date(with: "2017-03-21T18:25:02"),
-               dateModified: date(with: "2017-03-21T18:25:02"),
+               dateCreated: DateFormatter.dateFromString(with: "2017-03-21T18:25:02"),
+               dateModified: DateFormatter.dateFromString(with: "2017-03-21T18:25:02"),
                discountType: .fixedCart,
                description: "Coupon description",
-               dateExpires: date(with: "2017-03-31T15:25:02"),
+               dateExpires: DateFormatter.dateFromString(with: "2017-03-31T15:25:02"),
                usageCount: 10,
                individualUse: true, productIds: [12893712, 12389],
                excludedProductIds: [12213],
@@ -424,12 +424,5 @@ private extension CouponsRemoteTests {
                maximumAmount: "500.00",
                emailRestrictions: ["*@a8c.com", "someone.else@example.com"],
                usedBy: ["someone.else@example.com", "person@a8c.com"])
-    }
-
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -48,10 +48,10 @@ final class ProductVariationsRemoteTests: XCTestCase {
             XCTAssertEqual(expectedVariation.sku, "99%-nuts-marble")
             XCTAssertEqual(expectedVariation.permalink, "https://chocolate.com/marble")
 
-            XCTAssertEqual(expectedVariation.dateCreated, self.dateFromGMT("2019-11-14T12:40:55"))
-            XCTAssertEqual(expectedVariation.dateModified, self.dateFromGMT("2019-11-14T13:06:42"))
-            XCTAssertEqual(expectedVariation.dateOnSaleStart, self.dateFromGMT("2019-10-15T21:30:00"))
-            XCTAssertEqual(expectedVariation.dateOnSaleEnd, self.dateFromGMT("2019-10-27T21:29:59"))
+            XCTAssertEqual(expectedVariation.dateCreated, DateFormatter.dateFromString(with: "2019-11-14T12:40:55"))
+            XCTAssertEqual(expectedVariation.dateModified, DateFormatter.dateFromString(with: "2019-11-14T13:06:42"))
+            XCTAssertEqual(expectedVariation.dateOnSaleStart, DateFormatter.dateFromString(with: "2019-10-15T21:30:00"))
+            XCTAssertEqual(expectedVariation.dateOnSaleEnd, DateFormatter.dateFromString(with: "2019-10-27T21:29:59"))
 
             let expectedPrice = 12
             XCTAssertEqual(expectedVariation.price, "\(expectedPrice)")
@@ -334,14 +334,14 @@ private extension ProductVariationsRemoteTests {
                                 productVariationID: id,
                                 attributes: sampleProductVariationAttributes(),
                                 image: ProductImage(imageID: 2432,
-                                                    dateCreated: dateFromGMT("2020-03-13T03:13:57"),
-                                                    dateModified: dateFromGMT("2020-07-21T08:29:16"),
+                                                    dateCreated: DateFormatter.dateFromString(with: "2020-03-13T03:13:57"),
+                                                    dateModified: DateFormatter.dateFromString(with: "2020-07-21T08:29:16"),
                                                     src: imageSource,
                                                     name: "DSC_0010",
                                                     alt: ""),
                                 permalink: "https://chocolate.com/marble",
-                                dateCreated: dateFromGMT("2020-06-12T14:36:02"),
-                                dateModified: dateFromGMT("2020-07-21T08:35:47"),
+                                dateCreated: DateFormatter.dateFromString(with: "2020-06-12T14:36:02"),
+                                dateModified: DateFormatter.dateFromString(with: "2020-07-21T08:35:47"),
                                 dateOnSaleStart: nil,
                                 dateOnSaleEnd: nil,
                                 status: .published,
@@ -386,10 +386,5 @@ private extension ProductVariationsRemoteTests {
                                       productID: Int64) -> CreateProductVariation {
         let createVariation = CreateProductVariation(regularPrice: "5.0", attributes: sampleProductVariationAttributes())
         return createVariation
-    }
-
-    func dateFromGMT(_ dateStringInGMT: String) -> Date {
-        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-        return dateFormatter.date(from: dateStringInGMT)!
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -48,9 +48,9 @@ final class ProductsRemoteTests: XCTestCase {
                                       name: "Product",
                                       slug: "product",
                                       permalink: "https://example.com/product/product/",
-                                      date: date(with: "2020-09-03T02:52:44"),
-                                      dateCreated: date(with: "2020-09-03T02:52:44"),
-                                      dateModified: date(with: "2020-09-03T02:52:44"),
+                                      date: DateFormatter.dateFromString(with: "2020-09-03T02:52:44"),
+                                      dateCreated: DateFormatter.dateFromString(with: "2020-09-03T02:52:44"),
+                                      dateModified: DateFormatter.dateFromString(with: "2020-09-03T02:52:44"),
                                       dateOnSaleStart: nil,
                                       dateOnSaleEnd: nil,
                                       productTypeKey: ProductType.simple.rawValue,
@@ -151,9 +151,9 @@ final class ProductsRemoteTests: XCTestCase {
                                       name: "Product",
                                       slug: "product",
                                       permalink: "https://example.com/product/product/",
-                                      date: date(with: "2020-09-03T02:52:44"),
-                                      dateCreated: date(with: "2020-09-03T02:52:44"),
-                                      dateModified: date(with: "2020-09-03T02:52:44"),
+                                      date: DateFormatter.dateFromString(with: "2020-09-03T02:52:44"),
+                                      dateCreated: DateFormatter.dateFromString(with: "2020-09-03T02:52:44"),
+                                      dateModified: DateFormatter.dateFromString(with: "2020-09-03T02:52:44"),
                                       dateOnSaleStart: nil,
                                       dateOnSaleEnd: nil,
                                       productTypeKey: ProductType.simple.rawValue,
@@ -553,11 +553,11 @@ private extension ProductsRemoteTests {
                        name: "Book the Green Room",
                        slug: "book-the-green-room",
                        permalink: "https://example.com/product/book-the-green-room/",
-                       date: date(with: "2019-02-19T17:33:31"),
-                       dateCreated: date(with: "2019-02-19T17:33:31"),
-                       dateModified: date(with: "2019-02-19T17:48:01"),
-                       dateOnSaleStart: date(with: "2019-10-15T21:30:00"),
-                       dateOnSaleEnd: date(with: "2019-10-27T21:29:59"),
+                       date: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateCreated: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateModified: DateFormatter.dateFromString(with: "2019-02-19T17:48:01"),
+                       dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                       dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                        productTypeKey: "booking",
                        statusKey: "publish",
                        featured: false,
@@ -643,8 +643,8 @@ private extension ProductsRemoteTests {
 
     func sampleImages() -> [Networking.ProductImage] {
         let image1 = ProductImage(imageID: 19,
-                                  dateCreated: date(with: "2018-01-26T21:49:45"),
-                                  dateModified: date(with: "2018-01-26T21:50:11"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2018-01-26T21:49:45"),
+                                  dateModified: DateFormatter.dateFromString(with: "2018-01-26T21:50:11"),
                                   src: "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
                                   name: "Vneck Tshirt",
                                   alt: "")
@@ -676,12 +676,5 @@ private extension ProductsRemoteTests {
         let defaultAttribute2 = ProductDefaultAttribute(attributeID: 0, name: "Size", option: "Medium")
 
         return [defaultAttribute1, defaultAttribute2]
-    }
-
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 }

--- a/TestKit/Sources/TestKit/DateFormatter+Helpers.swift
+++ b/TestKit/Sources/TestKit/DateFormatter+Helpers.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// DateFormatter Extensions
+///
+extension DateFormatter {
+
+    /// Date And Time Formatter. Converts String to Date type
+    ///
+    static public func dateFromString(with dateString: String) -> Date {
+
+        let formatter = DateFormatter()
+
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH:mm:ss"
+
+        guard let date = formatter.date(from: dateString) else {
+            return Date()
+        }
+
+        return date
+    }
+}

--- a/TestKit/Sources/TestKit/DateFormatter+Helpers.swift
+++ b/TestKit/Sources/TestKit/DateFormatter+Helpers.swift
@@ -6,13 +6,16 @@ extension DateFormatter {
 
     /// Date And Time Formatter. Converts String to Date type
     ///
-    static public func dateFromString(with dateString: String) -> Date {
+    static public func dateFromString(with dateString: String,
+                                      locale: Locale? = .init(identifier: "en_US_POSIX"),
+                                      timeZone: TimeZone? = .init(identifier: "GMT"),
+                                      dateFormat: String? = "yyyy'-'MM'-'dd'T'HH:mm:ss") -> Date {
 
         let formatter = DateFormatter()
 
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(identifier: "GMT")
-        formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH:mm:ss"
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        formatter.dateFormat = dateFormat
 
         guard let date = formatter.date(from: dateString) else {
             return Date()

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -56,11 +56,11 @@ extension MockReviews {
                        name: productName,
                        slug: "book-the-green-room",
                        permalink: "https://example.com/product/book-the-green-room/",
-                       date: date(with: "2019-02-19T17:33:31"),
-                       dateCreated: date(with: "2019-02-19T17:33:31"),
-                       dateModified: date(with: "2019-02-19T17:48:01"),
-                       dateOnSaleStart: date(with: "2019-10-15T21:30:00"),
-                       dateOnSaleEnd: date(with: "2019-10-27T21:29:59"),
+                       date: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateCreated: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateModified: DateFormatter.dateFromString(with: "2019-02-19T17:48:01"),
+                       dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                       dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                        productTypeKey: "booking",
                        statusKey: "publish",
                        featured: false,
@@ -146,8 +146,8 @@ extension MockReviews {
 
     func sampleImages() -> [Networking.ProductImage] {
         let image1 = ProductImage(imageID: 19,
-                                  dateCreated: date(with: "2018-01-26T21:49:45"),
-                                  dateModified: date(with: "2018-01-26T21:50:11"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2018-01-26T21:49:45"),
+                                  dateModified: DateFormatter.dateFromString(with: "2018-01-26T21:50:11"),
                                   src: "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
                                   name: "Vneck Tshirt",
                                   alt: "")
@@ -202,11 +202,11 @@ extension MockReviews {
                        name: productName,
                        slug: "book-the-green-room",
                        permalink: "https://example.com/product/book-the-green-room/",
-                       date: date(with: "2019-02-19T17:33:31"),
-                       dateCreated: date(with: "2019-02-19T17:33:31"),
-                       dateModified: date(with: "2019-02-19T17:48:01"),
-                       dateOnSaleStart: date(with: "2019-10-15T21:30:00"),
-                       dateOnSaleEnd: date(with: "2019-10-27T21:29:59"),
+                       date: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateCreated: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateModified: DateFormatter.dateFromString(with: "2019-02-19T17:48:01"),
+                       dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                       dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                        productTypeKey: "booking",
                        statusKey: "publish",
                        featured: false,
@@ -289,14 +289,14 @@ extension MockReviews {
 
     func sampleImagesMutated() -> [Networking.ProductImage] {
         let image1 = ProductImage(imageID: 19,
-                                  dateCreated: date(with: "2018-01-26T21:49:45"),
-                                  dateModified: date(with: "2018-01-26T21:50:11"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2018-01-26T21:49:45"),
+                                  dateModified: DateFormatter.dateFromString(with: "2018-01-26T21:50:11"),
                                   src: "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
                                   name: "Vneck Tshirt",
                                   alt: "")
         let image2 = ProductImage(imageID: 999,
-                                  dateCreated: date(with: "2019-01-26T21:44:45"),
-                                  dateModified: date(with: "2019-01-26T21:54:11"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2019-01-26T21:44:45"),
+                                  dateModified: DateFormatter.dateFromString(with: "2019-01-26T21:54:11"),
                                   src: "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/test.png",
                                   name: "ZZZTest Image",
                                   alt: "")
@@ -328,11 +328,11 @@ extension MockReviews {
                        name: "Paper Airplane - Black, Long",
                        slug: "paper-airplane-3",
                        permalink: "https://paperairplane.store/product/paper-airplane/?attribute_color=Black&attribute_length=Long",
-                       date: date(with: "2019-04-04T22:06:45"),
-                       dateCreated: date(with: "2019-04-04T22:06:45"),
-                       dateModified: date(with: "2019-04-09T20:24:03"),
-                       dateOnSaleStart: date(with: "2019-10-15T21:30:00"),
-                       dateOnSaleEnd: date(with: "2019-10-27T21:29:59"),
+                       date: DateFormatter.dateFromString(with: "2019-04-04T22:06:45"),
+                       dateCreated: DateFormatter.dateFromString(with: "2019-04-04T22:06:45"),
+                       dateModified: DateFormatter.dateFromString(with: "2019-04-09T20:24:03"),
+                       dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                       dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                        productTypeKey: "variation",
                        statusKey: "publish",
                        featured: false,
@@ -394,8 +394,8 @@ extension MockReviews {
 
     func sampleVariationTypeImages() -> [Networking.ProductImage] {
         let image1 = ProductImage(imageID: 301,
-                                  dateCreated: date(with: "2019-04-09T20:23:58"),
-                                  dateModified: date(with: "2019-04-09T20:23:58"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2019-04-09T20:23:58"),
+                                  dateModified: DateFormatter.dateFromString(with: "2019-04-09T20:23:58"),
                                   src: "https://i0.wp.com/paperairplane.store/wp-content/uploads/2019/04/paper_plane_black.png?fit=600%2C473&ssl=1",
                                   name: "paper_plane_black",
                                   alt: "")
@@ -421,14 +421,6 @@ extension MockReviews {
 
         return [attribute1, attribute2]
     }
-
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
-    }
-
 }
 
 

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import Foundation
 
 final class MockOrders {
     let siteID: Int64 = 1234
@@ -23,9 +24,9 @@ final class MockOrders {
                                  status: status,
                                  currency: "USD",
                                  customerNote: "",
-                                 dateCreated: date(with: "2018-04-03T23:05:12"),
-                                 dateModified: date(with: "2018-04-03T23:05:14"),
-                                 datePaid: date(with: "2018-04-03T23:05:14"),
+                                 dateCreated: DateFormatter.dateFromString(with: "2018-04-03T23:05:12"),
+                                 dateModified: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
+                                 datePaid: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
                                  discountTotal: "30.00",
                                  discountTax: "1.20",
                                  shippingTotal: "0.00",
@@ -195,15 +196,6 @@ final class MockOrders {
                             total: "0.00",
                             totalTax: "0.00",
                             taxes: [])]
-    }
-
-    /// Converts a date string to a date type
-    ///
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 
     func refundsWithNegativeValue() -> [OrderRefundCondensed] {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsValidatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsValidatorTests.swift
@@ -21,8 +21,8 @@ final class ProductPriceSettingsValidatorTests: XCTestCase {
 
     func test_validation_with_sale_date_range_with_nil_regular_price() {
         // Given
-        let dateOnSaleStart = date(from: "2019-09-02T21:30:00")
-        let dateOnSaleEnd = date(from: "2019-09-27T21:30:00")
+        let dateOnSaleStart = DateFormatter.dateFromString(with: "2019-09-02T21:30:00")
+        let dateOnSaleEnd = DateFormatter.dateFromString(with: "2019-09-27T21:30:00")
         let regularPrice: String? = nil
         let salePrice = "10.0"
 
@@ -35,8 +35,8 @@ final class ProductPriceSettingsValidatorTests: XCTestCase {
 
     func test_validation_with_sale_date_range_with_nil_sale_price() {
         // Given
-        let dateOnSaleStart = date(from: "2019-09-02T21:30:00")
-        let dateOnSaleEnd = date(from: "2019-09-27T21:30:00")
+        let dateOnSaleStart = DateFormatter.dateFromString(with: "2019-09-02T21:30:00")
+        let dateOnSaleEnd = DateFormatter.dateFromString(with: "2019-09-27T21:30:00")
         let regularPrice = "10.0"
         let salePrice: String? = nil
 
@@ -49,8 +49,8 @@ final class ProductPriceSettingsValidatorTests: XCTestCase {
 
     func test_validation_with_sale_date_range_with_nil_sale_and_regular_price() {
         // Given
-        let dateOnSaleStart = date(from: "2019-09-02T21:30:00")
-        let dateOnSaleEnd = date(from: "2019-09-27T21:30:00")
+        let dateOnSaleStart = DateFormatter.dateFromString(with: "2019-09-02T21:30:00")
+        let dateOnSaleEnd = DateFormatter.dateFromString(with: "2019-09-27T21:30:00")
         let regularPrice: String? = nil
         let salePrice: String? = nil
 
@@ -63,8 +63,8 @@ final class ProductPriceSettingsValidatorTests: XCTestCase {
 
     func test_validation_with_sale_date_range_and_sale_price_higher_than_regular_price() {
         // Given
-        let dateOnSaleStart = date(from: "2019-09-02T21:30:00")
-        let dateOnSaleEnd = date(from: "2019-09-27T21:30:00")
+        let dateOnSaleStart = DateFormatter.dateFromString(with: "2019-09-02T21:30:00")
+        let dateOnSaleEnd = DateFormatter.dateFromString(with: "2019-09-27T21:30:00")
         let regularPrice = "10.0"
         let salePrice = "20.0"
 
@@ -118,8 +118,8 @@ final class ProductPriceSettingsValidatorTests: XCTestCase {
 
     func test_validation_with_sale_date_range_and_regular_price_higher_than_sale_price() {
         // Given
-        let dateOnSaleStart = date(from: "2019-09-02T21:30:00")
-        let dateOnSaleEnd = date(from: "2019-09-27T21:30:00")
+        let dateOnSaleStart = DateFormatter.dateFromString(with: "2019-09-02T21:30:00")
+        let dateOnSaleEnd = DateFormatter.dateFromString(with: "2019-09-27T21:30:00")
         let regularPrice = "20.0"
         let salePrice = "10.0"
 
@@ -139,12 +139,5 @@ final class ProductPriceSettingsValidatorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(priceDecimal, 42.0)
-    }
-}
-
-private extension ProductPriceSettingsValidatorTests {
-
-    func date(from dateString: String) -> Date? {
-        DateFormatter.Defaults.dateTimeFormatter.date(from: dateString)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -149,8 +149,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
 
         // Action
         let newImage = ProductImage(imageID: 17,
-                                    dateCreated: date(with: "2018-01-26T21:49:45"),
-                                    dateModified: date(with: "2018-01-26T21:50:11"),
+                                    dateCreated: DateFormatter.dateFromString(with: "2018-01-26T21:49:45"),
+                                    dateModified: DateFormatter.dateFromString(with: "2018-01-26T21:50:11"),
                                     src: "https://somewebsite.com/shirt.jpg",
                                     name: "Tshirt",
                                     alt: "")
@@ -335,15 +335,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.downloadableFiles.count, newDownloadableFiles.count)
         XCTAssertEqual(viewModel.productModel.downloadLimit, newDownloadLimit)
         XCTAssertEqual(viewModel.productModel.product.downloadExpiry, newDownloadExpiry)
-    }
-}
-
-private extension ProductFormViewModel_UpdatesTests {
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -103,8 +103,8 @@ private extension Product_ProductFormTests {
                        date: Date(),
                        dateCreated: Date(),
                        dateModified: Date(),
-                       dateOnSaleStart: date(with: "2019-10-15T21:30:00"),
-                       dateOnSaleEnd: date(with: "2019-10-27T21:29:59"),
+                       dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                       dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                        productTypeKey: "booking",
                        statusKey: "publish",
                        featured: false,
@@ -158,12 +158,5 @@ private extension Product_ProductFormTests {
                        groupedProducts: [],
                        menuOrder: 0,
                        addOns: [])
-    }
-
-    private func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/MockProductVariation.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockProductVariation.swift
@@ -10,14 +10,14 @@ final class MockProductVariation {
                                 productVariationID: variationID,
                                 attributes: [],
                                 image: ProductImage(imageID: 2432,
-                                                    dateCreated: dateFromGMT("2020-03-13T03:13:57"),
-                                                    dateModified: dateFromGMT("2020-07-21T08:29:16"),
+                                                    dateCreated: DateFormatter.dateFromString(with: "2020-03-13T03:13:57"),
+                                                    dateModified: DateFormatter.dateFromString(with: "2020-07-21T08:29:16"),
                                                     src: "",
                                                     name: "DSC_0010",
                                                     alt: ""),
                                 permalink: "https://chocolate.com/marble",
-                                dateCreated: dateFromGMT("2020-06-12T14:36:02"),
-                                dateModified: dateFromGMT("2020-07-21T08:35:47"),
+                                dateCreated: DateFormatter.dateFromString(with: "2020-06-12T14:36:02"),
+                                dateModified: DateFormatter.dateFromString(with: "2020-07-21T08:35:47"),
                                 dateOnSaleStart: nil,
                                 dateOnSaleEnd: nil,
                                 status: .published,
@@ -49,10 +49,5 @@ final class MockProductVariation {
                                 shippingClassID: 0,
                                 menuOrder: 1)
 
-    }
-
-    private func dateFromGMT(_ dateStringInGMT: String) -> Date {
-        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-        return dateFormatter.date(from: dateStringInGMT)!
     }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
@@ -335,7 +335,7 @@ class OrderNoteStoreTests: XCTestCase {
 private extension OrderNoteStoreTests {
     func sampleCustomerNote() -> Networking.OrderNote {
         return OrderNote(noteID: 2261,
-                         dateCreated: date(with: "2018-06-23T17:06:55"),
+                         dateCreated: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
                          note: "I love your products!",
                          isCustomerNote: true,
                          author: sampleAuthor)
@@ -343,7 +343,7 @@ private extension OrderNoteStoreTests {
 
     func sampleCustomerNoteMutated() -> Networking.OrderNote {
         return OrderNote(noteID: 2261,
-                         dateCreated: date(with: "2018-06-23T18:07:55"),
+                         dateCreated: DateFormatter.dateFromString(with: "2018-06-23T18:07:55"),
                          note: "I HATE your products!",
                          isCustomerNote: true,
                          author: sampleAuthor)
@@ -351,7 +351,7 @@ private extension OrderNoteStoreTests {
 
     func sampleSellerNote() -> Networking.OrderNote {
         return OrderNote(noteID: 2260,
-                         dateCreated: date(with: "2018-06-23T16:05:55"),
+                         dateCreated: DateFormatter.dateFromString(with: "2018-06-23T16:05:55"),
                          note: "This order is going to be a problem.",
                          isCustomerNote: false,
                          author: sampleAdminAuthor)
@@ -359,7 +359,7 @@ private extension OrderNoteStoreTests {
 
     func sampleSystemNote() -> Networking.OrderNote {
         return OrderNote(noteID: 2099,
-                         dateCreated: date(with: "2018-05-29T03:07:46"),
+                         dateCreated: DateFormatter.dateFromString(with: "2018-05-29T03:07:46"),
                          note: "Order status changed from Completed to Processing.",
                          isCustomerNote: false,
                          author: sampleSystemAuthor)
@@ -367,7 +367,7 @@ private extension OrderNoteStoreTests {
 
     func sampleNewNote() -> Networking.OrderNote {
         return OrderNote(noteID: 2235,
-                         dateCreated: date(with: "2018-06-22T15:36:20"),
+                         dateCreated: DateFormatter.dateFromString(with: "2018-06-22T15:36:20"),
                          note: "This order would be so much better with ketchup.",
                          isCustomerNote: true,
                          author: sampleAdminAuthor)
@@ -382,9 +382,9 @@ private extension OrderNoteStoreTests {
                                  status: .processing,
                                  currency: "USD",
                                  customerNote: "",
-                                 dateCreated: date(with: "2018-04-03T23:05:12"),
-                                 dateModified: date(with: "2018-04-03T23:05:14"),
-                                 datePaid: date(with: "2018-04-03T23:05:14"),
+                                 dateCreated: DateFormatter.dateFromString(with: "2018-04-03T23:05:12"),
+                                 dateModified: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
+                                 datePaid: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
                                  discountTotal: "30.00",
                                  discountTax: "1.20",
                                  shippingTotal: "0.00",
@@ -423,10 +423,4 @@ private extension OrderNoteStoreTests {
                        email: "scrambled@scrambled.com")
     }
 
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
-    }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1132,9 +1132,9 @@ private extension OrderStoreTests {
                                  status: .processing,
                                  currency: "USD",
                                  customerNote: "",
-                                 dateCreated: date(with: "2018-04-03T23:05:12"),
-                                 dateModified: date(with: "2018-04-03T23:05:14"),
-                                 datePaid: date(with: "2018-04-03T23:05:14"),
+                                 dateCreated: DateFormatter.dateFromString(with: "2018-04-03T23:05:12"),
+                                 dateModified: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
+                                 datePaid: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
                                  discountTotal: "30.00",
                                  discountTax: "1.20",
                                  shippingTotal: "0.00",
@@ -1335,13 +1335,6 @@ private extension OrderStoreTests {
                               attributes: [])
 
         return [item1]
-    }
-
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 
     func taxes() -> [Networking.OrderItemTax] {

--- a/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -441,7 +441,7 @@ private extension ProductReviewStoreTests {
         return Networking.ProductReview(siteID: sampleSiteID,
                                         reviewID: reviewID ?? sampleReviewID,
                                         productID: sampleProductID,
-                                        dateCreated: dateFromGMT("2019-08-20T06:06:29"),
+                                        dateCreated: DateFormatter.dateFromString(with: "2019-08-20T06:06:29"),
                                         statusKey: "approved",
                                         reviewer: "somereviewer",
                                         reviewerEmail: "somewhere@intheinternet.com",
@@ -455,7 +455,7 @@ private extension ProductReviewStoreTests {
         return Networking.ProductReview(siteID: sampleSiteID,
                                         reviewID: sampleReviewID,
                                         productID: sampleProductID,
-                                        dateCreated: dateFromGMT("2019-08-20T06:06:29"),
+                                        dateCreated: DateFormatter.dateFromString(with: "2019-08-20T06:06:29"),
                                         statusKey: "hold",
                                         reviewer: "someone else mutated",
                                         reviewerEmail: "somewhere@theinternet.com",
@@ -463,10 +463,5 @@ private extension ProductReviewStoreTests {
                                         review: "Meh",
                                         rating: 1,
                                         verified: true)
-    }
-
-    func dateFromGMT(_ dateStringInGMT: String) -> Date {
-        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-        return dateFormatter.date(from: dateStringInGMT)!
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1098,8 +1098,8 @@ final class ProductStoreTests: XCTestCase {
         let expectedStockStatus = ProductStockStatus.inStock
         let expectedProductRegularPrice = "12.00"
         let expectedProductSalePrice = "10.00"
-        let expectedProductSaleStart = date(with: "2019-10-15T21:30:11")
-        let expectedProductSaleEnd = date(with: "2019-10-27T21:29:50")
+        let expectedProductSaleStart = DateFormatter.dateFromString(with: "2019-10-15T21:30:11")
+        let expectedProductSaleEnd = DateFormatter.dateFromString(with: "2019-10-27T21:29:50")
         let expectedProductTaxStatus = "taxable"
         let expectedProductTaxClass = "reduced-rate"
         let expectedDownloadableFileCount = 0
@@ -1546,11 +1546,11 @@ private extension ProductStoreTests {
                        name: "Book the Green Room",
                        slug: "book-the-green-room",
                        permalink: "https://example.com/product/book-the-green-room/",
-                       date: date(with: "2019-02-19T17:33:31"),
-                       dateCreated: date(with: "2019-02-19T17:33:31"),
-                       dateModified: date(with: "2019-02-19T17:48:01"),
-                       dateOnSaleStart: date(with: "2019-10-15T21:30:00"),
-                       dateOnSaleEnd: date(with: "2019-10-27T21:29:59"),
+                       date: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateCreated: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateModified: DateFormatter.dateFromString(with: "2019-02-19T17:48:01"),
+                       dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                       dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                        productTypeKey: "booking",
                        statusKey: "publish",
                        featured: false,
@@ -1636,8 +1636,8 @@ private extension ProductStoreTests {
 
     func sampleImages() -> [Networking.ProductImage] {
         let image1 = ProductImage(imageID: 19,
-                                  dateCreated: date(with: "2018-01-26T21:49:45"),
-                                  dateModified: date(with: "2018-01-26T21:50:11"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2018-01-26T21:49:45"),
+                                  dateModified: DateFormatter.dateFromString(with: "2018-01-26T21:50:11"),
                                   src: "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
                                   name: "Vneck Tshirt",
                                   alt: "")
@@ -1702,11 +1702,11 @@ private extension ProductStoreTests {
                        name: "Book the Green Room",
                        slug: "book-the-green-room",
                        permalink: "https://example.com/product/book-the-green-room/",
-                       date: date(with: "2019-02-19T17:33:31"),
-                       dateCreated: date(with: "2019-02-19T17:33:31"),
-                       dateModified: date(with: "2019-02-19T17:48:01"),
-                       dateOnSaleStart: date(with: "2019-10-15T21:30:00"),
-                       dateOnSaleEnd: date(with: "2019-10-27T21:29:59"),
+                       date: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateCreated: DateFormatter.dateFromString(with: "2019-02-19T17:33:31"),
+                       dateModified: DateFormatter.dateFromString(with: "2019-02-19T17:48:01"),
+                       dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                       dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                        productTypeKey: "booking",
                        statusKey: "publish",
                        featured: false,
@@ -1789,14 +1789,14 @@ private extension ProductStoreTests {
 
     func sampleImagesMutated() -> [Networking.ProductImage] {
         let image1 = ProductImage(imageID: 19,
-                                  dateCreated: date(with: "2018-01-26T21:49:45"),
-                                  dateModified: date(with: "2018-01-26T21:50:11"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2018-01-26T21:49:45"),
+                                  dateModified: DateFormatter.dateFromString(with: "2018-01-26T21:50:11"),
                                   src: "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
                                   name: "Vneck Tshirt",
                                   alt: "")
         let image2 = ProductImage(imageID: 999,
-                                  dateCreated: date(with: "2019-01-26T21:44:45"),
-                                  dateModified: date(with: "2019-01-26T21:54:11"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2019-01-26T21:44:45"),
+                                  dateModified: DateFormatter.dateFromString(with: "2019-01-26T21:54:11"),
                                   src: "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/test.png",
                                   name: "ZZZTest Image",
                                   alt: "")
@@ -1837,9 +1837,9 @@ private extension ProductStoreTests {
                        name: "Paper Airplane - Black, Long",
                        slug: "paper-airplane-3",
                        permalink: "https://paperairplane.store/product/paper-airplane/?attribute_color=Black&attribute_length=Long",
-                       date: date(with: "2019-04-04T22:06:45"),
-                       dateCreated: date(with: "2019-04-04T22:06:45"),
-                       dateModified: date(with: "2019-04-09T20:24:03"),
+                       date: DateFormatter.dateFromString(with: "2019-04-04T22:06:45"),
+                       dateCreated: DateFormatter.dateFromString(with: "2019-04-04T22:06:45"),
+                       dateModified: DateFormatter.dateFromString(with: "2019-04-09T20:24:03"),
                        dateOnSaleStart: nil,
                        dateOnSaleEnd: nil,
                        productTypeKey: "variation",
@@ -1903,8 +1903,8 @@ private extension ProductStoreTests {
 
     func sampleVariationTypeImages() -> [Networking.ProductImage] {
         let image1 = ProductImage(imageID: 301,
-                                  dateCreated: date(with: "2019-04-09T20:23:58"),
-                                  dateModified: date(with: "2019-04-09T20:23:58"),
+                                  dateCreated: DateFormatter.dateFromString(with: "2019-04-09T20:23:58"),
+                                  dateModified: DateFormatter.dateFromString(with: "2019-04-09T20:23:58"),
                                   src: "https://i0.wp.com/paperairplane.store/wp-content/uploads/2019/04/paper_plane_black.png?fit=600%2C473&ssl=1",
                                   name: "paper_plane_black",
                                   alt: "")
@@ -1972,12 +1972,5 @@ private extension ProductStoreTests {
                                                             Networking.ProductAddOnOption.fake().copy(label: "No", price: "", priceType: .flatFee)
                                                            ])
         return [topping, soda, delivery]
-    }
-
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -841,16 +841,16 @@ private extension ProductVariationStoreTests {
                                 productVariationID: id,
                                 attributes: sampleProductVariationAttributes(),
                                 image: ProductImage(imageID: 1063,
-                                                    dateCreated: dateFromGMT("2019-11-01T04:12:05"),
-                                                    dateModified: dateFromGMT("2019-11-01T04:12:05"),
+                                                    dateCreated: DateFormatter.dateFromString(with: "2019-11-01T04:12:05"),
+                                                    dateModified: DateFormatter.dateFromString(with: "2019-11-01T04:12:05"),
                                                     src: imageSource,
                                                     name: "DSC_0010",
                                                     alt: ""),
                                 permalink: "https://chocolate.com/marble",
-                                dateCreated: dateFromGMT("2019-11-14T12:40:55"),
-                                dateModified: dateFromGMT("2019-11-14T13:06:42"),
-                                dateOnSaleStart: dateFromGMT("2019-10-15T21:30:00"),
-                                dateOnSaleEnd: dateFromGMT("2019-10-27T21:29:59"),
+                                dateCreated: DateFormatter.dateFromString(with: "2019-11-14T12:40:55"),
+                                dateModified: DateFormatter.dateFromString(with: "2019-11-14T13:06:42"),
+                                dateOnSaleStart: DateFormatter.dateFromString(with: "2019-10-15T21:30:00"),
+                                dateOnSaleEnd: DateFormatter.dateFromString(with: "2019-10-27T21:29:59"),
                                 status: .published,
                                 description: "<p>Nutty chocolate marble, 99% and organic.</p>\n",
                                 sku: "99%-nuts-marble",
@@ -890,9 +890,9 @@ private extension ProductVariationStoreTests {
                           status: .processing,
                           currency: "USD",
                           customerNote: "",
-                          dateCreated: dateFromGMT("2018-04-03T23:05:12"),
-                          dateModified: dateFromGMT("2018-04-03T23:05:14"),
-                          datePaid: dateFromGMT("2018-04-03T23:05:14"),
+                          dateCreated: DateFormatter.dateFromString(with: "2018-04-03T23:05:12"),
+                          dateModified: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
+                          datePaid: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
                           discountTotal: "30.00",
                           discountTax: "1.20",
                           shippingTotal: "0.00",
@@ -919,10 +919,5 @@ private extension ProductVariationStoreTests {
               total: "30.00",
               totalTax: "1.20",
               attributes: [])
-    }
-
-    func dateFromGMT(_ dateStringInGMT: String) -> Date {
-        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-        return dateFormatter.date(from: dateStringInGMT)!
     }
 }

--- a/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
@@ -476,7 +476,7 @@ private extension RefundStoreTests {
     ///
     func sampleRefund(_ siteID: Int64? = nil, refundID: Int64? = nil) -> Networking.Refund {
         let testSiteID = siteID ?? sampleSiteID
-        let testDate = date(with: "2019-10-09T16:18:23")
+        let testDate = DateFormatter.dateFromString(with: "2019-10-09T16:18:23")
         return Refund(refundID: refundID ?? sampleRefundID,
                       orderID: sampleOrderID,
                       siteID: testSiteID,
@@ -494,7 +494,7 @@ private extension RefundStoreTests {
     ///
     func sampleRefundMutated(_ siteID: Int64? = nil) -> Networking.Refund {
         let testSiteID = siteID ?? sampleSiteID
-        let testDate = date(with: "2019-10-09T16:18:23")
+        let testDate = DateFormatter.dateFromString(with: "2019-10-09T16:18:23")
         return Refund(refundID: sampleRefundID,
                       orderID: sampleOrderID,
                       siteID: testSiteID,
@@ -512,7 +512,7 @@ private extension RefundStoreTests {
     ///
     func sampleRefund2(_ siteID: Int64? = nil) -> Networking.Refund {
         let testSiteID = siteID ?? sampleSiteID
-        let testDate = date(with: "2019-10-01T19:33:46")
+        let testDate = DateFormatter.dateFromString(with: "2019-10-01T19:33:46")
         return Refund(refundID: refundID,
                       orderID: sampleOrderID,
                       siteID: testSiteID,
@@ -579,14 +579,5 @@ private extension RefundStoreTests {
                      total: "-7.00",
                      totalTax: "-0.62",
                      taxes: [.init(taxID: 1, subtotal: "", total: "-0.62")])
-    }
-
-    /// Format GMT string to Date type
-    ///
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
     }
 }

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -51,8 +51,8 @@ final class StatsStoreV4Tests: XCTestCase {
         let result: Result<Void, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveStats(siteID: self.sampleSiteID,
                                                      timeRange: .thisYear,
-                                                     earliestDateToInclude: self.date(with: "2018-06-23T17:06:55"),
-                                                     latestDateToInclude: self.date(with: "2018-06-23T17:06:55"),
+                                                     earliestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
+                                                     latestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
                                                      quantity: 2) { result in
                 promise(result)
             }
@@ -78,8 +78,8 @@ final class StatsStoreV4Tests: XCTestCase {
         let result: Result<Void, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveStats(siteID: self.sampleSiteID,
                                                      timeRange: .thisYear,
-                                                     earliestDateToInclude: self.date(with: "2018-06-23T17:06:55"),
-                                                     latestDateToInclude: self.date(with: "2018-06-23T17:06:55"),
+                                                     earliestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
+                                                     latestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
                                                      quantity: 2) { result in
                 promise(result)
             }
@@ -100,8 +100,8 @@ final class StatsStoreV4Tests: XCTestCase {
         let result: Result<Void, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveStats(siteID: self.sampleSiteID,
                                                      timeRange: .thisYear,
-                                                     earliestDateToInclude: self.date(with: "2018-06-23T17:06:55"),
-                                                     latestDateToInclude: self.date(with: "2018-06-23T17:06:55"),
+                                                     earliestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
+                                                     latestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
                                                      quantity: 2) { result in
                 promise(result)
             }
@@ -128,7 +128,7 @@ final class StatsStoreV4Tests: XCTestCase {
             let action = StatsActionV4.retrieveSiteVisitStats(siteID: self.sampleSiteID,
                                                               siteTimezone: .current,
                                                               timeRange: .thisWeek,
-                                                              latestDateToInclude: self.date(with: "2018-08-06T17:06:55")) { result in
+                                                              latestDateToInclude: DateFormatter.dateFromString(with: "2018-08-06T17:06:55")) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -158,7 +158,7 @@ final class StatsStoreV4Tests: XCTestCase {
             let action = StatsActionV4.retrieveSiteVisitStats(siteID: self.sampleSiteID,
                                                               siteTimezone: .current,
                                                               timeRange: .thisYear,
-                                                              latestDateToInclude: self.date(with: "2018-08-06T17:06:55")) { result in
+                                                              latestDateToInclude: DateFormatter.dateFromString(with: "2018-08-06T17:06:55")) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -184,7 +184,7 @@ final class StatsStoreV4Tests: XCTestCase {
             let action = StatsActionV4.retrieveSiteVisitStats(siteID: self.sampleSiteID,
                                                               siteTimezone: .current,
                                                               timeRange: .thisYear,
-                                                              latestDateToInclude: self.date(with: "2018-08-06T17:06:55")) { result in
+                                                              latestDateToInclude: DateFormatter.dateFromString(with: "2018-08-06T17:06:55")) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -205,7 +205,7 @@ final class StatsStoreV4Tests: XCTestCase {
             let action = StatsActionV4.retrieveSiteVisitStats(siteID: self.sampleSiteID,
                                                               siteTimezone: .current,
                                                               timeRange: .thisYear,
-                                                              latestDateToInclude: self.date(with: "2018-08-06T17:06:55")) { result in
+                                                              latestDateToInclude: DateFormatter.dateFromString(with: "2018-08-06T17:06:55")) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -264,8 +264,8 @@ final class StatsStoreV4Tests: XCTestCase {
         let result: Result<Void, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisYear,
-                                                              earliestDateToInclude: self.date(with: "2020-01-01T00:00:00"),
-                                                              latestDateToInclude: self.date(with: "2020-07-22T12:00:00"),
+                                                              earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
+                                                              latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: 3) { result in
                 promise(result)
             }
@@ -291,8 +291,8 @@ final class StatsStoreV4Tests: XCTestCase {
         let quantity = 6
         let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                           timeRange: .thisYear,
-                                                          earliestDateToInclude: self.date(with: "2020-01-01T00:00:00"),
-                                                          latestDateToInclude: self.date(with: "2020-07-22T12:00:00"),
+                                                          earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
+                                                          latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                           quantity: quantity) { _ in }
         store.onAction(action)
 
@@ -314,8 +314,8 @@ final class StatsStoreV4Tests: XCTestCase {
         let result: Result<Void, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisYear,
-                                                              earliestDateToInclude: self.date(with: "2020-01-01T00:00:00"),
-                                                              latestDateToInclude: self.date(with: "2020-07-22T12:00:00"),
+                                                              earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
+                                                              latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: 3) { result in
                 promise(result)
             }
@@ -412,13 +412,6 @@ final class StatsStoreV4Tests: XCTestCase {
 // MARK: - Private Methods
 //
 private extension StatsStoreV4Tests {
-    func date(with dateString: String) -> Date {
-        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
-            return Date()
-        }
-        return date
-    }
-
     // MARK: - Order Stats V4 Sample
 
     func sampleStats() -> Networking.OrderStatsV4 {


### PR DESCRIPTION
Closes: #2551

### Description

Problem: We use the same (or very similar) DateFormatter function across dozens of our Unit Tests, this is generally added as an extension to each individual file. This function is used to convert from String to Date type, for example in [ProductPriceSettingsValidatorTests.swift](https://github.com/woocommerce/woocommerce-ios/blob/762d30f9b166741c99f64a5d74009fba68f67d3d/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit%20Product/Edit%20Price/ProductPriceSettingsValidatorTests.swift#L147-L149)

The function can be found [here](https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/Networking/Networking/Extensions/DateFormatter%2BWoo.swift#L14):

```
        /// Date And Time Formatter
        ///
        public static let dateTimeFormatter: DateFormatter = {
            let formatter = DateFormatter()
            formatter.locale = Locale(identifier: "en_US_POSIX")
            formatter.timeZone = TimeZone(identifier: "GMT")
            formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH:mm:ss"
            return formatter
        }()
```

Proposed solution: This PR creates a shared helper function that can be used across unit tests. As these belong to different frameworks, like WooCommerce, Yosemite, or Networking, we can declare this shared helper in `TestKit`, where we already have general assert functions and helpers for unit tests.

The new helper function also allows optional parameters for the locale, timezone, and date format. Or defaults to the old ones if nothing needs to be changed. Thanks @itsmeichigo for the idea!

### Testing instructions

As there are a bunch of files that needed changes, I made different commits grouping these files by Framework to make it easier.

1 - Run the tests
2 - Note that the Test Suite is executed and passes successfully.

### Todo:

- [x] Check if all Unit Tests pass
- [x] Change the rest of the Unit Tests where this function is used.
- [x] Investigate: Do we need to hardcode these dates on tests? Or we can create them in the Helper? For example some sort of `date.random()`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
