### PR TITLE
[Order Creation] Expand new order UI test to include adding shipping

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -67,6 +67,7 @@ struct OrderPaymentSection: View {
             }
             .buttonStyle(PlusButtonStyle())
             .padding()
+            .accessibilityIdentifier("add-shipping-button")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/ShippingLineDetails.swift
@@ -37,6 +37,7 @@ struct ShippingLineDetails: View {
                                         .onTapGesture {
                                             focusAmountInput = true
                                         }
+                                        .accessibilityIdentifier("add-shipping-amount-field")
                                 }
                             }
                             .frame(minHeight: Layout.amountRowHeight)
@@ -50,6 +51,7 @@ struct ShippingLineDetails: View {
                                                  text: $viewModel.methodTitle,
                                                  symbol: nil,
                                                  keyboardType: .default)
+                                .accessibilityIdentifier("add-shipping-name-field")
                         }
                         .padding(.horizontal, insets: safeAreaInsets)
                         .addingTopAndBottomDividers()
@@ -90,6 +92,7 @@ struct ShippingLineDetails: View {
                         presentation.wrappedValue.dismiss()
                     }
                     .disabled(viewModel.shouldDisableDoneButton)
+                    .accessibilityIdentifier("add-shipping-done-button")
                 }
             }
         }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
@@ -1,0 +1,56 @@
+import ScreenObject
+import XCTest
+
+public final class AddShippingScreen: ScreenObject {
+
+    private let shippingAmountGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["add-shipping-amount-field"]
+    }
+
+    private let shippingNameGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["add-shipping-name-field"]
+    }
+
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["add-shipping-done-button"]
+    }
+
+    private var shippingAmountField: XCUIElement { shippingAmountGetter(app) }
+
+    private var shippingNameField: XCUIElement { shippingNameGetter(app) }
+
+    private var doneButton: XCUIElement { doneButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ shippingAmountGetter ],
+            app: app
+        )
+    }
+
+    /// Enters a shipping amount.
+    /// - Returns: Add Shipping screen object.
+    @discardableResult
+    public func enterShippingAmount(_ amount: String) throws -> Self {
+        shippingAmountField.tap()
+        shippingAmountField.typeText(amount)
+        return self
+    }
+
+    /// Enters a shipping name.
+    /// - Returns: Add Shipping screen object.
+    @discardableResult
+    public func enterShippingName(_ name: String) throws -> Self {
+        shippingNameField.tap()
+        shippingNameField.typeText(name)
+        return self
+    }
+
+    /// Confirms entered shipping details and closes Add Shipping screen.
+    /// - Returns: New Order screen object.
+    @discardableResult
+    public func confirmShippingDetails() throws -> NewOrderScreen {
+        doneButton.tap()
+        return try NewOrderScreen()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -23,6 +23,10 @@ public final class NewOrderScreen: ScreenObject {
         $0.staticTexts["Add Customer Details"]
     }
 
+    private let addShippingButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["add-shipping-button"]
+    }
+
     private var createButton: XCUIElement { createButtonGetter(app) }
 
     /// Cancel button in the Navigation bar.
@@ -40,6 +44,10 @@ public final class NewOrderScreen: ScreenObject {
     /// Add Customer Details button in the Customer Details section.
     ///
     private var addCustomerDetailsButton: XCUIElement { addCustomerDetailsButtonGetter(app) }
+
+    /// Add Shipping button in the Payment section.
+    ///
+    private var addShippingButton: XCUIElement { addShippingButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -74,6 +82,14 @@ public final class NewOrderScreen: ScreenObject {
         return try CustomerDetailsScreen()
     }
 
+    /// Opens the Add Shipping screen.
+    /// - Returns: Add Shipping screen object.
+    @discardableResult
+    public func openAddShippingScreen() throws -> AddShippingScreen {
+        addShippingButton.tap()
+        return try AddShippingScreen()
+    }
+
 // MARK: - High-level Order Creation actions
 
     /// Creates a remote order with all of the entered order data.
@@ -105,6 +121,18 @@ public final class NewOrderScreen: ScreenObject {
     public func addCustomerDetails(name: String) throws -> NewOrderScreen {
         return try openCustomerDetailsScreen()
             .enterCustomerDetails(name: name)
+    }
+
+    /// Adds shipping on the Add Shipping screen.
+    /// - Parameters:
+    ///   - amount: Amount (in the store currency) to add for shipping.
+    ///   - name: Name of the shipping method (e.g. "Free Shipping" or "Flat Rate").
+    /// - Returns: New Order screen object.
+    public func addShipping(amount: String, name: String) throws -> NewOrderScreen {
+        return try openAddShippingScreen()
+            .enterShippingAmount(amount)
+            .enterShippingName(name)
+            .confirmShippingDetails()
     }
 
     /// Cancels Order Creation process

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1283,6 +1283,7 @@
 		CC666F2627F359590045AF1E /* OrdersTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC666F2527F359590045AF1E /* OrdersTopBannerFactory.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
 		CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */; };
+		CC71353B2862285300A28B42 /* AddShippingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC71353A2862285300A28B42 /* AddShippingScreen.swift */; };
 		CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC72BB6327BD842500837876 /* DisclosureIndicator.swift */; };
 		CC770C8A27B1497700CE6ABC /* SearchHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC770C8927B1497700CE6ABC /* SearchHeader.swift */; };
 		CC77488E2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */; };
