### PR TITLE
Background product image upload: show upload failure notice with an action to view product details

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -15,6 +15,15 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         self.stores = stores
     }
 
+    func switchStore(with storeID: Int64) async -> Bool {
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self = self else { return }
+            self.switchStore(with: storeID) { siteChanged in
+                continuation.resume(returning: siteChanged)
+            }
+        }
+    }
+
     /// A static method which allows easily to switch store. The boolean argument in `onCompletion` indicates that the site was changed.
     /// When `onCompletion` is called, the selected site ID is updated while `Site` might still not be available if the site does not exist in storage yet
     /// (e.g. a newly connected site).

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -15,6 +15,9 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         self.stores = stores
     }
 
+    /// The async version of `switchStore` that wraps the completion block version.
+    /// - Parameter storeID: target store ID.
+    /// - Returns: a boolean that indicates whether the site was changed.
     func switchStore(with storeID: Int64) async -> Bool {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }

--- a/WooCommerce/Classes/Extensions/UIViewController+Navigation.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Navigation.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+extension UIViewController {
+    /// Depending on how a VC is presented we need to check different things to know whether it's being dismissed or not.
+    /// A VC presented as the first VC in a navigation controller needs to check if the navigation controller is being dismissed.
+    /// A VC added to an existing navigation controller is dismissed when `isMovingFromParent` is `true`.
+    /// For any other scenario `isBeingDismissed` will do.
+    var isBeingDismissedInAnyWay: Bool {
+        isMovingFromParent || isBeingDismissed || navigationController?.isBeingDismissed == true
+    }
+}

--- a/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
@@ -1,7 +1,10 @@
+import Combine
 import struct Yosemite.ProductImage
 
 /// Used for `ServiceLocator.productImageUploader` if `backgroundProductImageUpload` feature flag is off.
 final class LegacyProductImageUploader: ProductImageUploaderProtocol {
+    let statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never> = Empty<ProductImageUploadUpdate, Never>().eraseToAnyPublisher()
+
     func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
         ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses)
     }
@@ -14,6 +17,14 @@ final class LegacyProductImageUploader: ProductImageUploaderProtocol {
                                                          productID: Int64,
                                                          isLocalID: Bool,
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
+        // no-op
+    }
+
+    func startEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
+        // no-op
+    }
+
+    func stopEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
         // no-op
     }
 

--- a/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
@@ -3,7 +3,7 @@ import struct Yosemite.ProductImage
 
 /// Used for `ServiceLocator.productImageUploader` if `backgroundProductImageUpload` feature flag is off.
 final class LegacyProductImageUploader: ProductImageUploaderProtocol {
-    let statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never> = Empty<ProductImageUploadUpdate, Never>().eraseToAnyPublisher()
+    let errors: AnyPublisher<ProductImageUploadError, Never> = Empty<ProductImageUploadError, Never>().eraseToAnyPublisher()
 
     func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
         ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses)
@@ -20,11 +20,11 @@ final class LegacyProductImageUploader: ProductImageUploaderProtocol {
         // no-op
     }
 
-    func startEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func startEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
         // no-op
     }
 
-    func stopEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func stopEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
         // no-op
     }
 

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -105,6 +105,9 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         actionHandlersByProduct.removeValue(forKey: key)
         let keyWithRemoteProductID = ProductKey(siteID: siteID, productID: remoteProductID, isLocalID: false)
         actionHandlersByProduct[keyWithRemoteProductID] = handler
