### PR TITLE
Fix BottomSheets visual tap feedback

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/DiscountTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/DiscountTypeBottomSheetListSelectorCommand.swift
@@ -29,7 +29,8 @@ final class DiscountTypeBottomSheetListSelectorCommand: BottomSheetListSelectorC
                                                                     imageTintColor: .gray(.shade20),
                                                                     numberOfLinesForText: 0,
                                                                     isSelected: isSelected(model: model),
-                                                                    isActionable: false)
+                                                                    isActionable: false,
+                                                                    showsDisclosureIndicator: true)
         cell.updateUI(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/DiscountTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/DiscountTypeBottomSheetListSelectorCommand.swift
@@ -28,9 +28,8 @@ final class DiscountTypeBottomSheetListSelectorCommand: BottomSheetListSelectorC
                                                                     image: model.actionSheetIcon,
                                                                     imageTintColor: .gray(.shade20),
                                                                     numberOfLinesForText: 0,
-                                                                    isSelected: isSelected(model: model),
-                                                                    isActionable: false,
-                                                                    showsDisclosureIndicator: true)
+                                                                    isSelected: isSelected(model: model)
+        )
         cell.updateUI(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
@@ -78,7 +78,7 @@ final class OrderTypeBottomSheetListSelectorCommand: BottomSheetListSelectorComm
                                                                     imageTintColor: .gray(.shade20),
                                                                     numberOfLinesForTitle: 0,
                                                                     numberOfLinesForText: 0,
-                                                                    isActionable: false)
+                                                                    isActionable: true)
         cell.updateUI(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/FlowCoordinator/BottomSheetOrderType.swift
@@ -77,8 +77,7 @@ final class OrderTypeBottomSheetListSelectorCommand: BottomSheetListSelectorComm
                                                                     image: model.actionSheetImage,
                                                                     imageTintColor: .gray(.shade20),
                                                                     numberOfLinesForTitle: 0,
-                                                                    numberOfLinesForText: 0,
-                                                                    isActionable: true)
+                                                                    numberOfLinesForText: 0)
         cell.updateUI(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -163,8 +163,7 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
                                                                     text: model.actionSheetDescription,
                                                                     image: model.actionSheetImage,
                                                                     imageTintColor: .gray(.shade20),
-                                                                    numberOfLinesForText: 0,
-                                                                    isActionable: false)
+                                                                    numberOfLinesForText: 0)
         cell.updateUI(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -68,6 +68,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         let numberOfLinesForText: Int
         let isActionable: Bool
         let isSelected: Bool
+        let showsDisclosureIndicator: Bool
         let showsSeparator: Bool
 
         init(title: String?,
@@ -80,6 +81,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
              numberOfLinesForText: Int = 1,
              isSelected: Bool = false,
              isActionable: Bool = true,
+             showsDisclosureIndicator: Bool = false,
              showsSeparator: Bool = true) {
             self.title = title
             self.titleFontStyle = titleFontStyle
@@ -91,6 +93,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
             self.numberOfLinesForText = numberOfLinesForText
             self.isSelected = isSelected
             self.isActionable = isActionable
+            self.showsDisclosureIndicator = showsDisclosureIndicator
             self.showsSeparator = showsSeparator
         }
     }
