### PR TITLE
[Unified Order Editing] Sync status and customer note in Order Edit flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -191,7 +191,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// View model for the customer note section.
     ///
-    lazy private(set) var noteViewModel = { OrderFormCustomerNoteViewModel(originalNote: "") }()
+    lazy private(set) var noteViewModel = { OrderFormCustomerNoteViewModel(originalNote: customerNoteDataViewModel.customerNote) }()
 
     // MARK: Payment properties
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -250,11 +250,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.storageManager = storageManager
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.analytics = analytics
-        if case let .editing(initialOrder) = flow {
-            self.orderSynchronizer = RemoteOrderSynchronizer(siteID: siteID, initialOrder: initialOrder, stores: stores, currencySettings: currencySettings)
-        } else {
-            self.orderSynchronizer = RemoteOrderSynchronizer(siteID: siteID, initialOrder: nil, stores: stores, currencySettings: currencySettings)
-        }
+        self.orderSynchronizer = RemoteOrderSynchronizer(siteID: siteID, flow: flow, stores: stores, currencySettings: currencySettings)
         self.featureFlagService = featureFlagService
 
         // Set a temporary initial view model, as a workaround to avoid making it optional.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -212,8 +212,10 @@ private extension RemoteOrderSynchronizer {
             .share()
             .eraseToAnyPublisher()
 
-        bindOrderCreation(trigger: syncTrigger)
         bindOrderUpdate(trigger: syncTrigger)