@@ -3054,6 +3055,7 @@
 		CC666F2527F359590045AF1E /* OrdersTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersTopBannerFactory.swift; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
+		CC71353A2862285300A28B42 /* AddShippingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddShippingScreen.swift; sourceTree = "<group>"; };
 		CC72BB6327BD842500837876 /* DisclosureIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclosureIndicator.swift; sourceTree = "<group>"; };
 		CC770C8927B1497700CE6ABC /* SearchHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHeader.swift; sourceTree = "<group>"; };
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
@@ -8073,6 +8075,7 @@
 				F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */,
 				CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */,
 				C044961228058FE8003B3081 /* AddProductScreen.swift */,
+				CC71353A2862285300A28B42 /* AddShippingScreen.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -8779,6 +8782,7 @@
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
 				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,
 				3F0CF3012704490A00EF3D71 /* ReviewsScreen.swift in Sources */,
+				CC71353B2862285300A28B42 /* AddShippingScreen.swift in Sources */,
 				3F0CF30A2704490A00EF3D71 /* OrdersScreen.swift in Sources */,
 				C044961328058FE8003B3081 /* AddProductScreen.swift in Sources */,
 				3F0CF3132704490A00EF3D71 /* PrologueScreen.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1260,6 +1260,7 @@
 		CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */; };
 		CC254F3626C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */; };
 		CC254F3826C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */; };
+		CC2A08022862400100510C4B /* orders_3337_add_shipping.json in Resources */ = {isa = PBXBuildFile; fileRef = CC2A08012862400100510C4B /* orders_3337_add_shipping.json */; };
 		CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */; };
 		CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
@@ -3032,6 +3033,7 @@
 		CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageSelection.swift; sourceTree = "<group>"; };
 		CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageForm.swift; sourceTree = "<group>"; };
 		CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModel.swift; sourceTree = "<group>"; };
+		CC2A08012862400100510C4B /* orders_3337_add_shipping.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_3337_add_shipping.json; sourceTree = "<group>"; };
 		CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatterTests.swift; sourceTree = "<group>"; };
 		CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrderViewModel.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
@@ -6904,6 +6906,7 @@
 				CC5C278A27EE314E00B25D2A /* orders_3337_create_order.json */,
 				CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */,
 				C0A37CB7282957EB00E0826D /* orders_3337_add_customer_details.json */,
+				CC2A08012862400100510C4B /* orders_3337_add_shipping.json */,
 				CCF27B39280EF98F00B755E1 /* orders_3337.json */,
 				800A5B9A2755E0B9009DE2CD /* orders_any.json */,
 				800A5B9F27562EE5009DE2CD /* orders_processing.json */,
@@ -8586,6 +8589,7 @@
 				800A5BB027586898009DE2CD /* products_2132.json in Resources */,
 				800A5BA6275719E5009DE2CD /* orders_2201_refunds.json in Resources */,
 				800A5BA827586126009DE2CD /* products_2129.json in Resources */,
+				CC2A08022862400100510C4B /* orders_3337_add_shipping.json in Resources */,
 				800A5BC027586AFC009DE2CD /* products_reviews_6164.json in Resources */,
 				800A5BC5275889ED009DE2CD /* reports_revenue_stats_day.json in Resources */,
 				800A5B972755BA02009DE2CD /* status.json in Resources */,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_customer_details.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_customer_details.json
