### PR TITLE
Skip GlotPress file update while bumping release version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -155,7 +155,7 @@ platform :ios do
   lane :code_freeze do |options|
     ios_codefreeze_prechecks(options)
 
-    ios_bump_version_release
+    ios_bump_version_release(skip_glotpress: true)
     new_version = ios_get_app_version
     extract_release_notes_for_version(
       version: new_version,


### PR DESCRIPTION
With the recent localization tooling changes we no longer need to update the GlotPress file while bumping the release version. (or so I am told 😓 )