### PR TITLE
[Unified Order Editing] Add non-editable banner

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -981,6 +981,12 @@ extension UIImage {
     static var welcomeImage: UIImage {
         UIImage(imageLiteralResourceName: "img-welcome")
     }
+
+    /// Lock Image
+    ///
+    static var lockImage: UIImage {
+        UIImage.gridicon(.lock, size: CGSize(width: 24, height: 24))
+    }
 }
 
 private extension UIImage {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -101,6 +101,9 @@ final class EditableOrderViewModel: ObservableObject {
     /// Defines if the view should be disabled.
     @Published private(set) var disabled: Bool = false
 
+    /// Defines if the non editable banner should be shown.
+    @Published private(set) var shouldShowNonEditableBanner: Bool = false
+
     /// Status Results Controller.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
@@ -266,6 +269,7 @@ final class EditableOrderViewModel: ObservableObject {
         configureCustomerDataViewModel()
         configurePaymentDataViewModel()
         configureCustomerNoteDataViewModel()
+        configureNonEditableBanner()
         resetAddressForm()
     }
 
@@ -701,6 +705,21 @@ private extension EditableOrderViewModel {
                                             currencyFormatter: self.currencyFormatter)
             }
             .assign(to: &$paymentDataViewModel)
+    }
+
+    /// Binds the order state to the `shouldShowNonEditableBanner` property.
+    ///
+    func configureNonEditableBanner() {
+        Publishers.CombineLatest(orderSynchronizer.orderPublisher, Just(flow))
+            .map { order, flow in
+                switch flow {
+                case .creation:
+                    return false
+                case .editing:
+                    return !order.isEditable
+                }
+            }
+            .assign(to: &$shouldShowNonEditableBanner)
     }
 
     /// Tracks when customer details have been added

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -108,10 +108,13 @@ struct OrderForm: View {
                 ScrollView {
                     VStack(spacing: Layout.noSpacing) {
 
-                        NonEditableOrderBanner(width: geometry.size.width)
-                            .renderedIf(viewModel.shouldShowNonEditableBanner)
+                        Group {
+                            Divider() // Needed because `NonEditableOrderBanner` does not have a top divider
+                            NonEditableOrderBanner(width: geometry.size.width)
+                        }
+                        .renderedIf(viewModel.shouldShowNonEditableBanner)
 
-                        OrderStatusSection(viewModel: viewModel)
+                        OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableBanner)
 
                         Spacer(minLength: Layout.sectionSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -107,6 +107,10 @@ struct OrderForm: View {
             ScrollViewReader { scroll in
                 ScrollView {
                     VStack(spacing: Layout.noSpacing) {
+
+                        NonEditableOrderBanner(width: geometry.size.width)
+                            .renderedIf(viewModel.shouldShowNonEditableBanner)
+
                         OrderStatusSection(viewModel: viewModel)
 
                         Spacer(minLength: Layout.sectionSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -4,12 +4,19 @@ import Yosemite
 /// Represents the Status section with date label, status badge and edit button.
 ///
 struct OrderStatusSection: View {
+
     @ObservedObject var viewModel: EditableOrderViewModel
 
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
+    /// Set false to not render the top divider.
+    /// Useful when there is a content on top that has its own divider.
+    ///
+    private(set) var topDivider: Bool = true
+
     var body: some View {
         Divider()
+            .renderedIf(topDivider)
 
         VStack(alignment: .leading, spacing: .zero) {
             Text(viewModel.dateString)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Edition/Banners/NonEditableOrderBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Edition/Banners/NonEditableOrderBanner.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SwiftUI
+
+/// Banner to inform that an order is not editable.
+///
+struct NonEditableOrderBanner: UIViewRepresentable {
+    typealias Callback = () -> ()
+
+    /// Desired `width` of the view.
+    ///
+    private let width: CGFloat
+
+    /// Create a view with the desired `width`. Needed to calculate a correct view `height` later.
+    ///
+    init(width: CGFloat) {
+        self.width = width
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(bannerWrapper: TopBannerWrapperView())
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let expandButton = TopBannerViewModel.TopButtonType.chevron {
+            context.coordinator.bannerWrapper.invalidateIntrinsicContentSize() // Forces the view to recalculate it's size as it collapses/expands
+        }
+
+        let viewModel = TopBannerViewModel(title: Localization.title,
+                                           infoText: Localization.description,
+                                           icon: UIImage.gridicon(.lock),
+                                           iconTintColor: .brand,
+                                           isExpanded: false,
+                                           topButton: expandButton)
+        let mainBanner = TopBannerView(viewModel: viewModel)
+
+        // Set the current super view width and the real view to be displayed inside the wrapper.
+        context.coordinator.bannerWrapper.width = width
+        context.coordinator.bannerWrapper.setBanner(mainBanner)
+        return context.coordinator.bannerWrapper
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.bannerWrapper.width = width
+    }
+}
+
+// MARK: Coordinator
+extension NonEditableOrderBanner {
+    /// Hold state across `SwiftUI` lifecycle passes.
+    ///
+    struct Coordinator {
+        /// Banner wrapper that will contain a `TopBannerView`.
+        ///
+        let bannerWrapper: TopBannerWrapperView
+    }
+}
+
+// MARK: Localization
+private extension NonEditableOrderBanner {
+    enum Localization {
+        static let title = NSLocalizedString("Parts of this order are not currently editable", comment: "Title of the banner when the order is not editable")
+        static let description = NSLocalizedString("To edit Products or Payment Details, please change the status to Pending Payment.",
+                                                   comment: "Content of the banner when the order is not editable")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Edition/Banners/NonEditableOrderBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Edition/Banners/NonEditableOrderBanner.swift
@@ -59,7 +59,7 @@ extension NonEditableOrderBanner {
 private extension NonEditableOrderBanner {
     enum Localization {
         static let title = NSLocalizedString("Parts of this order are not currently editable", comment: "Title of the banner when the order is not editable")
-        static let description = NSLocalizedString("To edit Products or Payment Details, please change the status to Pending Payment.",
+        static let description = NSLocalizedString("To edit Products or Payment Details, change the status to Pending Payment.",
                                                    comment: "Content of the banner when the order is not editable")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Edition/Banners/NonEditableOrderBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Edition/Banners/NonEditableOrderBanner.swift
@@ -27,7 +27,7 @@ struct NonEditableOrderBanner: UIViewRepresentable {
 
         let viewModel = TopBannerViewModel(title: Localization.title,
                                            infoText: Localization.description,
-                                           icon: UIImage.gridicon(.lock),
+                                           icon: UIImage.lockImage,
                                            iconTintColor: .brand,
                                            isExpanded: false,
                                            topButton: expandButton)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
+		26DB7E3528636D2200506173 /* NonEditableOrderBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
 		26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE12263359F900A5EB3B /* View+Conditionals.swift */; };
 		26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE1826335AA900A5EB3B /* Survey.swift */; };
@@ -2328,6 +2329,7 @@
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
+		26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonEditableOrderBanner.swift; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
 		26E0AE12263359F900A5EB3B /* View+Conditionals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Conditionals.swift"; sourceTree = "<group>"; };
 		26E0AE1826335AA900A5EB3B /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
@@ -4908,6 +4910,22 @@
 			path = CountrySelector;
 			sourceTree = "<group>";
 		};
+		26DB7E3228636CF200506173 /* Order Edition */ = {
+			isa = PBXGroup;
+			children = (
+				26DB7E3328636D1300506173 /* Banners */,
+			);
+			path = "Order Edition";
+			sourceTree = "<group>";
+		};
+		26DB7E3328636D1300506173 /* Banners */ = {
+			isa = PBXGroup;
+			children = (
+				26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */,
+			);
+			path = Banners;
+			sourceTree = "<group>";
+		};
 		26E1BEC7251BE50C0096D0A1 /* Issue Refunds */ = {
 			isa = PBXGroup;
 			children = (
@@ -7032,6 +7050,7 @@
 				02C1853927FED8BE00ABD764 /* Refund */,
 				2678897A270E6E3C00BD249E /* Simple Payments */,
 				CCFC50532743BBBF001E505F /* Order Creation */,
+				26DB7E3228636CF200506173 /* Order Edition */,
 				0206483923FA4160008441BB /* OrdersRootViewController.swift */,
 				45B0DF39273C20120026DC61 /* OrdersRootViewController.xib */,
 				57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */,
@@ -9126,6 +9145,7 @@
 				D8652E582630BFF500350F37 /* OrderDetailsPaymentAlerts.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
+				26DB7E3528636D2200506173 /* NonEditableOrderBanner.swift in Sources */,
 				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift in Sources */,
 				2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -648,4 +648,8 @@ final class IconsTests: XCTestCase {
     func test_rectangle_on_rectangle_angled_is_not_nil() {
         XCTAssertNotNil(UIImage.rectangleOnRectangleAngled)
     }
+
+    func test_lock_icon_is_not_nil() {
+        XCTAssertNotNil(UIImage.lockImage)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1116,6 +1116,36 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(isCallbackCalled)
     }
+
+    func test_creating_order_does_not_shows_banner() {
+        // Given
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID)
+
+        // When & Then
+        XCTAssertFalse(viewModel.shouldShowNonEditableBanner)
+    }
+
+    func test_editing_a_non_editable_order_shows_banner() {
+        // Given
+        let order = Order.fake().copy(isEditable: false)
+
+        // When
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, initialOrder: order)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowNonEditableBanner)
+    }
+
+    func test_editing_an_editable_order_does_not_shows_banner() {
+        // Given
+        let order = Order.fake().copy(isEditable: true)
+
+        // When
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, initialOrder: order)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowNonEditableBanner)
+    }
 }
 
 private extension MockStorageManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1119,7 +1119,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_creating_order_does_not_shows_banner() {
         // Given
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID)
 
         // When & Then
         XCTAssertFalse(viewModel.shouldShowNonEditableBanner)
@@ -1130,7 +1130,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let order = Order.fake().copy(isEditable: false)
 
         // When
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
 
         // Then
         XCTAssertTrue(viewModel.shouldShowNonEditableBanner)
@@ -1141,7 +1141,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let order = Order.fake().copy(isEditable: true)
 
         // When
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
 
         // Then
         XCTAssertFalse(viewModel.shouldShowNonEditableBanner)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1130,7 +1130,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let order = Order.fake().copy(isEditable: false)
 
         // When
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, initialOrder: order)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
 
         // Then
         XCTAssertTrue(viewModel.shouldShowNonEditableBanner)
@@ -1141,7 +1141,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let order = Order.fake().copy(isEditable: true)
 
         // When
-        let viewModel = NewOrderViewModel(siteID: sampleSiteID, initialOrder: order)
+        let viewModel = NewOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
 
         // Then
         XCTAssertFalse(viewModel.shouldShowNonEditableBanner)

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -355,11 +355,12 @@ private extension OrderStore {
         /// Optimistically update the Status
         let oldStatus = updateOrderStatus(siteID: siteID, orderID: orderID, statusKey: status)
 
-        remote.updateOrder(from: siteID, orderID: orderID, statusKey: status) { [weak self] (_, error) in
+        remote.updateOrder(from: siteID, orderID: orderID, statusKey: status) { [weak self] (order, error) in
             guard let error = error else {
-                // NOTE: We're *not* actually updating the whole entity here. Reason: Prevent UI inconsistencies!!
-                onCompletion(nil)
-                return
+                if let order = order {
+                    self?.upsertStoredOrder(readOnlyOrder: order)
+                }
+                return onCompletion(nil)
             }
 
             /// Revert Optimistic Update


### PR DESCRIPTION
Closes: #7051 

# Why

Some orders can't be fully editable, in order to inform about it, we will be displaying a top banner explaining the situation.

# How

- Added `NonEditableOrderBanner` SwiftUI wrapper.
- Updated `ViewModel` to expose a new `shouldShowNonEditableBanner` property.
- Update `OrderStore` to update the order object after an status update, to get the correct value dor the `isEditable` property.

# Screenshots

Editable | Non Editable Collapsed | Non Editable Expanded
--- | --- | ---
<img width="436" alt="editable" src="https://user-images.githubusercontent.com/562080/175354904-e7584518-2794-48ae-9cf2-ae89f6f3c296.png"> | <img width="437" alt="not-editable-collapsed" src="https://user-images.githubusercontent.com/562080/175354909-dc89cda4-9638-46de-a914-29d2327583e6.png"> | <img width="441" alt="not-editable-expanded" src="https://user-images.githubusercontent.com/562080/175354910-68ce2c49-4d9f-4cba-83b5-eb0ee5ce1799.png">

# Testing

- Open a pending payment order
- Tap the edit button
- See that no banner is presented
- Tap Done
- Update the order status to completed
- Tap the edit button
- See that the non-editable banner is presented.

**Note: Updating the status in the edit form does not work yet. https://github.com/woocommerce/woocommerce-ios/issues/7074**

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
