### PR TITLE
Coupons: Track when sharing coupon from the coupon creation success screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -590,6 +590,7 @@ public enum WooAnalyticsStat: String {
     case couponCreationInitiated = "coupon_creation_initiated"
     case couponCreationSuccess = "coupon_creation_success"
     case couponCreationFailed = "coupon_creation_failed"
+    case couponCreationSuccessShareTapped = "coupon_creation_success_share_tapped"
 
     // MARK: Inbox Notes
     case inboxNotesLoaded = "inbox_notes_loaded"

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponCreationSuccess.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponCreationSuccess.swift
@@ -36,7 +36,7 @@ struct CouponCreationSuccess: View {
             VStack(alignment: .center, spacing: Constants.contentPadding) {
                 Button(Localization.shareCoupon) {
                     showingShareSheet = true
-                    // TODO: add analytics
+                    ServiceLocator.analytics.track(.couponCreationSuccessShareTapped)
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .shareSheet(isPresented: $showingShareSheet) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6493 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a Tracks event to track when the share button on the coupon creation success screen is tapped.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu > Coupons > select "+" button on the top right of the list or the "Create Coupon" button if your coupon list is empty.
- Enter details in the form and tap "Create".
- When the new coupon is created, a success screen should be presented. Tap the "Share" button on that screen.
- Notice in Xcode console there's a log: "🔵 Tracked coupon_creation_success_share_tapped"

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
