### PR TITLE
[UITII] Bumped ScreenObject dependency version to 0.2.1

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,9 +50,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": null,
-          "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
-          "version": "0.2.0"
+          "branch": "UITII-reverse-waitForScreen-with-isLoaded",
+          "revision": "3edfe86135a11d2407131af75310303c30dcb035",
+          "version": null
         }
       },
       {

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,7 +51,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "5dee6f7b8b8abfdf3f872db225b1fef6c938c4fa",
+          "revision": "fec717878387245f89239cd255e11e18e779785c",
           "version": null
         }
       },

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,9 +50,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "3f57faf033e87dd50f111165286279eece20d1d1",
-          "version": null
+          "branch": null,
+          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
+          "version": "0.2.1"
         }
       },
       {

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,7 +51,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "fec717878387245f89239cd255e11e18e779785c",
+          "revision": "3f57faf033e87dd50f111165286279eece20d1d1",
           "version": null
         }
       },

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,7 +51,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "3edfe86135a11d2407131af75310303c30dcb035",
+          "revision": "5dee6f7b8b8abfdf3f872db225b1fef6c938c4fa",
           "version": null
         }
       },

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -6,7 +6,7 @@ public final class SingleOrderScreen: ScreenObject {
     // TODO: Remove force `try` once `ScreenObject` migration is completed
     let tabBar = try! TabNavComponent()
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.staticTexts["summary-table-view-cell-title-label"]} ],
             app: app

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -14,6 +14,12 @@ public final class SingleOrderScreen: ScreenObject {
     }
 
     @discardableResult
+    public func verifySingleOrderScreenLoaded() throws -> Self {
+        XCTAssertTrue(isLoaded)
+        return self
+    }
+
+    @discardableResult
     public func verifySingleOrder(order: OrderData) throws -> Self {
         // Check that navigation bar contains order number
         let navigationBarTitles = app.navigationBars.map { $0.staticTexts.element.label }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -10978,8 +10978,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				branch = "UITII-reverse-waitForScreen-with-isLoaded";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.1;
 			};
 		};
 		3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -10978,8 +10978,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				branch = "UITII-reverse-waitForScreen-with-isLoaded";
+				kind = branch;
 			};
 		};
 		3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */ = {

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -34,15 +34,13 @@ final class OrdersTests: XCTestCase {
             .addProduct(byName: products[0].name)
             .addCustomerDetails(name: "Mira")
             .createOrder()
-
-        XCTAssertTrue(try SingleOrderScreen().isLoaded)
+            .verifySingleOrderScreenLoaded()
     }
 
     func test_cancel_order_creation() throws {
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
             .cancelOrderCreation()
-
-        XCTAssertTrue(try OrdersScreen().isLoaded)
+            .verifyOrdersScreenLoaded()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -34,11 +34,15 @@ final class OrdersTests: XCTestCase {
             .addProduct(byName: products[0].name)
             .addCustomerDetails(name: "Mira")
             .createOrder()
+
+        XCTAssertTrue(try SingleOrderScreen().isLoaded)
     }
 
     func test_cancel_order_creation() throws {
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
             .cancelOrderCreation()
+
+        XCTAssertTrue(try SingleOrderScreen().isLoaded)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -43,6 +43,6 @@ final class OrdersTests: XCTestCase {
             .startOrderCreation()
             .cancelOrderCreation()
 
-        XCTAssertTrue(try SingleOrderScreen().isLoaded)
+        XCTAssertTrue(try OrdersScreen().isLoaded)
     }
 }


### PR DESCRIPTION
Now, once https://github.com/Automattic/ScreenObject/pull/11 has been merged, it's time to bump the `ScreenObject` dependency version.

Since two UI tests (`test_create_new_order` / `test_cancel_order_creation`) relied on implicit checks and contained no assertions, I've added an explicit `isLoaded` assertion to each test, to compensate for the implicit testing density loss. cc @thehenrybyrd 

### Test
- You should see that now it takes ~9 minutes to run UI tests on CI, instead of ~11 min previously.