### PR TITLE
Background image uploads: Add product flow.

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
@@ -6,6 +6,10 @@ final class LegacyProductImageUploader: ProductImageUploaderProtocol {
         ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses)
     }
 
+    func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
+        // no-op
+    }
+
     func saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: Int64,
                                                          productID: Int64,
                                                          isLocalID: Bool,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1690,6 +1690,7 @@
 		EEADF622281A40CB001B40F1 /* ShippingValueLocalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEADF621281A40CB001B40F1 /* ShippingValueLocalizer.swift */; };
 		EEADF624281A421A001B40F1 /* DefaultShippingValueLocalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEADF623281A421A001B40F1 /* DefaultShippingValueLocalizer.swift */; };
 		EEADF626281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEADF625281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift */; };
+		EECB7EE02862115C0028C888 /* MockProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */; };
 		F997170523DBB97500592D8E /* WooCommerceScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997170423DBB97500592D8E /* WooCommerceScreenshots.swift */; };
 		F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174323DC065900592D8E /* XLPagerStrip+AccessibilityIdentifier.swift */; };
 		F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174623DC070C00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift */; };
@@ -3471,6 +3472,7 @@
 		EEADF621281A40CB001B40F1 /* ShippingValueLocalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingValueLocalizer.swift; sourceTree = "<group>"; };
 		EEADF623281A421A001B40F1 /* DefaultShippingValueLocalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShippingValueLocalizer.swift; sourceTree = "<group>"; };
 		EEADF625281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShippingValueLocalizerTests.swift; sourceTree = "<group>"; };
+		EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImageUploader.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		F93E8E5724087FE10057FF21 /* ProductsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsScreen.swift; sourceTree = "<group>"; };
@@ -5816,6 +5818,7 @@
 				B9C4AB2A28003481007008B8 /* MockPaymentsPluginsDataProvider.swift */,
 				0375799C2822F9040083F2E1 /* MockCardPresentPaymentsOnboardingPresenter.swift */,
 				02BF9BAE2851E7EA008CE2DD /* MockAppleIDCredentialChecker.swift */,
+				EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10107,6 +10110,7 @@
 				262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */,
 				0234680A282CEA5F00CFC503 /* ReceiptViewModelTests.swift in Sources */,
 				B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */,
