### PR TITLE
[Unified Order Editing] Show non-editable indicators

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -268,6 +268,7 @@ extension OrderDetailsViewModel {
             ///
             self?.syncState = .synced
 
+            onReloadSections?()
             onCompletion?()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -493,6 +493,8 @@ extension EditableOrderViewModel {
         ///
         let isLoading: Bool
 
+        let showNonEditableIndicators: Bool
+
         let shippingLineViewModel: ShippingLineDetailsViewModel
         let feeLineViewModel: FeeLineDetailsViewModel
 
@@ -506,6 +508,7 @@ extension EditableOrderViewModel {
              taxesTotal: String = "0",
              orderTotal: String = "0",
              isLoading: Bool = false,
+             showNonEditableIndicators: Bool = false,
              saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
              saveFeeLineClosure: @escaping (OrderFeeLine?) -> Void = { _ in },
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
@@ -519,6 +522,7 @@ extension EditableOrderViewModel {
             self.taxesTotal = currencyFormatter.formatAmount(taxesTotal) ?? "0.00"
             self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? "0.00"
             self.isLoading = isLoading
+            self.showNonEditableIndicators = showNonEditableIndicators
             self.shippingLineViewModel = ShippingLineDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
                                                                       initialMethodTitle: shippingMethodTitle,
                                                                       shippingTotal: self.shippingTotal,
@@ -671,8 +675,8 @@ private extension EditableOrderViewModel {
     /// Updates payment section view model based on items in the order and order sync state.
     ///
     func configurePaymentDataViewModel() {
-        Publishers.CombineLatest(orderSynchronizer.orderPublisher, orderSynchronizer.statePublisher)
-            .map { [weak self] order, state in
+        Publishers.CombineLatest3(orderSynchronizer.orderPublisher, orderSynchronizer.statePublisher, $shouldShowNonEditableIndicators)
+            .map { [weak self] order, state, showNonEditableIndicators in
                 guard let self = self else {
                     return PaymentDataViewModel()
                 }
@@ -700,6 +704,7 @@ private extension EditableOrderViewModel {
                                             taxesTotal: order.totalTax.isNotEmpty ? order.totalTax : "0",
                                             orderTotal: order.total.isNotEmpty ? order.total : "0",
                                             isLoading: isDataSyncing,
+                                            showNonEditableIndicators: showNonEditableIndicators,
                                             saveShippingLineClosure: self.saveShippingLine,
                                             saveFeeLineClosure: self.saveFeeLine,
                                             currencyFormatter: self.currencyFormatter)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -101,8 +101,8 @@ final class EditableOrderViewModel: ObservableObject {
     /// Defines if the view should be disabled.
     @Published private(set) var disabled: Bool = false
 
-    /// Defines if the non editable banner should be shown.
-    @Published private(set) var shouldShowNonEditableBanner: Bool = false
+    /// Defines if the non editable indicators (banners, locks, fields) should be shown.
+    @Published private(set) var shouldShowNonEditableIndicators: Bool = false
 
     /// Status Results Controller.
     ///
@@ -269,7 +269,7 @@ final class EditableOrderViewModel: ObservableObject {
         configureCustomerDataViewModel()
         configurePaymentDataViewModel()
         configureCustomerNoteDataViewModel()
-        configureNonEditableBanner()
+        configureNonEditableIndicators()
         resetAddressForm()
     }
 
@@ -707,9 +707,9 @@ private extension EditableOrderViewModel {
             .assign(to: &$paymentDataViewModel)
     }
 
-    /// Binds the order state to the `shouldShowNonEditableBanner` property.
+    /// Binds the order state to the `shouldShowNonEditableIndicators` property.
     ///
-    func configureNonEditableBanner() {
+    func configureNonEditableIndicators() {
         Publishers.CombineLatest(orderSynchronizer.orderPublisher, Just(flow))
             .map { order, flow in
                 switch flow {
@@ -719,7 +719,7 @@ private extension EditableOrderViewModel {
                     return !order.isEditable
                 }
             }
-            .assign(to: &$shouldShowNonEditableBanner)
+            .assign(to: &$shouldShowNonEditableIndicators)
     }
 
     /// Tracks when customer details have been added

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -112,9 +112,9 @@ struct OrderForm: View {
                             Divider() // Needed because `NonEditableOrderBanner` does not have a top divider
                             NonEditableOrderBanner(width: geometry.size.width)
                         }
-                        .renderedIf(viewModel.shouldShowNonEditableBanner)
+                        .renderedIf(viewModel.shouldShowNonEditableIndicators)
 
-                        OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableBanner)
+                        OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
 
                         Spacer(minLength: Layout.sectionSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -201,9 +201,17 @@ private struct ProductsSection: View {
             Divider()
 
             VStack(alignment: .leading, spacing: OrderForm.Layout.verticalSpacing) {
-                Text(OrderForm.Localization.products)
-                    .accessibilityAddTraits(.isHeader)
-                    .headlineStyle()
+
+                HStack {
+                    Text(OrderForm.Localization.products)
+                        .accessibilityAddTraits(.isHeader)
+                        .headlineStyle()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Image(uiImage: .lockImage)
+                        .foregroundColor(Color(.brand))
+                        .renderedIf(viewModel.shouldShowNonEditableIndicators)
+                }
 
                 ForEach(viewModel.productRows) { productRow in
                     ProductRow(viewModel: productRow, accessibilityHint: OrderForm.Localization.productRowAccessibilityHint)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -206,7 +206,8 @@ private struct ProductsSection: View {
                     Text(OrderForm.Localization.products)
                         .accessibilityAddTraits(.isHeader)
                         .headlineStyle()
-                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Spacer()
 
                     Image(uiImage: .lockImage)
                         .foregroundColor(Color(.brand))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -119,10 +119,12 @@ struct OrderForm: View {
                         Spacer(minLength: Layout.sectionSpacing)
 
                         ProductsSection(scroll: scroll, viewModel: viewModel, navigationButtonID: $navigationButtonID)
+                            .disabled(viewModel.shouldShowNonEditableIndicators)
 
                         Spacer(minLength: Layout.sectionSpacing)
 
                         OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
+                            .disabled(viewModel.shouldShowNonEditableIndicators)
 
                         Spacer(minLength: Layout.sectionSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -30,6 +30,10 @@ struct OrderPaymentSection: View {
 
                 Spacer()
 
+                Image(uiImage: .lockImage)
+                    .foregroundColor(Color(.brand))
+                    .renderedIf(viewModel.showNonEditableIndicators)
+
                 ProgressView()
                     .renderedIf(viewModel.isLoading)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1117,15 +1117,15 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(isCallbackCalled)
     }
 
-    func test_creating_order_does_not_shows_banner() {
+    func test_creating_order_does_not_shows_editable_indicator() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID)
 
         // When & Then
-        XCTAssertFalse(viewModel.shouldShowNonEditableBanner)
+        XCTAssertFalse(viewModel.shouldShowNonEditableIndicators)
     }
 
-    func test_editing_a_non_editable_order_shows_banner() {
+    func test_editing_a_non_editable_order_shows_editable_indicator() {
         // Given
         let order = Order.fake().copy(isEditable: false)
 
@@ -1133,10 +1133,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
 
         // Then
-        XCTAssertTrue(viewModel.shouldShowNonEditableBanner)
+        XCTAssertTrue(viewModel.shouldShowNonEditableIndicators)
     }
 
-    func test_editing_an_editable_order_does_not_shows_banner() {
+    func test_editing_an_editable_order_does_not_shows_editable_indicator() {
         // Given
         let order = Order.fake().copy(isEditable: true)
 
@@ -1144,7 +1144,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
 
         // Then
-        XCTAssertFalse(viewModel.shouldShowNonEditableBanner)
+        XCTAssertFalse(viewModel.shouldShowNonEditableIndicators)
     }
 }
 


### PR DESCRIPTION
Closes: #6978 

# Why


When editing orders, some of them, based on their status will be uneditable. This PR makes sure that we block any editing on those sections and renders a small lock icon next to them.

# Screenshots

Editable | Non Editable
---- | ----
<img width="439" alt="editable" src="https://user-images.githubusercontent.com/562080/175789681-358b0035-eab3-489e-99ed-9590bc1d2853.png"> | <img width="439" alt="non-editable" src="https://user-images.githubusercontent.com/562080/175789685-f8199676-3be7-47ea-8dde-c636b27e2656.png">


# Testing Steps

- Go to an editable order
- Tap the edit button
- See that there is nothing blocking the order

----

- Go to a non-editable order
- Tap the edit button
- See that the non-editable banner is displayed
- See that the lock icons are displayed on the products and payments section
- See that the products and payments sections are disabled.

**Note: Changing the order status(to change the order editable state) in the edit flow does not work yet. #7074**

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
