### PR TITLE
SIWA account removal: disconnect WP.com account from Apple ID action

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -716,12 +716,8 @@ private extension StorePickerViewController {
     func removeAppleIDAccess() async -> Result<Void, Error> {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }
-            guard let credentials = self.stores.sessionManager.defaultCredentials else {
-                return continuation.resume(returning: .failure(RemoveAppleIDAccessError.noCredentials))
-            }
             let action = AccountAction.removeAppleIDAccess(dotcomAppID: ApiCredentials.dotcomAppId,
-                                                           dotcomSecret: ApiCredentials.dotcomSecret,
-                                                           authToken: credentials.authToken) { result in
+                                                           dotcomSecret: ApiCredentials.dotcomSecret) { result in
                 continuation.resume(returning: result)
             }
             self.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
@@ -123,6 +123,5 @@ private extension RemoveAppleIDAccessCoordinator {
 }
 
 enum RemoveAppleIDAccessError: Error {
-    case noCredentials
     case presenterDeallocated
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -264,12 +264,8 @@ private extension SettingsViewController {
     func removeAppleIDAccess() async -> Result<Void, Error> {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }
-            guard let credentials = self.stores.sessionManager.defaultCredentials else {
-                return continuation.resume(returning: .failure(RemoveAppleIDAccessError.noCredentials))
-            }
             let action = AccountAction.removeAppleIDAccess(dotcomAppID: ApiCredentials.dotcomAppId,
-                                                           dotcomSecret: ApiCredentials.dotcomSecret,
-                                                           authToken: credentials.authToken) { result in
+                                                           dotcomSecret: ApiCredentials.dotcomSecret) { result in
                 continuation.resume(returning: result)
             }
             self.stores.dispatch(action)

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -27,7 +27,7 @@ class AuthenticatedState: StoresManagerState {
         let network = AlamofireNetwork(credentials: credentials)
 
         services = [
-            AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: credentials.authToken),
             AppSettingsStore(dispatcher: dispatcher,
                              storageManager: storageManager,
                              fileStorage: PListFileStorage(),

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0218B4EE242E08B20083A847 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4ED242E08B20083A847 /* MediaType.swift */; };
 		0218B4F0242E091C0083A847 /* Media+MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4EF242E091C0083A847 /* Media+MediaType.swift */; };
 		0218B4F2242E09E80083A847 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4F1242E09E80083A847 /* MediaTypeTests.swift */; };
+		021BA0C428576940006E9886 /* MockDotcomAccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021BA0C328576940006E9886 /* MockDotcomAccountRemote.swift */; };
 		021EAA5C25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */; };
 		0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */; };
 		0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */; };
@@ -432,6 +433,7 @@
 		0218B4ED242E08B20083A847 /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
 		0218B4EF242E091C0083A847 /* Media+MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+MediaType.swift"; sourceTree = "<group>"; };
 		0218B4F1242E09E80083A847 /* MediaTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeTests.swift; sourceTree = "<group>"; };
+		021BA0C328576940006E9886 /* MockDotcomAccountRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDotcomAccountRemote.swift; sourceTree = "<group>"; };
 		021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItemAttribute+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Date.swift"; sourceTree = "<group>"; };
 		0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+DateTests.swift"; sourceTree = "<group>"; };
@@ -1151,6 +1153,7 @@
 				D4CBAE5F26D440FA00BBE6D1 /* MockAnnouncementsRemote.swift */,
 				02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */,
 				029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */,
+				021BA0C328576940006E9886 /* MockDotcomAccountRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -2109,6 +2112,7 @@
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				D8652E322630741000350F37 /* PaymentIntent+ReceiptParametersTests.swift in Sources */,
 				029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */,