+				EECB7EE02862115C0028C888 /* MockProductImageUploader.swift in Sources */,
 				022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,
 				26F94E34267AA42F00DB6CCF /* ProductAddOnViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -1,0 +1,26 @@
+@testable import Yosemite
+@testable import WooCommerce
+
+final class MockProductImageUploader: ProductImageUploaderProtocol {
+    var replaceLocalIDWasCalled = false
+    var saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = false
+
+    func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
+        replaceLocalIDWasCalled = true
+    }
+
+    func saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: Int64,
+                                                         productID: Int64,
+                                                         isLocalID: Bool,
+                                                         onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
+        saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = true
+    }
+
+    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
+        ProductImageActionHandler(siteID: 0, productID: 0, imageStatuses: [])
+    }
+
+    func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool {
+        false
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -68,7 +68,7 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         XCTAssertEqual(savedProduct, EditableProductModel(product: product.copy(statusKey: ProductStatus.pending.rawValue)))
     }
 
-    func test_adding_a_product_remotely_replaces_local_product_ID_in_productImagesUploader() throws {
+    func test_adding_a_product_remotely_fires_replaceLocalID_in_productImagesUploader() throws {
         // Given
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
         let productImagesUploader = MockProductImageUploader()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -118,11 +118,18 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
 }
 
 private extension ProductFormViewModel_SaveTests {
-    func createViewModel(product: Product, formType: ProductFormType) -> ProductFormViewModel {
+    func createViewModel(
+        product: Product,
+        formType: ProductFormType,
+        productImagesUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+        isBackgroundImageUploadEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload)
+    ) -> ProductFormViewModel {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
                                     formType: formType,
-                                    productImageActionHandler: productImageActionHandler)
+                                    productImageActionHandler: productImageActionHandler,
+                                    productImagesUploader: productImagesUploader,
+                                    isBackgroundImageUploadEnabled: isBackgroundImageUploadEnabled)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -89,6 +89,28 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         XCTAssertTrue(productImagesUploader.replaceLocalIDWasCalled)
     }
 
+    func test_adding_a_product_remotely_fires_method_to_save_images_in_background_using_productImagesUploader() throws {
+        // Given
+        let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
+        let productImagesUploader = MockProductImageUploader()
+        let viewModel = createViewModel(product: product, formType: .add, productImagesUploader: productImagesUploader, isBackgroundImageUploadEnabled: true)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let ProductAction.addProduct(product, onCompletion) = action {
+                onCompletion(.success(product))
+            }
+        }
+
+        // When
+        waitForExpectation { expectation in
+            viewModel.saveProductRemotely(status: .pending) { result in
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertTrue(productImagesUploader.saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled)
+    }
+
     // MARK: `saveProductRemotely` for editing a product
 
     func test_editing_a_product_remotely_with_nil_status_uses_the_original_product() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -158,6 +158,28 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         // Assert
         XCTAssertEqual(savedProduct, EditableProductModel(product: product.copy(statusKey: ProductStatus.pending.rawValue)))
     }
+
+    func test_editing_a_product_remotely_fires_method_to_save_images_in_background_using_productImagesUploader() throws {
+        // Given
+        let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
+        let productImagesUploader = MockProductImageUploader()
+        let viewModel = createViewModel(product: product, formType: .edit, productImagesUploader: productImagesUploader, isBackgroundImageUploadEnabled: true)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let ProductAction.updateProduct(product, onCompletion) = action {
+                onCompletion(.success(product))
+            }
+        }
+
+        // When
+        waitForExpectation { expectation in
+            viewModel.saveProductRemotely(status: .pending) { result in
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertTrue(productImagesUploader.saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled)
+    }
 }
 
 private extension ProductFormViewModel_SaveTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -135,4 +135,37 @@ final class ProductImageUploaderTests: XCTestCase {
         let images = try XCTUnwrap(resultOfSavedImages.get())
         XCTAssertEqual(images.map { $0.imageID }, [606, 645])
     }
+
+    func test_replaceLocalID_replaces_productID_properly() {
+        // Given
+        let imageUploader = ProductImageUploader()
+        let localProductID: Int64 = 0
+        let remoteProductID = productID
+        let originalStatuses: [ProductImageStatus] = [.remote(image: ProductImage.fake()),
+                                                      .uploading(asset: PHAsset()),
+                                                      .uploading(asset: PHAsset())]
+        _ = imageUploader.actionHandler(siteID: siteID,
+                                        productID: localProductID,
+                                        isLocalID: true,
+                                        originalStatuses: originalStatuses)
+
+        // Before replacing product ID
+
+        // Pass empty statuses to get the `actionHandler`, and validate that `actionHandler` with `originalStatuses` is returned.
+        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(siteID: siteID,
+                                                                     productID: localProductID,
+                                                                     isLocalID: true,
+                                                                     originalStatuses: []).productImageStatuses)
+
+        // When
+        imageUploader.replaceLocalID(siteID: siteID, localProductID: localProductID, remoteProductID: remoteProductID)
+
+        // After replacing local product ID with remote product ID
+
+        // Pass empty statuses and `remoteProductID` to get the `actionHandler`, and validate that `actionHandler` with `originalStatuses` is returned.
+        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(siteID: siteID,
+                                                                     productID: remoteProductID,
+                                                                     isLocalID: false,
+                                                                     originalStatuses: []).productImageStatuses)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -168,4 +168,29 @@ final class ProductImageUploaderTests: XCTestCase {
                                                                      isLocalID: false,
                                                                      originalStatuses: []).productImageStatuses)
     }
+
+    func test_calling_replaceLocalID_with_nonExistent_localProductID_does_nothing() {
+        // Given
+        let imageUploader = ProductImageUploader()
+        let localProductID: Int64 = 0
+        let nonExistentProductID: Int64 = 999
+        let remoteProductID = productID
+        let originalStatuses: [ProductImageStatus] = [.remote(image: ProductImage.fake()),
+                                                      .uploading(asset: PHAsset()),
+                                                      .uploading(asset: PHAsset())]
+        _ = imageUploader.actionHandler(siteID: siteID,
+                                        productID: localProductID,
+                                        isLocalID: true,
+                                        originalStatuses: originalStatuses)
+
+        // When
+        imageUploader.replaceLocalID(siteID: siteID, localProductID: nonExistentProductID, remoteProductID: remoteProductID)
+
+        // Then
+        // Ensure that trying to replace a non-existent product ID does nothing.
+        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(siteID: siteID,
+                                                                     productID: localProductID,
+                                                                     isLocalID: true,
+                                                                     originalStatuses: []).productImageStatuses)
+    }
 }


### PR DESCRIPTION
Part of #7021 

### Description
This PR is the second part to [the previous PR](https://github.com/woocommerce/woocommerce-ios/pull/7048) which added background image upload to the "Edit product" flow.

This PR adds the background image upload ability to the "Add product" flow.

### Testing instructions

#### Feature flag on

- Launch the app
- Navigte to `Products` tab and tap on `+` button on top right.
- In product creation form enter a product title and add a few images
- Tap "Publish" to save the product while the images are still being uploaded --> the product is saved remotely first, and there is no "Publish" button anymore when the images are still being uploaded
- You can stay in the product form or leave and come back --> after all images are uploaded, the product should be updated remotely again with all the uploaded images in wp-admin and in the app. If you make any changes on the product again, the "Save" button should appear again and tapping on it should save the latest images async

#### Feature flag off

- In code, return `false` for `backgroundProductImageUpload` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Navigte to `Products` tab and tap on `+` button on top right.
- In product creation form enter a product title and add a few images
- Publish the product while the images are still being uploaded --> the product is saved after all images are uploaded (production behavior)
- In product editing form, add a few images
- Leave the product form and quickly come back while the images are still being uploaded --> no pending images are shown (the discard changes sheet should be shown when leaving the product form, but there is a long standing iOS bug where it's not shown in debug builds)

### Screenshots

https://user-images.githubusercontent.com/524475/174942727-7051b777-7b69-44b5-810e-8130870330e1.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
