### PR TITLE
[Mobile Payments] Preselect WCPay payment gateway on selection screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -93,7 +93,9 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
-        assert(state == .selectPlugin)
+        assert(state == .selectPlugin(pluginSelectionWasCleared: true) ||
+               state == .selectPlugin(pluginSelectionWasCleared: false))
+
         preferredPluginLocal = selectedPlugin
         updateState()
         if case .completed(let pluginState) = state,
@@ -109,7 +111,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         preferredPluginLocal = nil
         let action = AppSettingsAction.forgetPreferredInPersonPaymentGateway(siteID: siteID)
         stores.dispatch(action)
-        updateState()
+        state = .selectPlugin(pluginSelectionWasCleared: true)
     }
 }
 
@@ -214,7 +216,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         }
 
         guard let preferredPlugin = preferredPluginLocal else {
-            return .selectPlugin
+            return .selectPlugin(pluginSelectionWasCleared: false)
         }
 
         let state = onboardingStateForPlugin(preferredPlugin, wcPay: wcPay, stripe: stripe)
@@ -226,7 +228,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             return .pluginShouldBeDeactivated(plugin: .stripe)
         }
 
-        return .selectPlugin
+        return .selectPlugin(pluginSelectionWasCleared: false)
     }
 
     func onboardingStateForPlugin(_ plugin: CardPresentPaymentsPlugin, wcPay: SystemPlugin, stripe: SystemPlugin) -> CardPresentPaymentOnboardingState {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -93,8 +93,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
-        assert(state == .selectPlugin(pluginSelectionWasCleared: true) ||
-               state == .selectPlugin(pluginSelectionWasCleared: false))
+        assert(state.isSelectPlugin)
 
         preferredPluginLocal = selectedPlugin
         updateState()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -94,8 +94,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
 
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
         assert(state == .selectPlugin(pluginSelectionWasCleared: true) ||
-               state == .selectPlugin(pluginSelectionWasCleared: false) ||
-               state == .selectPlugin(pluginSelectionWasCleared: nil))
+               state == .selectPlugin(pluginSelectionWasCleared: false))
 
         preferredPluginLocal = selectedPlugin
         updateState()
@@ -114,7 +113,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         stores.dispatch(action)
 
         var newState = checkOnboardingState()
-        if case .selectPlugin(pluginSelectionWasCleared: nil) = newState {
+        if case .selectPlugin = newState {
             newState = .selectPlugin(pluginSelectionWasCleared: true)
         }
 
@@ -223,7 +222,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         }
 
         guard let preferredPlugin = preferredPluginLocal else {
-            return .selectPlugin(pluginSelectionWasCleared: nil)
+            return .selectPlugin(pluginSelectionWasCleared: false)
         }
 
         let state = onboardingStateForPlugin(preferredPlugin, wcPay: wcPay, stripe: stripe)
@@ -235,7 +234,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             return .pluginShouldBeDeactivated(plugin: .stripe)
         }
 
-        return .selectPlugin(pluginSelectionWasCleared: nil)
+        return .selectPlugin(pluginSelectionWasCleared: false)
     }
 
     func onboardingStateForPlugin(_ plugin: CardPresentPaymentsPlugin, wcPay: SystemPlugin, stripe: SystemPlugin) -> CardPresentPaymentOnboardingState {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -94,7 +94,8 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
 
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
         assert(state == .selectPlugin(pluginSelectionWasCleared: true) ||
-               state == .selectPlugin(pluginSelectionWasCleared: false))
+               state == .selectPlugin(pluginSelectionWasCleared: false) ||
+               state == .selectPlugin(pluginSelectionWasCleared: nil))
 
         preferredPluginLocal = selectedPlugin
         updateState()
@@ -111,7 +112,13 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         preferredPluginLocal = nil
         let action = AppSettingsAction.forgetPreferredInPersonPaymentGateway(siteID: siteID)
         stores.dispatch(action)
-        state = .selectPlugin(pluginSelectionWasCleared: true)
+
+        var newState = checkOnboardingState()
+        if case .selectPlugin(pluginSelectionWasCleared: nil) = newState {
+            newState = .selectPlugin(pluginSelectionWasCleared: true)
+        }
+
+        state = newState
     }
 }
 
