### PR TITLE
Upgrade Swift Tools version from 5.3 to 5.5

### DIFF
--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -1,24 +1,17 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Codegen",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Codegen",
             type: .dynamic,
             targets: ["Codegen"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Codegen",
             dependencies: []),

--- a/TestKit/Package.swift
+++ b/TestKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/TestKit/Package.swift
+++ b/TestKit/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -7,19 +6,14 @@ let package = Package(
     name: "TestKit",
     platforms: [.iOS(.v14)],
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "TestKit",
             targets: ["TestKit"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "Difference", url: "https://github.com/krzysztofzablocki/Difference.git", .branch("master"))
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "TestKit",
             dependencies: ["Difference"]),


### PR DESCRIPTION
### Description
Having up-to-date tools is a good practice, ~~but in this case the upgrade is also a necessary requirement to integrate Buildkite Test Analytics in CI.~~ Update: The statement is still true, but neither package has any tests 😱 

### Testing instructions
If CI is green, then the updated packages still work correctly within Woo.

You can also `cd` into each package's folder and run `swift build`:

<table>
<tr>
	<td>

![image](https://user-images.githubusercontent.com/1218433/173999455-7af9153e-9d90-46c2-b876-5d5e4a7d4609.png)

</td>
	<td>

![image](https://user-images.githubusercontent.com/1218433/173999464-268c199e-976c-493c-880e-fec4c924539b.png)

</td>
</tr>
</table>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
