### PR TITLE
Background image upload: reset states after logging out

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
@@ -32,4 +32,8 @@ final class LegacyProductImageUploader: ProductImageUploaderProtocol {
         // The result is not used.
         return false
     }
+
+    func reset() {
+        // no-op
+    }
 }

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -71,6 +71,10 @@ protocol ProductImageUploaderProtocol {
     ///   - isLocalID: whether the product ID is a local ID like in product creation.
     ///   - originalImages: the image statuses before any edits.
     func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool
+
+    /// Resets all internal states and tracking of image uploads for connected stores.
+    /// Called when the user is logged out.
+    func reset()
 }
 
 /// Supports background image upload and product images update after the user leaves the product form.
@@ -179,6 +183,14 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
                                               error: .failedSavingProductAfterImageUpload(error: error)))
             }
         }
+    }
+
+    func reset() {
+        statusUpdatesExcludedProductKeys = []
+        statusUpdatesSubscriptions = []
+
+        actionHandlersByProduct = [:]
+        imagesSaverByProduct = [:]
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -354,6 +354,14 @@ extension ServiceLocator {
 
         _generalAppSettings = mock
     }
+
+    static func setProductImageUploader(_ mock: ProductImageUploaderProtocol) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _productImageUploader = mock
+    }
 }
 
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -166,6 +166,7 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.storageManager.reset()
+        ServiceLocator.productImageUploader.reset()
 
         NotificationCenter.default.post(name: .logOutEventReceived, object: nil)
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -9,6 +9,7 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
     var saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = false
     var startEmittingErrorsWasCalled = false
     var stopEmittingErrorsWasCalled = false
+    var resetWasCalled = false
 
     init(errors: AnyPublisher<ProductImageUploadErrorInfo, Never> =
          Empty<ProductImageUploadErrorInfo, Never>().eraseToAnyPublisher()) {
@@ -40,5 +41,9 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
 
     func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool {
         false
+    }
+
+    func reset() {
+        resetWasCalled = true
     }
 }

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -241,15 +241,15 @@ final class StoresManagerTests: XCTestCase {
     }
 
     func test_deauthenticating_invokes_ProductImageUploader_reset() {
-        // Arrange
+        // Given
         let mockProductImageUploader = MockProductImageUploader()
         ServiceLocator.setProductImageUploader(mockProductImageUploader)
         XCTAssertFalse(mockProductImageUploader.resetWasCalled)
 
-        // Action
+        // When
         ServiceLocator.stores.deauthenticate()
 
-        // Assert
+        // Then
         XCTAssertTrue(mockProductImageUploader.resetWasCalled)
     }
 }

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -239,6 +239,19 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertEqual(siteIDValues, [nil])
         XCTAssertNil(manager.sessionManager.defaultSite)
     }
+
+    func test_deauthenticating_invokes_ProductImageUploader_reset() {
+        // Arrange
+        let mockProductImageUploader = MockProductImageUploader()
+        ServiceLocator.setProductImageUploader(mockProductImageUploader)
+        XCTAssertFalse(mockProductImageUploader.resetWasCalled)
+
+        // Action
+        ServiceLocator.stores.deauthenticate()
+
+        // Assert
+        XCTAssertTrue(mockProductImageUploader.resetWasCalled)
+    }
 }
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the user logs out, the app shouldn't show any failure notice nor update the product with the uploaded images when none is pending upload. This PR added a `reset` function to `ProductImageUploaderProtocol` and implemented it by resetting all internal states. When the user logs out in `DefaultStoresManager.deauthenticate`, it then calls the global `ProductImageUploaderProtocol.reset` like other global dependencies.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### No more failure notices after logging out

One way to test image upload failure is by updating the [product images remote endpoint](https://github.com/woocommerce/woocommerce-ios/blob/3c2e5f2f08da760099517423061957d21b31a5dc/Networking/Networking/Remote/ProductsRemote.swift#L287) to an invalid one like adding some extra character at the end. You can also put `sleep(numberOfSeconds)` to simulate a longer response time.

- Launch the app
- In the product form, add one or more images
- Tap "Save" to save the product while the images are still being uploaded
- Leave the product form quickly, go to the Menu tab, and log out in the settings --> there should not be any error notices shown after logging out

#### Product not updated with the uploaded images after logging out

- Launch the app
- In the product form, add one or more images
- Tap "Save" to save the product while the images are still being uploaded
- Leave the product form quickly, go to the Menu tab, and log out in the settings --> if any image(s) is uploaded after logging out, the product shouldn't be updated with the newly uploaded image(s)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
