### PR TITLE
Background image upload: show failure notice from saving product images

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
@@ -3,7 +3,7 @@ import struct Yosemite.ProductImage
 
 /// Used for `ServiceLocator.productImageUploader` if `backgroundProductImageUpload` feature flag is off.
 final class LegacyProductImageUploader: ProductImageUploaderProtocol {
-    let errors: AnyPublisher<ProductImageUploadError, Never> = Empty<ProductImageUploadError, Never>().eraseToAnyPublisher()
+    let errors: AnyPublisher<ProductImageUploadErrorInfo, Never> = Empty<ProductImageUploadErrorInfo, Never>().eraseToAnyPublisher()
 
     func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
         ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses)

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -171,13 +171,13 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         }
         imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: handler) { [weak self] result in
             guard let self = self else { return }
+            onProductSave(result)
             if case let .failure(error) = result {
                 self.errorsSubject.send(.init(siteID: siteID,
                                               productID: productID,
                                               productImageStatuses: handler.productImageStatuses,
                                               error: .savingProductImages(error: error)))
             }
-            onProductSave(result)
         }
     }
 }

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -176,7 +176,7 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
                 self.errorsSubject.send(.init(siteID: siteID,
                                               productID: productID,
                                               productImageStatuses: handler.productImageStatuses,
-                                              error: .savingProductImages(error: error)))
+                                              error: .failedSavingProductAfterImageUpload(error: error)))
             }
         }
     }
@@ -191,7 +191,7 @@ private extension ProductImageUploader {
                 self.errorsSubject.send(.init(siteID: key.siteID,
                                               productID: key.productID,
                                               productImageStatuses: productImageStatuses,
-                                              error: .actionHandler(error: error)))
+                                              error: .failedUploadingImage(error: error)))
             }
         }
         statusUpdatesSubscriptions.insert(observationToken)
@@ -200,6 +200,6 @@ private extension ProductImageUploader {
 
 /// Possible errors from background image upload.
 enum ProductImageUploaderError: Error {
-    case savingProductImages(error: Error)
-    case actionHandler(error: Error)
+    case failedSavingProductAfterImageUpload(error: Error)
+    case failedUploadingImage(error: Error)
 }

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -3,7 +3,7 @@ import struct Yosemite.ProductImage
 import enum Yosemite.ProductAction
 import protocol Yosemite.StoresManager
 
-/// Information about a product image upload.
+/// Information about a background product image upload error.
 struct ProductImageUploadErrorInfo {
     let siteID: Int64
     let productID: Int64
@@ -175,7 +175,7 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
                 self.errorsSubject.send(.init(siteID: siteID,
                                               productID: productID,
                                               productImageStatuses: handler.productImageStatuses,
-                                              error: ProductImageUploaderError.savingProductImages(error: error)))
+                                              error: .savingProductImages(error: error)))
             }
             onProductSave(result)
         }
@@ -191,7 +191,7 @@ private extension ProductImageUploader {
                 self.errorsSubject.send(.init(siteID: key.siteID,
                                               productID: key.productID,
                                               productImageStatuses: productImageStatuses,
-                                              error: ProductImageUploaderError.actionHandler(error: error)))
+                                              error: .actionHandler(error: error)))
             }
         }
         statusUpdatesSubscriptions.insert(observationToken)

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -576,15 +576,15 @@ private extension MainTabBarController {
         productImageUploadErrorsSubscription = productImageUploader.errors.sink { [weak self] error in
             guard let self = self else { return }
             switch error.error {
-            case .savingProductImages:
-                self.handleImagesSaverError(error)
-            case .actionHandler:
-                self.handleBackgroundImageUploadError(error)
+            case .failedSavingProductAfterImageUpload:
+                self.handleErrorSavingProductAfterImageUpload(error)
+            case .failedUploadingImage:
+                self.handleErrorUploadingImage(error)
             }
         }
     }
 