+
+        statusUpdatesExcludedProductKeys.remove(key)
+        statusUpdatesExcludedProductKeys.insert(keyWithRemoteProductID)
     }
 
     func startEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -107,19 +107,30 @@ final class MainTabBarController: UITabBarController {
 
     private var cancellableSiteID: AnyCancellable?
     private let featureFlagService: FeatureFlagService
+    private let noticePresenter: NoticePresenter
+    private let productImageUploader: ProductImageUploaderProtocol
     private let stores: StoresManager = ServiceLocator.stores
+
+    private var productImageUploadStatusUpdatesSubscription: AnyCancellable?
 
     private lazy var isHubMenuFeatureFlagOn = featureFlagService.isFeatureFlagEnabled(.hubMenu)
 
     private lazy var isOrdersSplitViewFeatureFlagOn = featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
 
-    init?(coder: NSCoder, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init?(coder: NSCoder,
+          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.featureFlagService = featureFlagService
+        self.noticePresenter = noticePresenter
+        self.productImageUploader = productImageUploader
         super.init(coder: coder)
     }
 
     required init?(coder: NSCoder) {
         self.featureFlagService = ServiceLocator.featureFlagService
+        self.noticePresenter = ServiceLocator.noticePresenter
+        self.productImageUploader = ServiceLocator.productImageUploader
         super.init(coder: coder)
     }
 
@@ -135,6 +146,7 @@ final class MainTabBarController: UITabBarController {
 
         configureTabViewControllers()
         observeSiteIDForViewControllers()
+        observeProductImageUploadStatusUpdates()
 
         loadHubMenuTabNotificationCountAndUpdateBadge()
     }
@@ -551,5 +563,64 @@ private extension MainTabBarController {
         }
 
         viewModel.startObservingOrdersCount()
+    }
+}
+
+// MARK: - Background Product Image Upload Status Updates
+
+private extension MainTabBarController {
+    func observeProductImageUploadStatusUpdates() {
+        guard featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload) else {
+            return
+        }
+        productImageUploadStatusUpdatesSubscription = productImageUploader.statusUpdates.sink { [weak self] update in
+            self?.handleBackgroundImageUploadUpdate(update)
+        }
+    }
+
+    func handleBackgroundImageUploadUpdate(_ update: ProductImageUploadUpdate) {
+        if update.error != nil {
+            let notice = Notice(title: Localization.imageUploadFailureNoticeTitle,
+                                subtitle: nil,
+                                message: nil,
+                                feedbackType: .error,
+                                notificationInfo: nil,
+                                actionTitle: Localization.imageUploadFailureNoticeActionTitle,
+                                actionHandler: { [weak self] in
+                guard let self = self else { return }
+                Task { @MainActor in
+                    await self.showProductDetails(update: update)
+                }
+            })
+            noticePresenter.enqueue(notice: notice)
+        }
+    }
+
+    func showProductDetails(update: ProductImageUploadUpdate) async {
+        // Switches to the correct store first if needed.
+        let switchStoreUseCase = SwitchStoreUseCase(stores: stores)
+        let siteChanged = await switchStoreUseCase.switchStore(with: update.siteID)
+        if siteChanged {
+            let presenter = SwitchStoreNoticePresenter(siteID: update.siteID,
+                                                       noticePresenter: self.noticePresenter)
+            presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
+        }
+
+        let productViewController = ProductLoaderViewController(model: .product(productID: update.productID),
+                                                                siteID: update.siteID,
+                                                                forceReadOnly: false)
+        let productNavController = WooNavigationController(rootViewController: productViewController)
+        productsNavigationController.present(productNavController, animated: true)
+    }
+}
+
+private extension MainTabBarController {
+    enum Localization {
+        static let imageUploadFailureNoticeTitle =
+        NSLocalizedString("An image failed to upload",
+                          comment: "Title of the notice about an image upload failure in the background.")
+        static let imageUploadFailureNoticeActionTitle =
+        NSLocalizedString("View",
+                          comment: "Title of the action to view product details from a notice about an image upload failure in the background.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -141,11 +141,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
         view.endEditing(true)
 
-        /// Depending on how a VC is presented we need to check different things to know whether it's being dismissed or not.
-        /// A VC presented as the first VC in a navigation controller needs to check if the navigation controller is being dismissed.
-        /// A VC added to an existing navigation controller is dismissed when `isMovingFromParent` is `true`.
-        /// For any other scenario `isBeingDismissed` will do.
-        if isMovingFromParent || isBeingDismissed || navigationController?.isBeingDismissed == true {
+        if isBeingDismissedInAnyWay {
             productImageUploader.startEmittingErrors(siteID: viewModel.productModel.siteID,
                                                             productID: viewModel.productModel.productID,
                                                             isLocalID: !viewModel.productModel.existsRemotely)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -131,7 +131,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             self.viewModel.updateImages(productImageStatuses.images)
         }
 
-        productImageUploader.stopEmittingStatusUpdates(siteID: viewModel.productModel.siteID,
+        productImageUploader.stopEmittingErrors(siteID: viewModel.productModel.siteID,
                                                        productID: viewModel.productModel.productID,
                                                        isLocalID: !viewModel.productModel.existsRemotely)
     }
@@ -146,7 +146,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         /// A VC added to an existing navigation controller is dismissed when `isMovingFromParent` is `true`.
         /// For any other scenario `isBeingDismissed` will do.
         if isMovingFromParent || isBeingDismissed || navigationController?.isBeingDismissed == true {
-            productImageUploader.startEmittingStatusUpdates(siteID: viewModel.productModel.siteID,
+            productImageUploader.startEmittingErrors(siteID: viewModel.productModel.siteID,
                                                             productID: viewModel.productModel.productID,
                                                             isLocalID: !viewModel.productModel.existsRemotely)
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022A45ED237BADA6001417F0 /* Product+ProductFormTests.swift */; };
 		022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022BF7FB23B9D708000A1DFB /* InProgressViewController.swift */; };
 		022BF7FE23B9D708000A1DFB /* InProgressViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 022BF7FC23B9D708000A1DFB /* InProgressViewController.xib */; };
+		022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */; };
 		022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F7A0124A05F6400012601 /* LinkedProductsListSelectorViewController.swift */; };
 		022F7A0424A05F6400012601 /* LinkedProductsListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 022F7A0224A05F6400012601 /* LinkedProductsListSelectorViewController.xib */; };
 		022F941E257F8E820011CD94 /* BoldableTextParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F941D257F8E820011CD94 /* BoldableTextParser.swift */; };
