### PR TITLE
[Mobile Payments] Add VoiceOver accessibility to the IPP Select Plugin View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -28,9 +28,10 @@ struct InPersonPaymentsSelectPluginRow: View {
                 .background(Color(.tertiarySystemBackground))
                )
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(name)." +
-                            "\(Localization.accessibilitySelectableString)." +
-                            "\(selected ? Localization.accessibilitySelectedString : Localization.accessibilityNotSelectedString)")
+                .accessibilityLabel(name)
+                .accessibilityRemoveTraits([.isImage])
+                .accessibilityAddTraits([.isButton])
+                .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
     var borderColor: Color {
         if selected {
@@ -103,15 +104,6 @@ private enum Localization {
     static let confirm = NSLocalizedString(
         "Confirm Payment Method",
         comment: "Button to confirm the preferred provider for In-Person Payments")
-    static let accessibilitySelectableString = NSLocalizedString(
-        "Selectable.",
-        comment: "VoiceOver accessibility hint informing the users that the row on the InPersonPaymentsSelectPluginView is selectable.")
-    static let accessibilitySelectedString = NSLocalizedString(
-        "Selected.",
-        comment: "VoiceOver accessibility hint informing the users that the row on the InPersonPaymentsSelectPluginView is selected.")
-    static let accessibilityNotSelectedString = NSLocalizedString(
-        "Not selected.",
-        comment: "VoiceOver accessibility hint informing the users that the row on the InPersonPaymentsSelectPluginView is not selected.")
 }
 
 struct InPersonPaymentsSelectPlugin_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -27,8 +27,11 @@ struct InPersonPaymentsSelectPluginRow: View {
                 .stroke(borderColor, lineWidth: 1)
                 .background(Color(.tertiarySystemBackground))
                )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(name)." +
+                            "\(Localization.accessibilitySelectableString)." +
+                            "\(selected ? Localization.accessibilitySelectedString : Localization.accessibilityNotSelectedString)")
     }
-
     var borderColor: Color {
         if selected {
             return Color(.primary)
@@ -46,6 +49,7 @@ struct InPersonPaymentsSelectPluginView: View {
         VStack(alignment: .leading, spacing: 16) {
             Image(uiImage: .creditCardGiveIcon)
                 .foregroundColor(Color(.primary))
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 32) {
                 Text(Localization.title)
@@ -99,6 +103,15 @@ private enum Localization {
     static let confirm = NSLocalizedString(
         "Confirm Payment Method",
         comment: "Button to confirm the preferred provider for In-Person Payments")
+    static let accessibilitySelectableString = NSLocalizedString(
+        "Selectable.",
+        comment: "VoiceOver accessibility hint informing the users that the row on the InPersonPaymentsSelectPluginView is selectable.")
+    static let accessibilitySelectedString = NSLocalizedString(
+        "Selected.",
+        comment: "VoiceOver accessibility hint informing the users that the row on the InPersonPaymentsSelectPluginView is selected.")
+    static let accessibilityNotSelectedString = NSLocalizedString(
+        "Not selected.",
+        comment: "VoiceOver accessibility hint informing the users that the row on the InPersonPaymentsSelectPluginView is not selected.")
 }
 
 struct InPersonPaymentsSelectPlugin_Previews: PreviewProvider {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7092
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we want to improve the VoiceOver accessibility in the `InPersonPaymentsSelectPluginView` so it can be easily navigated with VoiceOver on. For that, we:

- Hide images from accessibility
- Group plugin rows in one so it can be navigated as such.
- Add information for the rows: The name, that is selectable, and whether it is selected or not.

Furthermore, the "Confirm Payment Method" button should be navigatable and tappable as usual.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable VoiceOver
2. Tap on the Menu tab
3. Tap on the settings icon
4. Tap on In-Person Payments
5. Tap on Payment Provider
6. Check with VoiceOver that the above requirements are met

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
With sound on 🔊 

https://user-images.githubusercontent.com/1864060/176682946-de7334cb-4fcf-41ff-ad74-7ba59f008f05.MP4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
