### PR TITLE
Background image upload: Use different API for updating product ID of images in JCP site.

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -644,6 +644,7 @@
 		DEC51AFB2769C66B009F3DF4 /* SystemStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */; };
 		DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
+		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
 		EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */ = {isa = PBXBuildFile; fileRef = EECB7EE7286555180028C888 /* media-update-product-id.json */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1329,6 +1330,7 @@
 		DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapperTests.swift; sourceTree = "<group>"; };
 		DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+DropinMustUsePlugin.swift"; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
+		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
 		EECB7EE7286555180028C888 /* media-update-product-id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id.json"; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1823,6 +1825,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */,
 				D865CE6D278CC19A002C8520 /* stripe-location-error.json */,
 				D865CE6C278CC19A002C8520 /* stripe-location.json */,
 				D865CE6A278CA266002C8520 /* stripe-payment-intent-error.json */,
@@ -2507,6 +2510,7 @@
 				02A26F1B2744F5FC008E4EDB /* wc-site-settings-partial.json in Resources */,
 				028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */,
 				DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */,
+				EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */,
 				02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */,
 				CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */,
 				45150AA2268373F8006922EA /* countries.json in Resources */,

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -24,6 +24,10 @@ public protocol MediaRemoteProtocol {
                          productID: Int64,
                          mediaID: Int64,
                          completion: @escaping (Result<Media, Error>) -> Void)
+    func updateProductIDToWordPressSite(siteID: Int64,
+                                        productID: Int64,
+                                        mediaID: Int64,
+                                        completion: @escaping (Result<WordPressMedia, Error>) -> Void)
 }
 
 /// Media: Remote Endpoints
@@ -190,6 +194,32 @@ public class MediaRemote: Remote, MediaRemoteProtocol {
         let path = "sites/\(siteID)/media/\(mediaID)"
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: formParameters)
         let mapper = MediaMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Sets the provided `productID` as post ID of the Media in WordPress site using WordPress site API
+    ///
+    /// API reference: to the WordPress site.via WordPress site API
+    /// https://developer.wordpress.org/rest-api/reference/media/#update-a-media-item
+    ///
+    /// - Parameters:
+    ///     - siteID: Site in which the media was uploaded to.
+    ///     - productID: Product ID to use as post ID of the media.
+    ///     - mediaID: ID of media for which post ID needs to be updated.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateProductIDToWordPressSite(siteID: Int64,
+                                               productID: Int64,
+                                               mediaID: Int64,
+                                               completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+        let parameters: [String: String] = [
+            ParameterKey.wordPressMediaPostID: "\(productID)",
+            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
+        ]
+        let path = "sites/\(siteID)/media/\(mediaID)"
+        let request = DotcomRequest(wordpressApiVersion: .wpMark2, method: .post, path: path, parameters: parameters)
+        let mapper = WordPressMediaMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -257,4 +257,47 @@ final class MediaRemoteTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
     }
