### PR TITLE
App Store Listings: Update scripts for screenshots

### DIFF
--- a/Hardware/Hardware/CardReader/CardReader.swift
+++ b/Hardware/Hardware/CardReader/CardReader.swift
@@ -27,6 +27,17 @@ public struct CardReader {
 
     /// The CardReader location id
     public let locationId: String?
+
+    public init(serial: String, vendorIdentifier: String?, name: String?, status: CardReaderStatus, softwareVersion: String?, batteryLevel: Float?, readerType: CardReaderType, locationId: String?) {
+        self.serial = serial
+        self.vendorIdentifier = vendorIdentifier
+        self.name = name
+        self.status = status
+        self.softwareVersion = softwareVersion
+        self.batteryLevel = batteryLevel
+        self.readerType = readerType
+        self.locationId = locationId
+    }
 }
 
 

--- a/Hardware/Hardware/CardReader/CardReader.swift
+++ b/Hardware/Hardware/CardReader/CardReader.swift
@@ -28,7 +28,14 @@ public struct CardReader {
     /// The CardReader location id
     public let locationId: String?
 
-    public init(serial: String, vendorIdentifier: String?, name: String?, status: CardReaderStatus, softwareVersion: String?, batteryLevel: Float?, readerType: CardReaderType, locationId: String?) {
+    public init(serial: String,
+                vendorIdentifier: String?,
+                name: String?,
+                status: CardReaderStatus,
+                softwareVersion: String?,
+                batteryLevel: Float?,
+                readerType: CardReaderType,
+                locationId: String?) {
         self.serial = serial
         self.vendorIdentifier = vendorIdentifier
         self.name = name
@@ -50,7 +57,6 @@ extension CardReader: Identifiable {
         serial
     }
 }
-
 
 /// Instances of CardReader do not mutate state during their lifecycle.
 extension CardReader: Equatable {

--- a/Hardware/Hardware/CardReader/CardReaderStatus.swift
+++ b/Hardware/Hardware/CardReader/CardReaderStatus.swift
@@ -1,6 +1,6 @@
 /// Models the status of a Card Reader
 public struct CardReaderStatus {
-    
+
     /// Indicates if the CardReader is connected
     public let connected: Bool
 

--- a/Hardware/Hardware/CardReader/CardReaderStatus.swift
+++ b/Hardware/Hardware/CardReader/CardReaderStatus.swift
@@ -1,8 +1,14 @@
 /// Models the status of a Card Reader
 public struct CardReaderStatus {
+    
     /// Indicates if the CardReader is connected
     public let connected: Bool
 
     // Indicates if the CardReader is remembered by the service
     public let remembered: Bool
+
+    public init(connected: Bool, remembered: Bool) {
+        self.connected = connected
+        self.remembered = remembered
+    }
 }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -128,6 +128,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
         // Games should use this method to pause the game.
+        if ProcessConfiguration.shouldSimulatePushNotification {
+            let content = UNMutableNotificationContent()
+            content.title = "You have a new order! 🎉"
+            content.body = "New order for $13.98 on Your WooCommerce Store"
+            content.sound = UNNotificationSound.default
+
+            // show this notification seconds from now
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+
+            // choose a random identifier
+            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+
+            // add our notification request
+            UNUserNotificationCenter.current().add(request)
+        }
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
@@ -327,6 +342,10 @@ private extension AppDelegate {
 
             /// Trick found at: https://twitter.com/twannl/status/1232966604142653446
             UIApplication.shared.currentKeyWindow?.layer.speed = 100
+        }
+
+        if ProcessConfiguration.shouldSimulatePushNotification {
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { _, _ in }
         }
     }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -132,10 +132,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let content = UNMutableNotificationContent()
             content.title = "You have a new order! 🎉"
             content.body = "New order for $13.98 on Your WooCommerce Store"
-            content.sound = UNNotificationSound.default
 
             // show this notification seconds from now
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1.5, repeats: false)
 
             // choose a random identifier
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -130,8 +130,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Games should use this method to pause the game.
         if ProcessConfiguration.shouldSimulatePushNotification {
             let content = UNMutableNotificationContent()
-            content.title = "You have a new order! 🎉"
-            content.body = "New order for $13.98 on Your WooCommerce Store"
+            content.title = NSLocalizedString("You have a new order! 🎉", comment: "Title for the mocked order notification needed for the AppStore listing screenshot")
+            content.body = NSLocalizedString(
+                "New order for $13.98 on Your WooCommerce Store",
+                comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +
+                "'Your WooCommerce Store' is the name of the mocked store." 
+            )
 
             // show this notification seconds from now
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1.5, repeats: false)

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -137,7 +137,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             content.body = NSLocalizedString(
                 "New order for $13.98 on Your WooCommerce Store",
                 comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +
-                "'Your WooCommerce Store' is the name of the mocked store." 
+                "'Your WooCommerce Store' is the name of the mocked store."
             )
 
             // show this notification seconds from now

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -130,7 +130,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Games should use this method to pause the game.
         if ProcessConfiguration.shouldSimulatePushNotification {
             let content = UNMutableNotificationContent()
-            content.title = NSLocalizedString("You have a new order! 🎉", comment: "Title for the mocked order notification needed for the AppStore listing screenshot")
+            content.title = NSLocalizedString(
+                "You have a new order! 🎉",
+                comment: "Title for the mocked order notification needed for the AppStore listing screenshot"
+            )
             content.body = NSLocalizedString(
                 "New order for $13.98 on Your WooCommerce Store",
                 comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -123,11 +123,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state.
-        // This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message)
-        // or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
-        // Games should use this method to pause the game.
+        // Simulate push notification for capturing snapshot.
+        // This is supposed to be called only by the WooCommerceScreenshots target.
         if ProcessConfiguration.shouldSimulatePushNotification {
             let content = UNMutableNotificationContent()
             content.title = NSLocalizedString(

--- a/WooCommerce/Classes/System/ProcessConfiguration.swift
+++ b/WooCommerce/Classes/System/ProcessConfiguration.swift
@@ -16,4 +16,9 @@ struct ProcessConfiguration {
     static var shouldDisableAnimations: Bool {
         ProcessInfo.processInfo.arguments.contains("disable-animations")
     }
+
+    /// Returns `true` when wishing to simulate push notifications.
+    static var shouldSimulatePushNotification: Bool {
+        ProcessInfo.processInfo.arguments.contains("-mocks-push-notification")
+    }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -612,7 +612,8 @@ private extension OrderDetailsDataSource {
 
     private func configureCollectPaymentButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
         cell.configure(style: .primary,
-                       title: Titles.collectPayment) { [weak self] in
+                       title: Titles.collectPayment,
+                       accessibilityIdentifier: "order-detail-collect-payment-button") { [weak self] in
             self?.onCellAction?(.collectPayment, indexPath)
         }
         cell.hideSeparator()

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -194,6 +194,7 @@ private extension CardPresentPaymentsModalViewController {
 
     func configureTopTitle() {
         topTitleLabel.text = viewModel.topTitle
+        topTitleLabel.accessibilityIdentifier = "card-present-payments-modal-title-label"
     }
 
     func configureTopSubtitle() {
@@ -261,6 +262,7 @@ private extension CardPresentPaymentsModalViewController {
 
         primaryButton.isHidden = false
         primaryButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
+        primaryButton.accessibilityIdentifier = "card-present-payments-modal-primary-button"
     }
 
     func configureSecondaryButton() {
@@ -271,6 +273,7 @@ private extension CardPresentPaymentsModalViewController {
 
         secondaryButton.isHidden = false
         secondaryButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
+        secondaryButton.accessibilityIdentifier = "card-present-payments-modal-secondary-button"
     }
 
     func configureAuxiliaryButton() {
@@ -281,6 +284,7 @@ private extension CardPresentPaymentsModalViewController {
 
         auxiliaryButton.setTitleWithoutAnimation(viewModel.auxiliaryButtonTitle, for: .normal)
         auxiliaryButton.isHidden = false
+        auxiliaryButton.accessibilityIdentifier = "card-present-payments-modal-auxiliary-button"
     }
 
     func configureSpacer() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -35,11 +35,13 @@ final class ButtonTableViewCell: UITableViewCell {
     ///   - onButtonTouchUp: Called when the button is tapped.
     func configure(style: Style = .default,
                    title: String?,
+                   accessibilityIdentifier: String? = nil,
                    topSpacing: CGFloat = Constants.defaultSpacing,
                    bottomSpacing: CGFloat = Constants.defaultSpacing,
                    onButtonTouchUp: (() -> Void)? = nil) {
         apply(style: style)
         button.setTitle(title, for: .normal)
+        button.accessibilityIdentifier = accessibilityIdentifier
         self.onButtonTouchUp = onButtonTouchUp
 
         topConstraint.constant = topSpacing

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
@@ -11,12 +11,17 @@ public final class PeriodStatsTable: ScreenObject {
         $0.cells["period-data-thisWeek-tab"]
     }
 
+    private let monthsTabGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["period-data-thisMonth-tab"]
+    }
+
     private let yearsTabGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["period-data-thisYear-tab"]
     }
 
     private var daysTab: XCUIElement { daysTabGetter(app) }
     private var weeksTab: XCUIElement { weeksTabGetter(app) }
+    private var monthsTab: XCUIElement { monthsTabGetter(app) }
     private var yearsTab: XCUIElement { yearsTabGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
@@ -33,10 +38,16 @@ public final class PeriodStatsTable: ScreenObject {
     }
 
     @discardableResult
-       func switchToWeeksTab() -> Self {
-           weeksTab.tap()
-           return self
-       }
+    func switchToWeeksTab() -> Self {
+        weeksTab.tap()
+        return self
+    }
+
+    @discardableResult
+    public func switchToMonthsTab() -> Self {
+        monthsTab.tap()
+        return self
+    }
 
     @discardableResult
     public func switchToYearsTab() -> Self {

--- a/WooCommerce/UITestsFoundation/Screens/Orders/CardPresentPaymentsModalScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/CardPresentPaymentsModalScreen.swift
@@ -1,0 +1,26 @@
+import ScreenObject
+import XCTest
+
+public final class CardPresentPaymentsModalScreen: ScreenObject {
+
+    private let dismissButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["card-present-payments-modal-secondary-button"]
+    }
+
+    /// Button to dismiss a the modal
+    ///
+    private var dismissButton: XCUIElement { dismissButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.staticTexts["card-present-payments-modal-title-label"]} ],
+            app: app
+        )
+    }
+
+    @discardableResult
+    public func goBackToOrderScreen() throws -> SingleOrderScreen {
+        dismissButton.tap()
+        return try SingleOrderScreen()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -190,7 +190,13 @@ public final class NewOrderScreen: ScreenObject {
     /// - Returns: Orders Screen object.
     @discardableResult
     public func cancelOrderCreation() throws -> OrdersScreen {
-        cancelButton.tap()
+        // This cancel button exists only if the feature flag `.splitViewInOrdersTab` is on.
+        // For taking app store screenshot, the beta feature is turned off so we should pop to get out of this screen.
+        if cancelButton.exists {
+            cancelButton.tap()
+        } else {
+            pop()
+        }
         return try OrdersScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -6,6 +6,12 @@ public final class SingleOrderScreen: ScreenObject {
     // TODO: Remove force `try` once `ScreenObject` migration is completed
     let tabBar = try! TabNavComponent()
 
+    private let collectPaymentButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-detail-collect-payment-button"]
+    }
+
+    private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
+
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.staticTexts["summary-table-view-cell-title-label"]} ],
@@ -34,6 +40,12 @@ public final class SingleOrderScreen: ScreenObject {
         }
 
         return self
+    }
+
+    @discardableResult
+    public func tapCollectPaymentButton() throws -> CardPresentPaymentsModalScreen {
+        collectPaymentButton.tap()
+        return try CardPresentPaymentsModalScreen()
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -44,6 +44,10 @@ public final class SingleOrderScreen: ScreenObject {
 
     @discardableResult
     public func tapCollectPaymentButton() throws -> CardPresentPaymentsModalScreen {
+        let orderDetailTableView = app.tables["order-details-table-view"]
+        while !collectPaymentButton.isFullyVisibleOnScreen() {
+            orderDetailTableView.swipeUp()
+        }
         collectPaymentButton.tap()
         return try CardPresentPaymentsModalScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -33,13 +33,6 @@ public final class ProductsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func tapOutside() -> Self {
-        let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
-        coordinate.tap()
-        return self
-    }
-
-    @discardableResult
     public func collapseTopBannerIfNeeded() -> Self {
 
         /// Without the info label, we don't need to collapse the top banner

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -23,6 +23,23 @@ public final class ProductsScreen: ScreenObject {
     }
 
     @discardableResult
+    public func selectAddProduct() -> Self {
+        guard app.buttons["product-add-button"].waitForExistence(timeout: 3) else {
+            return self
+        }
+
+        app.buttons["product-add-button"].tap()
+        return self
+    }
+
+    @discardableResult
+    public func tapOutside() -> Self {
+        let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        coordinate.tap()
+        return self
+    }
+
+    @discardableResult
     public func collapseTopBannerIfNeeded() -> Self {
 
         /// Without the info label, we don't need to collapse the top banner

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1592,6 +1592,7 @@
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
 		DE3877E4283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E3283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift */; };
+		DE3C5B1F286B18520049E6AA /* CardPresentPaymentsModalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B1E286B18520049E6AA /* CardPresentPaymentsModalScreen.swift */; };
 		DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */; };
 		DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */; };
 		DE4B3B2E269455D400EEF2D8 /* MockShipmentActionStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */; };
@@ -3380,6 +3381,7 @@
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
 		DE3877E3283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		DE3C5B1E286B18520049E6AA /* CardPresentPaymentsModalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalScreen.swift; sourceTree = "<group>"; };
 		DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCountryListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModelTests.swift; sourceTree = "<group>"; };
 		DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShipmentActionStoresManager.swift; sourceTree = "<group>"; };
@@ -8116,6 +8118,7 @@
 				CC71353A2862285300A28B42 /* AddShippingScreen.swift */,
 				CC2A08032863206000510C4B /* AddFeeScreen.swift */,
 				CC2A0807286337A300510C4B /* CustomerNoteScreen.swift */,
+				DE3C5B1E286B18520049E6AA /* CardPresentPaymentsModalScreen.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -8803,6 +8806,7 @@
 			files = (
 				3F0CF3032704490A00EF3D71 /* GetStartedScreen.swift in Sources */,
 				3F0CF30B2704490A00EF3D71 /* MyStoreScreen.swift in Sources */,
+				DE3C5B1F286B18520049E6AA /* CardPresentPaymentsModalScreen.swift in Sources */,
 				3F0CF3082704490A00EF3D71 /* LoginUsernamePasswordScreen.swift in Sources */,
 				3F0CF3122704490A00EF3D71 /* LoginCheckMagicLinkScreen.swift in Sources */,
 				3F0CF30F2704490A00EF3D71 /* SingleProductScreen.swift in Sources */,

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -141,7 +141,7 @@ open class Snapshot: NSObject {
 
     open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
         if timeout > 0 {
-            waitForLoadingIndicatorToDisappear(within: timeout)
+//            waitForLoadingIndicatorToDisappear(within: timeout)
         }
 
         NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -141,7 +141,7 @@ open class Snapshot: NSObject {
 
     open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
         if timeout > 0 {
-//            waitForLoadingIndicatorToDisappear(within: timeout)
+            waitForLoadingIndicatorToDisappear(within: timeout)
         }
 
         NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -142,7 +142,7 @@ extension BaseScreen {
         let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(screenshotCount)-\(mode)-\(title)"
 
-        snapshot(filename)
+        snapshot(filename, timeWaitingForIdle: 0)
 
         return self
     }
@@ -164,7 +164,7 @@ extension ScreenObject {
         let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(screenshotCount)-\(mode)-\(title)"
 
-        snapshot(filename)
+        snapshot(filename, timeWaitingForIdle: 0)
 
         return self
     }

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -46,7 +46,7 @@ class WooCommerceScreenshots: XCTestCase {
         // Products
         .tabBar.goToProductsScreen()
         .selectAddProduct()
-        .thenTakeScreenshot(named: "create-product")
+        .thenTakeScreenshot(named: "product-add")
         .tapOutside()
     }
 

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -35,7 +35,7 @@ class WooCommerceScreenshots: XCTestCase {
 
         // My Store
         .dismissTopBannerIfNeeded()
-        .then { ($0 as! MyStoreScreen).periodStatsTable.switchToYearsTab() }
+        .then { ($0 as! MyStoreScreen).periodStatsTable.switchToMonthsTab() }
         .thenTakeScreenshot(named: "order-dashboard")
 
         // Orders

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -24,6 +24,7 @@ class WooCommerceScreenshots: XCTestCase {
         let app = XCUIApplication()
         setupSnapshot(app)
         app.launchArguments.append("mocked-network-layer")
+        app.launchArguments.append("-simulate-stripe-card-reader")
         app.launchArguments.append("disable-animations")
         app.launchArguments.append("-mocks-port")
         app.launchArguments.append("\(server.listenAddress.port)")
@@ -42,6 +43,12 @@ class WooCommerceScreenshots: XCTestCase {
         .startOrderCreation()
         .thenTakeScreenshot(named: "order-creation")
         .cancelOrderCreation()
+
+        .selectOrder(atIndex: 0)
+        .tapCollectPaymentButton()
+        .thenTakeScreenshot(named: "order-payment")
+        .goBackToOrderScreen()
+        .goBackToOrdersScreen()
 
         // Products
         .tabBar.goToProductsScreen()

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -32,37 +32,22 @@ class WooCommerceScreenshots: XCTestCase {
 
         try MyStoreScreen()
 
-            // My Store
-            .dismissTopBannerIfNeeded()
-            .then { ($0 as! MyStoreScreen).periodStatsTable.switchToYearsTab() }
-            .thenTakeScreenshot(named: "order-dashboard")
+        // My Store
+        .dismissTopBannerIfNeeded()
+        .then { ($0 as! MyStoreScreen).periodStatsTable.switchToYearsTab() }
+        .thenTakeScreenshot(named: "order-dashboard")
 
-            // Orders
-            .tabBar.goToOrdersScreen()
-            .thenTakeScreenshot(named: "order-list")
-            .selectOrder(atIndex: 0)
-            .thenTakeScreenshot(named: "order-detail")
-            .goBackToOrdersScreen()
+        // Orders
+        .tabBar.goToOrdersScreen()
+        .startOrderCreation()
+        .thenTakeScreenshot(named: "order-creation")
+        .cancelOrderCreation()
 
-            .openSearchPane()
-            .thenTakeScreenshot(named: "order-search")
-            .cancel()
-
-            // Products
-            .tabBar.goToProductsScreen()
-            .collapseTopBannerIfNeeded()
-            .thenTakeScreenshot(named: "product-list")
-            .selectProduct(atIndex: 1)
-            .thenTakeScreenshot(named: "product-details")
-            .goBackToProductList()
-
-            // Reviews
-            .tabBar.goToMenuScreen()
-            .goToReviewsScreen()
-            .thenTakeScreenshot(named: "review-list")
-            .selectReview(atIndex: 3)
-            .thenTakeScreenshot(named: "review-details")
-            .goBackToReviewsScreen()
+        // Products
+        .tabBar.goToProductsScreen()
+        .selectAddProduct()
+        .thenTakeScreenshot(named: "create-product")
+        .tapOutside()
     }
 
     private let loop = try! SelectorEventLoop(selector: try! KqueueSelector())

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -27,9 +27,16 @@ class WooCommerceScreenshots: XCTestCase {
         app.launchArguments.append("-simulate-stripe-card-reader")
         app.launchArguments.append("disable-animations")
         app.launchArguments.append("-mocks-port")
+        app.launchArguments.append("-mocks-push-notification")
         app.launchArguments.append("\(server.listenAddress.port)")
 
         app.launch()
+
+        let app2 = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let button = app2.alerts.firstMatch.buttons["Allow"]
+        if button.waitForExistence(timeout: 5) {
+            button.tap()
+        }
 
         try MyStoreScreen()
 
@@ -54,7 +61,9 @@ class WooCommerceScreenshots: XCTestCase {
         .tabBar.goToProductsScreen()
         .selectAddProduct()
         .thenTakeScreenshot(named: "product-add")
-        .tapOutside()
+
+        .lockScreen()
+        .thenTakeScreenshot(named: "order-notification")
     }
 
     private let loop = try! SelectorEventLoop(selector: try! KqueueSelector())
@@ -140,6 +149,13 @@ extension BaseScreen {
 }
 
 extension ScreenObject {
+
+    @discardableResult
+    func lockScreen() -> Self {
+        XCUIDevice.shared.perform(NSSelectorFromString("pressLockButton"))
+        sleep(2)
+        return self
+    }
 
     @discardableResult
     func thenTakeScreenshot(named title: String) -> Self {

--- a/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
@@ -16,10 +16,12 @@ public class CurrencyFormatter {
     ///
     public func convertToDecimal(_ stringValue: String, locale: Locale = .current) -> NSDecimalNumber? {
 
+        let latinValue = stringValue.applyingTransform(StringTransform.toLatin, reverse: false) ?? stringValue
+
         // NSDecimalNumber use by default the local decimal separator to evaluate a decimal amount.
         // We substitute the current decimal separator with the locale decimal separator.
         let localeDecimalSeparator = locale.decimalSeparator ?? currencySettings.decimalSeparator
-        var newStringValue = stringValue.replacingOccurrences(of: ",", with: localeDecimalSeparator)
+        var newStringValue = latinValue.replacingOccurrences(of: ",", with: localeDecimalSeparator)
         newStringValue = newStringValue.replacingOccurrences(of: ".", with: localeDecimalSeparator)
 
         // Removes the currency symbol, if any.

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 		D8C11A5622DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5522DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift */; };
 		D8C11A5822DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5722DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift */; };
 		D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */; };
+		DE3C5B1D286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */; };
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
@@ -776,6 +777,7 @@
 		D8C11A5522DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8C11A5722DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStoreV4Tests.swift; sourceTree = "<group>"; };
+		DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrderCardPresentPaymentEligibilityActionHandler.swift; sourceTree = "<group>"; };
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
@@ -1025,6 +1027,7 @@
 				02137900270AB204006430F7 /* MockUserActionHandler.swift */,
 				02137902270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift */,
 				02137906270AC5A0006430F7 /* MockReceiptActionHandler.swift */,
+				DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */,
 			);
 			path = ActionHandlers;
 			sourceTree = "<group>";
@@ -1997,6 +2000,7 @@
 				CE43A90222A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift in Sources */,
 				B5C9DE182087FF0E006B910A /* Assert.swift in Sources */,
 				571D7E3F251BB9FA00606E96 /* LogErrorAndExit.swift in Sources */,
+				DE3C5B1D286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift in Sources */,
 				CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */,
 				247CE87225832E7000F9D9D1 /* MockProductReviewAction.swift in Sources */,
 				0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */; };
 		DE3C5B1D286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */; };
 		DE3C5B21286BF2270049E6AA /* MockSystemStatusActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */; };
+		DE3C5B23286C03F90049E6AA /* MockCardPresentPaymentActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B22286C03F80049E6AA /* MockCardPresentPaymentActionHandler.swift */; };
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
@@ -780,6 +781,7 @@
 		D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStoreV4Tests.swift; sourceTree = "<group>"; };
 		DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrderCardPresentPaymentEligibilityActionHandler.swift; sourceTree = "<group>"; };
 		DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusActionHandler.swift; sourceTree = "<group>"; };
+		DE3C5B22286C03F80049E6AA /* MockCardPresentPaymentActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentActionHandler.swift; sourceTree = "<group>"; };
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
@@ -1031,6 +1033,7 @@
 				02137906270AC5A0006430F7 /* MockReceiptActionHandler.swift */,
 				DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */,
 				DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */,
+				DE3C5B22286C03F80049E6AA /* MockCardPresentPaymentActionHandler.swift */,
 			);
 			path = ActionHandlers;
 			sourceTree = "<group>";
@@ -1904,6 +1907,7 @@
 				247CE8562583269900F9D9D1 /* MockProductActionHandler.swift in Sources */,
 				D4CBAE6226D4460900BBE6D1 /* AnnouncementsStore.swift in Sources */,
 				312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */,
+				DE3C5B23286C03F90049E6AA /* MockCardPresentPaymentActionHandler.swift in Sources */,
 				2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */,
 				247CE8382582F21700F9D9D1 /* MockNotificationCountActionHandler.swift in Sources */,
 				02FF056523DE9C8B0058E6E7 /* MediaStore.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		D8C11A5822DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5722DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift */; };
 		D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */; };
 		DE3C5B1D286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */; };
+		DE3C5B21286BF2270049E6AA /* MockSystemStatusActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */; };
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
@@ -778,6 +779,7 @@
 		D8C11A5722DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStoreV4Tests.swift; sourceTree = "<group>"; };
 		DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrderCardPresentPaymentEligibilityActionHandler.swift; sourceTree = "<group>"; };
