### PR TITLE
[Order Details] Add tracking: Implement "Discard changes" ActionSheet

### DIFF
--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -63,7 +63,7 @@ protocol ManualTrackingViewModel {
 
     var shipmentProvider: ShipmentTrackingProvider? { get set }
     var shipmentProviderGroupName: String? { get set }
-
+    var isEmptyState: Bool { get }
     var canCommit: Bool { get }
     var isCustom: Bool { get }
     var isAdding: Bool { get }
@@ -128,6 +128,9 @@ final class AddTrackingViewModel: ManualTrackingViewModel {
     }
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.disclosureIndicator
+    var isEmptyState: Bool {
+        (shipmentProvider != nil || trackingNumber != nil) ? false : true
+    }
 
     var canCommit: Bool {
         return shipmentProvider != nil &&
@@ -231,6 +234,9 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
     }
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.none
+    var isEmptyState: Bool {
+        (providerName != nil || trackingNumber != nil) ? false : true
+    }
 
     var canCommit: Bool {
         let returnValue = providerName?.isEmpty == false &&

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -63,7 +63,6 @@ protocol ManualTrackingViewModel {
 
     var shipmentProvider: ShipmentTrackingProvider? { get set }
     var shipmentProviderGroupName: String? { get set }
-    var isEmptyState: Bool { get }
     var hasUnsavedChanges: Bool { get }
     var canCommit: Bool { get }
     var isCustom: Bool { get }
@@ -127,11 +126,8 @@ final class AddTrackingViewModel: ManualTrackingViewModel {
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.disclosureIndicator
 
-    var isEmptyState: Bool {
-        (shipmentProvider == nil && trackingNumber.isNilOrEmpty)
-    }
     var hasUnsavedChanges: Bool {
-        (shipmentProvider == nil || trackingNumber.isNilOrEmpty)
+        !trackingNumber.isNilOrEmpty
     }
 
     var canCommit: Bool {
@@ -236,11 +232,9 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
     }
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.none
-    var isEmptyState: Bool {
-        (providerName.isNilOrEmpty && trackingNumber.isNilOrEmpty) ? true : false
-    }
+
     var hasUnsavedChanges: Bool {
-        (providerName.isNilOrEmpty || trackingNumber.isNilOrEmpty) ? true : false
+        !providerName.isNilOrEmpty || !trackingNumber.isNilOrEmpty
     }
 
     var canCommit: Bool {

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -64,6 +64,7 @@ protocol ManualTrackingViewModel {
     var shipmentProvider: ShipmentTrackingProvider? { get set }
     var shipmentProviderGroupName: String? { get set }
     var isEmptyState: Bool { get }
+    var hasUnsavedChanges: Bool { get }
     var canCommit: Bool { get }
     var isCustom: Bool { get }
     var isAdding: Bool { get }
@@ -129,7 +130,10 @@ final class AddTrackingViewModel: ManualTrackingViewModel {
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.disclosureIndicator
     var isEmptyState: Bool {
-        (shipmentProvider != nil || trackingNumber != nil) ? false : true
+        (shipmentProvider == nil && trackingNumber.isNilOrEmpty) ? true : false
+    }
+    var hasUnsavedChanges: Bool {
+        (shipmentProvider == nil || trackingNumber.isNilOrEmpty) ? true : false
     }
 
     var canCommit: Bool {
@@ -235,7 +239,10 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.none
     var isEmptyState: Bool {
-        (providerName != nil || trackingNumber != nil) ? false : true
+        (providerName.isNilOrEmpty && trackingNumber.isNilOrEmpty) ? true : false
+    }
+    var hasUnsavedChanges: Bool {
+        (providerName.isNilOrEmpty || trackingNumber.isNilOrEmpty) ? true : false
     }
 
     var canCommit: Bool {

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -129,11 +129,12 @@ final class AddTrackingViewModel: ManualTrackingViewModel {
     }
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.disclosureIndicator
+
     var isEmptyState: Bool {
-        (shipmentProvider == nil && trackingNumber.isNilOrEmpty) ? true : false
+        (shipmentProvider == nil && trackingNumber.isNilOrEmpty)
     }
     var hasUnsavedChanges: Bool {
-        (shipmentProvider == nil || trackingNumber.isNilOrEmpty) ? true : false
+        (shipmentProvider == nil || trackingNumber.isNilOrEmpty)
     }
 
     var canCommit: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -72,6 +72,9 @@ private extension ManualTrackingViewController {
         configureTitle()
         configureDismissButton()
         configureAddButton()
+        // Disables the ability to dismiss the view controller via a pull-down gesture, in order to avoid losing unsaved changes.
+        isModalInPresentation = false
+        navigationController?.presentationController?.delegate = self
     }
 
     func configureTitle() {
@@ -452,6 +455,20 @@ private extension ManualTrackingViewController {
 private extension ManualTrackingViewController {
     private func activateActionButtonIfNecessary() {
         navigationItem.rightBarButtonItem?.isEnabled = viewModel.canCommit
+    }
+}
+
+// MARK: - UISheetPresentationControllerDelegate comformance
+//
+/// Asks permission to dismiss. We call this delegate method whenever the user attempts to dismiss the View Controller via the pull-down gesture.
+extension ManualTrackingViewController: UISheetPresentationControllerDelegate {
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        if hasUnsavedChanges {
+            displayDismissConfirmationAlert()
+            return false
+        } else {
+            return true
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -136,7 +136,11 @@ private extension ManualTrackingViewController {
     }
 
     @objc func dismissButtonTapped() {
-        if viewModel.shipmentProvider != nil || viewModel.trackingNumber != nil {
+        if viewModel.isEmptyState {
+            dismiss()
+        } else if viewModel.hasUnsavedChanges {
+            displayDismissConfirmationAlert()
+        } else if viewModel.canCommit {
             displayDismissConfirmationAlert()
         } else {
             dismiss()
@@ -459,7 +463,16 @@ private extension ManualTrackingViewController {
 /// Asks permission to dismiss. We call this delegate method whenever the user attempts to dismiss the View Controller via the pull-down gesture.
 extension ManualTrackingViewController: UISheetPresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        viewModel.canCommit ? true : false
+
+        if viewModel.isEmptyState {
+            return true
+        } else if viewModel.hasUnsavedChanges {
+            return false
+        } else if viewModel.canCommit {
+            return false
+        } else {
+            return true
+        }
     }
     func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
         displayDismissConfirmationAlert()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -134,7 +134,11 @@ private extension ManualTrackingViewController {
     }
 
     @objc func dismissButtonTapped() {
-        dismiss()
+        if viewModel.canCommit == false {
+            displayDismissConfirmationAlert()
+        } else {
+            dismiss()
+        }
     }
 
     @objc func primaryButtonTapped() {
@@ -546,6 +550,12 @@ private extension ManualTrackingViewController {
 
         ServiceLocator.stores.dispatch(action)
 
+    }
+    func displayDismissConfirmationAlert() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self,
+                                                           onDiscard: {[weak self] in self?.dismiss(animated: true)},
+                                                           onCancel: .none
+        )
     }
 
     func dismiss() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -462,12 +462,10 @@ private extension ManualTrackingViewController {
 /// Asks permission to dismiss. We call this delegate method whenever the user attempts to dismiss the View Controller via the pull-down gesture.
 extension ManualTrackingViewController: UISheetPresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        if hasUnsavedChanges {
-            displayDismissConfirmationAlert()
-            return false
-        } else {
-            return true
-        }
+        hasUnsavedChanges ? false : true
+    }
+    func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        displayDismissConfirmationAlert()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -34,8 +34,6 @@ final class ManualTrackingViewController: UIViewController {
 
     private var valueSubscriptions: Set<AnyCancellable> = []
 
-    var hasUnsavedChanges: Bool = true
-
     init(viewModel: ManualTrackingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: type(of: self).nibName, bundle: nil)
@@ -138,7 +136,7 @@ private extension ManualTrackingViewController {
     }
 
     @objc func dismissButtonTapped() {
-        if viewModel.canCommit == false || hasUnsavedChanges {
+        if viewModel.shipmentProvider != nil || viewModel.trackingNumber != nil {
             displayDismissConfirmationAlert()
         } else {
             dismiss()
@@ -148,7 +146,6 @@ private extension ManualTrackingViewController {
     @objc func primaryButtonTapped() {
         ServiceLocator.analytics.track(.orderShipmentTrackingAddButtonTapped)
         viewModel.isCustom ? addCustomTracking() : addTracking()
-        hasUnsavedChanges = false
     }
 }
 
@@ -462,7 +459,7 @@ private extension ManualTrackingViewController {
 /// Asks permission to dismiss. We call this delegate method whenever the user attempts to dismiss the View Controller via the pull-down gesture.
 extension ManualTrackingViewController: UISheetPresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        hasUnsavedChanges ? false : true
+        viewModel.canCommit ? true : false
     }
     func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
         displayDismissConfirmationAlert()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -136,11 +136,10 @@ private extension ManualTrackingViewController {
     }
 
     @objc func dismissButtonTapped() {
-        if viewModel.canCommit || viewModel.hasUnsavedChanges {
-            displayDismissConfirmationAlert()
-        } else {
-            dismiss()
+        guard !viewModel.hasUnsavedChanges else {
+            return displayDismissConfirmationAlert()
         }
+        dismiss()
     }
 
     @objc func primaryButtonTapped() {
@@ -462,13 +461,7 @@ private extension ManualTrackingViewController {
 //
 extension ManualTrackingViewController: UISheetPresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        if viewModel.canCommit || viewModel.hasUnsavedChanges {
-            return false
-        } else if viewModel.isEmptyState {
-            return true
-        } else {
-            return true
-        }
+        viewModel.hasUnsavedChanges == false
     }
     func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
         displayDismissConfirmationAlert()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -458,7 +458,6 @@ private extension ManualTrackingViewController {
 
 // MARK: - UISheetPresentationControllerDelegate comformance
 //
-/// Asks permission to dismiss. We call this delegate method whenever the user attempts to dismiss the View Controller via the pull-down gesture.
 extension ManualTrackingViewController: UISheetPresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         if viewModel.canCommit || viewModel.hasUnsavedChanges {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -34,6 +34,8 @@ final class ManualTrackingViewController: UIViewController {
 
     private var valueSubscriptions: Set<AnyCancellable> = []
 
+    var hasUnsavedChanges: Bool = true
+
     init(viewModel: ManualTrackingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: type(of: self).nibName, bundle: nil)
@@ -134,7 +136,7 @@ private extension ManualTrackingViewController {
     }
 
     @objc func dismissButtonTapped() {
-        if viewModel.canCommit == false {
+        if viewModel.canCommit == false || hasUnsavedChanges {
             displayDismissConfirmationAlert()
         } else {
             dismiss()
@@ -144,6 +146,7 @@ private extension ManualTrackingViewController {
     @objc func primaryButtonTapped() {
         ServiceLocator.analytics.track(.orderShipmentTrackingAddButtonTapped)
         viewModel.isCustom ? addCustomTracking() : addTracking()
+        hasUnsavedChanges = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -138,8 +138,6 @@ private extension ManualTrackingViewController {
     @objc func dismissButtonTapped() {
         if viewModel.canCommit || viewModel.hasUnsavedChanges {
             displayDismissConfirmationAlert()
-        } else if viewModel.isEmptyState {
-            dismiss()
         } else {
             dismiss()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -136,12 +136,10 @@ private extension ManualTrackingViewController {
     }
 
     @objc func dismissButtonTapped() {
-        if viewModel.isEmptyState {
+        if viewModel.canCommit || viewModel.hasUnsavedChanges {
+            displayDismissConfirmationAlert()
+        } else if viewModel.isEmptyState {
             dismiss()
-        } else if viewModel.hasUnsavedChanges {
-            displayDismissConfirmationAlert()
-        } else if viewModel.canCommit {
-            displayDismissConfirmationAlert()
         } else {
             dismiss()
         }
@@ -463,13 +461,10 @@ private extension ManualTrackingViewController {
 /// Asks permission to dismiss. We call this delegate method whenever the user attempts to dismiss the View Controller via the pull-down gesture.
 extension ManualTrackingViewController: UISheetPresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-
-        if viewModel.isEmptyState {
+        if viewModel.canCommit || viewModel.hasUnsavedChanges {
+            return false
+        } else if viewModel.isEmptyState {
             return true
-        } else if viewModel.hasUnsavedChanges {
-            return false
-        } else if viewModel.canCommit {
-            return false
         } else {
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -73,7 +73,6 @@ private extension ManualTrackingViewController {
         configureDismissButton()
         configureAddButton()
         // Disables the ability to dismiss the view controller via a pull-down gesture, in order to avoid losing unsaved changes.
-        isModalInPresentation = false
         navigationController?.presentationController?.delegate = self
     }
 
@@ -573,8 +572,7 @@ private extension ManualTrackingViewController {
     }
     func displayDismissConfirmationAlert() {
         UIAlertController.presentDiscardChangesActionSheet(viewController: self,
-                                                           onDiscard: {[weak self] in self?.dismiss(animated: true)},
-                                                           onCancel: .none
+                                                           onDiscard: {[weak self] in self?.dismiss(animated: true)}
         )
     }
 


### PR DESCRIPTION
Partial fix for: https://github.com/woocommerce/woocommerce-ios/issues/1949 in conjunction with https://github.com/woocommerce/woocommerce-ios/pull/7148

## Description
We want to avoid users dismissing views by accident, without saving data. This PR implements a "discard changes" alert when a user attempts to dismiss the "Add Tracking" view without saving changes first, either by tapping on the "dismiss" button or by attempting to dismiss the view via the pull-down-to-dismiss gesture.

It adds two new computed variables to the model, which, along with the existing `canCommit`, covers all the cases we need to check if there are unsaved changes.
- `isEmptyState`: All fields are empty, these vary depending on if the shipment provider is custom or not.
- `hasUnsavedChanges`: Some fields are not-empty, these vary depending on if the shipment provider is custom or not.

## Testing instructions:
- Install and activate https://woocommerce.com/products/shipment-tracking/
- All the cases can be tested by going to Orders > Select an Order > Scroll to `(+) Add tracking` :

![Simulator Screen Shot - iPhone 11 Pro Max - 2022-06-29 at 22 18 06](https://user-images.githubusercontent.com/3812076/176475801-0cb62512-a998-49f7-94bc-74057e9dc47f.png)


### Case 1: Tap dismiss or pull-to-dismiss with empty fields
1. Do not fill Shipping Carrier or Tracking number. Both fields have to be empty.
2. Tap dismiss, or pull-to-dismiss 
3. See how the view is dismissed

### Case 2: Tap dismiss or pull-to-dismiss with unsaved data in 1 field
1. Fill one field: Shipping Carrier or Tracking number
2. Tap dismiss, or pull-to-dismiss 
3. See the Discard Changes alert

### Case 3:  Tap dismiss or pull-to-dismiss with unsaved data in 2 fields
1. Fill both fields: Shipping Carrier and Tracking number
2. Tap dismiss, or pull-to-dismiss 
3. See the Discard Changes alert

### Case 4: Tap Add
1. Fill both fields: Shipping Carrier and Tracking number
2. Tap Add
3. See how the view is dismissed

### Case 5: Custom Carriers
1. Go to Orders > Select an Order > Scroll to `(+) Add tracking`, and in `Shipping Carrier `select `Custom Carrier`
2. Try to tap dismiss or pull-to-dismiss when any of the mandatory fields are empty or we have not saved the data
3. See the Discard Changes alert 


TODO
- [x] Case: Show ActionSheet when the user taps "Dismiss" and changes can't be committed 479c3f2d40e66093318f98cd9bc9b169a080bf17
- [x] Case: Show ActionSheet when the user taps "Dismiss", changes can be committed, but they aren't yet -> Added tracked numbers but haven't tapped "add" 3692817a17fbc8d0cee8e68105440fa29e8f0ad4
- [x] Case: Show ActionSheet when the user attempts to "pull to dismiss" d90d0c95f69e44fdd8f9f8f335df89add3c82ef2
- [x] Edge case: pull-to-dismiss & all fields empty
- [x] Test for Custom providers
- [x] Move checks to the viewModel
- [x] Clean-up logic for pull-to-dismiss