### PR TITLE
[Orders] Auto-confirm the selected country and state in the address form

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.5
 -----
-
+- [*] Orders: The customer shipping/billing address form now navigates back automatically after selecting a country or state. [https://github.com/woocommerce/woocommerce-ios/pull/7119]
 
 9.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -31,6 +31,7 @@ final class CountrySelectorCommand: ObservableListSelectorCommand {
 
     func handleSelectedChange(selected: Country, viewController: ViewController) {
         self.selected = selected
+        viewController.navigationController?.popViewController(animated: true)
     }
 
     func isSelected(model: Country) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
@@ -31,6 +31,7 @@ final class StateSelectorCommand: ObservableListSelectorCommand {
 
     func handleSelectedChange(selected: StateOfACountry, viewController: ViewController) {
         self.selected = selected
+        viewController.navigationController?.popViewController(animated: true)
     }
 
     func isSelected(model: StateOfACountry) -> Bool {


### PR DESCRIPTION
Closes: #6651

## Description

During Order Creation, we want to unify the list selection behavior so that making a list selection automatically confirms the selection and navigates you back to the previous screen.

This PR updates the behavior for selecting the country or state in the Customer Details address form. (This is used for both Order Creation and Order Editing.) Now, after selecting a country or state, you are automatically navigated back to the address form instead of having to tap the "Back" button.

## Changes

Updates the `ObservableListSelectorCommand` for the Country and State list selectors to pop the view controller after making the selection.

## Testing

1. Go to the Orders tab and create a new order.
2. Select "Add Customer Details" to open the address form.
3. Select "Country" to open the country list.
4. Select a country and confirm you are taken back to the address form with your selected country appearing in the form. (I suggest selecting a country with a defined set of states, such as Argentina, Brazil, or the United States, so you can test state list selection in the following steps. Other countries offer "State" as a text field instead of choosing from a list of states.)
5. Select "State" to open the state list.
6. Select a state and confirm you are taken back to the address form with your selected state appearing in the form.

You can also test these changes to the address form during order editing (with the Unified Order Editing feature flag disabled) while editing the shipping or billing address on an existing order.

## Screenshots

https://user-images.githubusercontent.com/8658164/174844045-485eb728-54ff-45a6-afd2-6cb418bdafbf.mp4


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