-    func handleImagesSaverError(_ error: ProductImageUploadErrorInfo) {
+    func handleErrorSavingProductAfterImageUpload(_ error: ProductImageUploadErrorInfo) {
         let notice = Notice(title: Localization.imagesSavingFailureNoticeTitle,
                             subtitle: nil,
                             message: nil,
@@ -600,7 +600,7 @@ private extension MainTabBarController {
         noticePresenter.enqueue(notice: notice)
     }
 
-    func handleBackgroundImageUploadError(_ error: ProductImageUploadErrorInfo) {
+    func handleErrorUploadingImage(_ error: ProductImageUploadErrorInfo) {
         let notice = Notice(title: Localization.imageUploadFailureNoticeTitle,
                             subtitle: nil,
                             message: nil,

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -573,12 +573,34 @@ private extension MainTabBarController {
         guard featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload) else {
             return
         }
-        productImageUploadErrorsSubscription = productImageUploader.errors.sink { [weak self] update in
-            self?.handleBackgroundImageUploadError(update)
+        productImageUploadErrorsSubscription = productImageUploader.errors.sink { [weak self] error in
+            guard let self = self else { return }
+            switch error.error {
+            case .savingProductImages:
+                self.handleImagesSaverError(error)
+            case .actionHandler:
+                self.handleBackgroundImageUploadError(error)
+            }
         }
     }
 
-    func handleBackgroundImageUploadError(_ update: ProductImageUploadError) {
+    func handleImagesSaverError(_ error: ProductImageUploadErrorInfo) {
+        let notice = Notice(title: Localization.imagesSavingFailureNoticeTitle,
+                            subtitle: nil,
+                            message: nil,
+                            feedbackType: .error,
+                            notificationInfo: nil,
+                            actionTitle: Localization.imageUploadFailureNoticeActionTitle,
+                            actionHandler: { [weak self] in
+            guard let self = self else { return }
+            Task { @MainActor in
+                await self.showProductDetails(for: error)
+            }
+        })
+        noticePresenter.enqueue(notice: notice)
+    }
+
+    func handleBackgroundImageUploadError(_ error: ProductImageUploadErrorInfo) {
         let notice = Notice(title: Localization.imageUploadFailureNoticeTitle,
                             subtitle: nil,
                             message: nil,
@@ -588,35 +610,38 @@ private extension MainTabBarController {
                             actionHandler: { [weak self] in
             guard let self = self else { return }
             Task { @MainActor in
-                await self.showProductDetails(update: update)
+                await self.showProductDetails(for: error)
             }
         })
         noticePresenter.enqueue(notice: notice)
     }
 
-    func showProductDetails(update: ProductImageUploadError) async {
+    func showProductDetails(for error: ProductImageUploadErrorInfo) async {
         // Switches to the correct store first if needed.
         let switchStoreUseCase = SwitchStoreUseCase(stores: stores)
-        let siteChanged = await switchStoreUseCase.switchStore(with: update.siteID)
+        let siteChanged = await switchStoreUseCase.switchStore(with: error.siteID)
         if siteChanged {
-            let presenter = SwitchStoreNoticePresenter(siteID: update.siteID,
+            let presenter = SwitchStoreNoticePresenter(siteID: error.siteID,
                                                        noticePresenter: self.noticePresenter)
             presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
         }
 
-        let productViewController = ProductLoaderViewController(model: .product(productID: update.productID),
-                                                                siteID: update.siteID,
+        let productViewController = ProductLoaderViewController(model: .product(productID: error.productID),
+                                                                siteID: error.siteID,
                                                                 forceReadOnly: false)
         let productNavController = WooNavigationController(rootViewController: productViewController)
         productsNavigationController.present(productNavController, animated: true)
     }
 }
 
-private extension MainTabBarController {
+extension MainTabBarController {
     enum Localization {
         static let imageUploadFailureNoticeTitle =
         NSLocalizedString("An image failed to upload",
                           comment: "Title of the notice about an image upload failure in the background.")
+        static let imagesSavingFailureNoticeTitle =
+        NSLocalizedString("Error saving product images",
+                          comment: "Title of the notice about an error saving images uploaded in the background to a product.")
         static let imageUploadFailureNoticeActionTitle =
         NSLocalizedString("View",
                           comment: "Title of the action to view product details from a notice about an image upload failure in the background.")

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
@@ -65,12 +65,12 @@ private extension ProductImagesSaver {
             switch result {
             case .success(let product):
                 onProductSave(.success(product.images))
-                self.imageStatusesToSave = []
-                self.assetUploadSubscription = nil
-                self.uploadStatusesSubscription = nil
             case .failure(let error):
                 onProductSave(.failure(error))
             }
+            self.imageStatusesToSave = []
+            self.assetUploadSubscription = nil
+            self.uploadStatusesSubscription = nil
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -3,15 +3,15 @@ import Combine
 @testable import WooCommerce
 
 final class MockProductImageUploader: ProductImageUploaderProtocol {
-    let errors: AnyPublisher<ProductImageUploadError, Never>
+    let errors: AnyPublisher<ProductImageUploadErrorInfo, Never>
 
     var replaceLocalIDWasCalled = false
     var saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = false
     var startEmittingStatusUpdatesWasCalled = false
     var stopEmittingStatusUpdatesWasCalled = false
 
-    init(statusUpdates: AnyPublisher<ProductImageUploadError, Never> =
-         Empty<ProductImageUploadError, Never>().eraseToAnyPublisher()) {
+    init(statusUpdates: AnyPublisher<ProductImageUploadErrorInfo, Never> =
+         Empty<ProductImageUploadErrorInfo, Never>().eraseToAnyPublisher()) {
         self.errors = statusUpdates
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -7,12 +7,12 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
 
     var replaceLocalIDWasCalled = false
     var saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = false
-    var startEmittingStatusUpdatesWasCalled = false
-    var stopEmittingStatusUpdatesWasCalled = false
+    var startEmittingErrorsWasCalled = false
+    var stopEmittingErrorsWasCalled = false
 
-    init(statusUpdates: AnyPublisher<ProductImageUploadErrorInfo, Never> =
+    init(errors: AnyPublisher<ProductImageUploadErrorInfo, Never> =
          Empty<ProductImageUploadErrorInfo, Never>().eraseToAnyPublisher()) {
-        self.errors = statusUpdates
+        self.errors = errors
     }
 
     func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
@@ -31,11 +31,11 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
     }
 
     func startEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
-        startEmittingStatusUpdatesWasCalled = true
+        startEmittingErrorsWasCalled = true
     }
 
     func stopEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
-        stopEmittingStatusUpdatesWasCalled = true
+        stopEmittingErrorsWasCalled = true
     }
 
     func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -289,7 +289,7 @@ final class MainTabBarControllerTests: XCTestCase {
         statusUpdates.send(.init(siteID: 134,
                                  productID: 606,
                                  productImageStatuses: [],
-                                 error: .actionHandler(error: NSError(domain: "", code: 8))))
+                                 error: .failedUploadingImage(error: NSError(domain: "", code: 8))))
 
         // Given
         XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
@@ -321,7 +321,7 @@ final class MainTabBarControllerTests: XCTestCase {
         statusUpdates.send(.init(siteID: 134,
                                  productID: 606,
                                  productImageStatuses: [],
-                                 error: .savingProductImages(error: NSError(domain: "", code: 18))))
+                                 error: .failedSavingProductAfterImageUpload(error: NSError(domain: "", code: 18))))
 
         // Given
         XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
@@ -351,7 +351,7 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // When
         let error = NSError(domain: "", code: 8)
-        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: .actionHandler(error: error)))
+        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: .failedUploadingImage(error: error)))
         let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
         notice.actionHandler?()
 
@@ -389,7 +389,7 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // When
         let error = NSError(domain: "", code: 8)
-        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: .actionHandler(error: error)))
+        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: .failedUploadingImage(error: error)))
 
         // Then
         XCTAssertEqual(noticePresenter.queuedNotices.count, 0)

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -270,7 +270,7 @@ final class MainTabBarControllerTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: true)
         let noticePresenter = MockNoticePresenter()
         let statusUpdates = PassthroughSubject<ProductImageUploadErrorInfo, Never>()
-        let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
+        let productImageUploader = MockProductImageUploader(errors: statusUpdates.eraseToAnyPublisher())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
@@ -302,7 +302,7 @@ final class MainTabBarControllerTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: true)
         let noticePresenter = MockNoticePresenter()
         let statusUpdates = PassthroughSubject<ProductImageUploadErrorInfo, Never>()
-        let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
+        let productImageUploader = MockProductImageUploader(errors: statusUpdates.eraseToAnyPublisher())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
@@ -334,7 +334,7 @@ final class MainTabBarControllerTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: true)
         let noticePresenter = MockNoticePresenter()
         let statusUpdates = PassthroughSubject<ProductImageUploadErrorInfo, Never>()
-        let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
+        let productImageUploader = MockProductImageUploader(errors: statusUpdates.eraseToAnyPublisher())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
@@ -372,7 +372,7 @@ final class MainTabBarControllerTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isBackgroundImageUploadEnabled: false)
         let noticePresenter = MockNoticePresenter()
         let statusUpdates = PassthroughSubject<ProductImageUploadErrorInfo, Never>()
-        let productImageUploader = MockProductImageUploader(statusUpdates: statusUpdates.eraseToAnyPublisher())
+        let productImageUploader = MockProductImageUploader(errors: statusUpdates.eraseToAnyPublisher())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
@@ -18,7 +18,7 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_triggering_viewDidLoad_invokes_stopEmittingStatusUpdates() throws {
+    func test_triggering_viewDidLoad_invokes_stopEmittingErrors() throws {
         // Given
         let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
         let productImageUploader = MockProductImageUploader()
@@ -35,11 +35,11 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
         productForm.viewDidLoad()
 
         // Then
-        XCTAssertFalse(productImageUploader.startEmittingStatusUpdatesWasCalled)
-        XCTAssertTrue(productImageUploader.stopEmittingStatusUpdatesWasCalled)
+        XCTAssertFalse(productImageUploader.startEmittingErrorsWasCalled)
+        XCTAssertTrue(productImageUploader.stopEmittingErrorsWasCalled)
     }
 
-    func test_dismissing_product_form_invokes_startEmittingStatusUpdates() throws {
+    func test_dismissing_product_form_invokes_startEmittingErrors() throws {
         // Given
         let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
         let productImageUploader = MockProductImageUploader()
@@ -64,10 +64,10 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(productImageUploader.startEmittingStatusUpdatesWasCalled)
+        XCTAssertTrue(productImageUploader.startEmittingErrorsWasCalled)
     }
 
-    func test_popping_product_form_invokes_startEmittingStatusUpdates() throws {
+    func test_popping_product_form_invokes_startEmittingErrors() throws {
         // Given
         let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
         let productImageUploader = MockProductImageUploader()
@@ -96,6 +96,6 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(productImageUploader.startEmittingStatusUpdatesWasCalled)
+        XCTAssertTrue(productImageUploader.startEmittingErrorsWasCalled)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -227,7 +227,7 @@ final class ProductImageUploaderTests: XCTestCase {
         assertEqual([.init(siteID: siteID,
                            productID: productID,
                            productImageStatuses: [],
-                           error: ProductImageUploaderError.actionHandler(error: error))],
+                           error: ProductImageUploaderError.failedUploadingImage(error: error))],
                     errors)
     }
 
@@ -271,7 +271,7 @@ final class ProductImageUploaderTests: XCTestCase {
         assertEqual([.init(siteID: siteID,
                            productID: productID,
                            productImageStatuses: [.uploading(asset: asset)],
-                           error: .savingProductImages(error: ProductUpdateError.unexpected))],
+                           error: .failedSavingProductAfterImageUpload(error: ProductUpdateError.unexpected))],
                     errors)
     }
 
@@ -331,7 +331,7 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // Then
-        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: .actionHandler(error: error))], errors)
+        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: .failedUploadingImage(error: error))], errors)
     }
 
     func test_error_is_not_emitted_after_stopEmittingErrors_when_image_upload_fails() {
@@ -430,7 +430,7 @@ final class ProductImageUploaderTests: XCTestCase {
         assertEqual([.init(siteID: siteID,
                            productID: productID,
                            productImageStatuses: [],
-                           error: ProductImageUploaderError.actionHandler(error: error))],
+                           error: ProductImageUploaderError.failedUploadingImage(error: error))],
                     errors)
     }
 }