@@ -2,46 +2,13 @@
     "request": {
         "method": "POST",
         "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
-        "bodyPatterns": [ {
-                "matches": ".*path=/wc/v3/orders/3337%26_method%3Dpost.*",
-                "equalToJson": {
-                    "line_items": [{
-                        "quantity": 1,
-                        "total": "110.00",
-                        "subtotal": "110.00",
-                        "id": 1,
-                        "product_id": 2129
-                    }],
-                    "fee_lines": [],
-                    "shipping_lines": [],
-                    "billing": {
-                        "first_name": "Mira",
-                        "last_name": "",
-                        "company": "",
-                        "address_1": "",
-                        "address_2": "",
-                        "city": "",
-                        "state": "",
-                        "postcode": "",
-                        "country": "",
-                        "email": null,
-                        "phone": ""
-                    },
-                    "shipping": {
-                        "first_name": "Mira",
-                        "last_name": "",
-                        "company": "",
-                        "address_1": "",
-                        "address_2": "",
-                        "city": "",
-                        "state": "",
-                        "postcode": "",
-                        "country": "",
-                        "email": null,
-                        "phone": ""
-                    }
-                }
-        } ]
+        "bodyPatterns": [
+            { "matches": ".*path=/wc/v3/orders/3337%26_method%3Dpost.*" },
+            { "contains": "%22product_id%22%3A2129" },
+            { "contains": "%22fee_lines%22%3A%5B%5D" },
+            { "contains": "%22shipping_lines%22%3A%5B%5D" },
+            { "contains": "%22first_name%22%3A%22Mira%22" }
+        ]
     },
     "response": {
         "status": 200,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_product.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_product.json
@@ -2,20 +2,11 @@
     "request": {
         "method": "POST",
         "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
-        "bodyPatterns": [ {
-                "matches": ".*path=/wc/v3/orders%26_method%3Dpost.*",
-                "equalToJson": {
-                    "line_items": [{
-                        "quantity": 1,
-                        "id": 0,
-                        "product_id": 2129
-                    }],
-                    "customer_note": "",
-                    "status": "auto-draft",
-                    "fee_lines": [],
-                    "shipping_lines": []
-                }
-        } ]
+        "bodyPatterns": [
+            { "matches": ".*path=/wc/v3/orders%26_method%3Dpost.*" },
+            { "contains": "%22status%22%3A%22auto-draft%22" },
+            { "contains": "%22product_id%22%3A2129" }
+        ]
     },
     "response": {
         "status": 200,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_shipping.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_shipping.json
@@ -1,15 +1,14 @@
 {
     "request": {
-        "method": "GET",
+        "method": "POST",
         "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
-        "queryParameters": {
-            "json": {
-                "equalTo": "true"
-            },
-            "path": {
-                "matches": "/wc/v3/orders/3337&_method=get"
-            }
-        }
+        "bodyPatterns": [
+            { "matches": ".*path=/wc/v3/orders/3337%26_method%3Dpost.*" },
+            { "contains": "%22product_id%22%3A2129" },
+            { "contains": "%22fee_lines%22%3A%5B%5D" },
+            { "contains": "%22method_title%22%3A%22Flat%20Rate%22" },
+            { "contains": "%22first_name%22%3A%22Mira%22" }
+        ]
     },
     "response": {
         "status": 200,
@@ -17,7 +16,7 @@
             "data": {
                 "id": 3337,
                 "parent_id": 0,
-                "status": "processing",
+                "status": "auto-draft",
                 "currency": "USD",
                 "version": "6.3.1",
                 "prices_include_tax": true,

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -33,6 +33,7 @@ final class OrdersTests: XCTestCase {
             .editOrderStatus()
             .addProduct(byName: products[0].name)
             .addCustomerDetails(name: "Mira")
+            .addShipping(amount: "1.25", name: "Flat Rate")
             .createOrder()
     }
 


### PR DESCRIPTION
Part of: #6524

## Description

Our existing UI test for Order Creation covers all of the features from Order Creation Milestone 1. This PR adds another step to that test, to add shipping before creating the new order. (This is part of expanding the UI test to include functionality from Order Creation Milestone 2.)

## Changes

Screen objects:

* Adds accessibility IDs to `ShippingLineDetails`, to use in the UI test.
* Adds a new screen object for the Add Shipping screen, with the relevant helpers.
* Updates the New Order screen object with methods to open the Add Shipping screen and enter shipping details.

Mocks:

* Fixes an issue with the `bodyPatterns` request matching in our existing mocks: Previously, we used `equalToJson` to check for JSON equality in the body of the request, to match the correct mocked response. However, I discovered these were being ignored and only the `matches` body pattern (with the request path parameter) was being used. Because of how the body is formatted in the request, checking for JSON equality doesn't work. Instead, I've used `contains` to check for unique, consistent strings from the encoded body parameters (taking into account that the body parameters are not always sent in the same order). FYI @thehenrybyrd 
* Adds a new mocked response for the request when the order syncs remotely after adding shipping.
* Updates the mocked response for the request to get the full order after it's created (to include the shipping details).

Test:

* Updates the UI test to include the add shipping step.

## Testing

Confirm test passes in CI.

## Screenshots


https://user-images.githubusercontent.com/8658164/174912740-4c9b2b04-0677-4bd0-94e6-430980567982.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
