### PR TITLE
SIWA account removal: update action to close account

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -42,7 +42,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .backgroundProductImageUpload:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .appleIDAccountDeletion:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Coupons: Fixed issue saving "Individual Use" and "Exclude Sale Items" fields. [https://github.com/woocommerce/woocommerce-ios/pull/7117]
 - [*] Orders: The customer shipping/billing address form now navigates back automatically after selecting a country or state. [https://github.com/woocommerce/woocommerce-ios/pull/7119]
+- [internal] In settings and empty stores screen, the "Close Account" link is shown for users who signed in with Apple (the only way to create an account) to close their WordPress.com account. [https://github.com/woocommerce/woocommerce-ios/pull/7143]
 
 9.4
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1125,6 +1125,31 @@ extension WooAnalyticsEvent {
     }
 }
 
+// MARK: - Close Account
+//
+extension WooAnalyticsEvent {
+    /// The source that presents the Jetpack install screen.
+    enum CloseAccountSource: String {
+        case settings
+        case emptyStores = "empty_stores"
+    }
+
+    /// Tracked when the user taps to close their WordPress.com account.
+    static func closeAccountTapped(source: CloseAccountSource) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .closeAccountTapped, properties: ["source": source.rawValue])
+    }
+
+    /// Tracked when the WordPress.com account closure succeeds.
+    static func closeAccountSuccess() -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .closeAccountSuccess, properties: [:])
+    }
+
+    /// Tracked when the WordPress.com account closure fails.
+    static func closeAccountFailed(error: Error) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .closeAccountFailed, properties: [:], error: error)
+    }
+}
+
 private extension PaymentMethod {
     var analyticsValue: String {
         switch self {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -595,6 +595,11 @@ public enum WooAnalyticsStat: String {
     case inboxNotesLoaded = "inbox_notes_loaded"
     case inboxNotesLoadedFailed = "inbox_notes_load_failed"
     case inboxNoteAction = "inbox_note_action"
+
+    // MARK: Close Account
+    case closeAccountTapped = "close_account_tapped"
+    case closeAccountSuccess = "close_account_success"
+    case closeAccountFailed = "close_account_failed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.swift
@@ -8,7 +8,7 @@ final class EmptyStoresTableViewCell: UITableViewCell {
 
     var onJetpackSetupButtonTapped: (() -> Void)?
 
-    var onRemoveAppleIDAccessButtonTapped: (() -> Void)?
+    var onCloseAccountButtonTapped: (() -> Void)?
 
     /// LegendLabel: To be displayed below the ImageView.
     ///
@@ -66,9 +66,9 @@ private extension EmptyStoresTableViewCell {
 
     func configureRemoveAppleIDAccessButton() {
         removeAppleIDAccessButton.applyLinkButtonStyle()
-        removeAppleIDAccessButton.setTitle(Localization.removeAppleIDAccessTitle, for: .normal)
+        removeAppleIDAccessButton.setTitle(Localization.closeAccountTitle, for: .normal)
         removeAppleIDAccessButton.on(.touchUpInside) { [weak self] _ in
-            self?.onRemoveAppleIDAccessButtonTapped?()
+            self?.onCloseAccountButtonTapped?()
         }
     }
 }
@@ -77,9 +77,9 @@ private extension EmptyStoresTableViewCell {
     enum Localization {
         static let actionTitle = NSLocalizedString("Connect your store with Jetpack",
                                                    comment: "Link on the store picker when there are no stores available. Opens a webview about Jetpack setup.")
-        static let removeAppleIDAccessTitle = NSLocalizedString(
-            "Remove Apple ID access",
-            comment: "Link on the store picker for users who signed in with Apple to disconnect their Apple ID from the app."
+        static let closeAccountTitle = NSLocalizedString(
+            "Close Account",
+            comment: "Link on the store picker for users who signed in with Apple to close their WordPress.com account."
         )
         static let legend =
             NSLocalizedString("If you already have a store, you’ll need to install the free Jetpack plugin and connect it to your WordPress.com account.",

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -716,8 +716,7 @@ private extension StorePickerViewController {
     func removeAppleIDAccess() async -> Result<Void, Error> {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: ApiCredentials.dotcomAppId,
-                                                           dotcomSecret: ApiCredentials.dotcomSecret) { result in
+            let action = AccountAction.closeAccount { result in
                 continuation.resume(returning: result)
             }
             self.stores.dispatch(action)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -650,6 +650,7 @@ extension StorePickerViewController: UITableViewDataSource {
             if isRemoveAppleIDAccessButtonVisible {
                 cell.onCloseAccountButtonTapped = { [weak self] in
                     guard let self = self else { return }
+                    ServiceLocator.analytics.track(event: .closeAccountTapped(source: .emptyStores))
                     self.removeAppleIDAccessCoordinator.start()
                 }
             }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -648,7 +648,7 @@ extension StorePickerViewController: UITableViewDataSource {
             && featureFlagService.isFeatureFlagEnabled(.appleIDAccountDeletion)
             cell.updateRemoveAppleIDAccessButtonVisibility(isVisible: isRemoveAppleIDAccessButtonVisible)
             if isRemoveAppleIDAccessButtonVisible {
-                cell.onRemoveAppleIDAccessButtonTapped = { [weak self] in
+                cell.onCloseAccountButtonTapped = { [weak self] in
                     guard let self = self else { return }
                     self.removeAppleIDAccessCoordinator.start()
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
@@ -7,6 +7,7 @@ import protocol Yosemite.StoresManager
     private let removeAction: () async -> Result<Void, Error>
     private let onRemoveSuccess: () -> Void
     private let stores: StoresManager
+    private let analytics: Analytics
 
     /// - Parameters:
     ///   - sourceViewController: the view controller that presents the in-progress UI and alerts.
@@ -15,11 +16,13 @@ import protocol Yosemite.StoresManager
     init(sourceViewController: UIViewController,
          removeAction: @escaping () async -> Result<Void, Error>,
          onRemoveSuccess: @escaping () -> Void,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.sourceViewController = sourceViewController
         self.removeAction = removeAction
         self.onRemoveSuccess = onRemoveSuccess
         self.stores = stores
+        self.analytics = analytics
     }
 
     func start() {
@@ -52,8 +55,10 @@ private extension RemoveAppleIDAccessCoordinator {
                     guard let self = self else { return }
                     switch result {
                     case .success:
+                        self.analytics.track(event: .closeAccountSuccess())
                         self.onRemoveSuccess()
                     case .failure(let error):
+                        self.analytics.track(event: .closeAccountFailed(error: error))
                         DDLogError("⛔️ Cannot close account: \(error)")
                         self.presentErrorAlert(error: error)
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/RemoveAppleIDAccessCoordinator.swift
@@ -1,10 +1,12 @@
 import UIKit
+import protocol Yosemite.StoresManager
 
 /// Coordinates navigation for removing Apple ID access from various entry points (settings and empty stores screens).
-final class RemoveAppleIDAccessCoordinator {
+@MainActor final class RemoveAppleIDAccessCoordinator {
     private let sourceViewController: UIViewController
     private let removeAction: () async -> Result<Void, Error>
     private let onRemoveSuccess: () -> Void
+    private let stores: StoresManager
 
     /// - Parameters:
     ///   - sourceViewController: the view controller that presents the in-progress UI and alerts.
@@ -12,10 +14,12 @@ final class RemoveAppleIDAccessCoordinator {
     ///   - onRemoveSuccess: called when the removal is successful.
     init(sourceViewController: UIViewController,
          removeAction: @escaping () async -> Result<Void, Error>,
-         onRemoveSuccess: @escaping () -> Void) {
+         onRemoveSuccess: @escaping () -> Void,
+         stores: StoresManager = ServiceLocator.stores) {
         self.sourceViewController = sourceViewController
         self.removeAction = removeAction
         self.onRemoveSuccess = onRemoveSuccess
+        self.stores = stores
     }
 
     func start() {
@@ -26,11 +30,15 @@ final class RemoveAppleIDAccessCoordinator {
 private extension RemoveAppleIDAccessCoordinator {
     func presentConfirmationAlert() {
         // TODO: 7068 - analytics
+
+        let username = stores.sessionManager.defaultAccount?.username ?? ""
+        let message = String.localizedStringWithFormat(Localization.ConfirmationAlert.alertMessageFormat, username)
         let alertController = UIAlertController(title: Localization.ConfirmationAlert.alertTitle,
-                                                message: Localization.ConfirmationAlert.alertMessage,
+                                                message: message,
                                                 preferredStyle: .alert)
         alertController.addActionWithTitle(Localization.ConfirmationAlert.cancelButtonTitle, style: .cancel) { _ in }
-        alertController.addActionWithTitle(Localization.ConfirmationAlert.removeButtonTitle, style: .destructive) { [weak self] _ in
+        let closeAccountAction = alertController.addActionWithTitle(Localization.ConfirmationAlert.removeButtonTitle,
+                                                                    style: .destructive) { [weak self] _ in
             guard let self = self else { return }
 
             // TODO: 7068 - analytics
@@ -46,12 +54,24 @@ private extension RemoveAppleIDAccessCoordinator {
                     case .success:
                         self.onRemoveSuccess()
                     case .failure(let error):
-                        DDLogError("⛔️ Cannot remove Apple ID access: \(error)")
-                        self.presentErrorAlert()
+                        DDLogError("⛔️ Cannot close account: \(error)")
+                        self.presentErrorAlert(error: error)
                     }
                 }
             }
         }
+
+        // Enables close account button based on whether the username matches the user input.
+        closeAccountAction.isEnabled = false
+
+        // Username text field.
+        alertController.addTextField { textField in
+            textField.clearButtonMode = .always
+            textField.on(.editingChanged) { textField in
+                closeAccountAction.isEnabled = textField.text == username
+            }
+        }
+
         sourceViewController.present(alertController, animated: true)
     }
 
@@ -66,12 +86,47 @@ private extension RemoveAppleIDAccessCoordinator {
         sourceViewController.dismiss(animated: true, completion: completion)
     }
 
-    func presentErrorAlert() {
+    func presentErrorAlert(error: Error) {
         let alertController = UIAlertController(title: Localization.ErrorAlert.alertTitle,
-                                                message: Localization.ErrorAlert.alertMessage,
+                                                message: generateLocalizedMessage(error: error),
                                                 preferredStyle: .alert)
+        alertController.addActionWithTitle(Localization.ErrorAlert.contactSupportButtonTitle, style: .default) { [weak self] _ in
+            guard let self = self else { return }
+            ZendeskProvider.shared.showNewRequestIfPossible(from: self.sourceViewController, with: nil)
+        }
         alertController.addActionWithTitle(Localization.ErrorAlert.dismissButtonTitle, style: .cancel) { _ in }
         sourceViewController.present(alertController, animated: true)
+    }
+
+    func generateLocalizedMessage(error: Error) -> String {
+        let errorCode = errorCode(error: error)
+
+        switch errorCode {
+        case "unauthorized":
+            return NSLocalizedString("You're not authorized to close the account.",
+                                     comment: "Error message displayed when unable to close user account due to being unauthorized.")
+        case "atomic-site":
+            return NSLocalizedString("To close this account now, contact our support team.",
+                                     comment: "Error message displayed when unable to close user account due to having active atomic site.")
+        case "chargebacked-site":
+            return NSLocalizedString("This user account cannot be closed if there are unresolved chargebacks.",
+                                     comment: "Error message displayed when unable to close user account due to unresolved chargebacks.")
+        case "active-subscriptions":
+            return NSLocalizedString("This user account cannot be closed while it has active subscriptions.",
+                                     comment: "Error message displayed when unable to close user account due to having active subscriptions.")
+        case "active-memberships":
+            return NSLocalizedString("This user account cannot be closed while it has active purchases.",
+                                     comment: "Error message displayed when unable to close user account due to having active purchases.")
+        default:
+            return NSLocalizedString("An error occured while closing account.",
+                                     comment: "Default error message displayed when unable to close user account.")
+        }
+    }
+
+    func errorCode(error: Error) -> String? {
+        let userInfo = (error as NSError).userInfo
+        let errorCode = userInfo[Constants.dotcomAPIErrorCodeKey] as? String
+        return errorCode
     }
 }
 
@@ -79,46 +134,51 @@ private extension RemoveAppleIDAccessCoordinator {
     enum Localization {
         enum RemoveAppleIDAccessInProgressView {
             static let title = NSLocalizedString(
-                "Removing Apple ID Access...",
-                comment: "Title of the Remove Apple ID Access in-progress view."
+                "Closing account...",
+                comment: "Title of the Close Account in-progress view."
             )
         }
 
         enum ConfirmationAlert {
             static let alertTitle = NSLocalizedString(
-                "Remove Apple ID Access",
-                comment: "Remove Apple ID Access confirmation alert title - confirms and revokes Apple ID token."
+                "Confirm Close Account",
+                comment: "Close Account confirmation alert title."
             )
-            static let alertMessage = NSLocalizedString(
-                "This will log you out and reset your Sign In With Apple access token. " +
-                "You will be asked to re-enter your WordPress.com password if you Sign In With Apple again.",
-                comment: "Alert message to confirm a user meant to remove Apple ID access."
+            static let alertMessageFormat = NSLocalizedString(
+                "To confirm, please re-enter your username before closing.\n\n%1$@",
+                comment: "Close Account confirmation alert message. The %1$@ is the user's WordPress.com username."
             )
             static let cancelButtonTitle = NSLocalizedString(
                 "Cancel",
-                comment: "Alert button title - dismisses alert, which cancels the Remove Apple ID Access attempt."
+                comment: "Close Account button title - dismisses alert, which cancels the Close Account attempt."
             )
 
             static let removeButtonTitle = NSLocalizedString(
-                "Remove",
-                comment: "Remove Apple ID Access button title - confirms and revokes Apple ID token."
+                "Permanently Close Account",
+                comment: "Close Account button title - confirms and closes user's WordPress.com account."
             )
         }
 
         enum ErrorAlert {
             static let alertTitle = NSLocalizedString(
-                "Error Removing Apple ID Access",
-                comment: "Remove Apple ID Access error alert title."
+                "Couldn’t close account automatically",
+                comment: "Error title displayed when unable to close user account."
             )
-            static let alertMessage = NSLocalizedString(
-                "Please try again or contact us for support.",
-                comment: "Remove Apple ID Access error alert message."
+            static let contactSupportButtonTitle = NSLocalizedString(
+                "Contact Support",
+                comment: "Close Account error alert button title - navigates the user to contact support."
             )
             static let dismissButtonTitle = NSLocalizedString(
-                "OK",
-                comment: "Alert button title - dismisses Remove Apple ID Access error alert."
+                "Cancel",
+                comment: "Close Account error alert button title - dismisses error alert."
             )
         }
+    }
+}
+
+private extension RemoveAppleIDAccessCoordinator {
+    enum Constants {
+        static let dotcomAPIErrorCodeKey = "WordPressComRestApiErrorCodeKey"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -231,7 +231,7 @@ private extension SettingsViewController {
         cell.selectionStyle = .default
         cell.textLabel?.textAlignment = .center
         cell.textLabel?.textColor = .error
-        cell.textLabel?.text = Localization.removeAppleIDAccess
+        cell.textLabel?.text = Localization.closeAccount
     }
 
     func configureLogout(cell: BasicTableViewCell) {
@@ -730,9 +730,9 @@ private extension SettingsViewController {
             comment: "Navigates to screen containing the latest WooCommerce Features"
         )
 
-        static let removeAppleIDAccess = NSLocalizedString(
-            "Remove Apple ID Access",
-            comment: "Remove Apple ID Access button title to revoke Apple ID token"
+        static let closeAccount = NSLocalizedString(
+            "Close Account",
+            comment: "Close Account button title to close the user's WordPress.com account"
         )
 
         static let logout = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -264,8 +264,7 @@ private extension SettingsViewController {
     func removeAppleIDAccess() async -> Result<Void, Error> {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: ApiCredentials.dotcomAppId,
-                                                           dotcomSecret: ApiCredentials.dotcomSecret) { result in
+            let action = AccountAction.closeAccount { result in
                 continuation.resume(returning: result)
             }
             self.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -258,6 +258,7 @@ private extension SettingsViewController {
 //
 private extension SettingsViewController {
     func removeAppleIDAccessWasPressed() {
+        ServiceLocator.analytics.track(event: .closeAccountTapped(source: .settings))
         removeAppleIDAccessCoordinator.start()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/RemoveAppleIDAccessCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/RemoveAppleIDAccessCoordinatorTests.swift
@@ -28,7 +28,7 @@ final class RemoveAppleIDAccessCoordinatorTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_alert_is_presented_when_starting_coordinator() throws {
+    @MainActor func test_alert_is_presented_when_starting_coordinator() throws {
         // Given
         let coordinator = RemoveAppleIDAccessCoordinator(sourceViewController: sourceViewController) {
             return .success(())

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -14,5 +14,5 @@ public enum AccountAction: Action {
     case synchronizeSites(selectedSiteID: Int64?, isJetpackConnectionPackageSupported: Bool, onCompletion: (Result<Bool, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
-    case removeAppleIDAccess(dotcomAppID: String, dotcomSecret: String, onCompletion: (Result<Void, Error>) -> Void)
+    case closeAccount(onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDotcomAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDotcomAccountRemote.swift
@@ -5,22 +5,18 @@ import XCTest
 /// Mock for `DotcomAccountRemoteProtocol`.
 ///
 final class MockDotcomAccountRemote {
-    /// Returns the value when `disconnectFromSocialService` is called.
-    var disconnectFromSocialServiceResult: Result<Void, NSError> = .success(())
+    /// Returns the value when `closeAccount` is called.
+    private var closeAccountResult: Result<Void, NSError> = .success(())
 
-    /// Returns the value as a publisher when `disconnectFromSocialService` is called.
-    func whenDisconnectingFromSocialService(thenReturn result: Result<Void, NSError>) {
-        disconnectFromSocialServiceResult = result
+    /// Returns the value as a publisher when `closeAccount` is called.
+    func whenClosingAccount(thenReturn result: Result<Void, NSError>) {
+        closeAccountResult = result
     }
 }
 
 extension MockDotcomAccountRemote: DotcomAccountRemoteProtocol {
-    func disconnectFromSocialService(_ service: SocialServiceName,
-                                     oAuthClientID: String,
-                                     oAuthClientSecret: String,
-                                     success: @escaping () -> Void,
-                                     failure: @escaping (NSError) -> Void) {
-        switch disconnectFromSocialServiceResult {
+    func closeAccount(success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        switch closeAccountResult {
         case .success:
             success()
         case .failure(let error):

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -798,7 +798,7 @@ final class AccountStoreTests: XCTestCase {
         // Given
         let network = MockNetwork()
         let dotcomRemote = MockDotcomAccountRemote()
-        dotcomRemote.whenDisconnectingFromSocialService(thenReturn: .success(()))
+        dotcomRemote.whenClosingAccount(thenReturn: .success(()))
         let accountStore = AccountStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
                                         network: network,
@@ -807,7 +807,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "") { result in
+            let action = AccountAction.closeAccount { result in
                 promise(result)
             }
             accountStore.onAction(action)
@@ -822,7 +822,7 @@ final class AccountStoreTests: XCTestCase {
         let network = MockNetwork()
         let dotcomRemote = MockDotcomAccountRemote()
         let error = NSError(domain: "disconnect", code: 134)
-        dotcomRemote.whenDisconnectingFromSocialService(thenReturn: .failure(error))
+        dotcomRemote.whenClosingAccount(thenReturn: .failure(error))
         let accountStore = AccountStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
                                         network: network,
@@ -831,7 +831,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = AccountAction.removeAppleIDAccess(dotcomAppID: "", dotcomSecret: "") { result in
+            let action = AccountAction.closeAccount { result in
                 promise(result)
             }
             accountStore.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7068 
More context: p91TBi-92G-p2
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After confirming our previous implementation of SIWA account removal with Apple, they informed us that disconnecting their Apple ID from the WP.com account isn't sufficient (ref p91TBi-92G-p2#comment-10711). Our app needs to delete the account and associated data (e.g. sites) to meet the [new requirements for app submissions after June 30th](https://developer.apple.com/support/offering-account-deletion-in-your-app/). Since we're approaching the deadline for code freeze next Monday, our best bet is to follow the [WPiOS implementation](https://github.com/wordpress-mobile/WordPress-iOS/pull/17029) to offer an option to close their WP.com account.

The major changes are:
- Updated "Remove Apple ID Access" CTA to "Close Account" in settings and empty stores view
- Updated the Yosemite action from `AccountServiceRemoteREST.disconnectFromSocialService` to `AccountSettingsRemote.closeAccount` from WordPressKit
- In the confirmation alert, added a new text field for the user to manually enter their username to enable the destructive action
- Added analytics in https://github.com/woocommerce/woocommerce-ios/pull/7143/commits/6c9ab99a098a0989365e14d1de7c034557228d29

There are still a few variables and functions and the coordinator class that need to be renamed to match the "close account" action, but I thought I'd leave the renaming to a separate PR for easier review.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please feel free to just test one of the following scenarios since the account closure isn't easily reversible and we can't sign up with the same email within 30 days until the account is restored 😬 

🗒️  In order for the Apple ID to be usable again after closing the WP.com account, you can update the account email on the web to a different email like `emailusername+testsiwa@gmail.com` after SIWA. If you'd like to restore an account with SIWA, just remember the email and I can help recover the WP.com account.

#### SIWA without a connected store

Prerequisite: the WP.com account associated with the Apple ID isn't connected to any WC stores

- Log out from the app if needed
- Tap "Continue with WordPress.com"
- Tap "Continue with Apple" to sign in with Apple --> after completing the SIWA flow, the empty stores screen should be shown. There should be a "Close Account" button. In WordPress.com `https://wordpress.com/me/security/social-login`, the Apple account should be connected
- Tap "Close Account" --> a confirmation alert should be shown with a text field, and an event `close_account_tapped` should be logged
- Type in the WP.com username --> the destructive "Permanently Close Account" action should only be enabled when the text matches the WP.com username
- Tap "Permanently Close Account" to confirm --> an in-progress UI modal should be shown and then dismissed, and the app is back to the beginning of the login screen if the closure is successful. An email should also be sent about the account closure and `close_account_success` should be logged. If there's an error (e.g. A8C account or the account owns an atomic site), an error alert should be shown and `close_account_failed` should be logged with the error reason

#### SIWA with a connected store

Prerequisite: the WP.com account associated with the Apple ID is connected to at least one WC store.

- Log out from the app if needed
- Tap "Continue with WordPress.com"
- Tap "Continue with Apple" to sign in with Apple --> after completing the SIWA flow, select a store if needed
- Go to Settings --> there should be a "Close Account" button above the Log Out section
- Tap "Close Account" --> a confirmation alert should be shown with a text field, and an event `close_account_tapped` should be logged
- Type in the WP.com username --> the destructive "Permanently Close Account" action should only be enabled when the text matches the WP.com username
- Tap "Permanently Close Account" to confirm --> an in-progress UI modal should be shown and then dismissed, and the app is back to the beginning of the login screen if the closure is successful. An email should also be sent about the account closure and `close_account_success` should be logged. If there's an error (e.g. A8C account or the account owns an atomic site), an error alert should be shown and `close_account_failed` should be logged with the error reason

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Error case:

https://user-images.githubusercontent.com/1945542/175384162-4f6e9b8f-b97e-4931-bc20-78007243f4ff.mov

Success case:

https://user-images.githubusercontent.com/1945542/175391718-357b7717-aa9a-448e-9deb-654238a62611.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->