+
+    // MARK: - updateProductIDToWordPressSite
+
+    /// Verifies that `updateProductIDToWordPressSite` properly parses the `media-update-product-id-in-wordpress-site` sample response.
+    ///
+    func test_updateProductIDToWordPressSite_properly_returns_parsed_media() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        let path = "sites/\(sampleSiteID)/media/\(sampleMediaID)"
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-update-product-id-in-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductIDToWordPressSite(siteID: self.sampleSiteID,
+                                   productID: self.sampleProductID,
+                                   mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let media = try XCTUnwrap(result.get())
+        XCTAssertEqual(media.mediaID, sampleMediaID)
+    }
+
+    /// Verifies that `updateProductIDToWordPressSite` properly relays Networking Layer errors.
+    ///
+    func test_updateProductIDToWordPressSite_properly_relays_networking_errors() {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductIDToWordPressSite(siteID: self.sampleSiteID,
+                                   productID: self.sampleProductID,
+                                   mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
 }

--- a/Networking/NetworkingTests/Responses/media-update-product-id-in-wordpress-site.json
+++ b/Networking/NetworkingTests/Responses/media-update-product-id-in-wordpress-site.json
@@ -1,0 +1,65 @@
+{
+  "id": 2352,
+  "date_gmt": "2022-06-29T09:14:15",
+  "slug": "img_0009",
+  "title": {
+    "raw": "img_0009",
+    "rendered": "img_0009"
+  },
+  "alt_text": "",
+  "mime_type": "image/jpeg",
+  "media_details": {
+    "width": 300,
+    "height": 168,
+    "file": "2022/06/img_0009.jpeg",
+    "filesize": 22718,
+    "sizes": {
+      "thumbnail": {
+        "file": "img_0009-150x150.jpeg",
+        "width": 150,
+        "height": 150,
+        "filesize": 7031,
+        "mime_type": "image/jpeg",
+        "source_url": "https://comfortable-polecat.jurassic.ninja/wp-content/uploads/2022/06/img_0009-150x150.jpeg"
+      },
+      "woocommerce_gallery_thumbnail": {
+        "file": "img_0009-100x100.jpeg",
+        "width": 100,
+        "height": 100,
+        "filesize": 4226,
+        "mime_type": "image/jpeg",
+        "source_url": "https://comfortable-polecat.jurassic.ninja/wp-content/uploads/2022/06/img_0009-100x100.jpeg"
+      },
+      "shop_thumbnail": {
+        "file": "img_0009-100x100.jpeg",
+        "width": 100,
+        "height": 100,
+        "filesize": 4226,
+        "mime_type": "image/jpeg",
+        "source_url": "https://comfortable-polecat.jurassic.ninja/wp-content/uploads/2022/06/img_0009-100x100.jpeg"
+      },
+      "full": {
+        "file": "img_0009.jpeg",
+        "width": 300,
+        "height": 168,
+        "mime_type": "image/jpeg",
+        "source_url": "https://comfortable-polecat.jurassic.ninja/wp-content/uploads/2022/06/img_0009.jpeg"
+      }
+    },
+    "image_meta": {
+      "aperture": "0",
+      "credit": "",
+      "camera": "",
+      "caption": "",
+      "created_timestamp": "0",
+      "copyright": "",
+      "focal_length": "0",
+      "iso": "0",
+      "shutter_speed": "0",
+      "title": "",
+      "orientation": "1",
+      "keywords": []
+    }
+  },
+  "source_url": "https://comfortable-polecat.jurassic.ninja/wp-content/uploads/2022/06/img_0009.jpeg"
+}

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -161,7 +161,14 @@ private extension MediaStore {
                          productID: Int64,
                          mediaID: Int64,
                          onCompletion: @escaping (Result<Media, Error>) -> Void) {
-        remote.updateProductID(siteID: siteID, productID: productID, mediaID: mediaID, completion: onCompletion)
+        let storage = storageManager.viewStorage
+        if let site = storage.loadSite(siteID: siteID)?.toReadOnly(), site.isJetpackCPConnected {
+            remote.updateProductIDToWordPressSite(siteID: siteID, productID: productID, mediaID: mediaID) { result in
+                onCompletion(result.map { $0.toMedia() })
+            }
+        } else {
+            remote.updateProductID(siteID: siteID, productID: productID, mediaID: mediaID, completion: onCompletion)
+        }
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
@@ -24,6 +24,9 @@ final class MockMediaRemote {
     /// The results to return based on the given site ID in `updateProductID`
     private var updateProductIDResultsBySiteID = [Int64: Result<Media, Error>]()
 
+    /// The results to return based on the given site ID in `updateProductIDToWordPressSite`
+    private var updateProductIDToWordPressSiteResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
+
     /// Returns the value as a publisher when `loadMediaLibrary` is called.
     func whenLoadingMediaLibrary(siteID: Int64, thenReturn result: Result<[Media], Error>) {
         loadMediaLibraryResultsBySiteID[siteID] = result
@@ -45,8 +48,13 @@ final class MockMediaRemote {
     }
 
     /// Returns the value as a publisher when `updateProductID` is called.
-    func whenUpdatingProductIDResultsBySiteIDToWordPressSite(siteID: Int64, thenReturn result: Result<Media, Error>) {
+    func whenUpdatingProductID(siteID: Int64, thenReturn result: Result<Media, Error>) {
         updateProductIDResultsBySiteID[siteID] = result
+    }
+
+    /// Returns the value as a publisher when `updateProductIDToWordPressSite` is called.
+    func whenUpdatingProductIDToWordPressSite(siteID: Int64, thenReturn result: Result<WordPressMedia, Error>) {
+        updateProductIDToWordPressSiteResultsBySiteID[siteID] = result
     }
 }
 
@@ -57,6 +65,7 @@ extension MockMediaRemote {
         case uploadMedia(siteID: Int64)
         case uploadMediaToWordPressSite(siteID: Int64)
         case updateProductID(siteID: Int64)
+        case updateProductIDToWordPressSite(siteID: Int64)
     }
 }
 
@@ -112,6 +121,18 @@ extension MockMediaRemote: MediaRemoteProtocol {
                          completion: @escaping (Result<Media, Error>) -> Void) {
         invocations.append(.updateProductID(siteID: siteID))
         guard let result = updateProductIDResultsBySiteID[siteID] else {
+            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func updateProductIDToWordPressSite(siteID: Int64,
+                                        productID: Int64,
+                                        mediaID: Int64,
+                                        completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+        invocations.append(.updateProductIDToWordPressSite(siteID: siteID))
+        guard let result = updateProductIDToWordPressSiteResultsBySiteID[siteID] else {
             XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
             return
         }


### PR DESCRIPTION
Part of #7021 

- [ ] Please make sure that https://github.com/woocommerce/woocommerce-ios/pull/7152 is reviewed and approved before reviewing this PR.

### Description
This PR takes care of using https://developer.wordpress.org/rest-api/reference/media/#update-a-media-item API for updating product ID of images in JCP sites. 

### Testing instructions

#### Store setup

- Create a Woo store using jurassic ninja.
- Don't install jetpack.
- To enable JCP, install `WooCommerce Payments` and setup the plugin. 
- Starting the setup process will initiate the WordPress - authentication step. You don't have to finish the other setup of `WooCommerce Payments` plugin to test this PR.
- Login into the app using the newly created JCP site.

#### Feature flag on

- Launch the app
- Switch to the JCP site if not already connected.
- Navigate to the `Products` tab and tap on `+` button on top right.
- In the product creation form enter a product title and add `image A`.
- Wait for `image A` to finish uploading.
- Tap "Publish" to save the product. 
- Stay on the product detail screen.
- Add another `image B` and wait for it to finish uploading and save the product again.
- From your computer, open your store's `Media Library` by navigating to https://yourstore.com/wp-admin/upload.php
- In the `Media Library` page,
  - Tap on `image A` and verify that `Uploaded to:` field is available. [Ref screenshot](https://user-images.githubusercontent.com/524475/175935720-22ba1b22-365b-49e5-95a1-59522dd9a58f.png) You can tap on the link to open the product that you created above.
  - Tap on `image B` and verify that `Uploaded to:` field is available for `image B` as well. 
  
#### Feature flag off

- Launch the app
- Switch to the JCP site if not already connected.
- Navigate to the `Products` tab and tap on `+` button on top right.
- In the product creation form enter a product title and add `image A`.
- Wait for `image A` to finish uploading.
- Tap "Publish" to save the product. 
- Stay on the product detail screen.
- Add another `image B` and wait for it to finish uploading and save the product again.
- From your computer, open your store's `Media Library` by navigating to https://yourstore.com/wp-admin/upload.php
- In the `Media Library` page,
  - Tap on `image A` and verify that `Uploaded to:` field is not available.
  - Tap on `image B` and verify that `Uploaded to:` field is not available.
  

### Screenshots
**Add images following the steps in the video below.**
https://user-images.githubusercontent.com/524475/175932567-ec893530-9ec9-4a57-af98-9f747b9ff307.mov


**Check the images from`wp-admin`. Screenshots below**
![FlowerImage](https://user-images.githubusercontent.com/524475/175935720-22ba1b22-365b-49e5-95a1-59522dd9a58f.png)
<img width="1295" alt="Screenshot 2022-06-27 at 5 05 52 PM" src="https://user-images.githubusercontent.com/524475/175933232-1dbf4804-7517-4f3f-a38a-7c0caf6b0d08.png">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
