### PR TITLE
[Order Details] Adds payment title check to Refund confirmation screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -191,14 +191,14 @@ private extension RefundConfirmationViewModel {
             case .some(.cardPresent(let cardDetails)), .some(.interacPresent(let cardDetails)):
                 return PaymentDetailsRow(cardIcon: cardDetails.brand.icon,
                                          cardIconAspectHorizontal: cardDetails.brand.iconAspectHorizontal,
-                                         paymentGateway: details.order.paymentMethodTitle,
+                                         paymentGateway: orderPaymentMethodTitle(),
                                          paymentMethodDescription: cardDetails.brand.cardDescription(last4: cardDetails.last4),
                                          accessibilityDescription: cardDetails.brand.cardAccessibilityDescription(last4: cardDetails.last4))
             default:
                 return SimpleTextRow(text: details.order.paymentMethodTitle)
             }
         } else {
-            return TitleAndBodyRow(title: Localization.manualRefund(via: details.order.paymentMethodTitle),
+            return TitleAndBodyRow(title: Localization.manualRefund(via: orderPaymentMethodTitle()),
                                    body: Localization.refundWillNotBeIssued(paymentMethod: details.order.paymentMethodTitle))
         }
     }
@@ -214,6 +214,12 @@ private extension RefundConfirmationViewModel {
             return false
         }
         return paymentGateway.features.contains(.refunds)
+    }
+    /// Returns "[Not Specified]" if the payment gateway associated with this order is empty.
+    /// For example: Orders marked directly as fullfilled, or simple payments with cash.
+    ///
+    func orderPaymentMethodTitle() -> String {
+        details.order.paymentMethodTitle.isEmpty ? "[Not Specified]" : details.order.paymentMethodTitle
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -198,8 +198,7 @@ private extension RefundConfirmationViewModel {
                 return SimpleTextRow(text: details.order.paymentMethodTitle)
             }
         } else {
-            return TitleAndBodyRow(title: Localization.manualRefund(via: orderPaymentMethodTitle()),
-                                   body: Localization.refundWillNotBeIssued(paymentMethod: details.order.paymentMethodTitle))
+            return TitleAndBodyRow(title: Localization.manualRefund, body: Localization.refundWillNotBeIssued)
         }
     }
 }
@@ -219,7 +218,7 @@ private extension RefundConfirmationViewModel {
     /// For example: Orders marked directly as fullfilled, or simple payments with cash.
     ///
     func orderPaymentMethodTitle() -> String {
-        details.order.paymentMethodTitle.isEmpty ? "[Not Specified]" : details.order.paymentMethodTitle
+        details.order.paymentMethodTitle.isEmpty ? Localization.manualRefund : details.order.paymentMethodTitle
     }
 }
 
@@ -297,24 +296,17 @@ private extension RefundConfirmationViewModel {
             NSLocalizedString("Reason for refunding order",
                               comment: "A placeholder for the text field that the user can edit to indicate why they are issuing a refund.")
 
-        static func manualRefund(via paymentMethod: String) -> String {
-            let format = NSLocalizedString(
-                     "Manual Refund via %1$@",
-                comment: "In Refund Confirmation, The title shown to the user to inform them that"
-                    + " they have to issue the refund manually."
-                    + " The %1$@ is the payment method like “Stripe”.")
-            return String.localizedStringWithFormat(format, paymentMethod)
-        }
+        static let manualRefund =
+            NSLocalizedString("Manual Refund",
+                              comment: "In Refund Confirmation, The title shown to the user to inform them that"
+                              + " they have to issue the refund manually.")
 
-        static func refundWillNotBeIssued(paymentMethod: String) -> String {
-            let format = NSLocalizedString(
-                "A refund will not be issued to the customer."
-                    + " You will need to manually issue the refund through %1$@.",
+        static let refundWillNotBeIssued =
+            NSLocalizedString(
+                "The payment method does not support automatic refunds."
+                    + " Complete the refund by transferring the money to the customer manually.",
                 comment: "In Refund Confirmation, The message shown to the user to inform them that"
-                    + " they have to issue the refund manually."
-                    + " The %1$@ is the payment method like “Stripe”.")
-            return String.localizedStringWithFormat(format, paymentMethod)
-        }
+                    + " they have to issue the refund manually.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -183,7 +183,8 @@ private extension RefundConfirmationViewModel {
         return TwoColumnRow(title: Localization.previouslyRefunded, value: totalRefundedFormatted, isHeadline: false)
     }
 
-    /// Returns a row with special formatting if the payment gateway does not support automatic money refunds.
+    /// Returns a row with different formatting depending if the payment gateway supports automatic refunds, does not,
+    /// and if the payment gateway is known, or it is not.
     ///
     func makeRefundViaRow() -> RefundConfirmationViewModelRow {
         if gatewaySupportsAutomaticRefunds() {
@@ -191,14 +192,18 @@ private extension RefundConfirmationViewModel {
             case .some(.cardPresent(let cardDetails)), .some(.interacPresent(let cardDetails)):
                 return PaymentDetailsRow(cardIcon: cardDetails.brand.icon,
                                          cardIconAspectHorizontal: cardDetails.brand.iconAspectHorizontal,
-                                         paymentGateway: paymentGatewayMethodTitle(),
+                                         paymentGateway: details.order.paymentMethodTitle,
                                          paymentMethodDescription: cardDetails.brand.cardDescription(last4: cardDetails.last4),
                                          accessibilityDescription: cardDetails.brand.cardAccessibilityDescription(last4: cardDetails.last4))
             default:
                 return SimpleTextRow(text: details.order.paymentMethodTitle)
             }
         } else {
-            return TitleAndBodyRow(title: Localization.manualRefund, body: Localization.refundWillNotBeIssued)
+            if details.order.paymentMethodTitle.isEmpty {
+                return TitleAndBodyRow(title: Localization.manualRefund, body: Localization.refundWillNotBeIssued)
+            } else {
+                return SimpleTextRow(text: details.order.paymentMethodTitle)
+            }
         }
     }
 }