@@ -216,7 +223,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         }
 
         guard let preferredPlugin = preferredPluginLocal else {
-            return .selectPlugin(pluginSelectionWasCleared: false)
+            return .selectPlugin(pluginSelectionWasCleared: nil)
         }
 
         let state = onboardingStateForPlugin(preferredPlugin, wcPay: wcPay, stripe: stripe)
@@ -228,7 +235,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
             return .pluginShouldBeDeactivated(plugin: .stripe)
         }
 
-        return .selectPlugin(pluginSelectionWasCleared: false)
+        return .selectPlugin(pluginSelectionWasCleared: nil)
     }
 
     func onboardingStateForPlugin(_ plugin: CardPresentPaymentsPlugin, wcPay: SystemPlugin, stripe: SystemPlugin) -> CardPresentPaymentOnboardingState {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -42,7 +42,7 @@ struct InPersonPaymentsView: View {
             case let .selectPlugin(pluginSelectionWasCleared):
                 if viewModel.gatewaySelectionAvailable {
                     // Preselect WCPay only if there was no selection done before
-                    InPersonPaymentsSelectPluginView(selectedPlugin: pluginSelectionWasCleared ? nil : .wcPay) { plugin in
+                    InPersonPaymentsSelectPluginView(selectedPlugin: pluginSelectionWasCleared == true ? nil : .wcPay) { plugin in
                         viewModel.selectPlugin(plugin)
                     }
                 } else if viewModel.userIsAdministrator {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -39,9 +39,10 @@ struct InPersonPaymentsView: View {
             switch viewModel.state {
             case .loading:
                 InPersonPaymentsLoading()
-            case .selectPlugin:
+            case let .selectPlugin(pluginSelectionWasCleared):
                 if viewModel.gatewaySelectionAvailable {
-                    InPersonPaymentsSelectPluginView(selectedPlugin: nil) { plugin in
+                    // Preselect WCPay only if there was no selection done before
+                    InPersonPaymentsSelectPluginView(selectedPlugin: pluginSelectionWasCleared ? nil : .wcPay) { plugin in
                         viewModel.selectPlugin(plugin)
                     }
                 } else if viewModel.userIsAdministrator {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -235,7 +235,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: nil))
+        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: false))
     }
 
     func test_onboarding_returns_select_plugin_when_both_stripe_and_wcpay_plugins_are_active_ignoring_preference_if_inPersonPaymentGatewaySelection_false() {
@@ -251,7 +251,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: nil))
+        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: false))
     }
 
     func test_onboarding_uses_selected_plugin_wcpay_when_both_stripe_and_wcpay_plugins_are_active() {
@@ -262,7 +262,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
-        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: nil))
+        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: false))
         useCase.selectPlugin(.wcPay)
         let state = useCase.state
 
@@ -278,7 +278,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
-        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: nil))
+        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: false))
         useCase.selectPlugin(.stripe)
         let state = useCase.state
 
@@ -294,7 +294,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
-        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: nil))
+        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: false))
         useCase.selectPlugin(.stripe)
         useCase.clearPluginSelection()
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -235,7 +235,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: false))
+        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: nil))
     }
 
     func test_onboarding_returns_select_plugin_when_both_stripe_and_wcpay_plugins_are_active_ignoring_preference_if_inPersonPaymentGatewaySelection_false() {
@@ -251,7 +251,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: false))
+        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: nil))
     }
 
     func test_onboarding_uses_selected_plugin_wcpay_when_both_stripe_and_wcpay_plugins_are_active() {
@@ -262,7 +262,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
-        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: false))
+        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: nil))
         useCase.selectPlugin(.wcPay)
         let state = useCase.state
 
@@ -278,7 +278,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
-        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: false))
+        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: nil))
         useCase.selectPlugin(.stripe)
         let state = useCase.state
 
@@ -294,7 +294,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
-        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: false))
+        XCTAssertEqual(useCase.state, .selectPlugin(pluginSelectionWasCleared: nil))
         useCase.selectPlugin(.stripe)
         useCase.clearPluginSelection()
 

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -123,4 +123,12 @@ extension CardPresentPaymentOnboardingState {
             return false
         }
     }