+		DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusActionHandler.swift; sourceTree = "<group>"; };
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
@@ -1028,6 +1030,7 @@
 				02137902270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift */,
 				02137906270AC5A0006430F7 /* MockReceiptActionHandler.swift */,
 				DE3C5B1C286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift */,
+				DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */,
 			);
 			path = ActionHandlers;
 			sourceTree = "<group>";
@@ -2035,6 +2038,7 @@
 				B56C1EBE20EABD2B00D749F9 /* ResultsController.swift in Sources */,
 				02BA23C222EEEABC009539E7 /* AvailabilityStore.swift in Sources */,
 				CE4FD4542350FC0100A16B31 /* OrderItemRefund+ReadOnlyConvertible.swift in Sources */,
+				DE3C5B21286BF2270049E6AA /* MockSystemStatusActionHandler.swift in Sources */,
 				247CE7D02582E1C100F9D9D1 /* MockSessionManager.swift in Sources */,
 				B5EED1A820F4F3CF00652449 /* Account+ReadOnlyConvertible.swift in Sources */,
 				74D7FFFA221F01E90008CC0E /* ShipmentStore.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Storage
 import Networking
+import Combine
 
 struct MockCardPresentPaymentActionHandler: MockActionHandler {
     typealias ActionType = CardPresentPaymentAction
@@ -12,6 +13,8 @@ struct MockCardPresentPaymentActionHandler: MockActionHandler {
         switch action {
         case .loadAccounts(let siteID, let onCompletion):
             loadAccounts(siteID: siteID, onCompletion: onCompletion)
+        case .publishCardReaderConnections(let onCompletion):
+            publishCardReaderConnections(onCompletion: onCompletion)
         default:
             break
         }
@@ -27,5 +30,10 @@ struct MockCardPresentPaymentActionHandler: MockActionHandler {
                 onCompletion(.success(()))
             }
         }
+    }
+
+    private func publishCardReaderConnections(onCompletion: @escaping (AnyPublisher<[CardReader], Never>) -> Void) {
+        let cardReaders = objectGraph.cardReaders
+        onCompletion(Just(cardReaders).eraseToAnyPublisher())
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Storage
+import Networking
+
+struct MockCardPresentPaymentActionHandler: MockActionHandler {
+    typealias ActionType = CardPresentPaymentAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case .loadAccounts(let siteID, let onCompletion):
+            loadAccounts(siteID: siteID, onCompletion: onCompletion)
+        default:
+            break
+        }
+    }
+
+    private func loadAccounts(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let accounts = objectGraph.paymentGatewayAccounts(for: siteID)
+
+        save(mocks: accounts, as: StoragePaymentGatewayAccount.self) { error in
+            if let error = error {
+                onCompletion(.failure(error))
+            } else {
+                onCompletion(.success(()))
+            }
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderCardPresentPaymentEligibilityActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderCardPresentPaymentEligibilityActionHandler.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Storage
+import Networking
+
+struct MockOrderCardPresentPaymentEligibilityActionHandler: MockActionHandler {
+    typealias ActionType = OrderCardPresentPaymentEligibilityAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case let .orderIsEligibleForCardPresentPayment(_, _, _, onCompletion):
+            onCompletion(.success(true))
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Storage
+import Networking
 
 struct MockSettingActionHandler: MockActionHandler {
     typealias ActionType = SettingAction
@@ -7,16 +8,42 @@ struct MockSettingActionHandler: MockActionHandler {
     let objectGraph: MockObjectGraph
     let storageManager: StorageManagerType
 
+    private let settingStore: SettingStore
+
+    init(objectGraph: MockObjectGraph, storageManager: StorageManagerType) {
+        self.objectGraph = objectGraph
+        self.storageManager = storageManager
+
+        settingStore = SettingStore(dispatcher: Dispatcher(), storageManager: storageManager, network: NullNetwork())
+    }
+
     func handle(action: ActionType) {
         switch action {
-            case .retrieveSiteAPI(let siteID, let onCompletion):
-                retreiveSiteAPI(siteId: siteID, onCompletion: onCompletion)
+        case .retrieveSiteAPI(let siteID, let onCompletion):
+            retrieveSiteAPI(siteId: siteID, onCompletion: onCompletion)
+        case .synchronizeGeneralSiteSettings(let siteID, let onCompletion):
+            synchronizeGeneralSiteSettings(siteID: siteID, onCompletion: onCompletion)
 
-            default: unimplementedAction(action: action)
+        default: unimplementedAction(action: action)
         }
     }
 
-    func retreiveSiteAPI(siteId: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void) {
+    func retrieveSiteAPI(siteId: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void) {
         onCompletion(.success(objectGraph.defaultSiteAPI))
+    }
+
+    func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
+        let settings = objectGraph.siteSettings(for: siteID)
+        let storage = storageManager.writerDerivedStorage
+
+        storage.perform {
+            settingStore.upsertStoredGeneralSiteSettings(siteID: siteID, readOnlySiteSettings: settings, in: storage)
+        }
+
+        storageManager.saveDerivedType(derivedStorage: storage) {
+            DispatchQueue.main.async {
+                onCompletion(nil)
+            }
+        }
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
@@ -34,16 +34,6 @@ struct MockSettingActionHandler: MockActionHandler {
 
     func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         let settings = objectGraph.siteSettings(for: siteID)
-        let storage = storageManager.writerDerivedStorage
-
-        storage.perform {
-            settingStore.upsertStoredGeneralSiteSettings(siteID: siteID, readOnlySiteSettings: settings, in: storage)
-        }
-
-        storageManager.saveDerivedType(derivedStorage: storage) {
-            DispatchQueue.main.async {
-                onCompletion(nil)
-            }
-        }
+        save(mocks: settings, as: StorageSiteSetting.self, onCompletion: onCompletion)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -29,7 +29,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
             case .thisWeek:
                 success(onCompletion)
             case .thisMonth:
-                success(onCompletion)
+                store.upsertStoredOrderStats(readOnlyStats: objectGraph.thisMonthOrderStats, timeRange: timeRange)
+                onCompletion(.success(()))
             case .thisYear:
                 store.upsertStoredOrderStats(readOnlyStats: objectGraph.thisYearOrderStats, timeRange: timeRange)
                 onCompletion(.success(()))
@@ -45,7 +46,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
             case .thisWeek:
                 success(onCompletion)
             case .thisMonth:
-                success(onCompletion)
+                store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisMonthVisitStats, timeRange: timeRange)
+                onCompletion(.success(()))
             case .thisYear:
                 store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisYearVisitStats, timeRange: timeRange)
                 onCompletion(.success(()))
@@ -61,7 +63,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
             case .thisWeek:
                 success(onCompletion)
             case .thisMonth:
-                success(onCompletion)
+                store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisMonthTopProducts)
+                onCompletion(.success(()))
             case .thisYear:
                 store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisYearTopProducts)
                 onCompletion(.success(()))

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Storage
+import Networking
+
+struct MockSystemStatusActionHandler: MockActionHandler {
+    typealias ActionType = SystemStatusAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case .synchronizeSystemPlugins(let siteID, let onCompletion):
+            synchronizeSystemPlugins(siteID: siteID, onCompletion: onCompletion)
+        default:
+            break
+        }
+    }
+
+    private func synchronizeSystemPlugins(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let systemPlugins = objectGraph.systemPlugins(for: siteID)
+
+        save(mocks: systemPlugins, as: StorageSystemPlugin.self) { error in
+            if let error = error {
+                onCompletion(.failure(error))
+            } else {
+                onCompletion(.success(()))
+            }
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -75,6 +75,10 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         createPaymentGatewayAccount()
     ]
 
+    var cardReaders: [CardReader] = [
+        createCardReader()
+    ]
+
     func accountWithId(id: Int64) -> Account {
         return defaultAccount
     }

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -213,7 +213,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
                 Self.createVisitStatsItem(
                     granularity: .day,
                     periodDate: date.monthStart.addingDays(dayIndex),
-                    visitors: Int.random(in: 10 ... 100)
+                    visitors: Int.random(in: 0 ... 20)
                 )
             }
         )
@@ -251,7 +251,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
 
     /// The possible value of an order when generating random stats
     ///
-    private let orderValueRange = 10 ..< 50
+    private let orderValueRange = 5 ..< 20
 
     var thisMonthOrderStats: OrderStatsV4 {
         Self.createStats(

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -71,6 +71,10 @@ struct ScreenshotObjectGraph: MockObjectGraph {
                            version: "3.2.1")
     ]
 
+    var paymentGatewayAccounts: [PaymentGatewayAccount] = [
+        createPaymentGatewayAccount()
+    ]
+
     func accountWithId(id: Int64) -> Account {
         return defaultAccount
     }

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -102,7 +102,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
             number: 2201,
             customer: Customers.MiraWorkman,
             status: .processing,
-            total: 1310.00,
+            total: 50.00,
             items: [
                 createOrderItem(from: Products.malayaShades, count: 4),
                 createOrderItem(from: Products.blackCoralShades, count: 5),
@@ -113,21 +113,21 @@ struct ScreenshotObjectGraph: MockObjectGraph {
             customer: Customers.LydiaDonin,
             status: .processing,
             daysOld: 3,
-            total: 300
+            total: 73.29
         ),
         createOrder(
             number: 2116,
             customer: Customers.ChanceVicarro,
             status: .processing,
             daysOld: 4,
-            total: 300
+            total: 66.15
         ),
         createOrder(
             number: 2104,
             customer: Customers.MarcusCurtis,
             status: .processing,
             daysOld: 5,
-            total: 420
+            total: 120.00
         ),
         createOrder(
             number: 2087,

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -57,14 +57,19 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         return [defaultSite]
     }
 
-    var siteSettings: [SiteSetting] {
-        [Self.createSiteSetting(siteID: defaultSite.siteID,
-                                settingID: "woocommerce_default_country",
-                                label: "Country and State",
-                                settingDescription: "The country and state or province, if any, in which your business is located.",
-                                value: "US:CA",
-                                settingGroupKey: "general")]
-    }
+    var siteSettings: [SiteSetting] = [
+        createSiteSetting(settingID: "woocommerce_default_country",
+                          label: "Country and State",
+                          settingDescription: "The country and state or province, if any, in which your business is located.",
+                          value: "US:CA",
+                          settingGroupKey: "general")
+    ]
+
+    var systemPlugins: [SystemPlugin] = [
+        createSystemPlugin(plugin: "woocommerce-payments",
+                           name: "WooCommerce Payments",
+                           version: "3.2.1")
+    ]
 
     func accountWithId(id: Int64) -> Account {
         return defaultAccount

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -205,6 +205,26 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         )
     ]
 
+    var thisMonthVisitStats: SiteVisitStats {
+        Self.createVisitStats(
+            siteID: 1,
+            granularity: .month,
+            items: [Int](0..<30).map { dayIndex in
+                Self.createVisitStatsItem(
+                    granularity: .day,
+                    periodDate: date.monthStart.addingDays(dayIndex),
+                    visitors: Int.random(in: 10 ... 100)
+                )
+            }
+        )
+    }
+
+    var thisMonthTopProducts: TopEarnerStats = createStats(siteID: 1, granularity: .month, items: [
+        createTopEarningItem(product: Products.akoyaPearlShades, quantity: 17),
+        createTopEarningItem(product: Products.blackCoralShades, quantity: 11),
+        createTopEarningItem(product: Products.coloradoShades, quantity: 5),
+    ])
+
     var thisYearVisitStats: SiteVisitStats {
         Self.createVisitStats(
             siteID: 1,
@@ -213,7 +233,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
                 Self.createVisitStatsItem(
                     granularity: .month,
                     periodDate: date.yearStart.addingMonths(monthIndex),
-                    visitors: Int.random(in: 100 ... 1000)
+                    visitors: Int.random(in: 100 ... 500)
                 )
             }
         )
@@ -231,14 +251,28 @@ struct ScreenshotObjectGraph: MockObjectGraph {
 
     /// The possible value of an order when generating random stats
     ///
-    private let orderValueRange = 100 ..< 500
+    private let orderValueRange = 10 ..< 50
+
+    var thisMonthOrderStats: OrderStatsV4 {
+        Self.createStats(
+            siteID: 1,
+            granularity: .monthly,
+            intervals: thisMonthVisitStats.items!.enumerated().map {
+                Self.createMonthlyInterval(
+                    date: date.monthStart.addingDays($0.offset),
+                    orderCount: Int(Double($0.element.visitors) * Double.random(in: orderProbabilityRange)),
+                    revenue: Decimal($0.element.visitors) * Decimal.random(in: orderValueRange)
+                )
+            }
+        )
+    }
 
     var thisYearOrderStats: OrderStatsV4 {
         Self.createStats(
             siteID: 1,
             granularity: .yearly,
             intervals: thisYearVisitStats.items!.enumerated().map {
-                Self.createInterval(
+                Self.createYearlyInterval(
                     date: date.yearStart.addingMonths($0.offset),
                     orderCount: Int(Double($0.element.visitors) * Double.random(in: orderProbabilityRange)),
                     revenue: Decimal($0.element.visitors) * Decimal.random(in: orderValueRange)

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -57,6 +57,15 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         return [defaultSite]
     }
 
+    var siteSettings: [SiteSetting] {
+        [Self.createSiteSetting(siteID: defaultSite.siteID,
+                                settingID: "woocommerce_default_country",
+                                label: "Country and State",
+                                settingDescription: "The country and state or province, if any, in which your business is located.",
+                                value: "US:CA",
+                                settingGroupKey: "general")]
+    }
+
     func accountWithId(id: Int64) -> Account {
         return defaultAccount
     }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -8,6 +8,7 @@ public protocol MockObjectGraph {
     var defaultSiteAPI: SiteAPI { get }
 
     var sites: [Site] { get }
+    var siteSettings: [SiteSetting] { get }
     var orders: [Order] { get }
     var products: [Product] { get }
     var reviews: [ProductReview] { get }
@@ -28,6 +29,13 @@ public protocol MockObjectGraph {
 }
 
 let mockResourceUrlHost = "http://localhost:\(UserDefaults.standard.integer(forKey: "mocks-port"))/"
+
+// MARK: SiteSetting Accessors
+extension MockObjectGraph {
+    func siteSettings(for siteID: Int64) -> [SiteSetting] {
+        return siteSettings.filter { $0.siteID == siteID }
+    }
+}
 
 // MARK: Product Accessors
 extension MockObjectGraph {
@@ -74,6 +82,23 @@ extension MockObjectGraph {
 
     func reviews(forSiteId siteId: Int64) -> [ProductReview] {
         reviews.filter { $0.siteID == siteId }
+    }
+}
+
+// MARK: SiteSetting Creation Helper
+extension MockObjectGraph {
+    static func createSiteSetting(siteID: Int64,
+                                  settingID: String,
+                                  label: String,
+                                  settingDescription: String,
+                                  value: String,
+                                  settingGroupKey: String) -> SiteSetting {
+        SiteSetting(siteID: siteID,
+                    settingID: settingID,
+                    label: label,
+                    settingDescription: settingDescription,
+                    value: value,
+                    settingGroupKey: settingGroupKey)
     }
 }
 

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -562,11 +562,11 @@ private extension Array where Element == OrderStatsV4Interval {
         let components = Calendar.current.dateComponents(in: .current, from: self)
         return components.month ?? 0
     }
-     
-     var day: Int {
-         let components = Calendar.current.dateComponents(in: .current, from: self)
-         return components.day ?? 0
-     }
+
+    var day: Int {
+        let components = Calendar.current.dateComponents(in: .current, from: self)
+        return components.day ?? 0
+    }
 
     var yearStart: Date {
         let year = Calendar.current.component(.year, from: self)

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -10,6 +10,7 @@ public protocol MockObjectGraph {
     var sites: [Site] { get }
     var siteSettings: [SiteSetting] { get }
     var systemPlugins: [SystemPlugin] { get }
+    var paymentGatewayAccounts: [PaymentGatewayAccount] { get }
     var orders: [Order] { get }
     var products: [Product] { get }
     var reviews: [ProductReview] { get }
@@ -42,6 +43,13 @@ extension MockObjectGraph {
 extension MockObjectGraph {
     func systemPlugins(for siteID: Int64) -> [SystemPlugin] {
         return systemPlugins.filter { $0.siteID == siteID }
+    }
+}
+
+// MARK: PaymentGateWayAccount Accessor
+extension MockObjectGraph {
+    func paymentGatewayAccounts(for siteID: Int64) -> [PaymentGatewayAccount] {
+        return paymentGatewayAccounts.filter { $0.siteID == siteID }
     }
 }
 
@@ -132,6 +140,38 @@ extension MockObjectGraph {
                      authorUrl: authorUrl,
                      networkActivated: networkActivated,
                      active: active)
+    }
+}
+
+// MARK: PaymentGatewayAccount Creation Helper
+extension MockObjectGraph {
+    static func createPaymentGatewayAccount(gatewayID: String = WCPayAccount.gatewayID,
+                                            status: WCPayAccountStatusEnum = .complete,
+                                            hasPendingRequirements: Bool = false,
+                                            hasOverdueRequirements: Bool = false,
+                                            currentDeadline: Date? = nil,
+                                            statementDescriptor: String = "",
+                                            defaultCurrency: String = "USD",
+                                            supportedCurrencies: [String] = ["US", "CA"],
+                                            country: String = "US",
+                                            isCardPresentEligible: Bool = true,
+                                            isLive: Bool = false,
+                                            isInTestMode: Bool = false) -> PaymentGatewayAccount {
+        PaymentGatewayAccount(
+            siteID: 1,
+            gatewayID: WCPayAccount.gatewayID,
+            status: status.rawValue,
+            hasPendingRequirements: hasPendingRequirements,
+            hasOverdueRequirements: hasOverdueRequirements,
+            currentDeadline: currentDeadline,
+            statementDescriptor: statementDescriptor,
+            defaultCurrency: defaultCurrency,
+            supportedCurrencies: supportedCurrencies,
+            country: country,
+            isCardPresentEligible: isCardPresentEligible,
+            isLive: isLive,
+            isInTestMode: isInTestMode
+        )
     }
 }
 

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -9,6 +9,7 @@ public protocol MockObjectGraph {
 
     var sites: [Site] { get }
     var siteSettings: [SiteSetting] { get }
+    var systemPlugins: [SystemPlugin] { get }
     var orders: [Order] { get }
     var products: [Product] { get }
     var reviews: [ProductReview] { get }
@@ -34,6 +35,13 @@ let mockResourceUrlHost = "http://localhost:\(UserDefaults.standard.integer(forK
 extension MockObjectGraph {
     func siteSettings(for siteID: Int64) -> [SiteSetting] {
         return siteSettings.filter { $0.siteID == siteID }
+    }
+}
+
+// MARK: SystemPlugin Accessors
+extension MockObjectGraph {
+    func systemPlugins(for siteID: Int64) -> [SystemPlugin] {
+        return systemPlugins.filter { $0.siteID == siteID }
     }
 }
 
@@ -87,7 +95,7 @@ extension MockObjectGraph {
 
 // MARK: SiteSetting Creation Helper
 extension MockObjectGraph {
-    static func createSiteSetting(siteID: Int64,
+    static func createSiteSetting(siteID: Int64 = 1,
                                   settingID: String,
                                   label: String,
                                   settingDescription: String,
@@ -99,6 +107,31 @@ extension MockObjectGraph {
                     settingDescription: settingDescription,
                     value: value,
                     settingGroupKey: settingGroupKey)
+    }
+}
+
+// MARK: SystemPlugin Creation Helper
+extension MockObjectGraph {
+    static func createSystemPlugin(siteID: Int64 = 1,
+                                   plugin: String,
+                                   name: String,
+                                   version: String,
+                                   versionLatest: String = "",
+                                   url: String = "",
+                                   authorName: String = "",
+                                   authorUrl: String = "",
+                                   networkActivated: Bool = true,
+                                   active: Bool = true) -> SystemPlugin {
+        SystemPlugin(siteID: siteID,
+                     plugin: plugin,
+                     name: name,
+                     version: version,
+                     versionLatest: versionLatest,
+                     url: url,
+                     authorName: authorName,
+                     authorUrl: authorUrl,
+                     networkActivated: networkActivated,
+                     active: active)
     }
 }
 

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -483,7 +483,7 @@ extension MockObjectGraph {
     static func createStats(siteID: Int64, granularity: StatGranularity, items: [TopEarnerStatsItem]) -> TopEarnerStats {
         TopEarnerStats(
             siteID: siteID,
-            date: String(Date().year),
+            date: StatsStoreV4.buildDateString(from: Date(), with: granularity),
             granularity: granularity,
             limit: "",
             items: items

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -17,6 +17,10 @@ public protocol MockObjectGraph {
     var products: [Product] { get }
     var reviews: [ProductReview] { get }
 
+    var thisMonthOrderStats: OrderStatsV4 { get }
+    var thisMonthVisitStats: SiteVisitStats { get }
+    var thisMonthTopProducts: TopEarnerStats { get }
+
     var thisYearOrderStats: OrderStatsV4 { get }
     var thisYearVisitStats: SiteVisitStats { get }
     var thisYearTopProducts: TopEarnerStats { get }
@@ -391,7 +395,20 @@ extension MockObjectGraph {
 // MARK: Stats Creation Helpers
 extension MockObjectGraph {
 
-    static func createInterval(
+    static func createMonthlyInterval(
+        date: Date,
+        orderCount: Int,
+        revenue: Decimal
+    ) -> OrderStatsV4Interval {
+        OrderStatsV4Interval(
+            interval: String(date.day),
+            dateStart: date.asOrderStatsString,
+            dateEnd: date.monthEnd.asOrderStatsString,
+            subtotals: createTotal(orderCount: orderCount, revenue: revenue)
+        )
+    }
+
+    static func createYearlyInterval(
         date: Date,
         orderCount: Int,
         revenue: Decimal
@@ -406,10 +423,10 @@ extension MockObjectGraph {
 
     static func createVisitStatsItem(granularity: StatGranularity, periodDate: Date, visitors: Int) -> SiteVisitStatsItem {
         switch granularity {
-            case .month:
-                return SiteVisitStatsItem(period: periodDate.asVisitStatsMonthString, visitors: visitors)
-            default:
-                fatalError("Not implemented yet")
+        case .day, .month:
+            return SiteVisitStatsItem(period: periodDate.asVisitStatsMonthString, visitors: visitors)
+        default:
+            fatalError("Not implemented yet")
         }
     }
 
@@ -446,14 +463,20 @@ extension MockObjectGraph {
         switch granularity {
             case .day: preconditionFailure("Not implemented")
             case .week: preconditionFailure("Not implemented")
-            case .month: preconditionFailure("Not implemented")
+            case .month:
+            return SiteVisitStats(
+                siteID: siteID,
+                date: Date().asVisitStatsMonthString,
+                granularity: .day,
+                items: items
+            )
             case .year:
-                return SiteVisitStats(
-                    siteID: siteID,
-                    date: Date().asVisitStatsYearString,
-                    granularity: .month,
-                    items: items
-                )
+            return SiteVisitStats(
+                siteID: siteID,
+                date: Date().asVisitStatsYearString,
+                granularity: .month,
+                items: items
+            )
         }
     }
 
@@ -539,6 +562,11 @@ private extension Array where Element == OrderStatsV4Interval {
         let components = Calendar.current.dateComponents(in: .current, from: self)
         return components.month ?? 0
     }
+     
+     var day: Int {
+         let components = Calendar.current.dateComponents(in: .current, from: self)
+         return components.day ?? 0
+     }
 
     var yearStart: Date {
         let year = Calendar.current.component(.year, from: self)

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Storage
+import Hardware
 
 public protocol MockObjectGraph {
     var userCredentials: Credentials { get }
@@ -11,6 +12,7 @@ public protocol MockObjectGraph {
     var siteSettings: [SiteSetting] { get }
     var systemPlugins: [SystemPlugin] { get }
     var paymentGatewayAccounts: [PaymentGatewayAccount] { get }
+    var cardReaders: [CardReader] { get }
     var orders: [Order] { get }
     var products: [Product] { get }
     var reviews: [ProductReview] { get }
@@ -172,6 +174,20 @@ extension MockObjectGraph {
             isLive: isLive,
             isInTestMode: isInTestMode
         )
+    }
+}
+
+// MARK: CardReader Creation Helper
+extension MockObjectGraph {
+    static func createCardReader() -> CardReader {
+        CardReader(serial: "WPE-SIMULATOR-1",
+                   vendorIdentifier: "SIMULATOR",
+                   name: "Simulated POS E",
+                   status: .init(connected: true, remembered: true),
+                   softwareVersion: "1.00.03.34-SZZZ_Generic_v45-300001",
+                   batteryLevel: 0.5,
+                   readerType: .chipper,
+                   locationId: "st_simulated")
     }
 }
 

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -35,6 +35,8 @@ public class MockStoresManager: StoresManager {
     private let statsV4ActionHandler: MockStatsActionV4Handler
     private let userActionHandler: MockUserActionHandler
     private let orderCardPresentPaymentEligibilityActionHandler: MockOrderCardPresentPaymentEligibilityActionHandler
+    private let systemStatusActionHandler: MockSystemStatusActionHandler
+    private let cardPresentPaymentActionHandler: MockCardPresentPaymentActionHandler
 
 
     init(objectGraph: MockObjectGraph, storageManager: StorageManagerType) {
@@ -63,6 +65,8 @@ public class MockStoresManager: StoresManager {
             objectGraph: objectGraph,
             storageManager: storageManager
         )
+        systemStatusActionHandler = MockSystemStatusActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        cardPresentPaymentActionHandler = MockCardPresentPaymentActionHandler(objectGraph: objectGraph, storageManager: storageManager)
     }
 
     /// Accessor for whether the user is logged in (spoiler: they always will be when mocking)
@@ -131,10 +135,12 @@ public class MockStoresManager: StoresManager {
             announcementsActionHandler.handle(action: action)
         case let action as ReceiptAction:
             receiptActionHandler.handle(action: action)
-        case _ as CardPresentPaymentAction, _ as SystemStatusAction:
-            break
         case let action as OrderCardPresentPaymentEligibilityAction:
             orderCardPresentPaymentEligibilityActionHandler.handle(action: action)
+        case let action as SystemStatusAction:
+            systemStatusActionHandler.handle(action: action)
+        case let action as CardPresentPaymentAction:
+            cardPresentPaymentActionHandler.handle(action: action)
         default:
             fatalError("Unable to handle action: \(action.identifier) \(String(describing: action))")
         }

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -166,7 +166,14 @@ public class MockStoresManager: StoresManager {
 
     @discardableResult
     public func synchronizeEntities(onCompletion: (() -> Void)?) -> StoresManager {
-        onCompletion?()
+        if let siteID = sessionManager.defaultStoreID {
+            let action = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { _ in
+                onCompletion?()
+            }
+            dispatch(action)
+        } else {
+            onCompletion?()
+        }
         return self
     }
 

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -34,6 +34,7 @@ public class MockStoresManager: StoresManager {
     private let shippingLabelActionHandler: MockShippingLabelActionHandler
     private let statsV4ActionHandler: MockStatsActionV4Handler
     private let userActionHandler: MockUserActionHandler
+    private let orderCardPresentPaymentEligibilityActionHandler: MockOrderCardPresentPaymentEligibilityActionHandler
 
 
     init(objectGraph: MockObjectGraph, storageManager: StorageManagerType) {
@@ -58,6 +59,7 @@ public class MockStoresManager: StoresManager {
         productReviewActionHandler = MockProductReviewActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         notificationActionHandler = MockNotificationActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         userActionHandler = MockUserActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        orderCardPresentPaymentEligibilityActionHandler = MockOrderCardPresentPaymentEligibilityActionHandler(objectGraph: objectGraph, storageManager: storageManager)
     }
 
     /// Accessor for whether the user is logged in (spoiler: they always will be when mocking)
@@ -128,6 +130,8 @@ public class MockStoresManager: StoresManager {
             receiptActionHandler.handle(action: action)
         case _ as CardPresentPaymentAction, _ as SystemStatusAction:
             break
+        case let action as OrderCardPresentPaymentEligibilityAction:
+            orderCardPresentPaymentEligibilityActionHandler.handle(action: action)
         default:
             fatalError("Unable to handle action: \(action.identifier) \(String(describing: action))")
         }

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -59,7 +59,10 @@ public class MockStoresManager: StoresManager {
         productReviewActionHandler = MockProductReviewActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         notificationActionHandler = MockNotificationActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         userActionHandler = MockUserActionHandler(objectGraph: objectGraph, storageManager: storageManager)
-        orderCardPresentPaymentEligibilityActionHandler = MockOrderCardPresentPaymentEligibilityActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        orderCardPresentPaymentEligibilityActionHandler = MockOrderCardPresentPaymentEligibilityActionHandler(
+            objectGraph: objectGraph,
+            storageManager: storageManager
+        )
     }
 
     /// Accessor for whether the user is logged in (spoiler: they always will be when mocking)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ FASTLANE_DIR = __dir__
 DERIVED_DATA_DIR = File.join(FASTLANE_DIR, 'DerivedData')
 SCREENSHOTS_DIR =  File.join(FASTLANE_DIR, 'screenshots')
 IOS_LOCALES = %w[ar de-DE en-US es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant].freeze
-SIMULATOR_VERSION = '14.3' # For screenshots
+SIMULATOR_VERSION = '15.5' # For screenshots
 SCREENSHOT_DEVICES = [
   'iPhone 11 Pro Max',
   'iPhone 8 Plus',
@@ -616,7 +616,7 @@ platform :ios do
     sh('bundle exec pod install --verbose')
 
     # Ensure we're using the right version of Xcode
-    xcversion(version: '~> 12.0')
+    xcversion(version: '~> 13.0')
 
     scan(
       workspace: 'WooCommerce.xcworkspace',
@@ -629,7 +629,7 @@ platform :ios do
   desc 'Take Screenshots'
   lane :take_screenshots do |options|
     # Ensure we're using the right version of Xcode
-    xcversion(version: '~> 12.0')
+    xcversion(version: '~> 13.0')
 
     # By default, clear previous screenshots
     languages = IOS_LOCALES
@@ -1015,7 +1015,7 @@ def screenshot_devices
 end
 
 def simulator_version
-  '14.4'
+  '15.5'
 end
 
 ########################################################################

--- a/fastlane/appstoreres/metadata/source/description.txt
+++ b/fastlane/appstoreres/metadata/source/description.txt
@@ -1,22 +1,22 @@
-Manage your business on the go with the WooCommerce Mobile App. Create products, process orders, and keep an eye on key stats in real-time. 
+Manage your business on the go with the WooCommerce Mobile App. Add products, create orders, take quick payments, and keep an eye on new sales and key stats in real time.
 
-ADD PRODUCTS
-Create, group, and publish products directly from your iPhone or iPad. Capture your creativity in the moment – turn your ideas into products in seconds, or save them as drafts for later.
+Add and edit products with a touch
+Get started in seconds! Create, group, and publish products directly from your iPhone or iPad. Capture your creativity the moment it strikes – turn your ideas into products immediately, or save them as drafts for later.
 
-GET NOTIFIED
-Never miss an order or a review. Keep that FOMO at bay by enabling real-time alerts – and listen out for that addictive “cha-ching” sound that comes with every new sale!
+Create orders on the fly
+Once you have some products created, it’s simple. Choose items from your catalog, add shipping, and then fill in customer details to quickly create an order that syncs with your inventory.
 
-VIEW AND MODIFY ORDERS
-Scroll the summaries, or search by customer or order specifics. Tap into the details to see itemized billing, begin fulfillment, and change order status. Add notes to the order or email customers directly to follow up.
+Take payments in person
+Collect physical payments using WooCommerce In-Person Payments and a card reader (available in the US and Canada). Start a new order – or find an existing one that’s pending payment – and collect payment using the card reader or a digital wallet, such as Apple Pay.
 
-TRACK YOUR STATS
-See which products are winning at a glance. Keep tabs on overall revenue, order count, and visitor data by week, month, and year. Knowledge = power!
+Get notified of every sale
+Now that you’re actively selling, never miss an order or a review. Keep yourself in the loop by enabling real-time alerts – and listen for that addictive “cha-ching” sound that comes with each new sale!
 
-SWITCH BETWEEN STORES
-For those with more than one, toggle seamlessly between your businesses in seconds.
+Track sales and bestselling products
+See which products are winning at a glance. Keep tabs on your overall revenue, order count, and visitor data by week, month, and year. Knowledge = power.
 
 WooCommerce is the world’s most customizable open-source eCommerce platform. Whether you’re launching a business, taking brick-and-mortar retail online, or developing sites for clients, use WooCommerce for a store that powerfully blends content and commerce.
 
-Requirements: WooCommerce v3.5+, the Jetpack plugin.
+Requirements: WooCommerce v3.5+. Jetpack is also required to receive notifications.
 
 View the Privacy Notice for California users at https://automattic.com/privacy/#california-consumer-privacy-act-ccpa.

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
@@ -1,2 +1,2 @@
-Track sales and high
-performing products
+Track sales and
+bestselling products

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
@@ -1,2 +1,2 @@
-View and manage
-orders on the go
+Create orders
+on the fly

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
@@ -1,2 +1,2 @@
-Review order details
-and payments
+Take payments
+in person

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
@@ -1,2 +1,2 @@
-View products and
-check inventory
+Add and edit products 
+with a touch

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
@@ -1,2 +1,2 @@
-Get notified about
-new reviews
+Get notified of 
+every sale

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -57,7 +57,7 @@
 	],
 	"entries": [
 		// iPhone 11 Pro Max
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-01.png",
@@ -65,41 +65,33 @@
 			"screenshot": "iPhone 11 Pro Max-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 11 Pro Max-2-light-order-list.png",
+			"screenshot": "iPhone 11 Pro Max-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-03.png",
 			"background": "#674399",
-			"screenshot": "iPhone 11 Pro Max-3-dark-order-detail.png",
+			"screenshot": "iPhone 11 Pro Max-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 11 Pro Max-5-light-product-list.png",
+			"screenshot": "iPhone 11 Pro Max-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPhone 11 Pro Max",
-			"filename": "iPhone 11 Pro Max-05.png",
-			"background": "#674399",
-			"screenshot": "iPhone 11 Pro Max-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 		// iPhone 8 Plus
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-01.png",
@@ -107,42 +99,34 @@
 			"screenshot": "iPhone 8 Plus-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 8 Plus-2-light-order-list.png",
+			"screenshot": "iPhone 8 Plus-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-03.png",
 			"background": "#674399",
-			"screenshot": "iPhone 8 Plus-3-dark-order-detail.png",
+			"screenshot": "iPhone 8 Plus-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 8 Plus-5-light-product-list.png",
+			"screenshot": "iPhone 8 Plus-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPhone 8 Plus",
-			"filename": "iPhone 8 Plus-05.png",
-			"background": "#674399",
-			"screenshot": "iPhone 8 Plus-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 
 		/// iPad Pro 12.9 (2nd Generation)
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-01.png",
@@ -150,41 +134,33 @@
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-2-light-order-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-03.png",
 			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-dark-order-detail.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-light-product-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPad Pro 12.9 (2nd Generation)",
-			"filename": "iPad Pro (12.9-inch) (2nd generation)-05.png",
-			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 		/// iPad Pro 12.9 (3rd Generation)
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-01.png",
@@ -192,37 +168,29 @@
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-2-light-order-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-03.png",
 			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-dark-order-detail.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-light-product-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPad Pro 12.9 (3rd Generation)",
-			"filename": "iPad Pro (12.9-inch) (3rd generation)-05.png",
-			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		}
 	]
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As per request from the marketing team (p91TBi-9eM-p2), this PR updates the automation scripts to take requested screenshots.

 **Capturing the collect payment alert**:
- Hardware: we need to create a mock card reader and card reader status, so public initializers for these had to be added.
- UI Layer: additional accessibility identifiers to access the buttons and detect the collect payment modal.
- Woo Foundation: a minor update to `CurrencyFormatter` was added to transform value from non-Latin to Latin. This is necessary to format the order total value from Arabic numerals to Latin ones. `CollectOrderPaymentUseCase` needs to check this value for collecting payments.
- Yosmite: add mocks for `OrderCardPresentPaymentEligibilityAction`, `SystemStatusAction` and `CardPresentPaymentAction`.

**Simulating push notifications**
We want to capture push notifications on the app, so the trick is to use the local notification API:
- Added a new process argument and requested permission for notification upon launch when this argument is enabled.
- To capture the screenshot for the notification, lock the device screen and sleep for 2 seconds before taking a screenshot. In the meantime, schedule a local notification in 1 second when the app is about to be sent to the background. This way the lock screen can be captured with the notification coming in.

**Capturing the monthly revenue**
Marketing needs to switch to capture the This Month tab of the My Store screen, so I added mock data for the monthly stats.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn off the feature flag `.splitViewInOrdersTab` in `DefaultFeatureFlagService`.
- Optionally set the simulator to a non-English language to make sure the test isn’t relying on anything English-specific. Try Arabic to check the case with Arabic numerals.
- Select target WooCommerceScreenshots. Run the `testScreenshots()` UI test.
- Confirm that the test succeeds.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->