### PR TITLE
[UITII] - Update test names to use snake case and disable tests instead of skip

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -13,18 +13,22 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.3.1
+    IMAGE_ID: xcode-13.4.1
 
 steps:
 
   #################
   # Build the CocoaPods Base Cache
-  # 
+  #
   # This prevents the base cache from infinite growth caused by storing every
   # version of every pod we've ever used.
   #################
   - label: ":cocoapods: Rebuild CocoaPods cache"
     command: |
+      # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+      echo "--- :rubygems: Fixing Ruby Setup"
+      gem install bundler
+
       echo "--- :rubygems: Setting up Gems"
       install_gems
 

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -6,7 +6,7 @@ IOS_VERSION=$3
 
 echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -4,7 +4,7 @@ echo "--- 📦 Downloading Build Artifacts"
 buildkite-agent artifact download build-products.tar .
 tar -xf build-products.tar
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.3.1
+    IMAGE_ID: xcode-13.4.1
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -10,7 +10,7 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.3.1
+    IMAGE_ID: xcode-13.4.1
 
 steps:
 

--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -1,24 +1,17 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Codegen",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Codegen",
             type: .dynamic,
             targets: ["Codegen"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Codegen",
             dependencies: []),

--- a/TestKit/Package.swift
+++ b/TestKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/TestKit/Package.swift
+++ b/TestKit/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -7,19 +6,14 @@ let package = Package(
     name: "TestKit",
     platforms: [.iOS(.v14)],
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "TestKit",
             targets: ["TestKit"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "Difference", url: "https://github.com/krzysztofzablocki/Difference.git", .branch("master"))
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "TestKit",
             dependencies: ["Difference"]),

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -716,12 +716,8 @@ private extension StorePickerViewController {
     func removeAppleIDAccess() async -> Result<Void, Error> {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }
-            guard let credentials = self.stores.sessionManager.defaultCredentials else {
-                return continuation.resume(returning: .failure(RemoveAppleIDAccessError.noCredentials))
-            }
             let action = AccountAction.removeAppleIDAccess(dotcomAppID: ApiCredentials.dotcomAppId,
-                                                           dotcomSecret: ApiCredentials.dotcomSecret,
-                                                           authToken: credentials.authToken) { result in
+                                                           dotcomSecret: ApiCredentials.dotcomSecret) { result in
                 continuation.resume(returning: result)
             }
             self.stores.dispatch(action)

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -771,7 +771,8 @@ extension UIImage {
     /// Rectangle on rectangle, angled
     ///
     static var rectangleOnRectangleAngled: UIImage {
-        return UIImage(systemName: "rectangle.on.rectangle.angled")!
+        return UIImage(systemName: "rectangle.on.rectangle.angled", withConfiguration: Configurations.barButtonItemSymbol)!
+            .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Search Icon - used in `UIBarButtonItem`

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -768,6 +768,12 @@ extension UIImage {
         return UIImage.gridicon(.minusSmall)
     }
 
+    /// Rectangle on rectangle, angled
+    ///
+    static var rectangleOnRectangleAngled: UIImage {
+        return UIImage(systemName: "rectangle.on.rectangle.angled")!
+    }
+
     /// Search Icon - used in `UIBarButtonItem`
     ///
     static var searchBarButtonItemImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -93,13 +93,22 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
-        assert(state == .selectPlugin)
         preferredPluginLocal = selectedPlugin
         updateState()
         if case .completed(let pluginState) = state,
            pluginState.preferred == selectedPlugin {
             savePreferredPlugin(selectedPlugin)
         }
+    }
+
+    func clearPluginSelection() {
+        guard let siteID = siteID else {
+            return
+        }
+        preferredPluginLocal = nil
+        let action = AppSettingsAction.forgetPreferredInPersonPaymentGateway(siteID: siteID)
+        stores.dispatch(action)
+        updateState()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -93,6 +93,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
+        assert(state == .selectPlugin)
         preferredPluginLocal = selectedPlugin
         updateState()
         if case .completed(let pluginState) = state,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 import Yosemite
 
+final class InPersonPaymentsSelectPluginViewController: UIHostingController<InPersonPaymentsSelectPluginView> {
+    init(selectedPlugin: CardPresentPaymentsPlugin?, onPluginSelected: @escaping (CardPresentPaymentsPlugin) -> Void) {
+        super.init(rootView: InPersonPaymentsSelectPluginView(selectedPlugin: selectedPlugin, onPluginSelected: onPluginSelected))
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 struct InPersonPaymentsSelectPluginRow: View {
     let icon: UIImage
     let name: String

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -1,16 +1,6 @@
 import SwiftUI
 import Yosemite
 
-final class InPersonPaymentsSelectPluginViewController: UIHostingController<InPersonPaymentsSelectPluginView> {
-    init(selectedPlugin: CardPresentPaymentsPlugin?, onPluginSelected: @escaping (CardPresentPaymentsPlugin) -> Void) {
-        super.init(rootView: InPersonPaymentsSelectPluginView(selectedPlugin: selectedPlugin, onPluginSelected: onPluginSelected))
-    }
-
-    @objc required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
 struct InPersonPaymentsSelectPluginRow: View {
     let icon: UIImage
     let name: String

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -76,7 +76,14 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsStripeRejected()
             case .completed(let pluginState):
                 if viewModel.showMenuOnCompletion {
-                    InPersonPaymentsMenu(pluginState: pluginState)
+                    InPersonPaymentsMenu(
+                        pluginState: pluginState,
+                        onPluginSelected: { plugin in
+                            viewModel.selectPlugin(plugin)
+                        },
+                        onPluginSelectionCleared: {
+                            viewModel.clearPluginSelection()
+                        })
                 } else {
                     InPersonPaymentsCompleted()
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -64,6 +64,10 @@ final class InPersonPaymentsViewModel: ObservableObject {
         useCase.selectPlugin(plugin)
     }
 
+    func clearPluginSelection() {
+        useCase.clearPluginSelection()
+    }
+
     private func updateLearnMoreURL(state: CardPresentPaymentOnboardingState) {
         let preferredPlugin: CardPresentPaymentsPlugin
         switch state {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
@@ -123,6 +123,5 @@ private extension RemoveAppleIDAccessCoordinator {
 }
 
 enum RemoveAppleIDAccessError: Error {
-    case noCredentials
     case presenterDeallocated
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -264,12 +264,8 @@ private extension SettingsViewController {
     func removeAppleIDAccess() async -> Result<Void, Error> {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }
-            guard let credentials = self.stores.sessionManager.defaultCredentials else {
-                return continuation.resume(returning: .failure(RemoveAppleIDAccessError.noCredentials))
-            }
             let action = AccountAction.removeAppleIDAccess(dotcomAppID: ApiCredentials.dotcomAppId,
-                                                           dotcomSecret: ApiCredentials.dotcomSecret,
-                                                           authToken: credentials.authToken) { result in
+                                                           dotcomSecret: ApiCredentials.dotcomSecret) { result in
                 continuation.resume(returning: result)
             }
             self.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleTableViewCell.swift
@@ -1,0 +1,68 @@
+import UIKit
+
+
+/// Represents a regular UITableView Cell with subtitle: [Image | Text + Subtitle |  Disclosure]
+///
+class LeftImageTitleSubtitleTableViewCell: UITableViewCell {
+
+    /// Left Image
+    ///
+    var leftImage: UIImage? {
+        get {
+            return imageView?.image
+        }
+        set {
+            imageView?.image = newValue
+        }
+    }
+
+    /// Label's Text
+    ///
+    var labelText: String? {
+        get {
+            return textLabel?.text
+        }
+        set {
+            textLabel?.text = newValue
+        }
+    }
+
+    /// Subtitle's text
+    ///
+    var subtitleLabelText: String? {
+        get {
+            return detailTextLabel?.text
+        }
+        set {
+            detailTextLabel?.text = newValue
+        }
+    }
+
+    // MARK: - Overridden Methods
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureBackground()
+        imageView?.tintColor = .primary
+        textLabel?.applyBodyStyle()
+        detailTextLabel?.applyFootnoteStyle()
+    }
+
+    private func configureBackground() {
+        applyDefaultBackgroundStyle()
+
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = .listBackground
+    }
+}
+
+// MARK: - Public Methods
+//
+extension LeftImageTitleSubtitleTableViewCell {
+    func configure(image: UIImage, text: String, subtitle: String) {
+        imageView?.image = image
+        textLabel?.text = text
+        detailTextLabel?.text = subtitle
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleTableViewCell.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="FM8-oB-eoH" detailTextLabel="UC4-Oa-QcG" style="IBUITableViewCellStyleSubtitle" id="KGk-i7-Jjw" customClass="LeftImageTitleSubtitleTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FM8-oB-eoH">
+                        <rect key="frame" x="16" y="6" width="25" height="14.5"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UC4-Oa-QcG">
+                        <rect key="frame" x="16" y="22.5" width="40.5" height="13.5"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="133" y="132"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -27,7 +27,7 @@ class AuthenticatedState: StoresManagerState {
         let network = AlamofireNetwork(credentials: credentials)
 
         services = [
-            AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: credentials.authToken),
             AppSettingsStore(dispatcher: dispatcher,
                              storageManager: storageManager,
                              fileStorage: PListFileStorage(),

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -57,11 +57,10 @@ msgctxt "app_store_promo_text"
 msgid "Run your store from anywhere"
 msgstr ""
 
-msgctxt "v9.3-whats-new"
+msgctxt "v9.4-whats-new"
 msgid ""
-"Hello Canada! We are thrilled to announce that in-person payments are now available to Canadian merchants currently using WooCommerce Payments.\n"
-"\n"
-"We also made several improvements elsewhere in the app, including support for Arabic numerals in amount fields, the ability to update coupon discount types, and copy & paste support for order notes. Thanks for all your feedback. It truly helps us make a better app for all.\n"
+"This release has several fixes for order creation and in person payments, including fixing a bug in the products section not showing the correct order of items, displaying the date and time for all orders and showing the issue refund button for all paid orders.\n"
+"Please continue to send us feedback – we are listening!\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,8 +1,2 @@
-- [*] Orders: Order details now displays both the date and time for all orders. [https://github.com/woocommerce/woocommerce-ios/pull/6996]
-- [*] Simple payments have the `Card` option available for stores with configuration issues to resolve, and show onboarding to help resolve them [https://github.com/woocommerce/woocommerce-ios/pull/7002]
-- [*] Order & Product list: Now, we can pull to refresh from an empty view. [https://github.com/woocommerce/woocommerce-ios/pull/7023, https://github.com/woocommerce/woocommerce-ios/pull/7030]
-- [*] Order Creation: Fixes a bug where selecting a variable product to add to a new order would sometimes open the wrong list of product variations. [https://github.com/woocommerce/woocommerce-ios/pull/7042]
-- [*] Collect payment button on Order Details no longer flickers when the screen loads [https://github.com/woocommerce/woocommerce-ios/pull/7043]
-- [*] Issue refund button on Order Details is shown for all paid orders [https://github.com/woocommerce/woocommerce-ios/pull/7046]
-- [*] Order Creation: Fixes several bugs with the Products section not showing the correct order items or not correctly updating the item quantity. [https://github.com/woocommerce/woocommerce-ios/pull/7067]
-
+This release has several fixes for order creation and in person payments, including fixing a bug in the products section not showing the correct order of items, displaying the date and time for all orders and showing the issue refund button for all paid orders.
+Please continue to send us feedback – we are listening!

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1665,6 +1665,8 @@
 		E15FC74126BC1CED00CF83E6 /* AttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74026BC1CED00CF83E6 /* AttributedText.swift */; };
 		E15FC74326BC1D2700CF83E6 /* SafariSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */; };
 		E15FC74526BC213500CF83E6 /* InPersonPaymentsLearnMore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */; };
+		E16058F7285876DE00E471D4 /* LeftImageTitleSubtitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E16058F6285876DE00E471D4 /* LeftImageTitleSubtitleTableViewCell.xib */; };
+		E16058F9285876E600E471D4 /* LeftImageTitleSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16058F8285876E600E471D4 /* LeftImageTitleSubtitleTableViewCell.swift */; };
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
@@ -3444,6 +3446,8 @@
 		E15FC74026BC1CED00CF83E6 /* AttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedText.swift; sourceTree = "<group>"; };
 		E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariSheet.swift; sourceTree = "<group>"; };
 		E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLearnMore.swift; sourceTree = "<group>"; };
+		E16058F6285876DE00E471D4 /* LeftImageTitleSubtitleTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LeftImageTitleSubtitleTableViewCell.xib; sourceTree = "<group>"; };
+		E16058F8285876E600E471D4 /* LeftImageTitleSubtitleTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeftImageTitleSubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
@@ -7400,6 +7404,8 @@
 				CE2A9FBE23BFB1BE002BEC1C /* LedgerTableViewCell.xib */,
 				CE1EC8EA20B8A3FF009762BF /* LeftImageTableViewCell.swift */,
 				CE1EC8EB20B8A3FF009762BF /* LeftImageTableViewCell.xib */,
+				E16058F8285876E600E471D4 /* LeftImageTitleSubtitleTableViewCell.swift */,
+				E16058F6285876DE00E471D4 /* LeftImageTitleSubtitleTableViewCell.xib */,
 				26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */,
 				318109E725E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift */,
 				318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */,
@@ -8430,6 +8436,7 @@
 				CE1EC8F020B8A408009762BF /* OrderNoteTableViewCell.xib in Resources */,
 				265BCA0E2430E771004E53EE /* ProductCategoryTableViewCell.xib in Resources */,
 				0379C51927BFE23400A7E284 /* RefundConfirmationCardDetailsCell.xib in Resources */,
+				E16058F7285876DE00E471D4 /* LeftImageTitleSubtitleTableViewCell.xib in Resources */,
 				4515262F2577D56C0076B03C /* AddAttributeViewController.xib in Resources */,
 				DECE13FC27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib in Resources */,
 				B55D4BFD20B5CDE700D7A50F /* replace_secrets.rb in Resources */,
@@ -9489,6 +9496,7 @@
 				26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */,
 				02E19B9E284745210010B254 /* LegacyProductImageUploader.swift in Sources */,
 				DE7B479527A38B8F0018742E /* CouponDetailsViewModel.swift in Sources */,
+				E16058F9285876E600E471D4 /* LeftImageTitleSubtitleTableViewCell.swift in Sources */,
 				DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */,
 				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,
 				7E7C5F862719A93C00315B61 /* ProductCategoryViewModelBuilder.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
@@ -47,6 +47,17 @@
                BlueprintName = "WooCommerceUITests"
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "LoginTests/test_WordPress_login_logout()">
+               </Test>
+               <Test
+                  Identifier = "LoginTests/test_site_address_login_logout()">
+               </Test>
+               <Test
+                  Identifier = "StatsTests/test_load_stats_screen()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
@@ -47,17 +47,6 @@
                BlueprintName = "WooCommerceUITests"
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "LoginTests/test_WordPress_login_logout()">
-               </Test>
-               <Test
-                  Identifier = "LoginTests/test_site_address_login_logout()">
-               </Test>
-               <Test
-                  Identifier = "StatsTests/test_load_stats_screen()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -19,7 +19,7 @@ class WooCommerceScreenshots: XCTestCase {
         stopWebServer()
     }
 
-    func testScreenshots() throws {
+    func test_screenshots() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         setupSnapshot(app)

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -644,4 +644,8 @@ final class IconsTests: XCTestCase {
     func test_wcpayIconImage_is_not_nil() {
         XCTAssertNotNil(UIImage.wcpayIcon)
     }
+
+    func test_rectangle_on_rectangle_angled_is_not_nil() {
+        XCTAssertNotNil(UIImage.rectangleOnRectangleAngled)
+    }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -12,10 +12,9 @@ final class LoginTests: XCTestCase {
         app.launch()
     }
 
+    // Test disabled - Pending update of the Settings flow
     // Login with Store Address and log out.
-    func testSiteAddressLoginLogout() throws {
-        try skipTillSettingsFixed()
-
+    func test_site_address_login_logout() throws {
         let prologue = try PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
@@ -33,10 +32,9 @@ final class LoginTests: XCTestCase {
         XCTAssert(prologue.isLoaded)
     }
 
+    // Test disabled - Pending update of the Settings flow
     // Login with WordPress.com account and log out
-    func testWordPressLoginLogout() throws {
-        try skipTillSettingsFixed()
-
+    func test_WordPress_login_logout() throws {
         let prologue = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
@@ -53,19 +51,10 @@ final class LoginTests: XCTestCase {
         XCTAssert(prologue.isLoaded)
     }
 
-    func testWordPressUnsuccessfullLogin() throws {
+    func test_WordPress_unsuccessfull_login() throws {
         _ = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()
-    }
-
-    func skipTillSettingsFixed(file: StaticString = #file, line: UInt = #line) throws {
-        try XCTSkipIf(true,
-            """
-            Skipping test because settings icon was moved from My Store to Hub Menu,
-            the icon no longer have an accessibilityIdentifier,
-            so test will fail during logout.
-            """, file: file, line: line)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -12,9 +12,10 @@ final class LoginTests: XCTestCase {
         app.launch()
     }
 
-    // Test disabled - Pending update of the Settings flow
     // Login with Store Address and log out.
     func test_site_address_login_logout() throws {
+        try skipTillSettingsFixed()
+
         let prologue = try PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
@@ -32,9 +33,10 @@ final class LoginTests: XCTestCase {
         XCTAssert(prologue.isLoaded)
     }
 
-    // Test disabled - Pending update of the Settings flow
     // Login with WordPress.com account and log out
     func test_WordPress_login_logout() throws {
+        try skipTillSettingsFixed()
+
         let prologue = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
@@ -56,5 +58,14 @@ final class LoginTests: XCTestCase {
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()
+    }
+
+    func skipTillSettingsFixed(file: StaticString = #file, line: UInt = #line) throws {
+        try XCTSkipIf(true,
+            """
+            Skipping test because settings icon was moved from My Store to Hub Menu,
+            the icon no longer have an accessibilityIdentifier,
+            so test will fail during logout.
+            """, file: file, line: line)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -13,7 +13,7 @@ final class OrdersTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    func testOrdersScreenLoads() throws {
+    func test_load_orders_screen() throws {
         let orders = try GetMocks.readOrdersData()
 
         try TabNavComponent().goToOrdersScreen()

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -12,7 +12,7 @@ final class ProductsTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    func testProductsScreenLoad() throws {
+    func test_load_products_screen() throws {
         let products = try GetMocks.readProductsData()
 
         try TabNavComponent().goToProductsScreen()

--- a/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
@@ -17,7 +17,7 @@ final class ReviewsTests: XCTestCase {
             .goToProductsScreen()
     }
 
-    func testReviewsScreenLoad() throws {
+    func test_load_reviews_screen() throws {
         let reviews = try GetMocks.readReviewsData()
 
         try TabNavComponent().goToMenuScreen()

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -2,8 +2,8 @@ import UITestsFoundation
 import XCTest
 
 final class StatsTests: XCTestCase {
-
     override func setUpWithError() throws {
+        try skipTillImplemented()
         continueAfterFailure = false
 
         // UI tests must launch the application that they test.
@@ -14,8 +14,12 @@ final class StatsTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    // Test disabled - Pending implementation
     func test_load_stats_screen() throws {
         try TabNavComponent().goToMyStoreScreen()
+    }
+
+    func skipTillImplemented(file: StaticString = #file, line: UInt = #line) throws {
+        try XCTSkipIf(true,
+            "Skipping until test is properly implemented", file: file, line: line)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -4,7 +4,6 @@ import XCTest
 final class StatsTests: XCTestCase {
 
     override func setUpWithError() throws {
-        try skipTillImplemented()
         continueAfterFailure = false
 
         // UI tests must launch the application that they test.
@@ -15,13 +14,8 @@ final class StatsTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    func testStatsScreenLoad() throws {
-        try skipTillImplemented()
+    // Test disabled - Pending implementation
+    func test_load_stats_screen() throws {
         try TabNavComponent().goToMyStoreScreen()
-    }
-
-    func skipTillImplemented(file: StaticString = #file, line: UInt = #line) throws {
-        try XCTSkipIf(true,
-            "Skipping until test is properly implemented", file: file, line: line)
     }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0218B4EE242E08B20083A847 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4ED242E08B20083A847 /* MediaType.swift */; };
 		0218B4F0242E091C0083A847 /* Media+MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4EF242E091C0083A847 /* Media+MediaType.swift */; };
 		0218B4F2242E09E80083A847 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4F1242E09E80083A847 /* MediaTypeTests.swift */; };
+		021BA0C428576940006E9886 /* MockDotcomAccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021BA0C328576940006E9886 /* MockDotcomAccountRemote.swift */; };
 		021EAA5C25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */; };
 		0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */; };
 		0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */; };
@@ -432,6 +433,7 @@
 		0218B4ED242E08B20083A847 /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
 		0218B4EF242E091C0083A847 /* Media+MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+MediaType.swift"; sourceTree = "<group>"; };
 		0218B4F1242E09E80083A847 /* MediaTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeTests.swift; sourceTree = "<group>"; };
+		021BA0C328576940006E9886 /* MockDotcomAccountRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDotcomAccountRemote.swift; sourceTree = "<group>"; };
 		021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItemAttribute+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Date.swift"; sourceTree = "<group>"; };
 		0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+DateTests.swift"; sourceTree = "<group>"; };
@@ -1151,6 +1153,7 @@
 				D4CBAE5F26D440FA00BBE6D1 /* MockAnnouncementsRemote.swift */,
 				02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */,
 				029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */,
+				021BA0C328576940006E9886 /* MockDotcomAccountRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -2109,6 +2112,7 @@
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				D8652E322630741000350F37 /* PaymentIntent+ReceiptParametersTests.swift in Sources */,
 				029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */,
+				021BA0C428576940006E9886 /* MockDotcomAccountRemote.swift in Sources */,
 				022F00C72472963E008CD97F /* NotificationCountStoreTests.swift in Sources */,
 				578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */,
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -14,4 +14,5 @@ public enum AccountAction: Action {
     case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Bool, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
+    case removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -14,5 +14,5 @@ public enum AccountAction: Action {
     case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Bool, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
-    case removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: (Result<Void, Error>) -> Void)
+    case removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -179,6 +179,10 @@ public enum AppSettingsAction: Action {
     ///
     case getPreferredInPersonPaymentGateway(siteID: Int64, onCompletion: (String?) -> Void)
 
+    /// Forgets the preferred payment gateway for In-Person Payments
+    ///
+    case forgetPreferredInPersonPaymentGateway(siteID: Int64)
+
     /// Clears all the products settings
     ///
     case resetGeneralStoreSettings

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -4,10 +4,22 @@ import Networking
 import Storage
 import WordPressKit
 
+/// For mocking `WordPressKit.AccountServiceRemoteREST`.
+protocol DotcomAccountRemoteProtocol {
+    func disconnectFromSocialService(_ service: SocialServiceName,
+                                     oAuthClientID: String,
+                                     oAuthClientSecret: String,
+                                     success: @escaping () -> Void,
+                                     failure: @escaping (NSError) -> Void)
+}
+
+extension AccountServiceRemoteREST: DotcomAccountRemoteProtocol {}
+
 // MARK: - AccountStore
 //
 public class AccountStore: Store {
     private let remote: AccountRemoteProtocol
+    private let dotcomRemote: DotcomAccountRemoteProtocol
     private var cancellables = Set<AnyCancellable>()
 
     /// Shared private StorageType for use during synchronizeSites and synchronizeSitePlan processes
@@ -16,13 +28,22 @@ public class AccountStore: Store {
         return storageManager.writerDerivedStorage
     }()
 
-    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
-        self.remote = AccountRemote(network: network)
-        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    public convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, dotcomAuthToken: String) {
+        let remote = AccountRemote(network: network)
+        let dotcomAPI = WordPressComRestApi(oAuthToken: dotcomAuthToken,
+                                            userAgent: UserAgent.defaultUserAgent,
+                                            baseUrlString: Settings.wordpressApiBaseURL)
+        let dotcomRemote = AccountServiceRemoteREST(wordPressComRestApi: dotcomAPI)
+        self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote, dotcomRemote: dotcomRemote)
     }
 
-    public init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: AccountRemoteProtocol) {
+    init(dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         network: Network,
+         remote: AccountRemoteProtocol,
+         dotcomRemote: DotcomAccountRemoteProtocol) {
         self.remote = remote
+        self.dotcomRemote = dotcomRemote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -207,10 +228,7 @@ private extension AccountStore {
     }
 
     func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let wpcomAPI = WordPressComRestApi(oAuthToken: authToken,
-                                           userAgent: UserAgent.defaultUserAgent,
-                                           baseUrlString: Settings.wordpressApiBaseURL)
-        AccountServiceRemoteREST(wordPressComRestApi: wpcomAPI)
+        dotcomRemote
             .disconnectFromSocialService(.apple,
                                          oAuthClientID: dotcomAppID,
                                          oAuthClientSecret: dotcomSecret) {

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 import Networking
 import Storage
-
+import WordPressKit
 
 // MARK: - AccountStore
 //
@@ -60,6 +60,8 @@ public class AccountStore: Store {
             synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
         case .updateAccountSettings(let userID, let tracksOptOut, let onCompletion):
             updateAccountSettings(userID: userID, tracksOptOut: tracksOptOut, onCompletion: onCompletion)
+        case .removeAppleIDAccess(let dotcomAppID, let dotcomSecret, let authToken, let onCompletion):
+            removeAppleIDAccess(dotcomAppID: dotcomAppID, dotcomSecret: dotcomSecret, authToken: authToken, onCompletion: onCompletion)
         }
     }
 }
@@ -202,6 +204,20 @@ private extension AccountStore {
                 onCompletion(.failure(error))
             }
         }
+    }
+
+    func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let wpcomAPI = WordPressComRestApi(oAuthToken: authToken,
+                                           userAgent: UserAgent.defaultUserAgent,
+                                           baseUrlString: Settings.wordpressApiBaseURL)
+        AccountServiceRemoteREST(wordPressComRestApi: wpcomAPI)
+            .disconnectFromSocialService(.apple,
+                                         oAuthClientID: dotcomAppID,
+                                         oAuthClientSecret: dotcomSecret) {
+                onCompletion(.success(()))
+            } failure: { error in
+                onCompletion(.failure(error))
+            }
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -81,8 +81,8 @@ public class AccountStore: Store {
             synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
         case .updateAccountSettings(let userID, let tracksOptOut, let onCompletion):
             updateAccountSettings(userID: userID, tracksOptOut: tracksOptOut, onCompletion: onCompletion)
-        case .removeAppleIDAccess(let dotcomAppID, let dotcomSecret, let authToken, let onCompletion):
-            removeAppleIDAccess(dotcomAppID: dotcomAppID, dotcomSecret: dotcomSecret, authToken: authToken, onCompletion: onCompletion)
+        case .removeAppleIDAccess(let dotcomAppID, let dotcomSecret, let onCompletion):
+            removeAppleIDAccess(dotcomAppID: dotcomAppID, dotcomSecret: dotcomSecret, onCompletion: onCompletion)
         }
     }
 }
@@ -227,7 +227,7 @@ private extension AccountStore {
         }
     }
 
-    func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, authToken: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         dotcomRemote
             .disconnectFromSocialService(.apple,
                                          oAuthClientID: dotcomAppID,

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -166,6 +166,8 @@ public class AppSettingsStore: Store {
             setPreferredInPersonPaymentGateway(siteID: siteID, gateway: gateway)
         case let .getPreferredInPersonPaymentGateway(siteID: siteID, onCompletion: onCompletion):
             getPreferredInPersonPaymentGateway(siteID: siteID, onCompletion: onCompletion)
+        case let .forgetPreferredInPersonPaymentGateway(siteID: siteID):
+            forgetPreferredInPersonPaymentGateway(siteID: siteID)
         case .resetGeneralStoreSettings:
             resetGeneralStoreSettings()
         case .setProductSKUInputScannerFeatureSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
@@ -721,6 +723,14 @@ private extension AppSettingsStore {
         let storeSettings = getStoreSettings(for: siteID)
         onCompletion(storeSettings.preferredInPersonPaymentGateway)
 
+    }
+
+    /// Forgets the preferred payment gateway for In-Person Payments
+    ///
+    func forgetPreferredInPersonPaymentGateway(siteID: Int64) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let newSettings = storeSettings.copy(preferredInPersonPaymentGateway: .some(nil))
+        setStoreSettings(settings: newSettings, for: siteID, onCompletion: nil)
     }
 
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDotcomAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDotcomAccountRemote.swift
@@ -1,0 +1,30 @@
+import WordPressKit
+import XCTest
+@testable import Yosemite
+
+/// Mock for `DotcomAccountRemoteProtocol`.
+///
+final class MockDotcomAccountRemote {
+    /// Returns the value when `disconnectFromSocialService` is called.
+    var disconnectFromSocialServiceResult: Result<Void, NSError> = .success(())
+
+    /// Returns the value as a publisher when `disconnectFromSocialService` is called.
+    func whenDisconnectingFromSocialService(thenReturn result: Result<Void, NSError>) {
+        disconnectFromSocialServiceResult = result
+    }
+}
+
+extension MockDotcomAccountRemote: DotcomAccountRemoteProtocol {
+    func disconnectFromSocialService(_ service: SocialServiceName,
+                                     oAuthClientID: String,
+                                     oAuthClientSecret: String,
+                                     success: @escaping () -> Void,
+                                     failure: @escaping (NSError) -> Void) {
+        switch disconnectFromSocialServiceResult {
+        case .success:
+            success()
+        case .failure(let error):
+            failure(error)
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -44,7 +44,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccount_returns_error_upon_empty_response() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         // When
         let result: Result<Yosemite.Account, Error> = waitFor { promise in
@@ -63,7 +63,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccount_returns_error_upon_reponse_error() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         network.simulateResponse(requestUrlSuffix: "me", filename: "generic_error")
 
         // When
@@ -83,7 +83,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccount_returns_expected_account_details() throws {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         network.simulateResponse(requestUrlSuffix: "me", filename: "me")
         XCTAssertNil(viewStorage.firstObject(ofType: Storage.Account.self, matching: nil))
 
@@ -109,7 +109,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_upsertStoredAccount_effectively_updates_preexistant_accounts() {
         // Given
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         XCTAssertNil(viewStorage.firstObject(ofType: Storage.Account.self, matching: nil))
 
         // When
@@ -128,7 +128,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_upsertStoredAccount_effectively_persists_new_accounts() {
         // Given
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let remoteAccount = sampleAccountPristine()
         XCTAssertNil(viewStorage.loadAccount(userID: remoteAccount.userID))
 
@@ -146,7 +146,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccountSettings_returns_error_on_empty_response() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         // When
         let result: Result<Yosemite.AccountSettings, Error> = waitFor { promise in
@@ -164,7 +164,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccountSettings_effectively_persists_retrieved_settings() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.AccountSettings.self), 0)
 
@@ -185,7 +185,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeAccountSettings_effectively_update_retrieved_settings() throws {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         storageManager.insertSampleAccountSettings(readOnlyAccountSettings: sampleAccountSettings())
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.AccountSettings.self), 1)
@@ -215,7 +215,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeSites_returns_error_on_empty_response() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
@@ -450,7 +450,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeSites_deletes_sites_that_do_not_exist_remotely() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let siteIDInStorageOnly = Int64(127)
         storageManager.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteIDInStorageOnly))
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
@@ -476,7 +476,7 @@ final class AccountStoreTests: XCTestCase {
     ///
     func test_synchronizeSites_does_not_delete_selected_site_that_does_not_exist_remotely() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let selectedSiteID = Int64(127)
         storageManager.insertSampleSite(readOnlySite: Site.fake().copy(siteID: selectedSiteID))
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
@@ -550,7 +550,7 @@ final class AccountStoreTests: XCTestCase {
 
     func test_loadAccount_returns_expected_account() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Account.self), 0)
         store.upsertStoredAccount(readOnlyAccount: sampleAccountPristine())
@@ -571,7 +571,7 @@ final class AccountStoreTests: XCTestCase {
 
     func test_loadAccount_returns_nil_for_unknown_account() {
         // Given
-        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
 
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Account.self), 0)
         store.upsertStoredAccount(readOnlyAccount: sampleAccountPristine())
@@ -594,7 +594,7 @@ final class AccountStoreTests: XCTestCase {
     func test_loadAndSynchronizeSite_returns_site_already_in_storage_without_making_network_request_if_forcedUpdate_is_false() throws {
         // Given
         let network = MockNetwork()
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
         let siteID = Int64(999)
@@ -627,7 +627,7 @@ final class AccountStoreTests: XCTestCase {
         // Given
         let network = MockNetwork()
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
         // The site ID value is in `sites.json` used in the mock network.
@@ -661,7 +661,7 @@ final class AccountStoreTests: XCTestCase {
 
     func test_loadAndSynchronizeSite_returns_unknown_site_error_after_syncing_failure() throws {
         // Given
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let group = DispatchGroup()
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
@@ -693,7 +693,7 @@ final class AccountStoreTests: XCTestCase {
         // Given
         let network = MockNetwork()
         network.simulateResponse(requestUrlSuffix: "me/sites", filename: "sites")
-        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: "")
         let group = DispatchGroup()
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self), 0)
 
@@ -793,8 +793,61 @@ final class AccountStoreTests: XCTestCase {
         // Then
         XCTAssertEqual(remote.invocations, [.loadSites])
     }
+
+    func test_disconnectFromSocialService_returns_success_on_dotcom_remote_success() throws {
+        // Given
+        let network = MockNetwork()
+        let dotcomRemote = MockDotcomAccountRemote()
+        dotcomRemote.whenDisconnectingFromSocialService(thenReturn: .success(()))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockAccountRemote(),
+                                        dotcomRemote: dotcomRemote)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_disconnectFromSocialService_returns_failure_on_dotcom_remote_failure() throws {
+        // Given
+        let network = MockNetwork()
+        let dotcomRemote = MockDotcomAccountRemote()
+        let error = NSError(domain: "disconnect", code: 134)
+        dotcomRemote.whenDisconnectingFromSocialService(thenReturn: .failure(error))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockAccountRemote(),
+                                        dotcomRemote: dotcomRemote)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NSError, error)
+    }
 }
 
+private extension AccountStore {
+    convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: AccountRemoteProtocol) {
+        self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote, dotcomRemote: MockDotcomAccountRemote())
+    }
+}
 
 // MARK: - Private Methods
 //

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -807,7 +807,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "") { result in
                 promise(result)
             }
             accountStore.onAction(action)
@@ -831,7 +831,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "", authToken: "") { result in
+            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "") { result in
                 promise(result)
             }
             accountStore.onAction(action)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -184,8 +184,13 @@ platform :ios do
   lane :complete_code_freeze do |options|
     ios_completecodefreeze_prechecks(options)
     generate_strings_file_for_glotpress
-    version = ios_get_app_version
-    trigger_beta_build(branch_to_build: "release/#{version}")
+
+    if ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false) || UI.confirm('Push changes to the remote and trigger the beta build?')
+      push_to_git_remote(tags: false)
+      trigger_beta_build(branch_to_build: "release/#{ios_get_app_version}")
+    else
+      UI.message('Aborting code freeze completion as requested.')
+    end
   end
 
   #####################################################################################


### PR DESCRIPTION
### Description
- To ensure that all tests naming conventions are consistent in this repo, updating UI existing UI tests to use snake_case instead of camelCase. 
- Update skipped tests to be disabled instead of skipping the test steps. Noticed that when a test is skipped, the simulator is still launched and then closed since there's nothing to run. This took more than 5 seconds each time when tested locally. When the test is disabled, the simulator is not launched for that test and should save us some time. I was also the one who added the skip function initially thinking it might be beneficial to have it printed in the logs. Considering we have not revisited the skipped tests since looks like the initial idea was not really valuable so having it disabled instead should be fine. 

### Testing instructions
Ensure that UI tests still pass on the CI.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
This was tested using the same device/iOS combo that's used by CI, locally:
Using skip instead of disabling tests:
```
Test Suite 'WooCommerceUITests.xctest' passed at 2022-06-15 16:05:55.940.
	 Executed 9 tests, with 3 tests skipped and 0 failures (0 unexpected) in 340.568 (340.577) seconds
Test Suite 'All tests' passed at 2022-06-15 16:05:55.940.
	 Executed 9 tests, with 3 tests skipped and 0 failures (0 unexpected) in 340.568 (340.579) seconds
```

Disabling tests instead of using skip functions:
```
Test Suite 'WooCommerceUITests.xctest' passed at 2022-06-15 15:59:08.960.
	 Executed 6 tests, with 0 failures (0 unexpected) in 322.119 (322.128) seconds
Test Suite 'Selected tests' passed at 2022-06-15 15:59:08.961.
	 Executed 6 tests, with 0 failures (0 unexpected) in 322.119 (322.130) seconds
```

Time savings: ~18 seconds

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
