### PR TITLE
Use Xcode 13.4.1 in Buildkite 

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -13,18 +13,22 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.3.1
+    IMAGE_ID: xcode-13.4.1
 
 steps:
 
   #################
   # Build the CocoaPods Base Cache
-  # 
+  #
   # This prevents the base cache from infinite growth caused by storing every
   # version of every pod we've ever used.
   #################
   - label: ":cocoapods: Rebuild CocoaPods cache"
     command: |
+      # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+      echo "--- :rubygems: Fixing Ruby Setup"
+      gem install bundler
+
       echo "--- :rubygems: Setting up Gems"
       install_gems
 

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -6,7 +6,7 @@ IOS_VERSION=$3
 
 echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -4,7 +4,7 @@ echo "--- 📦 Downloading Build Artifacts"
 buildkite-agent artifact download build-products.tar .
 tar -xf build-products.tar
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.3.1
+    IMAGE_ID: xcode-13.4.1
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -10,7 +10,7 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.3.1
+    IMAGE_ID: xcode-13.4.1
 
 steps:
 


### PR DESCRIPTION
### Description
Upgrade CI to use Xcode 13.4.1

### Testing instructions
If CI is green, we're good to go. 😄 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – Not necessary

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
