### PR TITLE
[Order Details] Fix race condition for missing products request

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -192,17 +192,23 @@ extension OrderDetailsViewModel {
         syncState = .syncing
 
         group.enter()
-        syncOrder { _ in
-            group.leave()
-        }
+        syncOrder { [weak self] _ in
+            // Products require order.items data, so sync them only after the order is loaded
+            guard let self = self else {
+                group.leave()
+                return
+            }
 
-        group.enter()
-        syncProducts { _ in
-            group.leave()
-        }
+            group.enter()
+            self.syncProducts { _ in
+                group.leave()
+            }
 
-        group.enter()
-        syncProductVariations { _ in
+            group.enter()
+            self.syncProductVariations { _ in
+                group.leave()
+            }
+
             group.leave()
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -193,11 +193,12 @@ extension OrderDetailsViewModel {
 
         group.enter()
         syncOrder { [weak self] _ in
-            // Products require order.items data, so sync them only after the order is loaded
-            guard let self = self else {
+            defer {
                 group.leave()
-                return
             }
+
+            // Products require order.items data, so sync them only after the order is loaded
+            guard let self = self else { return }
 
             group.enter()
             self.syncProducts { _ in
@@ -208,8 +209,6 @@ extension OrderDetailsViewModel {
             self.syncProductVariations { _ in
                 group.leave()
             }
-
-            group.leave()
         }
 
         group.enter()

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -211,6 +211,12 @@ private extension ProductStore {
             }
         }
 
+        // Do not trigger API request for empty array of items
+        guard !missingIDs.isEmpty else {
+            onCompletion(nil)
+            return
+        }
+
         remote.loadProducts(for: order.siteID, by: missingIDs) { [weak self] result in
             switch result {
             case .success(let products):


### PR DESCRIPTION
Closes: #7132

## Description

This PR fixes race condition in Order Details screen, so products are always correctly loaded and displayed in edit flow.
Also it prevents some empty products sync requests when no data update is needed.

## How

The method `syncEverything` in `OrderDetailsViewModel` have separate `syncOrder()` and `syncProducts()` calls which are run in parallel.
In fact, products sync depends on order, because simple order (from the list, non-cached previously) doesn't have `items` data with product ids to sync at all. This is an edge case, because usually products and/or order are already cached.

## Testing

1. Logout, log back in to clear cache.
2. Go to Orders List.
3. Open Order Details.
4. Confirm products list with thumbnails is loaded (if products sync failed, list will also be there, but with basic data, no thumbnails)
5. Tap "•••" in navbar. Select "Edit".
6. Confirm products list is displayed correctly on Order Edit screen.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/175366484-929e6017-a3ca-44da-bc68-9b962e397ddb.png)|![Simulator Screen Shot - 3](https://user-images.githubusercontent.com/3132438/175366500-3364e7c4-abd3-4520-acb3-d5dc23455755.png)
![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/175366496-f770e48a-71d1-4b4a-9a8d-9eeb5a9e79ef.png)|![Simulator Screen Shot - 4](https://user-images.githubusercontent.com/3132438/175366503-79d5746b-ddec-4e2c-b760-53b3c95a6525.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.