+        if case .creation = flow {
+            bindOrderCreation(trigger: syncTrigger)
+        }
     }
 
     /// Binds the provided `trigger` and creates an order when needed(order does not exists remotely).

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -120,11 +120,13 @@ private extension RemoteOrderSynchronizer {
     ///
     func bindInputs(flow: EditableOrderViewModel.Flow) {
         setStatus.withLatestFrom(orderPublisher)
-            .sink { [weak self] newStatus, order in
-                let orderWithNewStatus = order.copy(status: newStatus)
-                self?.order = orderWithNewStatus
+            .map { newStatus, order in
+                order.copy(status: newStatus)
+            }
+            .sink { [weak self] order in
+                self?.order = order
                 if case .editing = flow {
-                    self?.orderSyncTrigger.send(orderWithNewStatus)
+                    self?.orderSyncTrigger.send(order)
                 }
             }
             .store(in: &subscriptions)
@@ -180,11 +182,13 @@ private extension RemoteOrderSynchronizer {
             .store(in: &subscriptions)
 
         setNote.withLatestFrom(orderPublisher)
-            .sink { [weak self] note, order in
-                let orderWithNewNote = order.copy(customerNote: note)
-                self?.order = orderWithNewNote
+            .map { note, order in
+                order.copy(customerNote: note)
+            }
+            .sink { [weak self] order in
+                self?.order = order
                 if case .editing = flow {
-                    self?.orderSyncTrigger.send(orderWithNewNote)
+                    self?.orderSyncTrigger.send(order)
                 }
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -216,7 +216,7 @@ private extension RemoteOrderSynchronizer {
             .share()
             .eraseToAnyPublisher()
 
-        if case .creation = flow {
+        if flow == .creation {
             bindOrderCreation(trigger: syncTrigger)
         }
         bindOrderUpdate(trigger: syncTrigger, flow: flow)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -135,7 +135,7 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_view_model_fires_error_notice_when_order_sync_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         let error = NSError(domain: "Error", code: 0)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -25,7 +25,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     func test_sending_status_input_updates_local_order() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         synchronizer.setStatus.send(.completed)
@@ -38,7 +38,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
@@ -55,7 +55,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
@@ -74,7 +74,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
@@ -91,7 +91,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let address = Address.fake().copy(firstName: "Woo", lastName: "Customer")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let input = OrderSyncAddressesInput(billing: address, shipping: address)
@@ -106,7 +106,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let address = Address.fake().copy(firstName: "Woo", lastName: "Customer")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let input = OrderSyncAddressesInput(billing: address, shipping: address)
@@ -123,7 +123,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let shippingLine = ShippingLine.fake().copy(shippingID: sampleShippingID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         synchronizer.setShipping.send(shippingLine)
@@ -136,7 +136,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let shippingLine = ShippingLine.fake().copy(shippingID: sampleShippingID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         synchronizer.setShipping.send(shippingLine)
@@ -151,7 +151,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let orderCreationInvoked: Bool = waitFor { promise in
@@ -176,7 +176,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "20.0")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let submittedItems: [OrderItem] = waitFor { promise in
@@ -205,7 +205,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "20.0")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let submittedItems: [OrderItem] = waitFor { promise in
@@ -233,7 +233,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "20.0")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let submittedItems: [OrderItem] = waitFor { promise in
@@ -267,7 +267,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let address = Address.fake().copy(firstName: "Woo", lastName: "Customer")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let orderCreationInvoked: Bool = waitFor { promise in
@@ -292,7 +292,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let shippingLine = ShippingLine.fake().copy(shippingID: sampleShippingID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let orderCreationInvoked: Bool = waitFor { promise in
@@ -316,7 +316,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let fee = OrderFeeLine.fake().copy()
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let orderCreationInvoked: Bool = waitFor { promise in
@@ -340,7 +340,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let feeLine = OrderFeeLine.fake().copy(feeID: sampleFeeID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         synchronizer.setFee.send(feeLine)
@@ -354,7 +354,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     func test_sending_customer_note_input_updates_local_order() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         let expectedNotes = "Test customer note"
 
         // When
@@ -367,7 +367,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     func test_creating_customer_note_input_updates_local_order() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         let randomNote = "Unexpected customer note"
         let expectedNote = "Second customer note"
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
@@ -394,7 +394,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     func test_updating_customer_note_input_updates_local_order() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         let product = Product.fake().copy(productID: sampleProductID)
         let firstNote = "First customer note"
         let expectedNote = "Second customer note"
@@ -432,7 +432,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .createOrder(_, _, let completion):
@@ -464,7 +464,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .createOrder(_, _, let completion):
@@ -502,7 +502,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
@@ -542,7 +542,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let error = NSError(domain: "", code: 0, userInfo: nil)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let receivedError: Bool = waitFor { promise in
@@ -584,7 +584,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let error = NSError(domain: "", code: 0, userInfo: nil)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .createOrder(_, _, let completion):
@@ -617,7 +617,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let error = NSError(domain: "", code: 0, userInfo: nil)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .createOrder(_, _, let completion):
@@ -655,7 +655,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let exp = expectation(description: #function)
@@ -685,7 +685,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         waitForExpectation { exp in
@@ -726,7 +726,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
                 XCTFail("Unexpected action received: \(action)")
             }
         }
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         XCTAssertEqual(synchronizer.order.status, .pending) // initial status
 
         // When
@@ -753,7 +753,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let updateFields: [OrderUpdateField] = waitFor { promise in
@@ -790,7 +790,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let error = NSError(domain: "", code: 0, userInfo: nil)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let orderCreationFailed: Bool = waitFor { promise in
@@ -833,7 +833,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let error = NSError(domain: "", code: 0, userInfo: nil)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let orderUpdateFailed: Bool = waitFor { promise in
@@ -881,7 +881,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     func test_commit_changes_creates_order_if_order_has_not_been_created() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .createOrder(_, let order, let completion):
@@ -905,7 +905,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     func test_commit_changes_relays_error() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .createOrder(_, _, let completion):
@@ -930,7 +930,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
     func test_commit_changes_updates_order_if_order_has_been_created() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .createOrder(_, let order, let completion):
@@ -960,7 +960,7 @@ class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, stores: stores)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
         let exp = expectation(description: #function)


### PR DESCRIPTION
Closes: #7074.
Closes: #7075.

## Description

This PR updates `RemoteOrderSynchronizer` to sync status and customer note data in Order Edit flow.

## Testing

1. Go to the Orders tab, open any existing order.
2. Wait until order fully loads. Tap "•••" in navbar. Select "Edit".
3. Update status.
4. Update note.
5. Confirm the data is correctly updated in Edit Form.
6. Close Edit Form and confirm Order Details shows the same (updated) data.
7. *Optional:* Try creation flow and check that status in set to auto-draft when syncing before finishing the flow (check from wp-admin).

## Video

https://user-images.githubusercontent.com/3132438/176218456-7c71c867-d765-46f5-956d-a6c4a6b70df2.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.