+				021BA0C428576940006E9886 /* MockDotcomAccountRemote.swift in Sources */,
 				022F00C72472963E008CD97F /* NotificationCountStoreTests.swift in Sources */,
 				578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */,
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -14,4 +14,5 @@ public enum AccountAction: Action {
     case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Bool, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
+    case removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -14,5 +14,5 @@ public enum AccountAction: Action {
     case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Bool, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
-    case removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: (Result<Void, Error>) -> Void)
+    case removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -4,10 +4,22 @@ import Networking
 import Storage
 import WordPressKit
 
+/// For mocking `WordPressKit.AccountServiceRemoteREST`.
+protocol DotcomAccountRemoteProtocol {
+    func disconnectFromSocialService(_ service: SocialServiceName,
+                                     oAuthClientID: String,
+                                     oAuthClientSecret: String,
+                                     success: @escaping () -> Void,
+                                     failure: @escaping (NSError) -> Void)
+}
+
+extension AccountServiceRemoteREST: DotcomAccountRemoteProtocol {}
+
 // MARK: - AccountStore
 //
 public class AccountStore: Store {
     private let remote: AccountRemoteProtocol
+    private let dotcomRemote: DotcomAccountRemoteProtocol
     private var cancellables = Set<AnyCancellable>()
 
     /// Shared private StorageType for use during synchronizeSites and synchronizeSitePlan processes
@@ -16,13 +28,22 @@ public class AccountStore: Store {
         return storageManager.writerDerivedStorage
     }()
 
-    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
-        self.remote = AccountRemote(network: network)
-        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    public convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, dotcomAuthToken: String) {
+        let remote = AccountRemote(network: network)
+        let dotcomAPI = WordPressComRestApi(oAuthToken: dotcomAuthToken,
+                                            userAgent: UserAgent.defaultUserAgent,
+                                            baseUrlString: Settings.wordpressApiBaseURL)
+        let dotcomRemote = AccountServiceRemoteREST(wordPressComRestApi: dotcomAPI)
+        self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote, dotcomRemote: dotcomRemote)
     }
 
-    public init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: AccountRemoteProtocol) {
+    init(dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         network: Network,
+         remote: AccountRemoteProtocol,
+         dotcomRemote: DotcomAccountRemoteProtocol) {
         self.remote = remote
+        self.dotcomRemote = dotcomRemote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -207,10 +228,7 @@ private extension AccountStore {
     }
 
     func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let wpcomAPI = WordPressComRestApi(oAuthToken: authToken,
-                                           userAgent: UserAgent.defaultUserAgent,
-                                           baseUrlString: Settings.wordpressApiBaseURL)
-        AccountServiceRemoteREST(wordPressComRestApi: wpcomAPI)
+        dotcomRemote
             .disconnectFromSocialService(.apple,
                                          oAuthClientID: dotcomAppID,
                                          oAuthClientSecret: dotcomSecret) {

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 import Networking
 import Storage
-
+import WordPressKit
 
 // MARK: - AccountStore
 //
@@ -60,6 +60,8 @@ public class AccountStore: Store {
             synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
         case .updateAccountSettings(let userID, let tracksOptOut, let onCompletion):
             updateAccountSettings(userID: userID, tracksOptOut: tracksOptOut, onCompletion: onCompletion)
+        case .removeAppleIDAccess(let dotcomAppID, let dotcomSecret, let authToken, let onCompletion):
+            removeAppleIDAccess(dotcomAppID: dotcomAppID, dotcomSecret: dotcomSecret, authToken: authToken, onCompletion: onCompletion)
         }
     }
 }
@@ -202,6 +204,20 @@ private extension AccountStore {
                 onCompletion(.failure(error))
             }
         }
+    }
+
+    func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let wpcomAPI = WordPressComRestApi(oAuthToken: authToken,
+                                           userAgent: UserAgent.defaultUserAgent,
+                                           baseUrlString: Settings.wordpressApiBaseURL)
+        AccountServiceRemoteREST(wordPressComRestApi: wpcomAPI)
+            .disconnectFromSocialService(.apple,
+                                         oAuthClientID: dotcomAppID,
+                                         oAuthClientSecret: dotcomSecret) {
+                onCompletion(.success(()))
+            } failure: { error in
+                onCompletion(.failure(error))
+            }
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -81,8 +81,8 @@ public class AccountStore: Store {
             synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
         case .updateAccountSettings(let userID, let tracksOptOut, let onCompletion):
             updateAccountSettings(userID: userID, tracksOptOut: tracksOptOut, onCompletion: onCompletion)
-        case .removeAppleIDAccess(let dotcomAppID, let dotcomSecret, let authToken, let onCompletion):
-            removeAppleIDAccess(dotcomAppID: dotcomAppID, dotcomSecret: dotcomSecret, authToken: authToken, onCompletion: onCompletion)
+        case .removeAppleIDAccess(let dotcomAppID, let dotcomSecret, let onCompletion):
+            removeAppleIDAccess(dotcomAppID: dotcomAppID, dotcomSecret: dotcomSecret, onCompletion: onCompletion)
         }
     }
 }
@@ -227,7 +227,7 @@ private extension AccountStore {
         }
     }
 
