### PR TITLE
Update variable names not using snake case in `Fastfile`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1038,16 +1038,16 @@ lane :test_without_building do |options|
   # Find the referenced .xctestrun file based on its name
   buildProductsPath = File.expand_path('DerivedData/Build/Products/', File.dirname(Dir.pwd))
 
-  testPlanPath = Dir.glob(File.join(buildProductsPath, '*.xctestrun')).select do |e|
+  xctestrun_path = Dir.glob(File.join(buildProductsPath, '*.xctestrun')).select do |e|
     e.include?(options[:name])
   end.first
 
   # FIXME: I do realize the variable is called "test plan path" but we're
   # actually dealing with an `xctestrun`. I'll rename them all once established
   # this approach works
-  add_buildkite_analytics_token(xctestrun_path: testPlanPath)
+  add_buildkite_analytics_token(xctestrun_path: xctestrun_path)
 
-  UI.user_error!('Unable to find .xctestrun file') unless !testPlanPath.nil? && File.exist?((testPlanPath))
+  UI.user_error!('Unable to find .xctestrun file') unless !xctestrun_path.nil? && File.exist?((xctestrun_path))
 
   run_tests(
     workspace: 'WooCommerce.xcworkspace',
@@ -1055,7 +1055,7 @@ lane :test_without_building do |options|
     device: options[:device],
     deployment_target_version: options[:ios_version],
     test_without_building: true,
-    xctestrun: testPlanPath,
+    xctestrun: xctestrun_path,
     result_bundle: true,
     # settins for XML test report generation via `trainer`
     output_types: '',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -851,8 +851,8 @@ platform :ios do
                         download_path: './fastlane/metadata')
 
     # Copy appstoreres (screenshot-related) txt files into `en-US`
-    enUS_path = File.join(Dir.pwd, 'metadata', 'en-US')
-    FileUtils.mkdir_p(enUS_path)
+    en_us_path = File.join(Dir.pwd, 'metadata', 'en-US')
+    FileUtils.mkdir_p(en_us_path)
 
     [
       'promo_screenshot_1.txt',
@@ -862,7 +862,7 @@ platform :ios do
       'promo_screenshot_5.txt'
     ].each do |filename|
       source = File.join(Dir.pwd, 'appstoreres', 'metadata', 'source', filename)
-      destination = File.join(enUS_path, filename)
+      destination = File.join(en_us_path, filename)
       FileUtils.cp(source, destination)
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1036,9 +1036,9 @@ end
 desc 'Run tests without building'
 lane :test_without_building do |options|
   # Find the referenced .xctestrun file based on its name
-  buildProductsPath = File.expand_path('DerivedData/Build/Products/', File.dirname(Dir.pwd))
+  build_products_path = File.expand_path('DerivedData/Build/Products/', File.dirname(Dir.pwd))
 
-  xctestrun_path = Dir.glob(File.join(buildProductsPath, '*.xctestrun')).select do |e|
+  xctestrun_path = Dir.glob(File.join(build_products_path, '*.xctestrun')).select do |e|
     e.include?(options[:name])
   end.first
 


### PR DESCRIPTION

### Description
Noticed these [while working on Bulidkite Test Analytics](https://github.com/woocommerce/woocommerce-ios/pull/7097/files#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688R1045-R1048). Addressed in a dedicated PR to keep the diff neat.

### Testing instructions
Double check my find and replace was accurate? 🤔 

I used `bundle exec rubocop --only Naming/VariableName fastlane/Fastfile` to find the violations. If you run it locally, it should return no match.

![image](https://user-images.githubusercontent.com/1218433/174911886-db6500b1-806b-4daa-a406-78015bbfc856.png)

---
- [x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
