### PR TITLE
Coupons: Allow empty email list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponAllowedEmailsViewModel.swift
@@ -24,7 +24,7 @@ final class CouponAllowedEmailsViewModel: ObservableObject {
     func validateEmails(dismissHandler: @escaping () -> Void) {
         let emails = emailPatterns.components(separatedBy: ", ")
         let foundInvalidPatterns = emails.contains(where: { !EmailFormatValidator.validate(string: $0) })
-        if !foundInvalidPatterns {
+        if emailPatterns.isEmpty || !foundInvalidPatterns {
             onCompletion(emailPatterns)
             dismissHandler()
         } else {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -75,11 +75,11 @@ final class CouponRestrictionsViewModel: ObservableObject {
         }
     }()
 
-    lazy var allowedEmailsViewModel = {
+    var allowedEmailsViewModel: CouponAllowedEmailsViewModel {
         CouponAllowedEmailsViewModel(allowedEmails: allowedEmails) { [weak self] updatedEmails in
             self?.allowedEmails = updatedEmails
         }
-    }()
+    }
 
     private let siteID: Int64
     private let stores: StoresManager

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponAllowedEmailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponAllowedEmailsViewModelTests.swift
@@ -20,6 +20,23 @@ final class CouponAllowedEmailsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.notice)
     }
 
+    func test_completion_block_is_triggered_when_allowed_email_list_is_empty() {
+        // Given
+        var savedAddresses: String?
+        let completionBlock: (String) -> Void = { email in
+            savedAddresses = email
+        }
+        let viewModel = CouponAllowedEmailsViewModel(allowedEmails: "test@mail.com", onCompletion: completionBlock)
+
+        // When
+        viewModel.emailPatterns = ""
+        viewModel.validateEmails {}
+
+        // Then
+        XCTAssertEqual(savedAddresses, "")
+        XCTAssertNil(viewModel.notice)
+    }
+
     func test_completion_block_is_not_triggered_and_notice_is_not_nil_when_address_validation_fails() {
         var savedAddresses: String?
         let completionBlock: (String) -> Void = { email in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7106
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the case when email validation requires that the email list is not empty. This should not be required because merchants should be able to leave their allowed email list empty.

This also fixes the issue when the text field on the Allowed Emails screen keeps the old value from the previous update. This issue is fixed by creating a fresh instance of the view model every time the view is presented.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Edit a Coupon
- Go to "Usage Restrictions",
- Go to "Allowed Emails",
- Enter some valid email value, then tap Done,
- This will go back to the Usage Restrictions screen,
- Go to "Allowed Emails" again,
- Delete the entered email value, make sure the field is now empty, then tap Done. Notice that this succeeds and you should be navigated back to the  Usage Restrictions screen.
- Repeat the above steps without tapping Done. Instead, tap Back and then go to "Allowed Emails" again. Notice this time that the screen display the correct email list instead of the empty one.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/174747177-6eb43685-30b9-4d45-9dcc-585fd9b15635.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
