### PR TITLE
[Mobile Payments] Correctly handle cancelation on card reader modals

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -127,8 +127,9 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     /// 4. If failure: Allows retry
     ///
     ///
-    /// - Parameter onCollect: Closure Invoked after the collect process has finished.
-    /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed, Currently after merchant has handled the receipt.
+    /// - Parameter onCollect: Closure invoked after the collect process has finished.
+    /// - Parameter onCancel: Closure invoked after the flow is cancelled
+    /// - Parameter onCompleted: Closure invoked after the flow has been totally completed, currently after merchant has handled the receipt.
     func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (),
                         onCancel: @escaping () -> (),
                         onCompleted: @escaping () -> ()) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -150,7 +150,6 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                     // Inform about the collect payment state
                     switch result {
                     case .failure(CollectOrderPaymentUseCaseError.flowCanceledByUser):
-                        self.trackPaymentCancelation()
                         return onCancel()
                     default:
                         onCollect(result.map { _ in () }) // Transforms Result<CardPresentCapturedPaymentData, Error> to Result<Void, Error>

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -43,16 +43,16 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_cancelling_readerIsReady_alert_triggers_onCompleted_and_tracks_collectPaymentCanceled_event_and_dispatches_cancel_action() throws {
+    func test_cancelling_readerIsReady_alert_triggers_onCancel_and_tracks_collectPaymentCanceled_event_and_dispatches_cancel_action() throws {
         // Given
         assertEmpty(stores.receivedActions)
 
         // When
         mockCardPresentPaymentActions()
         let _: Void = waitFor { promise in
-            self.useCase.collectPayment(onCollect: { _ in }, onCompleted: {
+            self.useCase.collectPayment(onCollect: { _ in }, onCancel: {
                 promise(())
-            })
+            }, onCompleted: {})
             self.alerts.cancelReaderIsReadyAlert?()
         }
 
@@ -81,7 +81,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         waitFor { promise in
             self.useCase.collectPayment(onCollect: { _ in
                 promise(())
-            }, onCompleted: {})
+            }, onCancel: {}, onCompleted: {})
         }
 
         // Then
@@ -101,7 +101,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         waitFor { promise in
             self.useCase.collectPayment(onCollect: { _ in
                 promise(())
-            }, onCompleted: {})
+            }, onCancel: {}, onCompleted: {})
         }
 
         // Then
@@ -119,7 +119,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         waitFor { promise in
             self.useCase.collectPayment(onCollect: { _ in
                 promise(())
-            }, onCompleted: {})
+            }, onCancel: {}, onCompleted: {})
         }
         alerts.printReceiptFromSuccessAlert?()
 
@@ -139,7 +139,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         waitFor { promise in
             self.useCase.collectPayment(onCollect: { _ in
                 promise(())
-            }, onCompleted: {})
+            }, onCancel: {}, onCompleted: {})
         }
         alerts.emailReceiptFromSuccessAlert?()
 
@@ -171,7 +171,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         let _: Void = waitFor { [weak self] promise in
             useCase.collectPayment(onCollect: { collectPaymentResult in
                 result = collectPaymentResult
-            }, onCompleted: {
+            }, onCancel: {}, onCompleted: {
                 promise(())
             })
             // Dismisses error to complete the payment flow for `onCollect` to be triggered.
@@ -202,7 +202,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         waitFor { promise in
             self.useCase.collectPayment(onCollect: { _ in
                 promise(())
-            }, onCompleted: {})
+            }, onCancel: {}, onCompleted: {})
         }
 
         // Then
@@ -226,7 +226,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         waitFor { promise in
             self.useCase.collectPayment(onCollect: { _ in
                 promise(())
-            }, onCompleted: {})
+            }, onCancel: {}, onCompleted: {})
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/MockCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/MockCollectOrderPaymentUseCase.swift
@@ -11,7 +11,7 @@ struct MockCollectOrderPaymentUseCase: CollectOrderPaymentProtocol {
 
     /// Calls `onCollect` and `onCompleted` secuencially.
     ///
-    func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (), onCompleted: @escaping () -> ()) {
+    func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (), onCancel: @escaping () -> (), onCompleted: @escaping () -> ()) {
         onCollect(onCollectResult)
         if onCollectResult.isSuccess {
             onCompleted()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7157
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we used `onFailure` and `onCompletion` which were each triggered for some cancelation paths. The `onFailure` closure had an error that could be used to check whether it was a cancellation, but `onCompletion` did not, and was handled as a success.

This meant that the `canceled` Tracks event was logged along with the `completed` event or `failed` event.

Cancelation is not a failure, and is not completion either.

This change adds a specific handler for cancelation, and translates the `.flowCanceledByUser` errors to a cancel event, so that Tracks events are correctly logged. This means that a `card_payment_canceled` event is logged, but a `payment_flow_canceled` is not, because the payment flow remains on screen for the merchant to choose another payment method. Cancelling the whole flow with a dismiss drag or tapping back to the root and tapping dismiss in the nav bar will still track `payment_flow_canceled`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Simple Payments
Create a Simple Payment
Select `Card` payment method
On the card reader connection modal, tap cancel
Observe in the logs or in tracks that `card_present_collect_payment_canceled` is tracked, and `payments_flow_completed` is not tracked

Create a Simple Payment
Select `Card` payment method
Allow the reader to connect
On the card reader ready modal, tap cancel
Observe in the logs or in tracks that `card_present_collect_payment_canceled` is tracked, and `payments_flow_completed` is not tracked

#### Order Details
Repeat the above from an unpaid order, or the Create Order flow

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