+
+    public var isSelectPlugin: Bool {
+        if case .selectPlugin = self {
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -9,8 +9,10 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     case completed(plugin: CardPresentPaymentsPluginState)
 
     /// There is more than one plugin installed and activated. The user must deactivate one.
+    /// `pluginSelectionWasCleared` being true means that there was one plugin selected for payments
+    /// but that selection was just cleared (e.g when in settings asking to choose a plugin again)
     /// 
-    case selectPlugin
+    case selectPlugin(pluginSelectionWasCleared: Bool)
 
     /// The passed plugin should be deactivated. E.g. this state can happen when WCPay and Stripe
     /// are both installed and activated in a country that doesn't support Stripe. In that case

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -10,7 +10,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// There is more than one plugin installed and activated. The user must deactivate one.
     /// `pluginSelectionWasCleared` being true means that there was one plugin selected for payments
-    /// but that selection was just cleared (e.g when in settings asking to choose a plugin again)
+    /// but that selection was just cleared (e.g when in settings asking to choose a plugin again). Being `nil` means that we do not have that information.
     /// 
     case selectPlugin(pluginSelectionWasCleared: Bool?)
 

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -10,9 +10,9 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// There is more than one plugin installed and activated. The user must deactivate one.
     /// `pluginSelectionWasCleared` being true means that there was one plugin selected for payments
-    /// but that selection was just cleared (e.g when in settings asking to choose a plugin again). Being `nil` means that we do not have that information.
+    /// but that selection was just cleared (e.g when in settings asking to choose a plugin again)
     /// 
-    case selectPlugin(pluginSelectionWasCleared: Bool?)
+    case selectPlugin(pluginSelectionWasCleared: Bool)
 
     /// The passed plugin should be deactivated. E.g. this state can happen when WCPay and Stripe
     /// are both installed and activated in a country that doesn't support Stripe. In that case

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -12,7 +12,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     /// `pluginSelectionWasCleared` being true means that there was one plugin selected for payments
     /// but that selection was just cleared (e.g when in settings asking to choose a plugin again)
     /// 
-    case selectPlugin(pluginSelectionWasCleared: Bool)
+    case selectPlugin(pluginSelectionWasCleared: Bool?)
 
     /// The passed plugin should be deactivated. E.g. this state can happen when WCPay and Stripe
     /// are both installed and activated in a country that doesn't support Stripe. In that case


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7164
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we preselect WCPay in the payment gateway plugin selection screen so it gets more visibility. Please notice that this only happens when the onboarding detects multiple plugin and provides an option for the merchant to choose between the gateways. When the merchant visits the payment gateway screen via "Payments Provider" settings from the IPP settings, there should not be any (pre)selection.
In order to pass the information of whether the screen is being shown in the onboarding or settings context, I had to enrich the `selectPlugin` of `CardPresentPaymentOnboardingState` with the information of whether the plugin selection was just cleared (settings case) or not (onboarding, there wasn't any selection yet). With that information, we can initialise the `InPersonPaymentsSelectPluginView` with WCPay as the selected plugin.
The main challenge was to know when `InPersonPaymentsSelectPluginView` was being shown from settings or the onboarding, since the view is shown as a side effect of updating the `CardPresentPaymentsOnboardingUseCase` `state`. To do that, we enrich the state on `clearPluginSelection`only if the state is .`selectPlugin`(nil), avoding this way undesired side effects.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Prerequisites
Have both WCPay and Stripe installed and active on an US based store

1. Start the app and go to settings
2. Tap on In-Person Payments
3. Payment plugins selection screen should be shown with WCPay preselected:
<img src="https://user-images.githubusercontent.com/1864060/176481062-a41f57d0-0a9c-4ff1-88e4-c21b95fbf61f.png" width="375">
4. Tap on Confirm Payment Method, you should go back to IPP Settings Menu
5. Tap on Payment Provider
6. Payment plugins selection screen should be shown without any preselection:
<img src="https://user-images.githubusercontent.com/1864060/176481636-c5364764-061c-4904-b1c2-43adb4bb31fa.png" width="375">

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