@@ -447,9 +447,9 @@ extension ProductImageUploadErrorInfo: Equatable {
 extension ProductImageUploaderError: Equatable {
     public static func == (lhs: ProductImageUploaderError, rhs: ProductImageUploaderError) -> Bool {
         switch (lhs, rhs) {
-        case (.actionHandler(let lhsError), .actionHandler(let rhsError)):
+        case (.failedUploadingImage(let lhsError), .failedUploadingImage(let rhsError)):
             return lhsError as NSError == rhsError as NSError
-        case (.savingProductImages(let lhsError), .savingProductImages(let rhsError)):
+        case (.failedSavingProductAfterImageUpload(let lhsError), .failedSavingProductAfterImageUpload(let rhsError)):
             return lhsError as NSError == rhsError as NSError
         default:
             return false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -198,7 +198,7 @@ final class ProductImageUploaderTests: XCTestCase {
 
     // MARK: - Status Updates
 
-    func test_update_is_emitted_when_image_upload_fails() {
+    func test_actionHandler_error_is_emitted_when_image_upload_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
@@ -214,20 +214,68 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // When
-        var updates: [ProductImageUploadError] = []
+        var errors: [ProductImageUploadErrorInfo] = []
         let _: Void = waitFor { promise in
-            self.errorsSubscription = imageUploader.errors.sink { update in
-                updates.append(update)
+            self.errorsSubscription = imageUploader.errors.sink { error in
+                errors.append(error)
                 promise(())
             }
             actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
         }
 
         // Then
-        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: error)], updates)
+        assertEqual([.init(siteID: siteID,
+                           productID: productID,
+                           productImageStatuses: [],
+                           error: ProductImageUploaderError.actionHandler(error: error))],
+                    errors)
     }
 
-    func test_updates_are_not_emitted_when_image_upload_succeeds() {
+    func test_savingProductImages_error_is_emitted_when_saving_images_fails() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let actionHandler = imageUploader.actionHandler(siteID: siteID, productID: productID, isLocalID: false, originalStatuses: [])
+
+        stores.whenReceivingAction(ofType: MediaAction.self) { action in
+            if case let .uploadMedia(_, _, _, onCompletion) = action {
+                onCompletion(.success(.fake()))
+            }
+        }
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .updateProductImages(_, _, _, onCompletion) = action {
+                onCompletion(.failure(.unexpected))
+            }
+        }
+
+        // When
+        let asset = PHAsset()
+        actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: asset)
+        waitFor { promise in
+            actionHandler.addUpdateObserver(self) { statuses in
+                promise(())
+            }
+        }
+        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: siteID,
+                                                                      productID: productID,
+                                                                      isLocalID: false) { result in }
+        var errors: [ProductImageUploadErrorInfo] = []
+        let _: Void = waitFor { promise in
+            self.errorsSubscription = imageUploader.errors.sink { error in
+                errors.append(error)
+                promise(())
+            }
+        }
+
+        // Then
+        assertEqual([.init(siteID: siteID,
+                           productID: productID,
+                           productImageStatuses: [.uploading(asset: asset)],
+                           error: .savingProductImages(error: ProductUpdateError.unexpected))],
+                    errors)
+    }
+
+    func test_errors_are_not_emitted_when_image_upload_succeeds() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
@@ -242,20 +290,20 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // When
-        var updates: [ProductImageUploadError] = []
-        errorsSubscription = imageUploader.errors.sink { update in
-            updates.append(update)
-            XCTFail("Image upload update should be emitted: \(update)")
+        var errors: [ProductImageUploadErrorInfo] = []
+        errorsSubscription = imageUploader.errors.sink { error in
+            errors.append(error)
+            XCTFail("Image upload update should be emitted: \(error)")
         }
         actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
 
         // Then
-        XCTAssertTrue(updates.isEmpty)
+        XCTAssertTrue(errors.isEmpty)
     }
 
     // MARK: - `stopEmittingErrors`
 
