### PR TITLE
Move `BUILDKITE_ANALYTICS_TOKEN` injection to Test Plan

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -20,6 +20,34 @@
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
         "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
+      },
+      {
+        "key" : "BUILDKITE_BRANCH",
+        "value" : "$(BUILDKITE_BRANCH)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_ID",
+        "value" : "$(BUILDKITE_BUILD_ID)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_NUMBER",
+        "value" : "$(BUILDKITE_BUILD_NUMBER)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_URL",
+        "value" : "$(BUILDKITE_BUILD_URL)"
+      },
+      {
+        "key" : "BUILDKITE_COMMIT",
+        "value" : "$(BUILDKITE_COMMIT)"
+      },
+      {
+        "key" : "BUILDKITE_JOB_ID",
+        "value" : "$(BUILDKITE_JOB_ID)"
+      },
+      {
+        "key" : "BUILDKITE_MESSAGE",
+        "value" : "$(BUILDKITE_MESSAGE)"
       }
     ],
     "language" : "en",

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -16,6 +16,12 @@
         "enabled" : false
       }
     ],
+    "environmentVariableEntries" : [
+      {
+        "key" : "BUILDKITE_ANALYTICS_TOKEN",
+        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
+      }
+    ],
     "language" : "en",
     "region" : "US",
     "targetForVariableExpansion" : {

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -9,6 +9,12 @@
     }
   ],
   "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "BUILDKITE_ANALYTICS_TOKEN",
+        "value" : "$BUILDKITE_ANALYTICS_TOKEN"
+      }
+    ],
     "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -13,6 +13,34 @@
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
         "value" : "$BUILDKITE_ANALYTICS_TOKEN"
+      },
+      {
+        "key" : "BUILDKITE_BRANCH",
+        "value" : "$(BUILDKITE_BRANCH)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_ID",
+        "value" : "$(BUILDKITE_BUILD_ID)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_NUMBER",
+        "value" : "$(BUILDKITE_BUILD_NUMBER)"
+      },
+      {
+        "key" : "BUILDKITE_BUILD_URL",
+        "value" : "$(BUILDKITE_BUILD_URL)"
+      },
+      {
+        "key" : "BUILDKITE_COMMIT",
+        "value" : "$(BUILDKITE_COMMIT)"
+      },
+      {
+        "key" : "BUILDKITE_JOB_ID",
+        "value" : "$(BUILDKITE_JOB_ID)"
+      },
+      {
+        "key" : "BUILDKITE_MESSAGE",
+        "value" : "$(BUILDKITE_MESSAGE)"
       }
     ],
     "testRepetitionMode" : "retryOnFailure"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1042,11 +1042,6 @@ lane :test_without_building do |options|
     e.include?(options[:name])
   end.first
 
-  # FIXME: I do realize the variable is called "test plan path" but we're
-  # actually dealing with an `xctestrun`. I'll rename them all once established
-  # this approach works
-  add_buildkite_analytics_token(xctestrun_path: xctestrun_path)
-
   UI.user_error!('Unable to find .xctestrun file') unless !xctestrun_path.nil? && File.exist?((xctestrun_path))
 
   run_tests(
@@ -1105,21 +1100,4 @@ def trigger_buildkite_release_build(branch:, beta:)
     environment: { BETA_RELEASE: beta },
     pipeline_file: 'release-builds.yml'
   )
-end
-
-def add_buildkite_analytics_token(xctestrun_path:)
-  require 'plist'
-
-  token_key = 'BUILDKITE_ANALYTICS_TOKEN'
-  token = ENV[token_key]
-  return if token.nil?
-
-  xctestrun = Plist.parse_xml(xctestrun_path)
-  xctestrun['TestConfigurations'].each do |configuration|
-    configuration['TestTargets'].each do |target|
-      target['EnvironmentVariables'][token_key] = token
-    end
-  end
-
-  File.write(xctestrun_path, Plist::Emit.dump(xctestrun))
 end


### PR DESCRIPTION
### Description

I've been discussing the best way to pass the Buildkite test analytics token to the tests runner with @iampatbrown from the Buildkite crew. He found a better approach than mine, via the configuration options in the Test Plan 🎉 

This is a simpler approach because it doesn't require any extra work _and_ makes it even less likely for the token to be committed to Git.

In the context of this PR, I also tackled forwarding all the [remaining environment variables](https://buildkite.com/docs/test-analytics/ci-environments#buildkite). As a bonus, this allows Buildkite to establish a link between a build and its analytics.

_I haven't yet split the analytics into two, one for unit and one for UI tests. That will come next._

### Testing instructions

Verify CI is green and checkout the Test Analytics page for the build. 

![Untitled](https://user-images.githubusercontent.com/1218433/176156031-152c5b2a-1ddd-454e-92d3-53b164c536eb.jpg)

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/1218433/176156208-6d71fd32-a050-43be-a645-253df5ce70d5.png">

_Side note: The trend numbers in the page make a clear case for splitting unit and UI tests into two. The UI tests take so much longer and mess up the  "faster/slower" reports._

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
