### PR TITLE
[Mobile Payments] Payment gateway selection tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -170,6 +170,9 @@ public enum WooAnalyticsStat: String {
     case cardPresentOnboardingLearnMoreTapped = "card_present_onboarding_learn_more_tapped"
     case cardPresentOnboardingNotCompleted = "card_present_onboarding_not_completed"
 
+    // MARK: Payment Gateways selection
+    case cardPresentOnboardingPaymentGatewaySelected = "card_present_onboarding_payment_gateway_selected" 
+
     // MARK: Order View Events
     //
     case ordersSelected = "main_tab_orders_selected"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -171,7 +171,7 @@ public enum WooAnalyticsStat: String {
     case cardPresentOnboardingNotCompleted = "card_present_onboarding_not_completed"
 
     // MARK: Payment Gateways selection
-    case cardPresentOnboardingPaymentGatewaySelected = "card_present_onboarding_payment_gateway_selected" 
+    case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"
 
     // MARK: Order View Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -129,6 +129,7 @@ public enum WooAnalyticsStat: String {
     case settingsSelectedStoreTapped = "settings_selected_site_tapped"
     case settingsContactSupportTapped = "main_menu_contact_support_tapped"
     case settingsCardReadersTapped = "settings_card_readers_tapped"
+    case settingsCardPresentSelectedPaymentGatewayTapped = "settings_card_present_select_payment_gateway_tapped"
 
     case settingsBetaFeaturesButtonTapped = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled = "settings_beta_features_products_toggled"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -173,6 +173,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"
+    case cardPresentSelectPaymentGatewayShow = "card_present_select_payment_gateway_show"
 
     // MARK: Order View Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -178,6 +178,7 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func managePaymentGatewaysWasPressed() {
+        ServiceLocator.analytics.track(.settingsCardPresentSelectedPaymentGatewayTapped)
         onPluginSelectionCleared()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -74,6 +74,9 @@ struct InPersonPaymentsSelectPluginView: View {
         .padding(.horizontal, 16)
         .padding(.bottom, 24)
         .background(Color(.tertiarySystemBackground).ignoresSafeArea())
+        .onAppear {
+            ServiceLocator.analytics.track(.cardPresentSelectPaymentGatewayShow)
+        }
     }
 
     private func confirmPluginSelection() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -43,6 +43,7 @@ struct InPersonPaymentsView: View {
                 if viewModel.gatewaySelectionAvailable {
                     InPersonPaymentsSelectPluginView(selectedPlugin: nil) { plugin in
                         viewModel.selectPlugin(plugin)
+                        ServiceLocator.analytics.track(.cardPresentOnboardingPaymentGatewaySelected, withProperties: ["payment_gateway": plugin.pluginName])
                     }
                 } else if viewModel.userIsAdministrator {
                     InPersonPaymentsPluginConflictAdmin(onRefresh: viewModel.refresh)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -43,7 +43,7 @@ struct InPersonPaymentsView: View {
                 if viewModel.gatewaySelectionAvailable {
                     InPersonPaymentsSelectPluginView(selectedPlugin: nil) { plugin in
                         viewModel.selectPlugin(plugin)
-                        ServiceLocator.analytics.track(.cardPresentOnboardingPaymentGatewaySelected, withProperties: ["payment_gateway": plugin.pluginName])
+                        ServiceLocator.analytics.track(.cardPresentPaymentGatewaySelected, withProperties: ["payment_gateway": plugin.pluginName])
                     }
                 } else if viewModel.userIsAdministrator {
                     InPersonPaymentsPluginConflictAdmin(onRefresh: viewModel.refresh)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -10,7 +10,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// There is more than one plugin installed and activated. The user must deactivate one.
     /// 
-    case selectPlugin
+    case selectPlugin(source: String)
 
     /// The passed plugin should be deactivated. E.g. this state can happen when WCPay and Stripe
     /// are both installed and activated in a country that doesn't support Stripe. In that case

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -10,7 +10,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// There is more than one plugin installed and activated. The user must deactivate one.
     /// 
-    case selectPlugin(source: String)
+    case selectPlugin
 
     /// The passed plugin should be deactivated. E.g. this state can happen when WCPay and Stripe
     /// are both installed and activated in a country that doesn't support Stripe. In that case


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #6994
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the relevant tracking events for the new selection payment gateway screens. Namely, these events are:
- Tap on IPP Settings Menu row
- Show of IPP Payment Gateway selection screen
- Selection of the plugin in the screen
See also here pdfdoF-Zb-p2 for more information.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Prerequisites
Have both WCPay and Stripe installed and active on an US based store
#### From Settings
1. Start the app and go to settings
2. Tap on In-Person Payments
3. Select payment gateway screen should be shown and show tracked event logged:
`🔵 Tracked card_present_select_payment_gateway_show, properties: [AnyHashable("blog_id"): 205113380, AnyHashable("is_wpcom_store")`
4. Select a method and tap on Confirm Payment Method. Tracked event should be logged:
`Tracked card_present_payment_gateway_selected, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("payment_gateway"): "WooCommerce Payments", AnyHashable("blog_id"): 205113380]`
5. After this it should go back to the In-Person Payments settings screen. Tap on Payment Provider. Tracked event should be logged:
`Tracked settings_card_present_select_payment_gateway_tapped, properties: [AnyHashable("blog_id"): 205113380, AnyHashable("is_wpcom_store"): true]`
#### From Payment Collection
1. Start the app and go to orders
2. Tap on an unpaid order whose payment can be collected
3. Tap on Collect Payment
4. Tap on Card
5. Select payment gateway screen should be shown and show tracked event logged:
`🔵 Tracked card_present_select_payment_gateway_show, properties: [AnyHashable("blog_id"): 205113380, AnyHashable("is_wpcom_store")`
6. Select a method and tap on Confirm Payment Method. Tracked event should be logged:
`Tracked card_present_payment_gateway_selected, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("payment_gateway"): "WooCommerce Payments", AnyHashable("blog_id"): 205113380]`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->