-    func test_update_is_emitted_after_stopEmittingErrors_with_a_different_product_when_image_upload_fails() {
+    func test_error_is_emitted_after_stopEmittingErrors_with_a_different_product_when_image_upload_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
@@ -273,20 +321,20 @@ final class ProductImageUploaderTests: XCTestCase {
         // When
         imageUploader.stopEmittingErrors(siteID: siteID, productID: 9999, isLocalID: true)
 
-        var updates: [ProductImageUploadError] = []
+        var errors: [ProductImageUploadErrorInfo] = []
         let _: Void = waitFor { promise in
-            self.errorsSubscription = imageUploader.errors.sink { update in
-                updates.append(update)
+            self.errorsSubscription = imageUploader.errors.sink { error in
+                errors.append(error)
                 promise(())
             }
             actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
         }
 
         // Then
-        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: error)], updates)
+        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: .actionHandler(error: error))], errors)
     }
 
-    func test_update_is_not_emitted_after_stopEmittingErrors_when_image_upload_fails() {
+    func test_error_is_not_emitted_after_stopEmittingErrors_when_image_upload_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
@@ -304,15 +352,15 @@ final class ProductImageUploaderTests: XCTestCase {
         // When
         imageUploader.stopEmittingErrors(siteID: siteID, productID: productID, isLocalID: true)
 
-        var updates: [ProductImageUploadError] = []
-        errorsSubscription = imageUploader.errors.sink { update in
-            updates.append(update)
-            XCTFail("Image upload update should be emitted: \(update)")
+        var errors: [ProductImageUploadErrorInfo] = []
+        errorsSubscription = imageUploader.errors.sink { error in
+            errors.append(error)
+            XCTFail("Image upload update should be emitted: \(error)")
         }
         actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
 
         // Then
-        XCTAssertTrue(updates.isEmpty)
+        XCTAssertTrue(errors.isEmpty)
     }
 
     func test_calling_replaceLocalID_updates_excluded_product_from_status_updates() {
@@ -331,9 +379,9 @@ final class ProductImageUploaderTests: XCTestCase {
         imageUploader.stopEmittingErrors(siteID: siteID, productID: localProductID, isLocalID: true)
         imageUploader.replaceLocalID(siteID: siteID, localProductID: nonExistentProductID, remoteProductID: remoteProductID)
 
-        var updates: [ProductImageUploadError] = []
-        _ = imageUploader.errors.sink { update in
-            updates.append(update)
+        var errors: [ProductImageUploadErrorInfo] = []
+        _ = imageUploader.errors.sink { error in
+            errors.append(error)
         }
 
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
@@ -345,12 +393,12 @@ final class ProductImageUploaderTests: XCTestCase {
 
         // Then
         // Ensure that trying to replace a non-existent product ID does nothing.
-        XCTAssertTrue(updates.isEmpty)
+        XCTAssertTrue(errors.isEmpty)
     }
 
     // MARK: - `startEmittingErrors`
 
-    func test_update_is_emitted_after_stop_and_startEmittingErrors_when_image_upload_fails() {
+    func test_error_is_emitted_after_stop_and_startEmittingErrors_when_image_upload_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
@@ -369,25 +417,42 @@ final class ProductImageUploaderTests: XCTestCase {
         imageUploader.stopEmittingErrors(siteID: siteID, productID: productID, isLocalID: true)
         imageUploader.startEmittingErrors(siteID: siteID, productID: productID, isLocalID: true)
 
-        var updates: [ProductImageUploadError] = []
+        var errors: [ProductImageUploadErrorInfo] = []
         let _: Void = waitFor { promise in
-            self.errorsSubscription = imageUploader.errors.sink { update in
-                updates.append(update)
+            self.errorsSubscription = imageUploader.errors.sink { error in
+                errors.append(error)
                 promise(())
             }
             actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
         }
 
         // Then
-        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: error)], updates)
+        assertEqual([.init(siteID: siteID,
+                           productID: productID,
+                           productImageStatuses: [],
+                           error: ProductImageUploaderError.actionHandler(error: error))],
+                    errors)
     }
 }
 
-extension ProductImageUploadError: Equatable {
-    public static func == (lhs: ProductImageUploadError, rhs: ProductImageUploadError) -> Bool {
+extension ProductImageUploadErrorInfo: Equatable {
+    public static func == (lhs: ProductImageUploadErrorInfo, rhs: ProductImageUploadErrorInfo) -> Bool {
         return lhs.siteID == rhs.siteID &&
         lhs.productID == rhs.productID &&
         lhs.productImageStatuses == rhs.productImageStatuses &&
-        (lhs.error as NSError) == (rhs.error as NSError)
+        lhs.error == rhs.error
+    }
+}
+
+extension ProductImageUploaderError: Equatable {
+    public static func == (lhs: ProductImageUploaderError, rhs: ProductImageUploaderError) -> Bool {
+        switch (lhs, rhs) {
+        case (.actionHandler(let lhsError), .actionHandler(let rhsError)):
+            return lhsError as NSError == rhsError as NSError
+        case (.savingProductImages(let lhsError), .savingProductImages(let rhsError)):
+            return lhsError as NSError == rhsError as NSError
+        default:
+            return false
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -196,7 +196,7 @@ final class ProductImageUploaderTests: XCTestCase {
                                                                      originalStatuses: []).productImageStatuses)
     }
 
-    // MARK: - Status Updates
+    // MARK: - Error updates
 
     func test_actionHandler_error_is_emitted_when_image_upload_fails() {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
@@ -94,6 +94,44 @@ final class ProductImagesSaverTests: XCTestCase {
         XCTAssertEqual(imagesSaver.imageStatusesToSave, [])
     }
 
+    func test_imageStatusesToSave_stays_empty_after_saving_product_fails() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let actionHandler = ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: [], stores: stores)
+        let asset = PHAsset()
+        let imagesSaver = ProductImagesSaver(siteID: siteID, productID: productID, stores: stores)
+
+        // Mocks product images update failure.
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .updateProductImages(_, _, _, onCompletion) = action {
+                onCompletion(.failure(.unexpected))
+            }
+        }
+
+        // Uploads an image and waits for the image upload completion closure to be called later.
+        let imageUploadCompletion: ((Result<Media, Error>) -> Void) = waitFor { promise in
+            stores.whenReceivingAction(ofType: MediaAction.self) { action in
+                if case let .uploadMedia(_, _, _, onCompletion) = action {
+                    promise(onCompletion)
+                }
+            }
+            actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: asset)
+        }
+
+        let _: Void = waitFor { promise in
+            // Saves product images.
+            imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: actionHandler) { _ in
+                promise(())
+            }
+            XCTAssertEqual(imagesSaver.imageStatusesToSave, [.uploading(asset: asset)])
+
+            // Mocks successful image upload.
+            imageUploadCompletion(.success(.fake().copy(mediaID: 645)))
+        }
+
+        // Then
+        XCTAssertEqual(imagesSaver.imageStatusesToSave, [])
+    }
 }
 
 private extension ProductImagesSaverTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021 
- [x] ⚠️ Please make sure https://github.com/woocommerce/woocommerce-ios/pull/7145 is approved before reviewing ⚠️ 

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As suggested from showing a notice from image upload failure in https://github.com/woocommerce/woocommerce-ios/pull/7145, it'd be helpful to also show a notice from an error updating product images. In this PR, a new error enum `ProductImageUploaderError` was created for these two error scenarios (action handler like media upload API request, and saving product images at the end). `ProductImageUploadError` was also renamed to `ProductImageUploadErrorInfo` to minimize confusion.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

One way to test image upload failure is by updating the [product images remote endpoint](https://github.com/woocommerce/woocommerce-ios/blob/3c2e5f2f08da760099517423061957d21b31a5dc/Networking/Networking/Remote/ProductsRemote.swift#L287) to an invalid one like adding some extra character at the end. You can also put `sleep(numberOfSeconds)` to simulate a longer response time.

- Launch the app
- In the product form, add one or more images
- Tap "Save" to save the product while the images are still being uploaded
- Leave the product form quickly, and feel free to do anything in the app including switching stores --> when the image(s) is uploaded but the product's images cannot be saved, an in-app notice (snackbar) should be shown with a title `Error saving product images` and an action `View` (if you are viewing a modal when the failure occurs, the notice is shown after dismissing the modal)
- Tap on "View" to view product details --> it should switch to the original store if needed, and present the product form. There should not be a "Save" CTA in the product form

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1945542/176068841-4c535c80-080e-4c62-b817-b43e09527d6c.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
