### PR TITLE
[Order Details] Add tracking: shipmentProvider shouldn't be saved on dismissal

### DIFF
--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -69,6 +69,7 @@ protocol ManualTrackingViewModel {
     var isAdding: Bool { get }
 
     func registerCells(for tableView: UITableView)
+    func saveSelectedShipmentProvider()
 }
 
 extension ManualTrackingViewModel {
@@ -148,7 +149,7 @@ final class AddTrackingViewModel: ManualTrackingViewModel {
 
 // MARK: - Persistence of the selected ShipmentTrackingProvider
 //
-private extension AddTrackingViewModel {
+extension AddTrackingViewModel {
     func saveSelectedShipmentProvider() {
         guard let shipmentProvider = shipmentProvider else {
             return
@@ -167,7 +168,7 @@ private extension AddTrackingViewModel {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func loadSelectedShipmentProvider() {
+    private func loadSelectedShipmentProvider() {
         let siteID = order.siteID
 
         let action = AppSettingsAction.loadTrackingProvider(siteID: siteID) { [weak self] (provider, providerGroup, error) in
@@ -237,7 +238,7 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
             trackingNumber?.isEmpty == false
 
         if returnValue {
-            saveSelectedCustomShipmentProvider()
+            saveSelectedShipmentProvider()
         }
 
         return returnValue
@@ -261,8 +262,8 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
 }
 
 
-private extension AddCustomTrackingViewModel {
-    func saveSelectedCustomShipmentProvider() {
+extension AddCustomTrackingViewModel {
+    func saveSelectedShipmentProvider() {
         guard let providerName = providerName else {
             return
         }
@@ -280,7 +281,7 @@ private extension AddCustomTrackingViewModel {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func loadSelectedCustomShipmentProvider() {
+    private func loadSelectedCustomShipmentProvider() {
         let siteID = order.siteID
 
         let action = AppSettingsAction.loadCustomTrackingProvider(siteID: siteID) { [weak self] (provider, error) in

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -230,14 +230,11 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
     let providerCellAccessoryType = UITableViewCell.AccessoryType.none
 
     var canCommit: Bool {
-        let returnValue = providerName?.isEmpty == false &&
-            trackingNumber?.isEmpty == false
-
-        if returnValue {
-            saveSelectedShipmentProvider()
+        guard let providerName = providerName,
+                let trackingNumber = trackingNumber else {
+            return false
         }
-
-        return returnValue
+        return providerName.isNotEmpty && trackingNumber.isNotEmpty
     }
 
     let isAdding: Bool = true

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -116,11 +116,7 @@ final class AddTrackingViewModel: ManualTrackingViewModel {
 
     }
 
-    var shipmentProvider: ShipmentTrackingProvider? {
-        didSet {
-            saveSelectedShipmentProvider()
-        }
-    }
+    var shipmentProvider: ShipmentTrackingProvider?
 
     var shipmentProviderGroupName: String?
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -139,8 +139,10 @@ private extension ManualTrackingViewController {
 
     @objc func primaryButtonTapped() {
         ServiceLocator.analytics.track(.orderShipmentTrackingAddButtonTapped)
-        viewModel.isCustom ? addCustomTracking() : addTracking()
-        viewModel.saveSelectedShipmentProvider()
+        if viewModel.canCommit {
+            viewModel.isCustom ? addCustomTracking() : addTracking()
+            viewModel.saveSelectedShipmentProvider()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -140,6 +140,7 @@ private extension ManualTrackingViewController {
     @objc func primaryButtonTapped() {
         ServiceLocator.analytics.track(.orderShipmentTrackingAddButtonTapped)
         viewModel.isCustom ? addCustomTracking() : addTracking()
+        viewModel.saveSelectedShipmentProvider()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -139,10 +139,11 @@ private extension ManualTrackingViewController {
 
     @objc func primaryButtonTapped() {
         ServiceLocator.analytics.track(.orderShipmentTrackingAddButtonTapped)
-        if viewModel.canCommit {
-            viewModel.isCustom ? addCustomTracking() : addTracking()
-            viewModel.saveSelectedShipmentProvider()
+        guard viewModel.canCommit else {
+            return
         }
+        viewModel.isCustom ? addCustomTracking() : addTracking()
+        viewModel.saveSelectedShipmentProvider()
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -415,7 +415,7 @@ private extension AppSettingsStore {
                               onCompletion: onCompletion)
             return
         }
-        upsertTrackingProvider(siteID: siteID,
+        saveTrackingProvider(siteID: siteID,
                                providerName: providerName,
                                preselectedData: settings,
                                toFileURL: fileURL,
@@ -476,7 +476,7 @@ private extension AppSettingsStore {
         onCompletion(customProvider, nil)
     }
 
-    func upsertTrackingProvider(siteID: Int64,
+    func saveTrackingProvider(siteID: Int64,
                                 providerName: String,
                                 providerURL: String? = nil,
                                 preselectedData: [PreselectedProvider],
@@ -485,14 +485,7 @@ private extension AppSettingsStore {
         let newPreselectedProvider = PreselectedProvider(siteID: siteID,
                                                          providerName: providerName,
                                                          providerURL: providerURL)
-
-        var dataToSave = preselectedData
-
-        if preselectedData.contains(newPreselectedProvider) {
-            dataToSave[0] = newPreselectedProvider
-        } else {
-            dataToSave.insert(newPreselectedProvider, at: 0)
-        }
+        let dataToSave = [newPreselectedProvider]
 
         do {
             try fileStorage.write(dataToSave, to: toFileURL)

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -488,11 +488,10 @@ private extension AppSettingsStore {
 
         var dataToSave = preselectedData
 
-        if preselectedData.contains(newPreselectedProvider),
-           let index = preselectedData.firstIndex(of: newPreselectedProvider) {
-            dataToSave[index] = newPreselectedProvider
+        if preselectedData.contains(newPreselectedProvider) {
+            dataToSave[0] = newPreselectedProvider
         } else {
-            dataToSave.append(newPreselectedProvider)
+            dataToSave.insert(newPreselectedProvider, at: 0)
         }
 
         do {


### PR DESCRIPTION
Partially closes: #1949, together with https://github.com/woocommerce/woocommerce-ios/pull/7156

### Description

The way we currently insert or update the tracking provider within Order Details is not updating properly. The initial intention is to pre-populate the field with the latest selected provider, however, at the moment we find the following behavior:

**Expected:**

- If we select a provider and save it, this provider will appear as prepopulated next time we tap “add tracking”.
- If we select a new provider and save it, this will be updated and appear as prepopulated next time we tap “add tracking”.
- If we select a new provider and dismiss the data, no provider should show if we re-open it.

**What actually happens:**

- Once a provider is saved or dismissed without being saved, we’ll always get back the same provider prepopulating the field, even if we update it and choose a different one.


This PR addresses this problem mainly by changing the logic on upserting data, making our newPreselectedProvider always the first in the list, keeping the file for backward compatibility, as well as moving the call to upsert data into the actual button tapping action, rather than responding to changes as a property observer.

ref: p91TBi-9lY-p2

### Testing instructions
- Install and activate https://woocommerce.com/products/shipment-tracking/
- All the cases can be tested by going to Orders > Select an Order > Scroll to (+) Add tracking :

| Case 1:  Data update | Case 2: Data dismiss |
|---|---|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2022-07-01 at 10 03 56](https://user-images.githubusercontent.com/3812076/176815574-68f8e965-57e2-4391-8c2d-d3180e7e217b.png)  | ![Simulator Screen Shot - iPhone 11 Pro Max - 2022-07-01 at 10 03 39](https://user-images.githubusercontent.com/3812076/176815584-9e02eeac-6437-4715-977f-f84988b52d40.png)|

**Case 1: Data update**
- In your Order, under `Shipping Carrier` add a tracking provider, for example `Fedex`, enter a tracking number, and tap `Add`
- Attempt to add a new provider again by tapping `(+) Add tracking`
- See how `Fedex` is pre-populated.
- Add a new, and different, tracking provider, for example `OnTrac`, enter a tracking number, and tap `Add`
- Attempt to add a new provider again by tapping `(+) Add tracking`
- See how `OnTrac` is pre-populated. 

**Case 2: Data dismiss**
- In your Order, under `Shipping Carrier` add a tracking provider, for example `Fedex`, enter a tracking number, and tap `Dismiss`
- Attempt to add a new provider again by tapping `(+) Add tracking`
- See how nothing is pre-populated

