### PR TITLE
[Order Creation] Expand new order UI test to include adding fee

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeLineDetails.swift
@@ -99,6 +99,7 @@ struct FeeLineDetails: View {
                         presentation.wrappedValue.dismiss()
                     }
                     .disabled(viewModel.shouldDisableDoneButton)
+                    .accessibilityIdentifier("add-fee-done-button")
                 }
             }
         }
@@ -120,6 +121,7 @@ struct FeeLineDetails: View {
                     .onTapGesture {
                         focusFixedAmountInput = true
                     }
+                    .accessibilityIdentifier("add-fee-fixed-amount-field")
             }
         }
         .frame(minHeight: Layout.rowHeight)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -82,6 +82,7 @@ struct OrderPaymentSection: View {
             }
             .buttonStyle(PlusButtonStyle())
             .padding()
+            .accessibilityIdentifier("add-fee-button")
         }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddFeeScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddFeeScreen.swift
@@ -1,0 +1,41 @@
+import ScreenObject
+import XCTest
+
+public final class AddFeeScreen: ScreenObject {
+
+    private let feeFixedAmountGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["add-fee-fixed-amount-field"]
+    }
+
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["add-fee-done-button"]
+    }
+
+    private var feeFixedAmountField: XCUIElement { feeFixedAmountGetter(app) }
+
+    private var doneButton: XCUIElement { doneButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ feeFixedAmountGetter ],
+            app: app
+        )
+    }
+
+    /// Enters a fixed fee amount.
+    /// - Returns: Add Fee screen object.
+    @discardableResult
+    public func enterFixedFee(amount: String) throws -> Self {
+        feeFixedAmountField.tap()
+        feeFixedAmountField.typeText(amount)
+        return self
+    }
+
+    /// Confirms entered fee and closes Add Fee screen.
+    /// - Returns: New Order screen object.
+    @discardableResult
+    public func confirmFee() throws -> NewOrderScreen {
+        doneButton.tap()
+        return try NewOrderScreen()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -27,6 +27,10 @@ public final class NewOrderScreen: ScreenObject {
         $0.buttons["add-shipping-button"]
     }
 
+    private let addFeeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["add-fee-button"]
+    }
+
     private var createButton: XCUIElement { createButtonGetter(app) }
 
     /// Cancel button in the Navigation bar.
@@ -48,6 +52,10 @@ public final class NewOrderScreen: ScreenObject {
     /// Add Shipping button in the Payment section.
     ///
     private var addShippingButton: XCUIElement { addShippingButtonGetter(app) }
+
+    /// Add Fee button in the Payment section.
+    ///
+    private var addFeeButton: XCUIElement { addFeeButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -88,6 +96,14 @@ public final class NewOrderScreen: ScreenObject {
     public func openAddShippingScreen() throws -> AddShippingScreen {
         addShippingButton.tap()
         return try AddShippingScreen()
+    }
+
+    /// Opens the Add Fee screen.
+    /// - Returns: Add Fee screen object.
+    @discardableResult
+    public func openAddFeeScreen() throws -> AddFeeScreen {
+        addFeeButton.tap()
+        return try AddFeeScreen()
     }
 
 // MARK: - High-level Order Creation actions
@@ -133,6 +149,16 @@ public final class NewOrderScreen: ScreenObject {
             .enterShippingAmount(amount)
             .enterShippingName(name)
             .confirmShippingDetails()
+    }
+
+    /// Adds a fee on the Add Fee screen.
+    /// - Parameters:
+    ///   - amount: Amount (in the store currency) to add as a fee.
+    /// - Returns: New Order screen object.
+    public func addFee(amount: String) throws -> NewOrderScreen {
+        return try openAddFeeScreen()
+            .enterFixedFee(amount: amount)
+            .confirmFee()
     }
 
     /// Cancels Order Creation process

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1261,6 +1261,7 @@
 		CC254F3626C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */; };
 		CC254F3826C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */; };
 		CC2A08022862400100510C4B /* orders_3337_add_shipping.json in Resources */ = {isa = PBXBuildFile; fileRef = CC2A08012862400100510C4B /* orders_3337_add_shipping.json */; };
+		CC2A08042863206000510C4B /* AddFeeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2A08032863206000510C4B /* AddFeeScreen.swift */; };
 		CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */; };
 		CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
@@ -3034,6 +3035,7 @@
 		CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageForm.swift; sourceTree = "<group>"; };
 		CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModel.swift; sourceTree = "<group>"; };
 		CC2A08012862400100510C4B /* orders_3337_add_shipping.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_3337_add_shipping.json; sourceTree = "<group>"; };
+		CC2A08032863206000510C4B /* AddFeeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeeScreen.swift; sourceTree = "<group>"; };
 		CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatterTests.swift; sourceTree = "<group>"; };
 		CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrderViewModel.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
@@ -8079,6 +8081,7 @@
 				CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */,
 				C044961228058FE8003B3081 /* AddProductScreen.swift */,
 				CC71353A2862285300A28B42 /* AddShippingScreen.swift */,
+				CC2A08032863206000510C4B /* AddFeeScreen.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -8778,6 +8781,7 @@
 				3F0CF3042704490A00EF3D71 /* PeriodStatsTable.swift in Sources */,
 				3F0CF3142704494A00EF3D71 /* TabNavComponent.swift in Sources */,
 				3F0CF3072704490A00EF3D71 /* LoginEmailScreen.swift in Sources */,
