### PR TITLE
Background image upload: Fix naming in tests.

### DIFF
--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -475,9 +475,7 @@ final class MediaStoreTests: XCTestCase {
         XCTAssertEqual(error, .unauthorized)
     }
 
-    // MARK: test cases for `MediaAction.updateProductIDToWordPressSite`
-
-    /// Verifies that `MediaAction.updateProductIDToWordPressSite` returns the expected response.
+    /// Verifies that `MediaAction.updateProductID` returns the expected response while connecting to JCP sites.
     ///
     func test_updateProductIDToWordPressSite_returns_media() throws {
         // Given
@@ -505,7 +503,7 @@ final class MediaStoreTests: XCTestCase {
         XCTAssertEqual(mediaFromResult, media.toMedia())
     }
 
-    /// Verifies that `MediaAction.updateProductIDToWordPressSite` returns an error whenever there is an error response from the backend.
+    /// Verifies that `MediaAction.updateProductID` while connecting to JCP sites returns an error whenever there is an error response from the backend.
     ///
     func test_updateProductIDToWordPressSite_returns_error_upon_response_error() throws {
         // Given


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/7021

### Description
This PR updates the comments for `MediaAction.updateProductID` WordPress site API-related test methods. 


### Testing instructions
CI should pass.

### Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.