### PR TITLE
[WIP] [Mobile Payments] Use selected gateway for In-Person Payments

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -692,9 +692,9 @@ extension OrderDetailsViewModel {
     /// Handles receipt sharing.
     ///
     func collectPayment(rootViewController: UIViewController, onCollect: @escaping (Result<Void, Error>) -> Void) {
-        cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(from: rootViewController) { [weak self] in
+        cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(from: rootViewController) { [weak self] plugin in
             guard let self = self else { return }
-            guard let paymentGateway = self.cardPresentPaymentGatewayAccounts.first else {
+            guard let paymentGateway = self.cardPresentPaymentGatewayAccounts.first(where: { $0.gatewayID == plugin.gatewayID }) else {
                 return DDLogError("⛔️ Payment Gateway not found, can't collect payment.")
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -156,7 +156,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
                       onCompletion: @escaping (Result<Void, Error>) -> Void) {
         if let charge = details.charge, shouldRefundWithCardReader(details: details) {
             cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
-                from: rootViewController) { [weak self] in
+                from: rootViewController) { [weak self] _ in
                 guard let self = self else { return }
                 guard let refundAmount = self.currencyFormatter.convertToDecimal(self.details.amount) else {
                     DDLogError("Error: attempted to refund an order without a valid amount.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Method/SimplePaymentsMethodsViewModel.swift
@@ -185,7 +185,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
         }
 
         cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
-            from: rootViewController) { [weak self] in
+            from: rootViewController) { [weak self] plugin in
                 guard let self = self else { return }
 
                 guard let order = self.ordersResultController.fetchedObjects.first else {
@@ -193,7 +193,7 @@ final class SimplePaymentsMethodsViewModel: ObservableObject {
                     return self.presentNoticeSubject.send(.error(Localization.genericCollectError))
                 }
 
-                guard let paymentGateway = self.gatewayAccountResultsController.fetchedObjects.first else {
+                guard let paymentGateway = self.gatewayAccountResultsController.fetchedObjects.first(where: { $0.gatewayID == plugin.gatewayID}) else {
                     DDLogError("⛔️ Payment Gateway not found, can't collect payment.")
                     return self.presentNoticeSubject.send(.error(Localization.genericCollectError))
                 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
@@ -1,13 +1,14 @@
 import UIKit
+import Yosemite
 @testable import WooCommerce
 
 final class MockCardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting {
     var spyShowOnboardingWasCalled = false
 
     func showOnboardingIfRequired(from viewController: UIViewController,
-                                  readyToCollectPayment completion: @escaping (() -> ())) {
+                                  readyToCollectPayment completion: @escaping ((CardPresentPaymentsPlugin) -> ())) {
         spyShowOnboardingWasCalled = true
-        completion()
+        completion(.wcPay)
     }
 
     func refresh() {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -18,7 +18,15 @@ public final class CardPresentPaymentStore: Store {
     private let commonReaderConfigProvider: CommonReaderConfigProvider
 
     /// Which backend is the store using? Default to WCPay until told otherwise
-    private var usingBackend: CardPresentPaymentGatewayExtension = .wcpay
+    private var usingBackend: CardPresentPaymentGatewayExtension = .wcpay {
+        didSet {
+            if usingBackend != oldValue {
+                // If we switched backends, disconnect any connected reader
+                // as its connection token would be tied to the old backend
+                disconnect(onCompletion: { _ in })
+            }
+        }
+    }
 
     private let remote: WCPayRemote
     private let stripeRemote: StripeRemote


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7086 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This makes the payment flow actually use the stored preference for payments when there is more than one extension active.

It also ensures that we disconnect any connected readers when we select a different plugin to use. Connection tokens are tied to a specific account, and won't work if we switch to a different one, so we need to ensure we request a new one from the right account.

I'm putting this up for review, but also second-guessing the approach now. For this, I decided to include the selected plugin as part of the `CardPaymentReadiness` state, but thinking about #7098 and #7099, I think we'll need a more generic approach. `CardPresentPaymentsOnboardingUseCase` always dispatches `CardPresentPaymentAction.use` at the end of the account checks before returning a `complete` state, so `CardPresentPaymentStore` should always have an up-to-date selection in `usingBackend`. Maybe we can add a new `CardPresentPaymentAction.getActivePaymentGatewayAccount` to always get the right account.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Use a store that has both WCPay and Stripe extensions installed and set up.

1. Go to Settings > In-Person Payments
2. In Payment Options, make sure WCPay is selected
3. Go to orders, create a simple payment and pay with a card
4. When you go to the order details, it should say "Paid via WooCommerce In-Person Payments"
5. Go to Settings > In-Person Payments
6. In Payment Options, make sure Stripe is selected
7. Go to orders, create a simple payment and pay with a card. **Notice the reader has been disconnected and automatically reconnects.**
8. When you go to the order details, it should say "Paid via WooCommerce Stripe In-Person Payments"

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Paid with WCPay | Paid with Stripe
-|-
![Screen Shot 2022-06-15 at 16 42 40](https://user-images.githubusercontent.com/8739/173859615-4b3f54f4-c534-42f7-8d58-b383d0a00576.png) | ![Screen Shot 2022-06-15 at 16 56 29](https://user-images.githubusercontent.com/8739/173859637-7f3d7dcc-626a-4303-b559-f873b6bf0d76.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
