### PR TITLE
Hack Week: introduction of "hot reload" using Inject

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Please, remember to not add this information on your commits and PRs.
 - Features
     - [In-app Feedback](docs/in-app-feedback.md)
     - [Card Present Payments](docs/card-present-payments.md)
+- Other
+    - [Enable hot reload with Inject](docs/inject-hot-reload)
 
 ## 👏 Contributing
 

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "Inject",
+        "repositoryURL": "https://github.com/krzysztofzablocki/Inject.git",
+        "state": {
+          "branch": null,
+          "revision": "c0ed5f5de62475e286a3b7c676cec99fa34533ce",
+          "version": "1.1.1"
+        }
+      },
+      {
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -13,6 +13,9 @@ import AutomatticTracks
 
 import class Yosemite.ScreenshotStoresManager
 
+// In that way, Inject will be available in the entire target.
+@_exported import Inject
+
 #if DEBUG
 import Wormholy
 #endif
@@ -69,6 +72,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Upgrade check...
         checkForUpgrades()
+
+        // Since we are using Injection for refreshing the content of the app in debug mode,
+        // we are going to enable Inject.animation that will be used when
+        // ever new source code is injected into our application.
+        Inject.animation = .interactiveSpring()
 
         return true
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -6,6 +6,8 @@ import Yosemite
 /// and will be the entry point of the `Menu` Tab.
 ///
 struct HubMenu: View {
+    @ObservedObject private var iO = Inject.observer
+
     @ObservedObject private var viewModel: HubMenuViewModel
     @State private var showingWooCommerceAdmin = false
     @State private var showingViewStore = false
@@ -99,6 +101,7 @@ struct HubMenu: View {
                 EmptyView()
             }
         }
+        .enableInjection()
         .navigationBarHidden(true)
         .background(Color(.listBackground).edgesIgnoringSafeArea(.all))
         .onAppear {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -10288,10 +10288,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-Xlinker",
-					"-interposable",
-				);
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = ALPHA;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -10602,10 +10598,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-Xlinker",
-					"-interposable",
-				);
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WooCommerce-Bridging-Header.h";

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -795,6 +795,7 @@
 		4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */; };
 		45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EB92603F632006CDFB8 /* MapsHelper.swift */; };
 		45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EBF2604C167006CDFB8 /* PhoneHelper.swift */; };
+		4598298128574688003A9AFE /* Inject in Frameworks */ = {isa = PBXBuildFile; productRef = 4598298028574688003A9AFE /* Inject */; };
 		459D324327849B0B001155AA /* ReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459D324227849B0B001155AA /* ReviewDetailView.swift */; };
 		459DB7D52673721300E2CAD2 /* TopLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459DB7D42673721300E2CAD2 /* TopLoaderView.swift */; };
 		459DB7E2267372ED00E2CAD2 /* TopLoaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 459DB7E1267372ED00E2CAD2 /* TopLoaderView.xib */; };
@@ -3515,6 +3516,7 @@
 				3FFC5EAC2851942F00563C48 /* Charts in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
 				263E37E12641AD8300260D3B /* Codegen in Frameworks */,
+				4598298128574688003A9AFE /* Inject in Frameworks */,
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */,
@@ -8144,6 +8146,7 @@
 				45455E312657C3F300BBB0C4 /* Shimmer */,
 				174CA86927D90A6200126524 /* AutomatticAbout */,
 				3FFC5EAB2851942F00563C48 /* Charts */,
+				4598298028574688003A9AFE /* Inject */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -8306,6 +8309,7 @@
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
+				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -10284,6 +10288,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-Xlinker",
+					"-interposable",
+				);
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = ALPHA;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -10533,6 +10541,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-Xlinker",
+					"-interposable",
+				);
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WooCommerce-Bridging-Header.h";
@@ -10590,6 +10602,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-Xlinker",
+					"-interposable",
+				);
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WooCommerce-Bridging-Header.h";
@@ -10966,6 +10982,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/krzysztofzablocki/Inject.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -11026,6 +11050,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */;
 			productName = Shimmer;
+		};
+		4598298028574688003A9AFE /* Inject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */;
+			productName = Inject;
 		};
 		57150E0E24F462C200E81611 /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/docs/inject-hot-reload.md
+++ b/docs/inject-hot-reload.md
@@ -78,3 +78,7 @@ There are several reasons. I'd like to test everything in SwiftUI preview, but t
 If you need to test something fast, with real data, maybe in multiple flows, it's not the ideal solution. It's useful for small components (like a table row) but not too much useful for entire views or flows.
 Using hot reloading, allow us to have a faster workflow, and you don't need to restart the app in the simulator every time, which save you a lot of time.
 