+				CC2A08042863206000510C4B /* AddFeeScreen.swift in Sources */,
 				3F0CF30D2704490A00EF3D71 /* LoginSiteAddressScreen.swift in Sources */,
 				80C3626B27704EE1005CEAD3 /* ProductDataStructs.swift in Sources */,
 				80C3627127745737005CEAD3 /* ReviewDataStructs.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 		CC254F3826C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */; };
 		CC2A08022862400100510C4B /* orders_3337_add_shipping.json in Resources */ = {isa = PBXBuildFile; fileRef = CC2A08012862400100510C4B /* orders_3337_add_shipping.json */; };
 		CC2A08042863206000510C4B /* AddFeeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2A08032863206000510C4B /* AddFeeScreen.swift */; };
+		CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */ = {isa = PBXBuildFile; fileRef = CC2A08052863222500510C4B /* orders_3337_add_fee.json */; };
 		CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */; };
 		CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
@@ -3036,6 +3037,7 @@
 		CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModel.swift; sourceTree = "<group>"; };
 		CC2A08012862400100510C4B /* orders_3337_add_shipping.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_3337_add_shipping.json; sourceTree = "<group>"; };
 		CC2A08032863206000510C4B /* AddFeeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeeScreen.swift; sourceTree = "<group>"; };
+		CC2A08052863222500510C4B /* orders_3337_add_fee.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_3337_add_fee.json; sourceTree = "<group>"; };
 		CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatterTests.swift; sourceTree = "<group>"; };
 		CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrderViewModel.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
@@ -6909,6 +6911,7 @@
 				CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */,
 				C0A37CB7282957EB00E0826D /* orders_3337_add_customer_details.json */,
 				CC2A08012862400100510C4B /* orders_3337_add_shipping.json */,
+				CC2A08052863222500510C4B /* orders_3337_add_fee.json */,
 				CCF27B39280EF98F00B755E1 /* orders_3337.json */,
 				800A5B9A2755E0B9009DE2CD /* orders_any.json */,
 				800A5B9F27562EE5009DE2CD /* orders_processing.json */,
@@ -8597,6 +8600,7 @@
 				800A5BC5275889ED009DE2CD /* reports_revenue_stats_day.json in Resources */,
 				800A5B972755BA02009DE2CD /* status.json in Resources */,
 				800A5BC8275889ED009DE2CD /* reports_revenue_stats_year.json in Resources */,
+				CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */,
 				800A5BBC27586AE1009DE2CD /* products_reviews_6162.json in Resources */,
 				800A5B6127548F53009DE2CD /* sites_posts_password.json in Resources */,
 				800A5BB427586A0E009DE2CD /* products_reviews_6155.json in Resources */,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_fee.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337_add_fee.json
@@ -1,15 +1,14 @@
 {
     "request": {
-        "method": "GET",
+        "method": "POST",
         "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
-        "queryParameters": {
-            "json": {
-                "equalTo": "true"
-            },
-            "path": {
-                "matches": "/wc/v3/orders/3337&_method=get"
-            }
-        }
+        "bodyPatterns": [
+            { "matches": ".*path=/wc/v3/orders/3337%26_method%3Dpost.*" },
+            { "contains": "%22product_id%22%3A2129" },
+            { "contains": "%22name%22%3A%22Fee%22" },
+            { "contains": "%22method_title%22%3A%22Flat%20Rate%22" },
+            { "contains": "%22first_name%22%3A%22Mira%22" }
+        ]
     },
     "response": {
         "status": 200,
@@ -17,7 +16,7 @@
             "data": {
                 "id": 3337,
                 "parent_id": 0,
-                "status": "processing",
+                "status": "auto-draft",
                 "currency": "USD",
                 "version": "6.3.1",
                 "prices_include_tax": true,

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -34,6 +34,7 @@ final class OrdersTests: XCTestCase {
             .addProduct(byName: products[0].name)
             .addCustomerDetails(name: "Mira")
             .addShipping(amount: "1.25", name: "Flat Rate")
+            .addFee(amount: "2.34")
             .createOrder()
     }
 


### PR DESCRIPTION
Part of: #6524

⚠️ Depends on #7124; that PR should be merged first. ⚠️ 

## Description

Our existing UI test for Order Creation covers all of the features from Order Creation Milestone 1. This PR adds another step to that test, to add fee before creating the new order. (This is part of expanding the UI test to include functionality from Order Creation Milestone 2.)

## Changes

Screen objects:

* Adds accessibility IDs to `FeeLineDetails`, to use in the UI test.
* Adds a new screen object for the Add Fee screen, with the relevant helpers.
* Updates the New Order screen object with methods to open the Add Fee screen and enter fee amount.

Mocks:

* Adds a new mocked response for the request when the order syncs remotely after adding fee.
* Updates the mocked response for the request to get the full order after it's created (to include the fee).

Test:

* Updates the UI test to include the add fee step.

## Testing

Confirm test passes in CI.

## Screenshots

https://user-images.githubusercontent.com/8658164/175018808-1f9e3430-513d-426e-8bf3-1585fad215c4.mp4




## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
