### PR TITLE
[UITII] - Update test names to use snake case and skip tests earlier

### DIFF
--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -13,7 +13,7 @@ final class LoginTests: XCTestCase {
     }
 
     // Login with Store Address and log out.
-    func testSiteAddressLoginLogout() throws {
+    func skipped_test_site_address_login_logout() throws {
         try skipTillSettingsFixed()
 
         let prologue = try PrologueScreen().selectSiteAddress()
@@ -34,7 +34,7 @@ final class LoginTests: XCTestCase {
     }
 
     // Login with WordPress.com account and log out
-    func testWordPressLoginLogout() throws {
+    func skipped_test_WordPress_login_logout() throws {
         try skipTillSettingsFixed()
 
         let prologue = try PrologueScreen().selectContinueWithWordPress()
@@ -53,7 +53,7 @@ final class LoginTests: XCTestCase {
         XCTAssert(prologue.isLoaded)
     }
 
-    func testWordPressUnsuccessfullLogin() throws {
+    func test_WordPress_unsuccessfull_login() throws {
         _ = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -13,7 +13,7 @@ final class OrdersTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    func testOrdersScreenLoads() throws {
+    func test_load_orders_screen() throws {
         let orders = try GetMocks.readOrdersData()
 
         try TabNavComponent().goToOrdersScreen()

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -12,7 +12,7 @@ final class ProductsTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    func testProductsScreenLoad() throws {
+    func test_load_products_screen() throws {
         let products = try GetMocks.readProductsData()
 
         try TabNavComponent().goToProductsScreen()

--- a/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
@@ -17,7 +17,7 @@ final class ReviewsTests: XCTestCase {
             .goToProductsScreen()
     }
 
-    func testReviewsScreenLoad() throws {
+    func test_load_reviews_screen() throws {
         let reviews = try GetMocks.readReviewsData()
 
         try TabNavComponent().goToMenuScreen()

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -15,8 +15,7 @@ final class StatsTests: XCTestCase {
         try LoginFlow.logInWithWPcom()
     }
 
-    func testStatsScreenLoad() throws {
-        try skipTillImplemented()
+    func skipped_test_load_stats_screen() throws {
         try TabNavComponent().goToMyStoreScreen()
     }
 


### PR DESCRIPTION
### Description
- To ensure that all tests naming conventions are consistent in this repo, updating UI existing UI tests to use snake_case instead of camelCase. 
- Update skipped tests by adding `skipped` to the test name so that they are skipped and not run at all. Previously, the test still runs `setUp` which will launch the app and immediately closes it since the test is skipped. Now, the app won't be launched when the test is skipped.

### Testing instructions
Ensure that UI tests still pass on the CI and that only tests that are not skipped are included in the test run. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
