### PR TITLE
Adds support for the dedicated product leaderboard analytics endpoint

### DIFF
--- a/Networking/Networking/Remote/LeaderboardsRemote.swift
+++ b/Networking/Networking/Remote/LeaderboardsRemote.swift
@@ -19,16 +19,26 @@ public class LeaderboardsRemote: Remote {
                                  earliestDateToInclude: String,
                                  latestDateToInclude: String,
                                  quantity: Int,
+								 path: String = Constants.path,
                                  completion: @escaping (Result<[Leaderboard], Error>) -> Void) {
         let parameters = [ParameterKeys.interval: unit.rawValue,
                           ParameterKeys.after: earliestDateToInclude,
                           ParameterKeys.before: latestDateToInclude,
                           ParameterKeys.quantity: String(quantity)]
 
-        let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = LeaderboardListMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+	public func loadProductLeaderboard(for siteID: Int64,
+								 unit: StatsGranularityV4,
+								 earliestDateToInclude: String,
+								 latestDateToInclude: String,
+								 quantity: Int,
+								 completion: @escaping (Result<[Leaderboard], Error>) -> Void) {
+		loadLeaderboards(for: siteID, unit: unit, earliestDateToInclude: earliestDateToInclude, latestDateToInclude: latestDateToInclude, quantity: quantity, path: Constants.productPath, completion: completion)
+	}
 }
 
 
@@ -37,6 +47,7 @@ public class LeaderboardsRemote: Remote {
 private extension LeaderboardsRemote {
     enum Constants {
         static let path = "leaderboards"
+		static let productPath = "leaderboards/products"
     }
 
     enum ParameterKeys {


### PR DESCRIPTION
WooCommerce 6.7 has a dedicate product leaderboard endpoint. Since we
only use the product section in our apps, we can change the leaderboard
to use this new endpoint, which will be faster on sites that support it.

See https://github.com/woocommerce/woocommerce/pull/33185

Fixes #7034