### PR TITLE
Integrate Buildkite Test Analytics

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -83,6 +83,15 @@
         }
       },
       {
+        "package": "BuildkiteTestCollector",
+        "repositoryURL": "https://github.com/buildkite/test-collector-swift",
+        "state": {
+          "branch": null,
+          "revision": "87afcecfb58dd017d6e835ec8e88e9eaa18095ba",
+          "version": "0.1.1"
+        }
+      },
+      {
         "package": "XCUITestHelpers",
         "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
         "state": {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -662,6 +662,9 @@
 		3F0CF3142704494A00EF3D71 /* TabNavComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172F23DBCEB200592D8E /* TabNavComponent.swift */; };
 		3F1CA81D26C3542600228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81C26C3542600228BF2 /* XCUITestHelpers */; };
 		3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */; };
+		3F2C8A19285B038800B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */; };
+		3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */; };
+		3F2C8A1D285B03A400B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */; };
 		3F58701F281B947E004F7556 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F58701E281B947E004F7556 /* Main.storyboard */; };
 		3F587021281B9494004F7556 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F587020281B9494004F7556 /* LaunchScreen.storyboard */; };
 		3F587026281B9C19004F7556 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F587028281B9C19004F7556 /* InfoPlist.strings */; };
@@ -3547,6 +3550,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				263E38462641FF3400260D3B /* Codegen in Frameworks */,
+				3F2C8A19285B038800B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */,
 				B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */,
 				57150E0F24F462C200E81611 /* TestKit in Frameworks */,
@@ -3558,6 +3562,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */,
+				3F2C8A1D285B03A400B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */,
 				3F1CA81D26C3542600228BF2 /* XCUITestHelpers in Frameworks */,
 				3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */,
@@ -3569,6 +3574,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */,
+				3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				24C5AC7625A53021008FD769 /* Embassy in Frameworks */,
 				3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */,
 				3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */,
@@ -8189,6 +8195,7 @@
 			packageProductDependencies = (
 				57150E0E24F462C200E81611 /* TestKit */,
 				263E38452641FF3400260D3B /* Codegen */,
+				3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */,
 			);
 			productName = WooCommerceTests;
 			productReference = B56DB3DD2049BFAA00D4AA8E /* WooCommerceTests.xctest */;
@@ -8212,6 +8219,7 @@
 			packageProductDependencies = (
 				3FF2247226706AA3008FFA87 /* ScreenObject */,
 				3F1CA81C26C3542600228BF2 /* XCUITestHelpers */,
+				3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */,
 			);
 			productName = WooCommerceUITests;
 			productReference = CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */;
@@ -8236,6 +8244,7 @@
 				247CE89B2583402A00F9D9D1 /* Embassy */,
 				3FF22489267073AE008FFA87 /* ScreenObject */,
 				3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */,
+				3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */,
 			);
 			productName = WooCommerceScreenshots;
 			productReference = F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */;
@@ -8328,6 +8337,7 @@
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
+				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -10974,6 +10984,14 @@
 				minimumVersion = 0.3.0;
 			};
 		};
+		3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/buildkite/test-collector-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.1;
+			};
+		};
 		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
@@ -11036,6 +11054,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
 			productName = XCUITestHelpers;
+		};
+		3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */;
+			productName = BuildkiteTestCollector;
+		};
+		3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */;
+			productName = BuildkiteTestCollector;
+		};
+		3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */;
+			productName = BuildkiteTestCollector;
 		};
 		3FF2247226706AA3008FFA87 /* ScreenObject */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1042,6 +1042,11 @@ lane :test_without_building do |options|
     e.include?(options[:name])
   end.first
 
+  # FIXME: I do realize the variable is called "test plan path" but we're
+  # actually dealing with an `xctestrun`. I'll rename them all once established
+  # this approach works
+  add_buildkite_analytics_token(xctestrun_path: testPlanPath)
+
   UI.user_error!('Unable to find .xctestrun file') unless !testPlanPath.nil? && File.exist?((testPlanPath))
 
   run_tests(
@@ -1100,4 +1105,21 @@ def trigger_buildkite_release_build(branch:, beta:)
     environment: { BETA_RELEASE: beta },
     pipeline_file: 'release-builds.yml'
   )
+end
+
+def add_buildkite_analytics_token(xctestrun_path:)
+  require 'plist'
+
+  token_key = 'BUILDKITE_ANALYTICS_TOKEN'
+  token = ENV[token_key]
+  return if token.nil?
+
+  xctestrun = Plist.parse_xml(xctestrun_path)
+  xctestrun['TestConfigurations'].each do |configuration|
+    configuration['TestTargets'].each do |target|
+      target['EnvironmentVariables'][token_key] = token
+    end
+  end
+
+  File.write(xctestrun_path, Plist::Emit.dump(xctestrun))
 end


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Enables Buildkite Test Analytics. The process requires 3 steps:

1. Add the Buildkite test collector library via SPM
2. Make the `BUILDKITE_ANALYTICS_TOKEN` generated for this pipeline available in CI
3. Some shenanigans to pass the token from the CI agent environment to the iOS Simulator (see `add_buildkite_analytics_token`)

### Testing instructions
If CI is green, we're good.

Buildkite doesn't yet have a way to jump from one build to its test run, but you could launch a new build for this PR, wait for it to finish, then check there is [a test run](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios/runs?branch=all+branches) with a matching timestamp.

### Screenshots

![image](https://user-images.githubusercontent.com/1218433/174913121-51ba5ac8-be65-4f3e-bb1c-74a497f87d32.png)

![image](https://user-images.githubusercontent.com/1218433/174913131-ff63e6f1-a692-427e-9a3e-5ede73f7b414.png)

You can see more in [the Test Analytics page](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios?branch=all+branches).

### Next steps

- [After creating this, I realized I'd need to add the test collector package to the subprojects (Networking, Hardware, Yosemete, etc.)](https://github.com/woocommerce/woocommerce-ios/pull/7125)
- I wonder whether to split the analytics into two: unit and UI test. At the moment, the graph of the suite time is confusing because the UI tests and unit tests have different average durations:

<img width="373" alt="image" src="https://user-images.githubusercontent.com/1218433/174958570-5c284a74-e704-4378-bd57-090792e695b3.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