-    func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         dotcomRemote
             .disconnectFromSocialService(.apple,
                                          oAuthClientID: dotcomAppID,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDotcomAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDotcomAccountRemote.swift
@@ -1,0 +1,30 @@
+import WordPressKit
+import XCTest
+@testable import Yosemite
+
+/// Mock for `DotcomAccountRemoteProtocol`.
+///
+final class MockDotcomAccountRemote {
+    /// Returns the value when `disconnectFromSocialService` is called.
+    var disconnectFromSocialServiceResult: Result<Void, NSError> = .success(())
+
+    /// Returns the value as a publisher when `disconnectFromSocialService` is called.
+    func whenDisconnectingFromSocialService(thenReturn result: Result<Void, NSError>) {
+        disconnectFromSocialServiceResult = result
+    }
+}
+
+extension MockDotcomAccountRemote: DotcomAccountRemoteProtocol {
+    func disconnectFromSocialService(_ service: SocialServiceName,
+                                     oAuthClientID: String,
+                                     oAuthClientSecret: String,
+                                     success: @escaping () -> Void,
+                                     failure: @escaping (NSError) -> Void) {
+        switch disconnectFromSocialServiceResult {
+        case .success:
+            success()
+        case .failure(let error):
+            failure(error)
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -44,7 +44,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccount_returns_error_upon_empty_response() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         // When
         let result: Result<Yosemite.Account, Error> = waitFor { promise in
@@ -63,7 +63,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccount_returns_error_upon_reponse_error() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         network.simulateResponse(requestUrlSuffix: "me", filename: "generic_error")
 
         // When
@@ -83,7 +83,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccount_returns_expected_account_details() throws {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         network.simulateResponse(requestUrlSuffix: "me", filename: "me")
         XCTAssertNil(viewStorage.firstObject(ofType: Storage.Account.self, matching: nil))
 
@@ -109,7 +109,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_upsertStoredAccount_effectively_updates_preexistant_accounts() {
         // Given
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         XCTAssertNil(viewStorage.firstObject(ofType: Storage.Account.self, matching: nil))
 
         // When
@@ -128,7 +128,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_upsertStoredAccount_effectively_persists_new_accounts() {
         // Given
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let remoteAccount = sampleAccountPristine()
         XCTAssertNil(viewStorage.loadAccount(userID: remoteAccount.userID))
 
@@ -146,7 +146,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccountSettings_returns_error_on_empty_response() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         // When
         let result: Result<Yosemite.AccountSettings, Error> = waitFor { promise in
@@ -164,7 +164,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccountSettings_effectively_persists_retrieved_settings() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.AccountSettings.self), 0)
 
@@ -185,7 +185,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccountSettings_effectively_update_retrieved_settings() throws {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         storageManager.insertSampleAccountSettings(readOnlyAccountSettings: sampleAccountSettings())
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.AccountSettings.self), 1)
@@ -215,7 +215,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeSites_returns_error_on_empty_response() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
@@ -450,7 +450,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeSites_deletes_sites_that_do_not_exist_remotely() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let siteIDInStorageOnly = Int64(127)
         storageManager.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteIDInStorageOnly))
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
@@ -476,7 +476,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeSites_does_not_delete_selected_site_that_does_not_exist_remotely() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let selectedSiteID = Int64(127)
         storageManager.insertSampleSite(readOnlySite: Site.fake().copy(siteID: selectedSiteID))
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
@@ -550,7 +550,7 @@ final class AccountStoreTests: XCTestCase {
 
     func test_loadAccount_returns_expected_account() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Account.self), 0)
         store.upsertStoredAccount(readOnlyAccount: sampleAccountPristine())
@@ -571,7 +571,7 @@ final class AccountStoreTests: XCTestCase {
 
     func test_loadAccount_returns_nil_for_unknown_account() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Account.self), 0)
         store.upsertStoredAccount(readOnlyAccount: sampleAccountPristine())
@@ -594,7 +594,7 @@ final class AccountStoreTests: XCTestCase {
     func test_loadAndSynchronizeSite_returns_site_already_in_storage_without_making_network_request_if_forcedUpdate_is_false() throws {
         // Given
         let network = MockNetwork()
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
         let siteID = Int64(999)
@@ -627,7 +627,7 @@ final class AccountStoreTests: XCTestCase {
         // Given
         let network = MockNetwork()
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
         // The site ID value is in `sites.json` used in the mock network.
@@ -661,7 +661,7 @@ final class AccountStoreTests: XCTestCase {
 
     func test_loadAndSynchronizeSite_returns_unknown_site_error_after_syncing_failure() throws {
         // Given
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let group = DispatchGroup()
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
@@ -693,7 +693,7 @@ final class AccountStoreTests: XCTestCase {
         // Given
         let network = MockNetwork()
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let group = DispatchGroup()
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
@@ -793,8 +793,61 @@ final class AccountStoreTests: XCTestCase {
         // Then
         XCTAssertEqual(remote.invocations, [.loadSites])
     }
+
+    func test_disconnectFromSocialService_returns_success_on_dotcom_remote_success() throws {
+        // Given
+        let network = MockNetwork()
+        let dotcomRemote = MockDotcomAccountRemote()
+        dotcomRemote.whenDisconnectingFromSocialService(thenReturn: .success(()))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockAccountRemote(),
+                                        dotcomRemote: dotcomRemote)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_disconnectFromSocialService_returns_failure_on_dotcom_remote_failure() throws {
+        // Given
+        let network = MockNetwork()
+        let dotcomRemote = MockDotcomAccountRemote()
+        let error = NSError(domain: "disconnect", code: 134)
+        dotcomRemote.whenDisconnectingFromSocialService(thenReturn: .failure(error))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockAccountRemote(),
+                                        dotcomRemote: dotcomRemote)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NSError, error)
+    }
 }
 
+private extension AccountStore {
+    convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: AccountRemoteProtocol) {
+        self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote, dotcomRemote: MockDotcomAccountRemote())
+    }
+}
 
 // MARK: - Private Methods
 //

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -807,7 +807,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "") { result in
                 promise(result)
             }
             accountStore.onAction(action)
@@ -831,7 +831,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "") { result in
                 promise(result)
             }
             accountStore.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7068 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After the UI navigation in https://github.com/woocommerce/woocommerce-ios/pull/7070, this PR implemented the actual action in Yosemite layer to disconnect a WP.com account from user's Apple ID from SIWA. Since the actual API request is already implemented in `WordPressKit.AccountServiceRemoteREST`, the Yosemite layer called its `disconnectFromSocialService` function so that we don't reinvent the wheel. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please test this on a physical device, since SIWA doesn't work on simulators for both @itsmeichigo and me.

#### SIWA without a connected store

Prerequisite: the WP.com account associated with the Apple ID isn't connected to any WC stores

- Log out from the app if needed
- Tap "Continue with WordPress.com"
- Tap "Continue with Apple" to sign in with Apple --> after completing the SIWA flow, the empty stores screen should be shown. There should be a "Remove Apple ID Access" button. In WordPress.com `https://wordpress.com/me/security/social-login`, the Apple account should be connected
- Tap "Remove Apple ID Access" --> a confirmation alert should be shown
- Tap "Remove" to confirm --> an in-progress UI modal should be shown and then dismissed, and the app is back to the beginning of the login screen. In WordPress.com `https://wordpress.com/me/security/social-login`, the Apple account should not be connected anymore

#### SIWA with a connected store

Prerequisite: the WP.com account associated with the Apple ID is connected to at least one WC store.

- Log out from the app if needed
- Tap "Continue with WordPress.com"
- Tap "Continue with Apple" to sign in with Apple --> after completing the SIWA flow, select a store if needed
- Go to Settings --> there should be a "Remove Apple ID Access" button above the Log Out section
- Tap "Remove Apple ID Access" --> a confirmation alert should be shown
- Tap "Remove" to confirm --> an in-progress UI modal should be shown and then dismissed, and the app is now logged out. In WordPress.com `https://wordpress.com/me/security/social-login`, the Apple account should not be connected anymore

#### Error scenario

- [x] @jaclync tests the error scenario (e.g. offline)

<img src="https://user-images.githubusercontent.com/1945542/173506484-667fbe39-ca37-4fb9-850e-06a4395c61a9.PNG" width="300" />

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

The UI flow should be the same as the previous PR https://github.com/woocommerce/woocommerce-ios/pull/7070.

In WordPress.com:

connected | disconnected
-- | --
<img width="1193" alt="Screen Shot 2022-06-14 at 1 59 46 PM" src="https://user-images.githubusercontent.com/1945542/173506230-4f7825e6-982a-468a-9409-f0c4497ec570.png"> | <img width="1192" alt="Screen Shot 2022-06-14 at 1 58 28 PM" src="https://user-images.githubusercontent.com/1945542/173506212-121d6360-5027-4333-8ef2-86852edaf42e.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