@@ -1873,6 +1874,7 @@
 		022A45ED237BADA6001417F0 /* Product+ProductFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductFormTests.swift"; sourceTree = "<group>"; };
 		022BF7FB23B9D708000A1DFB /* InProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressViewController.swift; sourceTree = "<group>"; };
 		022BF7FC23B9D708000A1DFB /* InProgressViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InProgressViewController.xib; sourceTree = "<group>"; };
+		022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewController+ProductImageUploaderTests.swift"; sourceTree = "<group>"; };
 		022F7A0124A05F6400012601 /* LinkedProductsListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsListSelectorViewController.swift; sourceTree = "<group>"; };
 		022F7A0224A05F6400012601 /* LinkedProductsListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkedProductsListSelectorViewController.xib; sourceTree = "<group>"; };
 		022F941D257F8E820011CD94 /* BoldableTextParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoldableTextParser.swift; sourceTree = "<group>"; };
@@ -3655,6 +3657,7 @@
 				0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */,
 				0215C6FB2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift */,
 				2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */,
+				022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -10116,6 +10119,7 @@
 				D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */,
 				A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */,
 				D83A6A7A23792B2400419D48 /* UIColor+Muriel-Tests.swift in Sources */,
+				022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */,
 				093B265927DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift in Sources */,
 				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		021A84E1257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021A84DF257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib */; };
 		021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */; };
 		021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */; };
+		021DD44D286A3A8D004F0468 /* UIViewController+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */; };
 		021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */; };
 		021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021E2A1623A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib */; };
 		021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1923AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift */; };
@@ -1854,6 +1855,7 @@
 		021A84DF257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundShippingLabelViewController.xib; sourceTree = "<group>"; };
 		021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductImageStatus+HelpersTests.swift"; sourceTree = "<group>"; };
 		021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHAssetImageLoader.swift; sourceTree = "<group>"; };
+		021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Navigation.swift"; sourceTree = "<group>"; };
 		021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewController.swift; sourceTree = "<group>"; };
 		021E2A1623A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductInventorySettingsViewController.xib; sourceTree = "<group>"; };
 		021E2A1923AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+InventorySettingsViewModels.swift"; sourceTree = "<group>"; };
@@ -7129,6 +7131,7 @@
 				02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */,
 				02645D8727BA2E820065DC68 /* NSAttributedString+Attributes.swift */,
 				B9B6DEEE283F8B9F00901FB7 /* Site+URL.swift */,
+				021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9400,6 +9403,7 @@
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
 				0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */,
 				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,