@@ -157,7 +160,7 @@ extension ImageAndTitleAndTextTableViewCell {
         descriptionLabel.numberOfLines = viewModel.numberOfLinesForText
         contentImageView.image = viewModel.image
         contentImageStackView.isHidden = viewModel.image == nil
-        accessoryType = viewModel.isActionable ? .disclosureIndicator : (viewModel.isSelected ? .checkmark : .none)
+        accessoryType = viewModel.showsDisclosureIndicator ? .disclosureIndicator : .none
         selectionStyle = viewModel.isActionable ? .default: .none
         accessoryView = nil
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -161,11 +161,11 @@ extension ImageAndTitleAndTextTableViewCell {
         contentImageView.image = viewModel.image
         contentImageStackView.isHidden = viewModel.image == nil
         accessoryType = viewModel.showsDisclosureIndicator ? .disclosureIndicator : .none
-        if viewModel.isActionable && viewModel.showsDisclosureIndicator == false {
-            accessoryType = .none
-        } else if viewModel.isActionable == false && viewModel.showsDisclosureIndicator && viewModel.isSelected {
+        if viewModel.showsDisclosureIndicator {
+            accessoryType = .disclosureIndicator
+        } else if viewModel.isSelected {
             accessoryType = .checkmark
-        } else if viewModel.isActionable == false && viewModel.showsDisclosureIndicator && viewModel.isSelected == false {
+        } else {
             accessoryType = .none
         }
         selectionStyle = viewModel.isActionable ? .default: .none

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -132,7 +132,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         configureContentStackView()
         configureTitleAndTextStackView()
         applyDefaultBackgroundStyle()
-        configureBackground()
+        configureSelectedBackground()
     }
 
     override func prepareForReuse() {
@@ -300,7 +300,8 @@ private extension ImageAndTitleAndTextTableViewCell {
     func configureTitleAndTextStackView() {
         titleAndTextStackView.spacing = 2
     }
-    func configureBackground() {
+
+    func configureSelectedBackground() {
         selectedBackgroundView = UIView()
         selectedBackgroundView?.backgroundColor = .listBackground
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -163,6 +163,10 @@ extension ImageAndTitleAndTextTableViewCell {
         accessoryType = viewModel.showsDisclosureIndicator ? .disclosureIndicator : .none
         if viewModel.isActionable && viewModel.showsDisclosureIndicator == false {
             accessoryType = .none
+        } else if viewModel.isActionable == false && viewModel.showsDisclosureIndicator && viewModel.isSelected {
+            accessoryType = .checkmark
+        } else if viewModel.isActionable == false && viewModel.showsDisclosureIndicator && viewModel.isSelected == false {
+            accessoryType = .none
         }
         selectionStyle = viewModel.isActionable ? .default: .none
         accessoryView = nil

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -160,15 +160,10 @@ extension ImageAndTitleAndTextTableViewCell {
         descriptionLabel.numberOfLines = viewModel.numberOfLinesForText
         contentImageView.image = viewModel.image
         contentImageStackView.isHidden = viewModel.image == nil
-        
         accessoryType = viewModel.showsDisclosureIndicator ? .disclosureIndicator : .none
-        
-        if viewModel.isActionable == false && viewModel.isSelected {
-            accessoryType = .checkmark
-        } else if viewModel.isActionable == false && viewModel.isSelected == false {
+        if viewModel.isActionable && viewModel.showsDisclosureIndicator == false {
             accessoryType = .none
         }
-
         selectionStyle = viewModel.isActionable ? .default: .none
         accessoryView = nil
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -132,6 +132,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         configureContentStackView()
         configureTitleAndTextStackView()
         applyDefaultBackgroundStyle()
+        configureBackground()
     }
 
     override func prepareForReuse() {
@@ -160,7 +161,6 @@ extension ImageAndTitleAndTextTableViewCell {
         descriptionLabel.numberOfLines = viewModel.numberOfLinesForText
         contentImageView.image = viewModel.image
         contentImageStackView.isHidden = viewModel.image == nil
-        accessoryType = viewModel.showsDisclosureIndicator ? .disclosureIndicator : .none
         if viewModel.showsDisclosureIndicator {
             accessoryType = .disclosureIndicator
         } else if viewModel.isSelected {
@@ -299,6 +299,10 @@ private extension ImageAndTitleAndTextTableViewCell {
 
     func configureTitleAndTextStackView() {
         titleAndTextStackView.spacing = 2
+    }
+    func configureBackground() {
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = .listBackground
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -160,7 +160,15 @@ extension ImageAndTitleAndTextTableViewCell {
         descriptionLabel.numberOfLines = viewModel.numberOfLinesForText
         contentImageView.image = viewModel.image
         contentImageStackView.isHidden = viewModel.image == nil
+        
         accessoryType = viewModel.showsDisclosureIndicator ? .disclosureIndicator : .none
+        
+        if viewModel.isActionable == false && viewModel.isSelected {
+            accessoryType = .checkmark
+        } else if viewModel.isActionable == false && viewModel.isSelected == false {
+            accessoryType = .none
+        }
+
         selectionStyle = viewModel.isActionable ? .default: .none
         accessoryView = nil
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
@@ -26,7 +26,8 @@ final class DownloadableFileBottomSheetListSelectorCommand: BottomSheetListSelec
                                                                     textTintColor: .text,
                                                                     image: model.image,
                                                                     imageTintColor: .gray(.shade20),
-                                                                    numberOfLinesForText: 0)
+                                                                    numberOfLinesForText: 0,
+                                                                    showsDisclosureIndicator: true)
         cell.updateUI(viewModel: viewModel)
     }
 


### PR DESCRIPTION
Closes: #6613 

### Description

This PR addresses the case of not seeing visual feedback when tapping a Bottom Sheet component, for example through the Order Creation flow, or adding Downloadable Files to a Downloadable Product.

This happened to be a side effect of having the [disclosure indicator](https://developer.apple.com/documentation/uikit/uitableviewcell/accessorytype/disclosureindicator) coupled with the `isActionable` check, within `ImageAndTitleAndTextTableViewCell.ViewModel`

The proposed solution is to extract the disclosure indicator as a new `showsDisclosureIndicator` parameter in the Model, so we can perform checks separately. Now the user can see the cell being tapped with a selection state despite not having a disclosure indicator. Not all actionable cells display more information, so not all need to display a disclosure indicator.

### Testing instructions

**Case 1: Create Order**
- Go to Orders > Tap "+"
- Note that "Create Order" and "Simple Payments" do provide visual feedback when we tap on each cell and do not show any disclosure indicators like chevrons or checkmarks



**Case 2: Downloadable Products**

- If you have no Downloadable Products, create one: Products > Tap "+" > "Simple Virtual Product" > Tap "..." > "Product Settings" > Enable "Downloadable Product"
- Go to Products > Edit your Virtual/Downloadable product > Tap "Downloadable Files" > Tap "Add File".
- Note that tapping on any option provides visual feedback, and shows a Chevron as well as an accessory.


| Case 1:  Create Order (No accessory) | Case 2: Downloadable Products (Chevron) | Case 3: Coupons (Checkmark)
|---|---|---|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2022-06-16 at 11 48 34](https://user-images.githubusercontent.com/3812076/173994003-4180877a-4486-4b8c-9ce2-8e84fa043ba4.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2022-06-16 at 11 53 16](https://user-images.githubusercontent.com/3812076/173993994-6fb96964-c5d8-4ab2-ab07-649154798f96.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2022-06-16 at 12 21 59](https://user-images.githubusercontent.com/3812076/173997789-a51c208f-b5cc-4c64-bfec-3e2ed86d1beb.png)|

**Case 3: Coupons**
At the moment this is only being used within the Coupons project, which is still an experimental feature.
- In the app: Enable the Coupons Management at Menu > Settings > Experimental Features > Coupon Management
- In the site: Create a coupon under yoursite/wp-admin > Marketing > Coupons
- In the app: Go to Menu > Coupons > Select the Coupon you've created > Edit Coupon > Discount type
- Note that shows a checkmark when an option is selected, and is updated each time we open the option (this is a known issue, outside of the scope of this PR)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
