### PR TITLE
[Product List] Removed productsVariationsFeedback and surveys

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -65,8 +65,8 @@ extension WooAnalyticsEvent {
     public enum FeedbackContext: String {
         /// Shown in Stats but is for asking general feedback.
         case general
-        /// Shown in products banner for Variations release.
-        case productsVariations = "products_variations"
+        /// Shown in products banner for general feedback.
+        case productsGeneral  = "products_general"
         /// Shown in shipping labels banner for Milestone 3 features.
         case shippingLabelsRelease3 = "shipping_labels_m3"
         /// Shown in beta feature banner for order add-ons.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -83,10 +83,6 @@ extension WooConstants {
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
 #endif
 
-        /// URL for the products feedback survey
-        ///
-        case productsFeedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
-
         /// URL for the shipping labels M3 feedback survey
         ///
 #if DEBUG

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -83,6 +83,10 @@ extension WooConstants {
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
 #endif
 
+        /// URL for the products feedback survey
+        ///
+        case productsFeedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
+
         /// URL for the shipping labels M3 feedback survey
         ///
 #if DEBUG

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -4,7 +4,7 @@ import Yosemite
 struct ProductsTopBannerFactory {
 
     enum BannerType {
-        case variations
+        case general
 
         var title: String {
             Localization.title
@@ -12,15 +12,15 @@ struct ProductsTopBannerFactory {
 
         var info: String {
             switch self {
-            case .variations:
-                return Localization.infoVariations
+            case .general:
+                return Localization.topBannerInfo
             }
         }
 
         var feedbackContext: WooAnalyticsEvent.FeedbackContext {
             switch self {
-            case .variations:
-                return .productsVariations
+            case .general:
+                return .general
             }
         }
     }
@@ -70,7 +70,7 @@ private extension ProductsTopBannerFactory {
         static let title = NSLocalizedString("New features available!",
                                              comment: "The title of the top banner on the Products tab.")
 
-        static let infoVariations = NSLocalizedString("You can now create and manage product variations!",
+        static let topBannerInfo = NSLocalizedString("",
                                                       comment: "The info of the top banner on the Products tab.")
 
         static let giveFeedback =

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -70,8 +70,7 @@ private extension ProductsTopBannerFactory {
         static let title = NSLocalizedString("New features available!",
                                              comment: "The title of the top banner on the Products tab.")
 
-        static let topBannerInfo = NSLocalizedString("",
-                                                      comment: "The info of the top banner on the Products tab.")
+        static let topBannerInfo = "" // The info of the top banner on the Products tab.
 
         static let giveFeedback =
             NSLocalizedString("Give feedback",

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -20,7 +20,7 @@ struct ProductsTopBannerFactory {
         var feedbackContext: WooAnalyticsEvent.FeedbackContext {
             switch self {
             case .general:
-                return .general
+                return .productsGeneral
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -686,10 +686,10 @@ private extension ProductsViewController {
         filters = FilterProductListViewModel.Filters()
     }
 
-    /// Presents inAppFeedback survey. 
+    /// Presents productsFeedback survey. 
     ///
     func presentFeedback() {
-        let navigationController = SurveyCoordinatingController(survey: .inAppFeedback)
+        let navigationController = SurveyCoordinatingController(survey: .productsFeedback)
         present(navigationController, animated: true, completion: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -451,7 +451,7 @@ private extension ProductsViewController {
                                            expandedStateChangeHandler: { [weak self] in
             self?.updateTableHeaderViewHeight()
         }, onGiveFeedbackButtonPressed: { [weak self] in
-            self?.presentFeedback()
+            self?.presentProductsFeedback()
         }, onDismissButtonPressed: { [weak self] in
             self?.hideTopBannerView()
         }, onCompletion: { [weak self] topBannerView in
@@ -686,9 +686,9 @@ private extension ProductsViewController {
         filters = FilterProductListViewModel.Filters()
     }
 
-    /// Presents productsFeedback survey. 
+    /// Presents productsFeedback survey.
     ///
-    func presentFeedback() {
+    func presentProductsFeedback() {
         let navigationController = SurveyCoordinatingController(survey: .productsFeedback)
         present(navigationController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -451,7 +451,7 @@ private extension ProductsViewController {
                                            expandedStateChangeHandler: { [weak self] in
             self?.updateTableHeaderViewHeight()
         }, onGiveFeedbackButtonPressed: { [weak self] in
-            self?.presentProductsFeedback()
+            self?.presentFeedback()
         }, onDismissButtonPressed: { [weak self] in
             self?.hideTopBannerView()
         }, onCompletion: { [weak self] topBannerView in
@@ -686,11 +686,10 @@ private extension ProductsViewController {
         filters = FilterProductListViewModel.Filters()
     }
 
-    /// Presents products survey
+    /// Presents inAppFeedback survey. 
     ///
-    func presentProductsFeedback() {
-        // Present survey
-        let navigationController = SurveyCoordinatingController(survey: .productsVariationsFeedback)
+    func presentFeedback() {
+        let navigationController = SurveyCoordinatingController(survey: .inAppFeedback)
         present(navigationController, animated: true, completion: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -63,7 +63,6 @@ final class SurveyViewController: UIViewController, SurveyViewControllerOutputs 
 extension SurveyViewController {
     enum Source {
         case inAppFeedback
-        case productsVariationsFeedback
         case shippingLabelsRelease3Feedback
         case addOnsI1
         case orderCreation
@@ -73,12 +72,6 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return WooConstants.URLs.inAppFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-
-            case .productsVariationsFeedback:
-                return WooConstants.URLs.productsFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -110,7 +103,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsVariationsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
+            case .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
                 return Localization.giveFeedback
             }
         }
@@ -120,8 +113,6 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return .general
-            case .productsVariationsFeedback:
-                return .productsVariations
             case .shippingLabelsRelease3Feedback:
                 return .shippingLabelsRelease3
             case .addOnsI1:

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -63,6 +63,7 @@ final class SurveyViewController: UIViewController, SurveyViewControllerOutputs 
 extension SurveyViewController {
     enum Source {
         case inAppFeedback
+        case productsFeedback
         case shippingLabelsRelease3Feedback
         case addOnsI1
         case orderCreation
@@ -72,6 +73,11 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return WooConstants.URLs.inAppFeedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
+            case .productsFeedback:
+                return WooConstants.URLs.productsFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -103,7 +109,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
+            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
                 return Localization.giveFeedback
             }
         }
@@ -113,6 +119,8 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return .general
+            case .productsFeedback:
+                return .productsGeneral
             case .shippingLabelsRelease3Feedback:
                 return .shippingLabelsRelease3
             case .addOnsI1:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -27,7 +27,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
 
     func test_it_tracks_featureFeedbackBanner_gaveFeedback_event_when_giveFeedback_button_is_pressed() throws {
         // Given
-        let bannerMirror = try makeBannerViewMirror(for: .variations)
+        let bannerMirror = try makeBannerViewMirror(for: .general)
         let giveFeedbackButton = try XCTUnwrap(bannerMirror.actionButtons.first)
 
         assertEmpty(analyticsProvider.receivedEvents)
@@ -40,13 +40,13 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "products_variations")
+        XCTAssertEqual(properties["context"] as? String, "general")
         XCTAssertEqual(properties["action"] as? String, "gave_feedback")
     }
 
     func test_it_tracks_featureFeedbackBanner_dismissed_event_when_dismiss_button_is_pressed() throws {
         // Given
-        let bannerMirror = try makeBannerViewMirror(for: .variations)
+        let bannerMirror = try makeBannerViewMirror(for: .general)
         let dismissButton = try XCTUnwrap(bannerMirror.actionButtons.last)
 
         assertEmpty(analyticsProvider.receivedEvents)
@@ -59,7 +59,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "products_variations")
+        XCTAssertEqual(properties["context"] as? String, "general")
         XCTAssertEqual(properties["action"] as? String, "dismissed")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -40,7 +40,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "general")
+        XCTAssertEqual(properties["context"] as? String, "products_general")
         XCTAssertEqual(properties["action"] as? String, "gave_feedback")
     }
 
@@ -59,7 +59,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "general")
+        XCTAssertEqual(properties["context"] as? String, "products_general")
         XCTAssertEqual(properties["action"] as? String, "dismissed")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -22,6 +22,20 @@ final class SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL().tagPlatform("ios").tagAppVersion(Bundle.main.bundleVersion()))
     }
 
+    func test_it_loads_the_correct_product_feedback_survey() throws {
+        // Given
+        let viewController = SurveyViewController(survey: .productsFeedback, onCompletion: {})
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+
+        // Then
+        XCTAssertTrue(mirror.webView.isLoading)
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsFeedback
+                        .asURL().tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion()))
+    }
+
     func test_it_loads_the_correct_shipping_labels_release_survey() throws {
         // Given
         let viewController = SurveyViewController(survey: .shippingLabelsRelease3Feedback, onCompletion: {})

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -22,21 +22,6 @@ final class SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL().tagPlatform("ios").tagAppVersion(Bundle.main.bundleVersion()))
     }
 
-    func test_it_loads_the_correct_product_feedback_survey() throws {
-        // Given
-        let viewController = SurveyViewController(survey: .productsVariationsFeedback, onCompletion: {})
-
-        // When
-        _ = try XCTUnwrap(viewController.view)
-        let mirror = try self.mirror(of: viewController)
-
-        // Then
-        XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsFeedback
-                        .asURL().tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion()))
-    }
-
     func test_it_loads_the_correct_shipping_labels_release_survey() throws {
         // Given
         let viewController = SurveyViewController(survey: .shippingLabelsRelease3Feedback, onCompletion: {})


### PR DESCRIPTION
Closes: #7139 

### Description
As a continuation of https://github.com/woocommerce/woocommerce-ios/pull/7129 , this PR removes code regarding requests/tracking feedback around the product variations feature, which is no longer necessary as was removed.

~~I also renamed `presentProductsFeedback()` to a more generic `presentFeedback()` to avoid confusion, as can be interpreted either as "show feedback about products", or "show feedback within the products view", but happy to revert it back or rename it to any other recommendation.~~ This was reverted, now tracks `.productFeedback` rather than `.inAppFeedback`

### Testing instructions
Since we removed the banner on #7129 , the "Give Feedback" request for product variations no longer appears either.

<img width="312" alt="Screenshot 2022-06-30 at 21 18 33" src="https://user-images.githubusercontent.com/3812076/176700936-e100361a-4b28-4f3c-aaf4-62c75dd061ca.png">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
