### PR TITLE
[Order Creation] Expand new order UI test to include adding customer note

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
@@ -83,6 +83,7 @@ private struct CustomerNoteSectionContent: View {
             }
             .buttonStyle(PlusButtonStyle())
             .padding([.leading, .bottom, .trailing])
+            .accessibilityIdentifier("add-customer-note-button")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -54,6 +54,7 @@ struct EditCustomerNote<ViewModel: EditCustomerNoteViewModelProtocol>: View {
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
+                .accessibilityIdentifier("edit-note-text-editor")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button(Localization.cancel, action: {
@@ -63,6 +64,7 @@ struct EditCustomerNote<ViewModel: EditCustomerNoteViewModelProtocol>: View {
                     }
                     ToolbarItem(placement: .confirmationAction) {
                         navigationBarTrailingItem()
+                            .accessibilityIdentifier("edit-note-done-button")
                     }
                 }
         }

--- a/WooCommerce/UITestsFoundation/OrderDataStructs.swift
+++ b/WooCommerce/UITestsFoundation/OrderDataStructs.swift
@@ -1,5 +1,16 @@
+/// Mock for a list of Orders
+public struct OrdersMock: Codable {
+    public let response: OrdersResponseData
+}
+
+/// Mocks for a single Order
 public struct OrderMock: Codable {
     public let response: OrderResponseData
+}
+
+public struct OrdersResponseData: Codable {
+    public let status: Int
+    public let jsonBody: OrdersBodyData
 }
 
 public struct OrderResponseData: Codable {
@@ -7,8 +18,12 @@ public struct OrderResponseData: Codable {
     public let jsonBody: OrderBodyData
 }
 
-public struct OrderBodyData: Codable {
+public struct OrdersBodyData: Codable {
     public let data: [OrderData]
+}
+
+public struct OrderBodyData: Codable {
+    public let data: OrderData
 }
 
 public struct OrderData: Codable {
@@ -18,6 +33,7 @@ public struct OrderData: Codable {
     public var total: String
     public let line_items: [LineItems]
     public let billing: BillingInformation
+    public let customer_note: String
 }
 
 public struct LineItems: Codable {

--- a/WooCommerce/UITestsFoundation/OrderDataStructs.swift
+++ b/WooCommerce/UITestsFoundation/OrderDataStructs.swift
@@ -33,6 +33,8 @@ public struct OrderData: Codable {
     public var total: String
     public let line_items: [LineItems]
     public let billing: BillingInformation
+    public let shipping_lines: [ShippingLine]
+    public let fee_lines: [FeeLine]
     public let customer_note: String
 }
 
@@ -44,4 +46,13 @@ public struct LineItems: Codable {
 public struct BillingInformation: Codable {
     public let first_name: String
     public let last_name: String
+}
+
+public struct ShippingLine: Codable {
+    public let method_title: String
+    public let total: String
+}
+
+public struct FeeLine: Codable {
+    public let amount: String
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
@@ -1,0 +1,41 @@
+import ScreenObject
+import XCTest
+
+public final class CustomerNoteScreen: ScreenObject {
+
+    private let noteTextEditorGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textViews["edit-note-text-editor"]
+    }
+
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["edit-note-done-button"]
+    }
+
+    private var noteTextEditor: XCUIElement { noteTextEditorGetter(app) }
+
+    private var doneButton: XCUIElement { doneButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ noteTextEditorGetter ],
+            app: app
+        )
+    }
+
+    /// Enters a customer note.
+    /// - Parameter text: Text to enter as the customer note.
+    /// - Returns: Customer Note screen object.
+    @discardableResult
+    public func enterNote(_ text: String) throws -> Self {
+        noteTextEditor.typeText(text)
+        return self
+    }
+
+    /// Confirms entered note and closes Customer Note screen.
+    /// - Returns: New Order screen object.
+    @discardableResult
+    public func confirmNote() throws -> NewOrderScreen {
+        doneButton.tap()
+        return try NewOrderScreen()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -31,6 +31,10 @@ public final class NewOrderScreen: ScreenObject {
         $0.buttons["add-fee-button"]
     }
 
+    private let addNoteButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["add-customer-note-button"]
+    }
+
     private var createButton: XCUIElement { createButtonGetter(app) }
 
     /// Cancel button in the Navigation bar.
@@ -56,6 +60,10 @@ public final class NewOrderScreen: ScreenObject {
     /// Add Fee button in the Payment section.
     ///
     private var addFeeButton: XCUIElement { addFeeButtonGetter(app) }
+
+    /// Add Note button in the Customer Note section.
+    ///
+    private var addNoteButton: XCUIElement { addNoteButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -104,6 +112,14 @@ public final class NewOrderScreen: ScreenObject {
     public func openAddFeeScreen() throws -> AddFeeScreen {
         addFeeButton.tap()
         return try AddFeeScreen()
+    }
+
+    /// Opens the Customer Note screen.
+    /// - Returns: Customer Note screen object.
+    @discardableResult
+    public func openCustomerNoteScreen() throws -> CustomerNoteScreen {
+        addNoteButton.tap()
+        return try CustomerNoteScreen()
     }
 
 // MARK: - High-level Order Creation actions
@@ -159,6 +175,15 @@ public final class NewOrderScreen: ScreenObject {
         return try openAddFeeScreen()
             .enterFixedFee(amount: amount)
             .confirmFee()
+    }
+
+    /// Adds a note on the Customer Note screen.
+    /// - Parameter text: Text to enter as the customer note.
+    /// - Returns: New Order screen object.
+    public func addCustomerNote(_ text: String) throws -> NewOrderScreen {
+        return try openCustomerNoteScreen()
+            .enterNote(text)
+            .confirmNote()
     }
 
     /// Cancels Order Creation process

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1263,6 +1263,7 @@
 		CC2A08022862400100510C4B /* orders_3337_add_shipping.json in Resources */ = {isa = PBXBuildFile; fileRef = CC2A08012862400100510C4B /* orders_3337_add_shipping.json */; };
 		CC2A08042863206000510C4B /* AddFeeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2A08032863206000510C4B /* AddFeeScreen.swift */; };
 		CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */ = {isa = PBXBuildFile; fileRef = CC2A08052863222500510C4B /* orders_3337_add_fee.json */; };
+		CC2A0808286337A300510C4B /* CustomerNoteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2A0807286337A300510C4B /* CustomerNoteScreen.swift */; };
 		CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */; };
 		CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
@@ -3038,6 +3039,7 @@
 		CC2A08012862400100510C4B /* orders_3337_add_shipping.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_3337_add_shipping.json; sourceTree = "<group>"; };
 		CC2A08032863206000510C4B /* AddFeeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeeScreen.swift; sourceTree = "<group>"; };
 		CC2A08052863222500510C4B /* orders_3337_add_fee.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_3337_add_fee.json; sourceTree = "<group>"; };
+		CC2A0807286337A300510C4B /* CustomerNoteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerNoteScreen.swift; sourceTree = "<group>"; };
 		CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatterTests.swift; sourceTree = "<group>"; };
 		CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrderViewModel.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
@@ -8085,6 +8087,7 @@
 				C044961228058FE8003B3081 /* AddProductScreen.swift */,
 				CC71353A2862285300A28B42 /* AddShippingScreen.swift */,
 				CC2A08032863206000510C4B /* AddFeeScreen.swift */,
+				CC2A0807286337A300510C4B /* CustomerNoteScreen.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -8773,6 +8776,7 @@
 				3F0CF30F2704490A00EF3D71 /* SingleProductScreen.swift in Sources */,
 				3F0CF30C2704490A00EF3D71 /* LoginPasswordScreen.swift in Sources */,
 				C02747102822673800985EAE /* CustomerDetailsScreen.swift in Sources */,
+				CC2A0808286337A300510C4B /* CustomerNoteScreen.swift in Sources */,
 				3F0CF30E2704490A00EF3D71 /* PasswordScreen.swift in Sources */,
 				3F0CF3092704490A00EF3D71 /* BetaFeaturesScreen.swift in Sources */,
 				80B8D34C278E8A0C00FE6E6B /* MenuScreen.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
@@ -53,7 +53,7 @@ class GetMocks {
     }
 
     static func readOrdersData() throws -> [OrderData] {
-        let originalData = try JSONDecoder().decode(OrderMock.self, from: self.getMockData(test: OrdersTests.self, filename: "orders_any"))
+        let originalData = try JSONDecoder().decode(OrdersMock.self, from: self.getMockData(test: OrdersTests.self, filename: "orders_any"))
         var updatedData = originalData.response.jsonBody.data
 
         for index in 0..<updatedData.count {
@@ -66,5 +66,10 @@ class GetMocks {
         }
 
         return updatedData
-}
+    }
+
+    static func readNewOrderData() throws -> OrderData {
+        let originalData = try JSONDecoder().decode(OrderMock.self, from: self.getMockData(test: OrdersTests.self, filename: "orders_3337"))
+        return try XCTUnwrap(originalData.response.jsonBody.data)
+    }
 }

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_3337.json
@@ -63,7 +63,7 @@
                 "customer_ip_address": "",
                 "customer_user_agent": "",
                 "created_via": "rest-api",
-                "customer_note": "",
+                "customer_note": "Adipiscing Ipsum Amet Ipsum Amet",
                 "date_completed": null,
                 "date_paid": null,
                 "cart_hash": "",

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -33,9 +33,9 @@ final class OrdersTests: XCTestCase {
             .startOrderCreation()
             .editOrderStatus()
             .addProduct(byName: products[0].name)
-            .addCustomerDetails(name: "Mira")
-            .addShipping(amount: "1.25", name: "Flat Rate")
-            .addFee(amount: "2.34")
+            .addCustomerDetails(name: order.billing.first_name)
+            .addShipping(amount: order.shipping_lines[0].total, name: order.shipping_lines[0].method_title)
+            .addFee(amount: order.fee_lines[0].amount)
             .addCustomerNote(order.customer_note)
             .createOrder()
     }

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -35,6 +35,7 @@ final class OrdersTests: XCTestCase {
             .addCustomerDetails(name: "Mira")
             .addShipping(amount: "1.25", name: "Flat Rate")
             .addFee(amount: "2.34")
+            .addCustomerNote(getRandomPhrase())
             .createOrder()
     }
 

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -27,6 +27,7 @@ final class OrdersTests: XCTestCase {
 
     func test_create_new_order() throws {
         let products = try GetMocks.readProductsData()
+        let order = try GetMocks.readNewOrderData()
 
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
@@ -35,7 +36,7 @@ final class OrdersTests: XCTestCase {
             .addCustomerDetails(name: "Mira")
             .addShipping(amount: "1.25", name: "Flat Rate")
             .addFee(amount: "2.34")
-            .addCustomerNote(getRandomPhrase())
+            .addCustomerNote(order.customer_note)
             .createOrder()
     }
 

--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -26,13 +26,13 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
      - [ ] Update order status
      - [ ] Issue refund
      - [ ] Add shipping details
-   - [ ] Create a new order:
+   - [x] Create a new order:
      - [x] With a selected order status
      - [x] With a product
      - [x] With customer details
-     - [ ] With shipping
-     - [ ] With a fee
-     - [ ] With a customer note
+     - [x] With shipping
+     - [x] With a fee
+     - [x] With a customer note
    - [x] Order Creation flow can be dismissed
 4. [Products](../WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift)
     - [x] Products list and single product screens load


### PR DESCRIPTION
Closes: #6524
⚠️ Depends on #7127; that PR should be merged first. ⚠️

## Description

Our existing UI test for Order Creation covers all of the features from Order Creation Milestone 1. This PR adds another step to that test, to add a customer note before creating the new order. (This finishes expanding the UI test to include all functionality from Order Creation Milestone 2.)

## Changes

Screen objects:

- Adds accessibility IDs to `EditCustomerNote`, to use in the UI test.
- Adds a new screen object for the Customer Note screen, with the relevant helpers.
- Updates the New Order screen object with methods to open the Customer Note screen and enter the note text.

Mocks:

- Updates the mocked response for the request to get the full order after it's created (to include the customer note).
- Updates the `MockDataReader` and the `OrderDataStructs` it relies on, so that the order creation UI Test can read and enter the data from the mock. (This ensures that the test and the mock are in sync, rather than entering unrelated/random data in the test.) The `MockDataReader` now differentiates between mock order data that returns a list of orders (an `OrdersMock`) and mock order data that returns a single order (an `OrderMock`).

Test:

- Updates the UI test to include the add fee step.
- Updates all steps in the UI test to use data from the `MockDataReader` (using `GetMocks.readNewOrderData()`).

## Testing

Confirm all tests pass in CI.

## Screenshots


https://user-images.githubusercontent.com/8658164/175041006-49279756-a617-4bbf-80c8-b495d1735395.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