+
+## Tips
+
+- If a view embedded in a `UIHostingController` is not refreshing properly, it's because you should wrap the view controller under `Inject.ViewControllerHost`.

--- a/docs/inject-hot-reload.md
+++ b/docs/inject-hot-reload.md
@@ -1,0 +1,77 @@
+# Hot Reloading using Inject
+
+In the app, we implemented an optional hot reloading functionality to speed up the development process.
+
+From an interesting [article](https://merowing.info/2022/04/hot-reloading-in-swift/) of Krzysztof Zabłocki:
+> Hot reloading is about getting rid of compiling your whole application and avoiding deploy/restart cycles as much as possible while allowing you to edit your running application code and see changes reflected immediately.
+> 
+> This process improvement can save you literally hours of development time, each day. I tracked my work for over a month, and for me, it was between 1-2h each day.
+
+I found too that the hot reloading functionality is an incredible time saver, since I don't have to recompile the entire app to see a change. Indeed, I can even modify the logic within a view model to immediately see the graphic or logical implications behind a specific change.
+
+## Inject
+For implementing the hot reloading functionality, we used [Inject](https://github.com/krzysztofzablocki/Inject), an open source library under MIT license that allow us with one or two lines of codes to enable the hot reloading functionality with `UIKit` or `SwiftUI`.
+
+The library is imported using SPM.
+
+## Setup
+For enabling the hot reload, there is a small individual developer setup that you should follow on your machine.
+
+1) Download the newest version of **Xcode Injection** app from it's [GitHub page](https://github.com/johnno1962/InjectionIII/releases) or from the [Mac App Store](https://apps.apple.com/app/injectioniii/id1380446739?mt=12) and install it.
+
+2) Unpack it and place it under `/Applications`.
+
+3) Make sure that the Xcode version you are using to compile our projects is under the default location: `/Applications/Xcode.app`. This is super important, unfortunately Xcode Injection doesn't work if your Xcode is not under this path or it's called with a different name.
+
+4) Run the injection application.
+
+5) From the injection application in the manu bar, select open project from it's menu and pick the right workspace file you are using.
+
+6) Launch the WCiOS app from Xcode. If everything works properly, you should see in the console log something similar:
+```
+💉 InjectionIII connected /Users/youruserpath/woocommerce-ios/WooCommerce/WooCommerce.xcodeproj
+💉 Watching files under /Users/youruserpath/woocommerce-ios/WooCommerce
+```
+
+## Enable hot reload in SwiftUI
+
+Just 2 steps to enable injection in your SwiftUI Views
+
+- Add `@ObservedObject private var iO = Inject.observer` yo your view struct.
+- Call `.enableInjection()` at the end of your body definition.
+
+**Remember you don't need to remove this code when you are done, it's NO-OP in production builds.**
+
+## Enable hot reload in UIKit / AppKit
+
+The situation here is a little bit more complex, but still feasable.
+
+If you are initializing and assigning a view or a view controller, just wrap it inside `Inject.ViewHost` or `Inject.ViewControllerHost`.
+
+Case for a view:
+```
+paneA = Inject.ViewHost(
+  PaneAView(whatever: arguments, you: want)
+)
+```
+
+Case for a view controller:
+```
+let viewController = Inject.ViewControllerHost(YourViewController())
+rootViewController.pushViewController(viewController, animated: true)
+```
+
+**Remember you don't need to remove this code when you are done, it's NO-OP in production builds.**
+
+
+## Questions
+
+#### Why not use Playground?
+While Apple has made great strides with [Playground](https://www.apple.com/swift/playgrounds/), it is not an environment born for large projects. You can only test small pieces of code in Playground, and it's not ideal for our app. Playground was born as an environment for experimenting, and is more useful for learning.
+
+#### Why not use SwiftUI preview?
+There are several reasons. I'd like to test everything in SwiftUI preview, but the preview functionality of SwiftUI is still broken and slow 🐌
+
+If you need to test something fast, with real data, maybe in multiple flows, it's not the ideal solution. It's useful for small components (like a table row) but not too much useful for entire views or flows.
+Using hot reloading, allow us to have a faster workflow, and you don't need to restart the app in the simulator every time, which save you a lot of time.
+

--- a/docs/inject-hot-reload.md
+++ b/docs/inject-hot-reload.md
@@ -37,7 +37,7 @@ For enabling the hot reload, there is a small individual developer setup that yo
 
 Just 2 steps to enable injection in your SwiftUI Views
 
-- Add `@ObservedObject private var iO = Inject.observer` yo your view struct.
+- Add `@ObservedObject private var iO = Inject.observer` to your view struct.
 - Call `.enableInjection()` at the end of your body definition.
 
 **Remember you don't need to remove this code when you are done, it's NO-OP in production builds.**

--- a/docs/inject-hot-reload.md
+++ b/docs/inject-hot-reload.md
@@ -17,15 +17,15 @@ The library is imported using SPM.
 ## Setup
 For enabling the hot reload, there is a small individual developer setup that you should follow on your machine.
 
-1) Download the newest version of **Xcode Injection** app from it's [GitHub page](https://github.com/johnno1962/InjectionIII/releases) or from the [Mac App Store](https://apps.apple.com/app/injectioniii/id1380446739?mt=12) and install it.
+1) Download the newest version of **Xcode Injection** app from its [GitHub page](https://github.com/johnno1962/InjectionIII/releases) or from the [Mac App Store](https://apps.apple.com/app/injectioniii/id1380446739?mt=12) and install it.
 
 2) Unpack it and place it under `/Applications`.
 
