### PR TITLE
Send test analytics to dedicated suites for unit, UI iOS, and UI iPadOS

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -24,7 +24,7 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
-echo "--- Configure Test Analytics"
+echo "--- :test-analytics: Configure Test Analytics"
 # Collect data separately for iPhone and iPad
 if [[ $DEVICE =~ ^iPhone ]]; then
   export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -24,6 +24,14 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
+echo "--- Configure Test Analytics"
+# Collect data separately for iPhone and iPad
+if [[ $DEVICE =~ ^iPhone ]]; then
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE
+else
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
+fi
+
 echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -32,6 +32,18 @@ else
   export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
 fi
 
+# Temporary notice about UI tests analytics
+#
+# First, remove any previous notice to avoid duplication
+context='ctx-ui-tests-notice'
+buildkite-agent annotation remove --context "$context" \
+  || true # `remove` will 401 if there's no annotation, but we don't want to fail because of it
+# Then, print a fresh notice
+buildkite-agent annotate \
+  'Test Analytics for UI tests are currently unavailable' \
+  --style 'info' \
+  --context "$context"
+
 echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -32,17 +32,10 @@ else
   export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
 fi
 
-# Temporary notice about UI tests analytics
-#
-# First, remove any previous notice to avoid duplication
-context='ctx-ui-tests-notice'
-buildkite-agent annotation remove --context "$context" \
-  || true # `remove` will 401 if there's no annotation, but we don't want to fail because of it
-# Then, print a fresh notice
 buildkite-agent annotate \
   'Test Analytics for UI tests are currently unavailable' \
   --style 'info' \
-  --context "$context"
+  --context 'ctx-ui-tests-notice'
 
 echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -19,7 +19,7 @@
     "environmentVariableEntries" : [
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
+        "value" : "$(BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS)"
       },
       {
         "key" : "BUILDKITE_BRANCH",

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -43,6 +43,11 @@
         "value" : "$(BUILDKITE_MESSAGE)"
       }
     ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:WooCommerce.xcodeproj",
+      "identifier" : "B56DB3C52049BFAA00D4AA8E",
+      "name" : "WooCommerce"
+    },
     "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -12,7 +12,7 @@
     "environmentVariableEntries" : [
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$BUILDKITE_ANALYTICS_TOKEN"
+        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
       },
       {
         "key" : "BUILDKITE_BRANCH",


### PR DESCRIPTION
### Description

I created three Test Analytics suites for unit, UI iOS, and UI iPadOS tests to collect more granular info. In particular, given the difference in test run time between unit and UI, having them split means we should have more accurate average figures.

> **Info** There's some issue with UI tests with I haven't yet been able to solve. I'd still like to merge this PR as it is, so that we can have more accurate unit tests metrics in the meantime.

I added a notice on this regard to the build page so we don't forget:

<img width="426" alt="image" src="https://user-images.githubusercontent.com/1218433/177246213-5297e241-fd88-4cfd-815b-c706c5e003a5.png">


### Testing instructions
Verify that analytics have been reported for this build by following the "Test Analytics" link in the [build page](https://buildkite.com/automattic/woocommerce-ios/builds/6498).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->