### PR TITLE
Update `complete_code_freeze` lane with missing step to push changes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -184,8 +184,13 @@ platform :ios do
   lane :complete_code_freeze do |options|
     ios_completecodefreeze_prechecks(options)
     generate_strings_file_for_glotpress
-    version = ios_get_app_version
-    trigger_beta_build(branch_to_build: "release/#{version}")
+
+    if ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false) || UI.confirm('Push changes to the remote and trigger the beta build?')
+      push_to_git_remote(tags: false)
+      trigger_beta_build(branch_to_build: "release/#{ios_get_app_version}")
+    else
+      UI.message('Aborting code freeze completion as requested.')
+    end
   end
 
   #####################################################################################


### PR DESCRIPTION
### Description

It's necessary to push when completing the code freeze to ensure that any commit on the branch that is not yet in the remote will reach it so that the beta build will include them.

I adopted the same pattern used by WordPress iOS, see https://github.com/wordpress-mobile/WordPress-iOS/blob/b24d907d0f6c1fffbd5df4347f4f1adefdf82b66/fastlane/lanes/release.rb#L66-L74

### Testing instructions

I tested this by hacking the lane so that 1) it could run on a non-release branch and 2) it would call the release trigger action, but not actually trigger a release (that's a safe test because this PR doesn't change that code)

You can see the changes I made [here](7d7c3878c8656a816227f105bdac60c6bde43d30). The results I got were:

<table>
<tr>
<td>

User input `n`


</td>
<td>

User input `y`

</td>
</tr>
<tr>
<td>

![image](https://user-images.githubusercontent.com/1218433/173489349-39b53be4-9231-4ce0-b840-2dd5f0f981f6.png)


</td>
<td>

![image](https://user-images.githubusercontent.com/1218433/173489359-fef0dfa9-149f-4e3f-a6a6-74f2c47b811f.png)

</td>
</tr>
</table>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