-3) Make sure that the Xcode version you are using to compile our projects is under the default location: `/Applications/Xcode.app`. This is super important, unfortunately Xcode Injection doesn't work if your Xcode is not under this path or it's called with a different name.
+3) Make sure that the Xcode version you are using to compile our projects is under the default location: `/Applications/Xcode.app`. This is super important, unfortunately, Xcode Injection doesn't work if your Xcode is not under this path or it's called with a different name.
 
 4) Run the injection application.
 
-5) From the injection application in the manu bar, select open project from it's menu and pick the right workspace file you are using.
+5) From the injection application in the menu bar, select "open project" from its menu and pick the right workspace file you are using.
 
 6) Launch the WCiOS app from Xcode. If everything works properly, you should see in the console log something similar:
 ```

--- a/docs/inject-hot-reload.md
+++ b/docs/inject-hot-reload.md
@@ -41,6 +41,8 @@ Just 2 steps to enable injection in your SwiftUI Views
 - Call `.enableInjection()` at the end of your body definition.
 
 **Remember you don't need to remove this code when you are done, it's NO-OP in production builds.**
+** Keep also in mind that if you try to add the injection in a view while the app is running, you will experience a crash **
+
 
 ## Enable hot reload in UIKit / AppKit
 
@@ -62,6 +64,7 @@ rootViewController.pushViewController(viewController, animated: true)
 ```
 
 **Remember you don't need to remove this code when you are done, it's NO-OP in production builds.**
+** Keep also in mind that if you try to add the injection in a view while the app is running, you will experience a crash **
 
 
 ## Questions


### PR DESCRIPTION
### Description
As part of the Hack Week, I started integrating the [Hot Reload](https://merowing.info/2022/04/hot-reloading-in-swift/) in our project using the [Inject](https://github.com/krzysztofzablocki/Inject) open-source library (MIT license). With hot reload, we can speed up our development process at 1000% 🚀 Stop the distractions of compiling the project. During my tests, I literally saved hours during the development phase, and this is confirmed by other developers who take advantage of the hot reload.

See the changes live in the app, in an instant, exactly like developing for the web. It is as if compilation times no longer exist, and it is as if Swift became an interpreted language. 🤯 

I'd like to merge this PR before the end of the Hack Week, in this way the whole team can test it, and eventually, if some issues come up, I can remove it. However, the library will only work in Debug, so there should be no problems during the release phases.

### Testing instructions
For enabling the hot reload, there is a small individual developer setup that you should follow on your machine.

1) Download the newest version of **Xcode Injection** app from its [GitHub page](https://github.com/johnno1962/InjectionIII/releases) or from the [Mac App Store](https://apps.apple.com/app/injectioniii/id1380446739?mt=12) and install it.

2) Unpack it and place it under `/Applications`.

3) Make sure that the Xcode version you are using to compile our projects is under the default location: `/Applications/Xcode.app`. This is super important, unfortunately, Xcode Injection doesn't work if your Xcode is not under this path or it's called with a different name.

4) Run the injection application.

5) From the injection application in the menu bar, select "open project" from its menu and pick the right workspace file you are using.

6) Launch the WCiOS app from Xcode. If everything works properly, you should see in the console log something similar:
```
💉 InjectionIII connected /Users/youruserpath/woocommerce-ios/WooCommerce/WooCommerce.xcodeproj
💉 Watching files under /Users/youruserpath/woocommerce-ios/WooCommerce
```

7) Enjoy it! 🚀 You can try to do some changes in `HubMenu` which is ready to use Inject. Read the documentation I pushed in this PR for applying hot reload to other views.

### Demo
https://user-images.githubusercontent.com/495617/173554333-54ea269c-191b-463f-918d-97eba56088bf.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
