### PR TITLE
Hotfix: Add condition check for "paid" cell index value

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -71,6 +71,12 @@ final class OrderDetailsDataSource: NSObject {
             !isEligibleForCardPresentPayment
     }
 
+    /// Whether the row for amount paid should be visible.
+    ///
+    private var shouldShowCustomerPaidRow: Bool {
+        order.datePaid != nil
+    }
+
     /// Whether the option to re-create shipping labels should be visible.
     ///
     var shouldAllowRecreatingShippingLabels: Bool {
@@ -515,7 +521,7 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureRefund(cell: TwoColumnHeadlineFootnoteTableViewCell, at indexPath: IndexPath) {
-        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell
+        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell(isDisplayed: shouldShowCustomerPaidRow)
         let condensedRefund = condensedRefunds[index]
         let refund = lookUpRefund(by: condensedRefund.refundID)
         let paymentViewModel = OrderPaymentDetailsViewModel(order: order, refund: refund)
@@ -1030,8 +1036,6 @@ extension OrderDetailsDataSource {
         let payment: Section = {
             var rows: [Row] = [.payment]
 
-            let shouldShowCustomerPaidRow = order.datePaid != nil
-
             if shouldShowCustomerPaidRow {
                 rows.append(.customerPaid)
             }
@@ -1109,7 +1113,7 @@ extension OrderDetailsDataSource {
     }
 
     func refund(at indexPath: IndexPath) -> Refund? {
-        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell
+        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell(isDisplayed: shouldShowCustomerPaidRow)
         let condensedRefund = condensedRefunds[index]
         let refund = refunds.first { $0.refundID == condensedRefund.refundID }
 
@@ -1501,10 +1505,15 @@ extension OrderDetailsDataSource {
         case editShippingAddress
     }
 
-    struct Constants {
+    enum Constants {
         static let addOrderCell = 1
         static let paymentCell = 1
-        static let paidByCustomerCell = 1
+
+        /// Input value required because cell is displayed conditionally
+        ///
+        static func paidByCustomerCell(isDisplayed: Bool) -> Int {
+            isDisplayed ? 1 : 0
+        }
     }
 }
 


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/7112

## Description

In `OrderDetailsDataSource` refunds logic is relying on directly accessing array by index. Since refunds list is sharing section with other cells (see `let payment: Section`), index is calculated by subtracting 1 for "Payment" and "Paid by Customer" cells.

The crash appeared because we added condition to hide "Paid by Customer" when there are no payments yet.
Because index constants are static and not directly connected with section logic - we still subtract "-2" when there is only 1 extra cell in a section.

## Fix

Static index replaced by a func (in the same `Constants` namespace) that requires boolean for its state to remind about the condition.
Maybe there is a better way without padding constants? I decided against logic refactor for now.

## Testing

1. Prepare order without payments, but with refunds. Easy to do on the web, not sure about mobile.
2. Go to the Order tab, open order.
3. Confirm it doesn't crash.
4. Open "Refunded Products" list, confirm correct data.

## Screenshots

<img width=350 src=https://user-images.githubusercontent.com/3132438/174664029-c9741c14-7047-4c4b-889f-e6d8b2aa0179.png>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.