+				021DD44D286A3A8D004F0468 /* UIViewController+Navigation.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				CCF87BC02790582500461C43 /* ProductVariationSelector.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -10,6 +10,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let shippingLabelsOnboardingM1: Bool
     private let inPersonPaymentGatewaySelection: Bool
     private let isAppleIDAccountDeletionEnabled: Bool
+    private let isBackgroundImageUploadEnabled: Bool
 
     init(isJetpackConnectionPackageSupportOn: Bool = false,
          isHubMenuOn: Bool = false,
@@ -18,7 +19,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
          inPersonPaymentGatewaySelection: Bool = false,
-         isAppleIDAccountDeletionEnabled: Bool = false) {
+         isAppleIDAccountDeletionEnabled: Bool = false,
+         isBackgroundImageUploadEnabled: Bool = false) {
         self.isJetpackConnectionPackageSupportOn = isJetpackConnectionPackageSupportOn
         self.isHubMenuOn = isHubMenuOn
         self.isInboxOn = isInboxOn
@@ -27,6 +29,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.inPersonPaymentGatewaySelection = inPersonPaymentGatewaySelection
         self.isAppleIDAccountDeletionEnabled = isAppleIDAccountDeletionEnabled
+        self.isBackgroundImageUploadEnabled = isBackgroundImageUploadEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -47,6 +50,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return inPersonPaymentGatewaySelection
         case .appleIDAccountDeletion:
             return isAppleIDAccountDeletionEnabled
+        case .backgroundProductImageUpload:
+            return isBackgroundImageUploadEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -3,16 +3,16 @@ import Combine
 @testable import WooCommerce
 
 final class MockProductImageUploader: ProductImageUploaderProtocol {
-    let statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never>
+    let errors: AnyPublisher<ProductImageUploadError, Never>
 
     var replaceLocalIDWasCalled = false
     var saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = false
     var startEmittingStatusUpdatesWasCalled = false
     var stopEmittingStatusUpdatesWasCalled = false
 
-    init(statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never> =
-         Empty<ProductImageUploadUpdate, Never>().eraseToAnyPublisher()) {
-        self.statusUpdates = statusUpdates
+    init(statusUpdates: AnyPublisher<ProductImageUploadError, Never> =
+         Empty<ProductImageUploadError, Never>().eraseToAnyPublisher()) {
+        self.errors = statusUpdates
     }
 
     func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
@@ -30,11 +30,11 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
         ProductImageActionHandler(siteID: 0, productID: 0, imageStatuses: [])
     }
 
-    func startEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func startEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
         startEmittingStatusUpdatesWasCalled = true
     }
 
-    func stopEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func stopEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
         stopEmittingStatusUpdatesWasCalled = true
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -3,12 +3,17 @@ import Combine
 @testable import WooCommerce
 
 final class MockProductImageUploader: ProductImageUploaderProtocol {
-    var statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never> = Empty<ProductImageUploadUpdate, Never>().eraseToAnyPublisher()
+    let statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never>
 
     var replaceLocalIDWasCalled = false
     var saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = false
     var startEmittingStatusUpdatesWasCalled = false
     var stopEmittingStatusUpdatesWasCalled = false
+
+    init(statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never> =
+         Empty<ProductImageUploadUpdate, Never>().eraseToAnyPublisher()) {
+        self.statusUpdates = statusUpdates
+    }
 
     func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
         replaceLocalIDWasCalled = true

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -1,9 +1,14 @@
+import Combine
 @testable import Yosemite
 @testable import WooCommerce
 
 final class MockProductImageUploader: ProductImageUploaderProtocol {
+    var statusUpdates: AnyPublisher<ProductImageUploadUpdate, Never> = Empty<ProductImageUploadUpdate, Never>().eraseToAnyPublisher()
+
     var replaceLocalIDWasCalled = false
     var saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = false
+    var startEmittingStatusUpdatesWasCalled = false
+    var stopEmittingStatusUpdatesWasCalled = false
 
     func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
         replaceLocalIDWasCalled = true
@@ -18,6 +23,14 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
 
     func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
         ProductImageActionHandler(siteID: 0, productID: 0, imageStatuses: [])
+    }
+
+    func startEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
+        startEmittingStatusUpdatesWasCalled = true
+    }
+
+    func stopEmittingStatusUpdates(siteID: Int64, productID: Int64, isLocalID: Bool) {
+        stopEmittingStatusUpdatesWasCalled = true
     }
 
     func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -6,7 +6,7 @@ import Yosemite
 
 final class MainTabBarControllerTests: XCTestCase {
     private var stores: StoresManager!
-    // Test cases that assert on a view controller's navigation behavior, a retained window is required
+    // For test cases that assert on a view controller's navigation behavior, a retained window is required
     // with its `rootViewController` set to the view controller.
     private let window = UIWindow(frame: UIScreen.main.bounds)
 
@@ -355,7 +355,7 @@ final class MainTabBarControllerTests: XCTestCase {
         let error = NSError(domain: "", code: 8)
         statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: error))
 
-        // Given
+        // Then
         XCTAssertEqual(noticePresenter.queuedNotices.count, 0)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import TestKit
 import XCTest
 @testable import WooCommerce
@@ -5,6 +6,9 @@ import Yosemite
 
 final class MainTabBarControllerTests: XCTestCase {
     private var stores: StoresManager!
+    // Test cases that assert on a view controller's navigation behavior, a retained window is required
+    // with its `rootViewController` set to the view controller.
+    private let window = UIWindow(frame: UIScreen.main.bounds)
 
     override func setUp() {
         super.setUp()
@@ -12,9 +16,14 @@ final class MainTabBarControllerTests: XCTestCase {
         ServiceLocator.setAuthenticationManager(mockAuthenticationManager)
         stores = DefaultStoresManager.testingInstance
         ServiceLocator.setStores(stores)
+
+        window.makeKeyAndVisible()
     }
 
     override func tearDown() {
+        window.resignKey()
+        window.rootViewController = nil
+
         SessionManager.testingInstance.reset()
         stores = nil
         super.tearDown()
@@ -254,6 +263,100 @@ final class MainTabBarControllerTests: XCTestCase {
 
                                                             isHubMenuFeatureFlagOn: isHubMenuFeatureFlagOn)?.topViewController,
                    isAnInstanceOf: ReviewDetailsViewController.self)
+    }
+
+    func test_when_receiving_product_image_upload_error_a_notice_is_enqueued() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: true)
+        let noticePresenter = MockNoticePresenter()
+        let statusUpdates = PassthroughSubject<ProductImageUploadUpdate, Never>()
+        let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
+
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
+            return MainTabBarController(coder: coder,
+                                        featureFlagService: featureFlagService,
+                                        noticePresenter: noticePresenter,
+                                        productImageUploader: productImageUploader)
+        }) else {
+            return
+        }
+
+        // Trigger `viewDidLoad`
+        XCTAssertNotNil(tabBarController.view)
+        XCTAssertEqual(noticePresenter.queuedNotices.count, 0)
+
+        // When
+        let error = NSError(domain: "", code: 8)
+        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: error))
+
+        // Given
+        XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
+    }
+
+    func test_when_tapping_product_image_upload_error_notice_product_details_is_pushed_to_products_tab() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: true)
+        let noticePresenter = MockNoticePresenter()
+        let statusUpdates = PassthroughSubject<ProductImageUploadUpdate, Never>()
+        let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
+
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
+            return MainTabBarController(coder: coder,
+                                        featureFlagService: featureFlagService,
+                                        noticePresenter: noticePresenter,
+                                        productImageUploader: productImageUploader)
+        }) else {
+            return
+        }
+        window.rootViewController = tabBarController
+
+        // Trigger `viewDidLoad`
+        XCTAssertNotNil(tabBarController.view)
+
+        // When
+        let error = NSError(domain: "", code: 8)
+        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: error))
+        let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
+        notice.actionHandler?()
+
+        let productsNavigationController = try XCTUnwrap(tabBarController
+            .tabNavigationController(tab: .products,
+                                     isHubMenuFeatureFlagOn: featureFlagService.isFeatureFlagEnabled(.hubMenu)))
+        waitUntil {
+            productsNavigationController.presentedViewController != nil
+        }
+
+        // Then
+        let productNavigationController = try XCTUnwrap(productsNavigationController.presentedViewController as? UINavigationController)
+        assertThat(productNavigationController.topViewController, isAnInstanceOf: ProductLoaderViewController.self)
+    }
+
+    func test_when_receiving_product_image_upload_error_with_feature_flag_off_a_notice_is_not_enqueued() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: false)
+        let noticePresenter = MockNoticePresenter()
+        let statusUpdates = PassthroughSubject<ProductImageUploadUpdate, Never>()
+        let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
+
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
+            return MainTabBarController(coder: coder,
+                                        featureFlagService: featureFlagService,
+                                        noticePresenter: noticePresenter,
+                                        productImageUploader: productImageUploader)
+        }) else {
+            return
+        }
+
+        // Trigger `viewDidLoad`
+        XCTAssertNotNil(tabBarController.view)
+        XCTAssertEqual(noticePresenter.queuedNotices.count, 0)
+
+        // When
+        let error = NSError(domain: "", code: 8)
+        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: error))
+
+        // Given
+        XCTAssertEqual(noticePresenter.queuedNotices.count, 0)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -269,7 +269,7 @@ final class MainTabBarControllerTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: true)
         let noticePresenter = MockNoticePresenter()
-        let statusUpdates = PassthroughSubject<ProductImageUploadUpdate, Never>()
+        let statusUpdates = PassthroughSubject<ProductImageUploadError, Never>()
         let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
@@ -297,7 +297,7 @@ final class MainTabBarControllerTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: true)
         let noticePresenter = MockNoticePresenter()
-        let statusUpdates = PassthroughSubject<ProductImageUploadUpdate, Never>()
+        let statusUpdates = PassthroughSubject<ProductImageUploadError, Never>()
         let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
@@ -335,7 +335,7 @@ final class MainTabBarControllerTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: false)
         let noticePresenter = MockNoticePresenter()
-        let statusUpdates = PassthroughSubject<ProductImageUploadUpdate, Never>()
+        let statusUpdates = PassthroughSubject<ProductImageUploadError, Never>()
         let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
@@ -4,6 +4,20 @@ import XCTest
 @testable import WooCommerce
 
 final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
+    private let window = UIWindow(frame: UIScreen.main.bounds)
+
+    override func setUp() {
+        super.setUp()
+        window.makeKeyAndVisible()
+    }
+
+    override func tearDown() {
+        window.resignKey()
+        window.rootViewController = nil
+
+        super.tearDown()
+    }
+
     func test_triggering_viewDidLoad_invokes_stopEmittingStatusUpdates() throws {
         // Given
         let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
@@ -25,23 +39,61 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
         XCTAssertTrue(productImageUploader.stopEmittingStatusUpdatesWasCalled)
     }
 
-    func test_deinit_invokes_startEmittingStatusUpdates() throws {
+    func test_dismissing_product_form_invokes_startEmittingStatusUpdates() throws {
         // Given
         let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
         let productImageUploader = MockProductImageUploader()
+        let productForm = ProductFormViewController(viewModel:
+                                                        ProductFormViewModel(product: .init(product: .fake()),
+                                                                             formType: .edit,
+                                                                             productImageActionHandler: actionHandler),
+                                                    eventLogger: ProductFormEventLogger(),
+                                                    productImageActionHandler: actionHandler,
+                                                    presentationStyle: .navigationStack,
+                                                    productImageUploader: productImageUploader)
+        let rootViewController = UIViewController()
+        window.rootViewController = rootViewController
 
         // When
-        var productForm: ProductFormViewController<ProductFormViewModel>? =
-        ProductFormViewController(viewModel:
-                                    ProductFormViewModel(product: .init(product: .fake()),
-                                                         formType: .edit,
-                                                         productImageActionHandler: actionHandler),
-                                  eventLogger: ProductFormEventLogger(),
-                                  productImageActionHandler: actionHandler,
-                                  presentationStyle: .navigationStack,
-                                  productImageUploader: productImageUploader)
-        productForm = nil
-        XCTAssertNil(productForm)
+        let _: Void = waitFor { promise in
+            rootViewController.present(productForm, animated: false) {
+                rootViewController.dismiss(animated: false) {
+                    promise(())
+                }
+            }
+        }
+
+        // Then
+        XCTAssertTrue(productImageUploader.startEmittingStatusUpdatesWasCalled)
+    }
+
+    func test_popping_product_form_invokes_startEmittingStatusUpdates() throws {
+        // Given
+        let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
+        let productImageUploader = MockProductImageUploader()
+        let productForm = ProductFormViewController(viewModel:
+                                                        ProductFormViewModel(product: .init(product: .fake()),
+                                                                             formType: .edit,
+                                                                             productImageActionHandler: actionHandler),
+                                                    eventLogger: ProductFormEventLogger(),
+                                                    productImageActionHandler: actionHandler,
+                                                    presentationStyle: .navigationStack,
+                                                    productImageUploader: productImageUploader)
+        let rootNavigationController = UINavigationController(rootViewController: .init())
+        window.rootViewController = rootNavigationController
+
+        // When
+        rootNavigationController.pushViewController(productForm, animated: false)
+
+        waitUntil {
+            rootNavigationController.viewControllers.count == 2
+        }
+
+        rootNavigationController.popViewController(animated: false)
+
+        waitUntil {
+            rootNavigationController.viewControllers.count == 1
+        }
 
         // Then
         XCTAssertTrue(productImageUploader.startEmittingStatusUpdatesWasCalled)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
@@ -1,0 +1,49 @@
+import Combine
+import XCTest
+
+@testable import WooCommerce
+
+final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
+    func test_triggering_viewDidLoad_invokes_stopEmittingStatusUpdates() throws {
+        // Given
+        let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
+        let productImageUploader = MockProductImageUploader()
+
+        // When
+        let productForm = ProductFormViewController(viewModel:
+                                                        ProductFormViewModel(product: .init(product: .fake()),
+                                                                             formType: .edit,
+                                                                             productImageActionHandler: actionHandler),
+                                                    eventLogger: ProductFormEventLogger(),
+                                                    productImageActionHandler: actionHandler,
+                                                    presentationStyle: .navigationStack,
+                                                    productImageUploader: productImageUploader)
+        productForm.viewDidLoad()
+
+        // Then
+        XCTAssertFalse(productImageUploader.startEmittingStatusUpdatesWasCalled)
+        XCTAssertTrue(productImageUploader.stopEmittingStatusUpdatesWasCalled)
+    }
+
+    func test_deinit_invokes_startEmittingStatusUpdates() throws {
+        // Given
+        let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
+        let productImageUploader = MockProductImageUploader()
+
+        // When
+        var productForm: ProductFormViewController<ProductFormViewModel>? =
+        ProductFormViewController(viewModel:
+                                    ProductFormViewModel(product: .init(product: .fake()),
+                                                         formType: .edit,
+                                                         productImageActionHandler: actionHandler),
+                                  eventLogger: ProductFormEventLogger(),
+                                  productImageActionHandler: actionHandler,
+                                  presentationStyle: .navigationStack,
+                                  productImageUploader: productImageUploader)
+        productForm = nil
+        XCTAssertNil(productForm)
+
+        // Then
+        XCTAssertTrue(productImageUploader.startEmittingStatusUpdatesWasCalled)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -1,4 +1,5 @@
 @testable import WooCommerce
+import Combine
 import Photos
 import XCTest
 import Yosemite
@@ -6,6 +7,7 @@ import Yosemite
 final class ProductImageUploaderTests: XCTestCase {
     private let siteID: Int64 = 134
     private let productID: Int64 = 606
+    private var statusUpdatesSubscription: AnyCancellable?
 
     func test_hasUnsavedChangesOnImages_becomes_false_after_uploading_and_saving() throws {
         // Given
@@ -192,5 +194,200 @@ final class ProductImageUploaderTests: XCTestCase {
                                                                      productID: localProductID,
                                                                      isLocalID: true,
                                                                      originalStatuses: []).productImageStatuses)
+    }
+
+    // MARK: - Status Updates
+
+    func test_update_is_emitted_when_image_upload_fails() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let actionHandler = imageUploader.actionHandler(siteID: siteID,
+                                                        productID: productID,
+                                                        isLocalID: true,
+                                                        originalStatuses: [])
+        let error = NSError(domain: "", code: 6)
+        stores.whenReceivingAction(ofType: MediaAction.self) { action in
+            if case let .uploadMedia(_, _, _, onCompletion) = action {
+                onCompletion(.failure(error))
+            }
+        }
+
+        // When
+        var updates: [ProductImageUploadUpdate] = []
+        let _: Void = waitFor { promise in
+            self.statusUpdatesSubscription = imageUploader.statusUpdates.sink { update in
+                updates.append(update)
+                promise(())
+            }
+            actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+        }
+
+        // Then
+        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: error)], updates)
+    }
+
+    func test_updates_are_not_emitted_when_image_upload_succeeds() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let actionHandler = imageUploader.actionHandler(siteID: siteID,
+                                                        productID: productID,
+                                                        isLocalID: true,
+                                                        originalStatuses: [])
+        stores.whenReceivingAction(ofType: MediaAction.self) { action in
+            if case let .uploadMedia(_, _, _, onCompletion) = action {
+                onCompletion(.success(.fake()))
+            }
+        }
+
+        // When
+        var updates: [ProductImageUploadUpdate] = []
+        statusUpdatesSubscription = imageUploader.statusUpdates.sink { update in
+            updates.append(update)
+            XCTFail("Image upload update should be emitted: \(update)")
+        }
+        actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+
+        // Then
+        XCTAssertTrue(updates.isEmpty)
+    }
+
+    // MARK: - `stopEmittingStatusUpdates`
+
+    func test_update_is_emitted_after_stopEmittingStatusUpdates_with_a_different_product_when_image_upload_fails() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let actionHandler = imageUploader.actionHandler(siteID: siteID,
+                                                        productID: productID,
+                                                        isLocalID: true,
+                                                        originalStatuses: [])
+        let error = NSError(domain: "", code: 6)
+        stores.whenReceivingAction(ofType: MediaAction.self) { action in
+            if case let .uploadMedia(_, _, _, onCompletion) = action {
+                onCompletion(.failure(error))
+            }
+        }
+
+        // When
+        imageUploader.stopEmittingStatusUpdates(siteID: siteID, productID: 9999, isLocalID: true)
+
+        var updates: [ProductImageUploadUpdate] = []
+        let _: Void = waitFor { promise in
+            self.statusUpdatesSubscription = imageUploader.statusUpdates.sink { update in
+                updates.append(update)
+                promise(())
+            }
+            actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+        }
+
+        // Then
+        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: error)], updates)
+    }
+
+    func test_update_is_not_emitted_after_stopEmittingStatusUpdates_when_image_upload_fails() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let actionHandler = imageUploader.actionHandler(siteID: siteID,
+                                                        productID: productID,
+                                                        isLocalID: true,
+                                                        originalStatuses: [])
+        let error = NSError(domain: "", code: 6)
+        stores.whenReceivingAction(ofType: MediaAction.self) { action in
+            if case let .uploadMedia(_, _, _, onCompletion) = action {
+                onCompletion(.failure(error))
+            }
+        }
+
+        // When
+        imageUploader.stopEmittingStatusUpdates(siteID: siteID, productID: productID, isLocalID: true)
+
+        var updates: [ProductImageUploadUpdate] = []
+        statusUpdatesSubscription = imageUploader.statusUpdates.sink { update in
+            updates.append(update)
+            XCTFail("Image upload update should be emitted: \(update)")
+        }
+        actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+
+        // Then
+        XCTAssertTrue(updates.isEmpty)
+    }
+
+    func test_calling_replaceLocalID_updates_excluded_product_from_status_updates() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let localProductID: Int64 = 0
+        let nonExistentProductID: Int64 = 999
+        let remoteProductID = productID
+        let actionHandler = imageUploader.actionHandler(siteID: siteID,
+                                                        productID: localProductID,
+                                                        isLocalID: true,
+                                                        originalStatuses: [])
+
+        // When
+        imageUploader.stopEmittingStatusUpdates(siteID: siteID, productID: localProductID, isLocalID: true)
+        imageUploader.replaceLocalID(siteID: siteID, localProductID: nonExistentProductID, remoteProductID: remoteProductID)
+
+        var updates: [ProductImageUploadUpdate] = []
+        _ = imageUploader.statusUpdates.sink { update in
+            updates.append(update)
+        }
+
+        stores.whenReceivingAction(ofType: MediaAction.self) { action in
+            if case let .uploadMedia(_, _, _, onCompletion) = action {
+                onCompletion(.failure(MediaActionError.unknown))
+            }
+        }
+        actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+
+        // Then
+        // Ensure that trying to replace a non-existent product ID does nothing.
+        XCTAssertTrue(updates.isEmpty)
+    }
+
+    // MARK: - `startEmittingStatusUpdates`
+
+    func test_update_is_emitted_after_stop_and_startEmittingStatusUpdates_when_image_upload_fails() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let actionHandler = imageUploader.actionHandler(siteID: siteID,
+                                                        productID: productID,
+                                                        isLocalID: true,
+                                                        originalStatuses: [])
+        let error = NSError(domain: "", code: 6)
+        stores.whenReceivingAction(ofType: MediaAction.self) { action in
+            if case let .uploadMedia(_, _, _, onCompletion) = action {
+                onCompletion(.failure(error))
+            }
+        }
+
+        // When
+        imageUploader.stopEmittingStatusUpdates(siteID: siteID, productID: productID, isLocalID: true)
+        imageUploader.startEmittingStatusUpdates(siteID: siteID, productID: productID, isLocalID: true)
+
+        var updates: [ProductImageUploadUpdate] = []
+        let _: Void = waitFor { promise in
+            self.statusUpdatesSubscription = imageUploader.statusUpdates.sink { update in
+                updates.append(update)
+                promise(())
+            }
+            actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+        }
+
+        // Then
+        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: error)], updates)
+    }
+}
+
+extension ProductImageUploadUpdate: Equatable {
+    public static func == (lhs: ProductImageUploadUpdate, rhs: ProductImageUploadUpdate) -> Bool {
+        return lhs.siteID == rhs.siteID &&
+        lhs.productID == rhs.productID &&
+        lhs.productImageStatuses == rhs.productImageStatuses &&
+        (lhs.error as? NSError) == (rhs.error as? NSError)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When an image upload fails after the merchant leaves the product form, we want to show an in-app notice about the failure with an action to view product details. It was tricky to only notify the image upload updates when the merchant is **not** in the product form, since we currently show an error alert in the product form when an error occurs. We could also show an in-app notice in the product form, but we still want to customize the notice so that we don't show the action to view product details. I ended up adding two methods `stopEmittingStatusUpdates` and `startEmittingStatusUpdates` to pause the emission of a new `statusUpdates` publisher, when the product form view controller is shown/dismissed. If you have other ideas to implement this, please feel free to share!

Because the image upload error could come from any connected store, I decided to subscribe to the status updates in `MainTabBarController` to present the product (`ProductLoaderViewController`) from the products tab navigation controller after tapping the notice. I also chose to present the product instead of pushing the view controller so that the merchant can come back to any screen they were at (e.g. order or product form) if it's from the same store.

The changes still went over 500 diffs, most of them are on unit tests 🙇🏻‍♀️

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

One way to test image upload failure is by updating the [media remote endpoint](https://github.com/woocommerce/woocommerce-ios/blob/0eae2a783db5f68577d613bf58b42cdda73e744f/Networking/Networking/Remote/MediaRemote.swift#L113) to an invalid one like adding some extra character at the end. You can also put `sleep(numberOfSeconds)` to simulate a longer response time.

Please note that there is a known issue (another subtask of #7021) where an error alert is shown every time you visit the product images screen after an upload failure.

#### Image upload failure outside of product form

- Launch the app
- In the product form, add one or more images
- Tap "Save" to save the product while the images are still being uploaded --> the product is saved remotely first, and there is no "Save" button anymore when the images are still being uploaded
- Leave the product form quickly, and feel free to do anything in the app including switching stores --> when an image fails to upload, an in-app notice (snackbar) should be shown with an action "View" (if you are viewing a modal when the failure occurs, the notice is shown after dismissing the modal)
- Tap on "View" to view product details --> it should switch to the original store if needed, and present the product form

#### Image upload failure within product form (production behavior)

- Launch the app
- In the product form, add one or more images
- Tap "Save" to save the product while the images are still being uploaded --> the product is saved remotely first, and there is no "Save" button anymore when the images are still being uploaded
- Stay in the product form and feel free to navigate within the form --> when an image fails to upload, an error alert should be shown like in production

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1945542/175632039-7b0d2ded-aa96-46d3-bebb-d5de6b0dbead.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