@@ -213,11 +218,6 @@ private extension RefundConfirmationViewModel {
             return false
         }
         return paymentGateway.features.contains(.refunds)
-    }
-    /// Returns "Manual Payment" if the payment gateway associated with this order and refund is empty, or the payment gateway if there is one.
-    ///
-    func paymentGatewayMethodTitle() -> String {
-        details.order.paymentMethodTitle.isEmpty ? Localization.manualRefund : details.order.paymentMethodTitle
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -191,7 +191,7 @@ private extension RefundConfirmationViewModel {
             case .some(.cardPresent(let cardDetails)), .some(.interacPresent(let cardDetails)):
                 return PaymentDetailsRow(cardIcon: cardDetails.brand.icon,
                                          cardIconAspectHorizontal: cardDetails.brand.iconAspectHorizontal,
-                                         paymentGateway: orderPaymentMethodTitle(),
+                                         paymentGateway: paymentGatewayMethodTitle(),
                                          paymentMethodDescription: cardDetails.brand.cardDescription(last4: cardDetails.last4),
                                          accessibilityDescription: cardDetails.brand.cardAccessibilityDescription(last4: cardDetails.last4))
             default:
@@ -214,10 +214,9 @@ private extension RefundConfirmationViewModel {
         }
         return paymentGateway.features.contains(.refunds)
     }
-    /// Returns "[Not Specified]" if the payment gateway associated with this order is empty.
-    /// For example: Orders marked directly as fullfilled, or simple payments with cash.
+    /// Returns "Manual Payment" if the payment gateway associated with this order and refund is empty, or the payment gateway if there is one.
     ///
-    func orderPaymentMethodTitle() -> String {
+    func paymentGatewayMethodTitle() -> String {
         details.order.paymentMethodTitle.isEmpty ? Localization.manualRefund : details.order.paymentMethodTitle
     }
 }
@@ -300,7 +299,6 @@ private extension RefundConfirmationViewModel {
             NSLocalizedString("Manual Refund",
                               comment: "In Refund Confirmation, The title shown to the user to inform them that"
                               + " they have to issue the refund manually.")
-
         static let refundWillNotBeIssued =
             NSLocalizedString(
                 "The payment method does not support automatic refunds."

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -136,8 +136,13 @@ final class RefundConfirmationViewModelTests: XCTestCase {
 
     func test_viewModel_has_manual_refundVia_values_when_using_a_gateway_that_does_not_support_refunds() throws {
         // Given
-        let order = MockOrders().empty().copy(paymentMethodID: "stripe", paymentMethodTitle: "Stripe")
-        let gateway = PaymentGateway(siteID: 123, gatewayID: "stripe", title: "Stripe", description: "", enabled: true, features: [])
+        let order = MockOrders().empty().copy(paymentMethodID: "Direct bank transfer", paymentMethodTitle: "Direct bank transfer")
+        let gateway = PaymentGateway(siteID: 123,
+                                     gatewayID: "Direct bank transfer",
+                                     title: "Direct bank transfer",
+                                     description: "",
+                                     enabled: true,
+                                     features: [])
         let details = RefundConfirmationViewModel.Details(order: order,
                                                           charge: nil,
                                                           amount: "",
@@ -151,15 +156,11 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let viewModel = RefundConfirmationViewModel(details: details)
 
         // We expect the Refund Via row to be the last item in the last row.
-        let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.TitleAndBodyRow)
+        let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.SimpleTextRow)
 
         // Then
-        let title = NSLocalizedString("Manual Refund", comment: "")
-        let body = NSLocalizedString("The payment method does not support automatic refunds." +
-                                     " Complete the refund by transferring the money to the customer manually.",
-                                     comment: "")
-        XCTAssertEqual(row.title, title)
-        XCTAssertEqual(row.body, body)
+        let text = NSLocalizedString("Direct bank transfer", comment: "")
+        XCTAssertEqual(row.text, text)
     }
     func test_viewModel_has_manual_refundVia_value_when_no_gateway_is_set() throws {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -154,8 +154,37 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.TitleAndBodyRow)
 
         // Then
-        let title = NSLocalizedString("Manual Refund via Stripe", comment: "")
-        let body = NSLocalizedString("A refund will not be issued to the customer. You will need to manually issue the refund through Stripe.", comment: "")
+        let title = NSLocalizedString("Manual Refund", comment: "")
+        let body = NSLocalizedString("The payment method does not support automatic refunds." +
+                                     " Complete the refund by transferring the money to the customer manually.",
+                                     comment: "")
+        XCTAssertEqual(row.title, title)
+        XCTAssertEqual(row.body, body)
+    }
+    func test_viewModel_has_manual_refundVia_value_when_no_gateway_is_set() throws {
+        // Given
+        let order = MockOrders().empty().copy(paymentMethodID: "", paymentMethodTitle: "")
+        let gateway = PaymentGateway(siteID: 123, gatewayID: "", title: "", description: "", enabled: true, features: [])
+        let details = RefundConfirmationViewModel.Details(order: order,
+                                                          charge: nil,
+                                                          amount: "",
+                                                          refundsShipping: false,
+                                                          refundsFees: false,
+                                                          items: [],
+                                                          paymentGateway: gateway,
+                                                          paymentGatewayAccount: nil)
+
+        // When
+        let viewModel = RefundConfirmationViewModel(details: details)
+
+        // We expect the Refund Via row to be the last item in the last row.
+        let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.TitleAndBodyRow)
+
+        // Then
+        let title = NSLocalizedString("Manual Refund", comment: "")
+        let body = NSLocalizedString("The payment method does not support automatic refunds." +
+                                     " Complete the refund by transferring the money to the customer manually.",
+                                     comment: "")
         XCTAssertEqual(row.title, title)
         XCTAssertEqual(row.body, body)
     }


### PR DESCRIPTION
Closes: #7088 

## Description
If an Order doesn't have a specified payment method, then the Refund Confirmation screen will show missing text on the "Refund via ..." and "You will need to manually issue the refund through ..." messages.

This PR fixes this problem by changing the text to show only "Manual Refund" when there's no associated payment method, as well as changes the refund comment for parity with Android (reference: p1655978471418269?thread_ts=1655977271.940149&cid=C025A8VV728). 

## Testing instructions

| Case 1: Supports automatic refunds  | Case 2: Does not support automatic refunds & unknown gateway  | Case 3: Does not support automatic refunds + known gateway|
|---|---|---|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2022-06-28 at 21 47 47](https://user-images.githubusercontent.com/3812076/176215436-5b9fbf07-d264-4a86-9a43-f2ef3a97fe64.png) |  ![Simulator Screen Shot - iPhone 11 Pro Max - 2022-06-28 at 21 41 24](https://user-images.githubusercontent.com/3812076/176215511-04d07aa9-28de-41ac-82f4-2cc8b748e6ee.png)| ![Simulator Screen Shot - iPhone 11 Pro Max - 2022-06-28 at 21 40 20](https://user-images.githubusercontent.com/3812076/176215560-355ebcb1-70ca-4758-bbb0-4b2c7f3fe9ea.png) |




### Case 1: Supports automatic refunds, for example via Debit/credit card. 

1 - Go to your site, and check out an Order using Stripe. Go to the app and attempt to refund the order.
2 - See how nothing changes, when you attempt a refund you should see the message:

```
Refund via
Credit card/debit card
```

### Case 2: Does not support automatic refunds, and no payment gateway is associated with the Order.

1 - Go to Orders > Tap "+" > Simple Payment > Enter any amount > Tap "Take Payment" > Select "Cash" > Tap "Mark as Paid"
2 - Go to Orders > Open the Order you've just created and attempt to Refund it
3 - See the new message:

```
Refund via
Manual refund
The payment method does not support automatic refunds. Complete the refund by transferring the money to the customer manually.
```
### Case 3: Does not support automatic refunds, however, a payment gateway is associated with the Order. For example BAC/Direct Bank Transfer/Cheque, or Cash on delivery

1 - Go to your site > Woocommerce > Settings > Payments > All payment methods > Enable Direct Bank Transfer and/or Check Payments. 
2 - Create an order via the website and checkout using one of these payment methods (BAC/Direct Bank Transfer/Cheque). This will create an order that has a payment gateway and does not allow automatic refunds. 
3 - By attempting a refund via the app, you should see the following (for example by using Direct bank transfer):

```
Refund via
Direct bank transfer
```

### Screenshots

This is the difference in the text before the changes, and after the changes, in order to get parity with the Android version.

| Manual Refund (before) | Manual Refund (after) |
|---|---|
|![](https://user-images.githubusercontent.com/3812076/175799367-c1470a82-a775-44a6-98e5-fc676549a9bc.png)|![](https://user-images.githubusercontent.com/3812076/175304137-32360df3-26c8-468b-b886-4a942ae01ef3.png)|

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
