### PR TITLE
Fix product image upload error alert in product images and a retain cycle between `ProductLoaderViewController` and `ProductFormViewController`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormPresentationStyle.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormPresentationStyle.swift
@@ -6,7 +6,8 @@ enum ProductFormPresentationStyle {
     case navigationStack
 
     /// Contained in another view controller in a navigation stack.
-    case contained(containerViewController: UIViewController)
+    /// `containerViewController` is a closure that returns an optional view controller so that the container is not retained to result in a retain cycle.
+    case contained(containerViewController: () -> UIViewController?)
 }
 
 extension ProductFormPresentationStyle {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -472,7 +472,7 @@ private extension ProductFormViewController {
     func configurePresentationStyle() {
         switch presentationStyle {
         case .contained(let containerViewController):
-            containerViewController.addCloseNavigationBarButton(target: self, action: #selector(closeNavigationBarButtonTapped))
+            containerViewController()?.addCloseNavigationBarButton(target: self, action: #selector(closeNavigationBarButtonTapped))
         case .navigationStack:
             break
         }
@@ -877,7 +877,7 @@ private extension ProductFormViewController {
         navigationItem.rightBarButtonItems = rightBarButtonItems
         switch presentationStyle {
         case .contained(let containerViewController):
-            containerViewController.navigationItem.rightBarButtonItems = rightBarButtonItems
+            containerViewController()?.navigationItem.rightBarButtonItems = rightBarButtonItems
         default:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -172,10 +172,6 @@ private extension ProductImagesViewController {
 
             self.productImageStatuses = productImageStatuses
 
-            if let error = error {
-                self.displayErrorAlert(error: error)
-            }
-
             self.updateHelperViews()
             self.updateAddButtonTitle(numberOfImages: productImageStatuses.count)
 

--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
@@ -228,7 +228,7 @@ private extension ProductLoaderViewController {
     ///
     func presentProductDetails(for product: Product) {
         ProductDetailsFactory.productDetails(product: product,
-                                             presentationStyle: .contained(containerViewController: self),
+                                             presentationStyle: .contained(containerViewController: { [weak self] in self }),
                                              forceReadOnly: forceReadOnly) { [weak self] viewController in
             self?.attachProductDetailsChildViewController(viewController)
         }
@@ -239,7 +239,7 @@ private extension ProductLoaderViewController {
     func presentProductVariationDetails(for productVariation: ProductVariation, parentProduct: Product) {
         ProductVariationDetailsFactory.productVariationDetails(productVariation: productVariation,
                                                                parentProduct: parentProduct,
-                                                               presentationStyle: .contained(containerViewController: self),
+                                                               presentationStyle: .contained(containerViewController: { [weak self] in self }),
                                                                forceReadOnly: forceReadOnly) { [weak self] viewController in
             self?.attachProductDetailsChildViewController(viewController)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While testing image upload, I noticed an UX issue:
When there is an image upload error, then going to the product images from the product form (by tapping on the images header) always triggers an alert about the error even after dismissing it before. This is because when we subscribe to `ProductImageActionHandler.addUpdateObserver` in `ProductImagesViewController`'s `viewDidLoad`, the subscription block is triggered by the initial value which contains an error and thus an alert is shown every time:

https://github.com/woocommerce/woocommerce-ios/blob/70ee2c9da5b5f5aed7e534d594a59495348c6f87/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift#L168-L177

This PR removed the code that displays an image upload error alert in `ProductImagesViewController`, since `ProductFormViewController` already shows an alert as long as the product form is in the navigation stack.

#### Retain cycle between `ProductLoaderViewController` and `ProductFormViewController`

While testing background product image upload, I also noticed that there was a retain cycle between `ProductLoaderViewController` and `ProductFormViewController` through `ProductFormPresentationStyle` enum. This could cause the subscription to `ProductImageActionHandler` to be active after a product form is dismissed. It's because the case `ProductFormPresentationStyle.contained` in the product form has a strong reference on the container view controller (like `ProductLoaderViewController`), while the container also has a strong reference to the product form as its child view controller. To break the retain cycle, I updated the associated value from a non-optional `UIViewController` to `() -> UIViewController?` where we can pass the weak version of the container view controller.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can simulate an image upload failure by updating the [media remote endpoint](https://github.com/woocommerce/woocommerce-ios/blob/0eae2a783db5f68577d613bf58b42cdda73e744f/Networking/Networking/Remote/MediaRemote.swift#L113) to an invalid one like adding some extra character at the end. You can also put `sleep(numberOfSeconds)` to simulate a longer response time.

- Go to the Products tab
- Tap on an editable product
- Tap on the "+" cell or any image cell in the images header
- Tap "Add Photos"
- Select one or more images
- Wait for the error alert to appear from image upload failure
- Tap on the images header again to view product images --> there should not be an error alert, while one is always shown in `trunk`

#### Retain cycle

- Go to the Orders tab
- Tap on an order with products
- Tap on a product that presents `ProductLoaderViewController`
- After the product form is loaded, dismiss the product form --> in Xcode memory debugger, there should be no `ProductLoaderViewController` or `ProductFormViewController` in the memory

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
