### PR TITLE
Update product ID in product image interface to `ProductOrVariationID` to support product variations

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -7,7 +7,6 @@ protocol SwitchStoreUseCaseProtocol {
 
 /// Simplifies and decouples the store picker from the caller
 ///
-@MainActor
 final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
 
     private let stores: StoresManager
@@ -19,6 +18,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
     /// The async version of `switchStore` that wraps the completion block version.
     /// - Parameter storeID: target store ID.
     /// - Returns: a boolean that indicates whether the site was changed.
+    @MainActor
     func switchStore(with storeID: Int64) async -> Bool {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -7,6 +7,7 @@ protocol SwitchStoreUseCaseProtocol {
 
 /// Simplifies and decouples the store picker from the caller
 ///
+@MainActor
 final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
 
     private let stores: StoresManager

--- a/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/LegacyProductImageUploader.swift
@@ -5,30 +5,28 @@ import struct Yosemite.ProductImage
 final class LegacyProductImageUploader: ProductImageUploaderProtocol {
     let errors: AnyPublisher<ProductImageUploadErrorInfo, Never> = Empty<ProductImageUploadErrorInfo, Never>().eraseToAnyPublisher()
 
-    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
-        ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses)
+    func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
+        ProductImageActionHandler(siteID: key.siteID, productID: key.productOrVariationID, imageStatuses: originalStatuses)
     }
 
-    func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
+    func replaceLocalID(siteID: Int64, localID: ProductOrVariationID, remoteID: Int64) {
         // no-op
     }
 
-    func saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: Int64,
-                                                         productID: Int64,
-                                                         isLocalID: Bool,
+    func saveProductImagesWhenNoneIsPendingUploadAnymore(key: ProductImageUploaderKey,
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
         // no-op
     }
 
-    func startEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func startEmittingErrors(key: ProductImageUploaderKey) {
         // no-op
     }
 
-    func stopEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func stopEmittingErrors(key: ProductImageUploaderKey) {
         // no-op
     }
 
-    func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool {
+    func hasUnsavedChangesOnImages(key: ProductImageUploaderKey, originalImages: [ProductImage]) -> Bool {
         // The result is not used.
         return false
     }

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -15,6 +15,16 @@ struct ProductImageUploadErrorInfo {
 enum ProductOrVariationID: Equatable, Hashable {
     case product(id: Int64)
     case variation(productID: Int64, variationID: Int64)
+
+    /// Returns the product ID for product type and variation ID for variation type.
+    var id: Int64 {
+        switch self {
+        case .product(let id):
+            return id
+        case .variation(_, let variationID):
+            return variationID
+        }
+    }
 }
 
 /// Identifiable information about a specific product or product variation of different sites for image upload.
@@ -217,18 +227,10 @@ private extension ProductImageUploader {
     func updateProductIDOfImagesUploadedUsingLocalProductID(siteID: Int64,
                                                             productOrVariationID: ProductOrVariationID,
                                                             images: [ProductImage]) {
-        let imageProductOrVariationID: Int64 = {
-            switch productOrVariationID {
-            case .product(let id):
-                return id
-            case .variation(_, let variationID):
-                return variationID
-            }
-        }()
         images.forEach { image in
             Task {
                 _ = try? await imagesProductIDUpdater.updateImageProductID(siteID: siteID,
-                                                                           productID: imageProductOrVariationID,
+                                                                           productID: productOrVariationID.id,
                                                                            productImage: image)
             }
         }

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -6,9 +6,20 @@ import protocol Yosemite.StoresManager
 /// Information about a background product image upload error.
 struct ProductImageUploadErrorInfo {
     let siteID: Int64
-    let productID: Int64
+    let productOrVariationID: ProductOrVariationID
     let productImageStatuses: [ProductImageStatus]
     let error: ProductImageUploaderError
+}
+
+enum ProductOrVariationID: Equatable, Hashable {
+    case product(id: Int64)
+    case variation(productID: Int64, variationID: Int64)
+}
+
+struct ProductImageUploaderKey: Equatable, Hashable {
+    let siteID: Int64
+    let productOrVariationID: ProductOrVariationID
+    let isLocalID: Bool
 }
 
 /// Handles product image upload to support background image upload.
@@ -22,7 +33,7 @@ protocol ProductImageUploaderProtocol {
     ///   - productID: the ID of the product where images are added to.
     ///   - isLocalID: whether the product ID is a local ID like in product creation.
     ///   - originalStatuses: the current image statuses of the product for initialization.
-    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler
+    func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler
 
     /// Replaces the local ID of the product with the remote ID from API.
     ///
@@ -35,7 +46,7 @@ protocol ProductImageUploaderProtocol {
     ///   - siteID: The ID of the site to which images are uploaded to.
     ///   - localProductID: A temporary local ID of the product.
     ///   - remoteProductID: Remote product ID received from API.
-    func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64)
+    func replaceLocalID(siteID: Int64, localID: ProductOrVariationID, remoteID: Int64)
 
     /// Saves the product remotely with the images after none is pending upload.
     /// - Parameters:
@@ -43,9 +54,7 @@ protocol ProductImageUploaderProtocol {
     ///   - productID: the ID of the product where images are added to.
     ///   - isLocalID: whether the product ID is a local ID like in product creation.
     ///   - onProductSave: called after the product is saved remotely with the uploaded images.
-    func saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: Int64,
-                                                         productID: Int64,
-                                                         isLocalID: Bool,
+    func saveProductImagesWhenNoneIsPendingUploadAnymore(key: ProductImageUploaderKey,
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void)
 
     /// Stops the emission of errors when the user is in the product form to edit a specific product.
@@ -53,14 +62,14 @@ protocol ProductImageUploaderProtocol {
     ///   - siteID: the ID of the site that the user is logged into.
     ///   - productID: the ID of the product that the user is editing.
     ///   - isLocalID: whether the product ID is a local ID like in product creation.
-    func stopEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool)
+    func stopEmittingErrors(key: ProductImageUploaderKey)
 
     /// Starts the emission of errors when the user leaves the product form.
     /// - Parameters:
     ///   - siteID: the ID of the site that the user is logged into.
     ///   - productID: the ID of the product that the user is navigating away.
     ///   - isLocalID: whether the product ID is a local ID like in product creation.
-    func startEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool)
+    func startEmittingErrors(key: ProductImageUploaderKey)
 
     /// Determines whether there are unsaved changes on a product's images.
     /// If the product had any save request before, it checks whether the image statuses to save match the latest image statuses.
@@ -70,7 +79,7 @@ protocol ProductImageUploaderProtocol {
     ///   - productID: the ID of the product where images are added to.
     ///   - isLocalID: whether the product ID is a local ID like in product creation.
     ///   - originalImages: the image statuses before any edits.
-    func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool
+    func hasUnsavedChangesOnImages(key: ProductImageUploaderKey, originalImages: [ProductImage]) -> Bool
 
     /// Resets all internal states and tracking of image uploads for connected stores.
     /// Called when the user is logged out.
@@ -83,18 +92,14 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         errorsSubject.eraseToAnyPublisher()
     }
 
+    typealias Key = ProductImageUploaderKey
+
     private let errorsSubject: PassthroughSubject<ProductImageUploadErrorInfo, Never> = .init()
-    private var statusUpdatesExcludedProductKeys: Set<ProductKey> = []
+    private var statusUpdatesExcludedProductKeys: Set<Key> = []
     private var statusUpdatesSubscriptions: Set<AnyCancellable> = []
 
-    private struct ProductKey: Equatable, Hashable {
-        let siteID: Int64
-        let productID: Int64
-        let isLocalID: Bool
-    }
-
-    private var actionHandlersByProduct: [ProductKey: ProductImageActionHandler] = [:]
-    private var imagesSaverByProduct: [ProductKey: ProductImagesSaver] = [:]
+    private var actionHandlersByProduct: [Key: ProductImageActionHandler] = [:]
+    private var imagesSaverByProduct: [Key: ProductImagesSaver] = [:]
     private let stores: StoresManager
     private let imagesProductIDUpdater: ProductImagesProductIDUpdaterProtocol
 
@@ -104,48 +109,48 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         self.imagesProductIDUpdater = imagesProductIDUpdater
     }
 
-    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
-        let key = ProductKey(siteID: siteID, productID: productID, isLocalID: isLocalID)
+    func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
         let actionHandler: ProductImageActionHandler
         if let handler = actionHandlersByProduct[key], handler.productImageStatuses.hasPendingUpload {
             actionHandler = handler
         } else {
-            actionHandler = ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: originalStatuses, stores: stores)
+            actionHandler = ProductImageActionHandler(siteID: key.siteID, productID: key.productOrVariationID, imageStatuses: originalStatuses, stores: stores)
             actionHandlersByProduct[key] = actionHandler
             observeStatusUpdatesForErrors(key: key, actionHandler: actionHandler)
         }
         return actionHandler
     }
 
-    func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
-        let key = ProductKey(siteID: siteID, productID: localProductID, isLocalID: true)
+    func replaceLocalID(siteID: Int64, localID: ProductOrVariationID, remoteID: Int64) {
+        let key = Key(siteID: siteID,
+                      productOrVariationID: localID,
+                      isLocalID: true)
         guard let handler = actionHandlersByProduct[key] else {
             return
         }
 
         // Update the product ID of handler to make sure that future product image uploads use the `remoteProductID` instead of `localProductID`
-        handler.updateProductID(remoteProductID)
+        handler.updateProductID(remoteID)
 
         actionHandlersByProduct.removeValue(forKey: key)
-        let keyWithRemoteProductID = ProductKey(siteID: siteID, productID: remoteProductID, isLocalID: false)
+        let keyWithRemoteProductID = Key(siteID: siteID,
+                                         productOrVariationID: localID.replacingID(remoteID),
+                                         isLocalID: false)
         actionHandlersByProduct[keyWithRemoteProductID] = handler
 
         statusUpdatesExcludedProductKeys.remove(key)
         statusUpdatesExcludedProductKeys.insert(keyWithRemoteProductID)
     }
 
-    func stopEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
-        let key = ProductKey(siteID: siteID, productID: productID, isLocalID: isLocalID)
+    func stopEmittingErrors(key: ProductImageUploaderKey) {
         statusUpdatesExcludedProductKeys.insert(key)
     }
 
-    func startEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
-        let key = ProductKey(siteID: siteID, productID: productID, isLocalID: isLocalID)
+    func startEmittingErrors(key: ProductImageUploaderKey) {
         statusUpdatesExcludedProductKeys.remove(key)
     }
 
-    func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool {
-        let key = ProductKey(siteID: siteID, productID: productID, isLocalID: isLocalID)
+    func hasUnsavedChangesOnImages(key: ProductImageUploaderKey, originalImages: [ProductImage]) -> Bool {
         guard let handler = actionHandlersByProduct[key] else {
             return false
         }
@@ -160,17 +165,14 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         }
     }
 
-    func saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: Int64,
-                                                         productID: Int64,
-                                                         isLocalID: Bool,
+    func saveProductImagesWhenNoneIsPendingUploadAnymore(key: ProductImageUploaderKey,
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
         // The product has to exist remotely in order to save its images remotely.
         // In product creation, this save function should be called after a new product is saved remotely for the first time.
-        guard isLocalID == false else {
+        guard key.isLocalID == false else {
             return
         }
 
-        let key = ProductKey(siteID: siteID, productID: productID, isLocalID: isLocalID)
         guard let handler = actionHandlersByProduct[key] else {
             return
         }
@@ -186,7 +188,9 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         if let productImagesSaver = imagesSaverByProduct[key] {
             imagesSaver = productImagesSaver
         } else {
-            imagesSaver = ProductImagesSaver(siteID: siteID, productID: productID, stores: stores)
+            imagesSaver = ProductImagesSaver(siteID: key.siteID,
+                                             productOrVariationID: key.productOrVariationID,
+                                             stores: stores)
             imagesSaverByProduct[key] = imagesSaver
         }
 
@@ -194,8 +198,8 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
             guard let self = self else { return }
             onProductSave(result)
             if case let .failure(error) = result {
-                self.errorsSubject.send(.init(siteID: siteID,
-                                              productID: productID,
+                self.errorsSubject.send(.init(siteID: key.siteID,
+                                              productOrVariationID: key.productOrVariationID,
                                               productImageStatuses: handler.productImageStatuses,
                                               error: .failedSavingProductAfterImageUpload(error: error)))
             }
@@ -229,18 +233,29 @@ private extension ProductImageUploader {
         }
     }
 
-    private func observeStatusUpdatesForErrors(key: ProductKey, actionHandler: ProductImageActionHandler) {
+    private func observeStatusUpdatesForErrors(key: Key, actionHandler: ProductImageActionHandler) {
         let observationToken = actionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
             guard let self = self else { return }
 
             if let error = error, self.statusUpdatesExcludedProductKeys.contains(key) == false {
                 self.errorsSubject.send(.init(siteID: key.siteID,
-                                              productID: key.productID,
+                                              productOrVariationID: key.productOrVariationID,
                                               productImageStatuses: productImageStatuses,
                                               error: .failedUploadingImage(error: error)))
             }
         }
         statusUpdatesSubscriptions.insert(observationToken)
+    }
+}
+
+private extension ProductOrVariationID {
+    func replacingID(_ id: Int64) -> ProductOrVariationID {
+        switch self {
+        case .product:
+            return .product(id: id)
+        case .variation(let productID, _):
+            return .variation(productID: productID, variationID: id)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -11,11 +11,13 @@ struct ProductImageUploadErrorInfo {
     let error: ProductImageUploaderError
 }
 
+/// Identifiable data about a product or product variation.
 enum ProductOrVariationID: Equatable, Hashable {
     case product(id: Int64)
     case variation(productID: Int64, variationID: Int64)
 }
 
+/// Identifiable information about a specific product or product variation of different sites for image upload.
 struct ProductImageUploaderKey: Equatable, Hashable {
     let siteID: Int64
     let productOrVariationID: ProductOrVariationID
@@ -29,9 +31,7 @@ protocol ProductImageUploaderProtocol {
 
     /// Called for product image upload use cases (e.g. product/variation form, downloadable product list).
     /// - Parameters:
-    ///   - siteID: the ID of the site where images are uploaded to.
-    ///   - productID: the ID of the product where images are added to.
-    ///   - isLocalID: whether the product ID is a local ID like in product creation.
+    ///   - key: identifiable information about the product.
     ///   - originalStatuses: the current image statuses of the product for initialization.
     func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler
 
@@ -44,40 +44,32 @@ protocol ProductImageUploaderProtocol {
     ///
     /// - Parameters:
     ///   - siteID: The ID of the site to which images are uploaded to.
-    ///   - localProductID: A temporary local ID of the product.
-    ///   - remoteProductID: Remote product ID received from API.
+    ///   - localID: A temporary local ID of the product.
+    ///   - remoteID: Remote product ID received from API.
     func replaceLocalID(siteID: Int64, localID: ProductOrVariationID, remoteID: Int64)
 
     /// Saves the product remotely with the images after none is pending upload.
     /// - Parameters:
-    ///   - siteID: the ID of the site where images are uploaded to.
-    ///   - productID: the ID of the product where images are added to.
-    ///   - isLocalID: whether the product ID is a local ID like in product creation.
+    ///   - key: identifiable information about the product.
     ///   - onProductSave: called after the product is saved remotely with the uploaded images.
     func saveProductImagesWhenNoneIsPendingUploadAnymore(key: ProductImageUploaderKey,
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void)
 
     /// Stops the emission of errors when the user is in the product form to edit a specific product.
     /// - Parameters:
-    ///   - siteID: the ID of the site that the user is logged into.
-    ///   - productID: the ID of the product that the user is editing.
-    ///   - isLocalID: whether the product ID is a local ID like in product creation.
+    ///   - key: identifiable information about the product.
     func stopEmittingErrors(key: ProductImageUploaderKey)
 
     /// Starts the emission of errors when the user leaves the product form.
     /// - Parameters:
-    ///   - siteID: the ID of the site that the user is logged into.
-    ///   - productID: the ID of the product that the user is navigating away.
-    ///   - isLocalID: whether the product ID is a local ID like in product creation.
+    ///   - key: identifiable information about the product.
     func startEmittingErrors(key: ProductImageUploaderKey)
 
     /// Determines whether there are unsaved changes on a product's images.
     /// If the product had any save request before, it checks whether the image statuses to save match the latest image statuses.
     /// Otherwise, it checks whether there is any pending upload or the image statuses match the given original image statuses.
     /// - Parameters:
-    ///   - siteID: the ID of the site where images are uploaded to.
-    ///   - productID: the ID of the product where images are added to.
-    ///   - isLocalID: whether the product ID is a local ID like in product creation.
+    ///   - key: identifiable information about the product.
     ///   - originalImages: the image statuses before any edits.
     func hasUnsavedChangesOnImages(key: ProductImageUploaderKey, originalImages: [ProductImage]) -> Bool
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -626,7 +626,15 @@ private extension MainTabBarController {
             presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
         }
 
-        let productViewController = ProductLoaderViewController(model: .product(productID: error.productID),
+        let model: ProductLoaderViewController.Model = {
+            switch error.productOrVariationID {
+            case .product(let id):
+                return .product(productID: id)
+            case .variation(let productID, let variationID):
+                return .productVariation(productID: productID, variationID: variationID)
+            }
+        }()
+        let productViewController = ProductLoaderViewController(model: model,
                                                                 siteID: error.siteID,
                                                                 forceReadOnly: false)
         let productNavController = WooNavigationController(rootViewController: productViewController)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -74,10 +74,11 @@ private extension AddProductCoordinator {
 
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let productImageActionHandler = productImageUploader.actionHandler(siteID: product.siteID,
-                                                                           productID: model.productID,
-                                                                           isLocalID: true,
-                                                                           originalStatuses: model.imageStatuses)
+        let productImageActionHandler = productImageUploader
+            .actionHandler(key: .init(siteID: product.siteID,
+                                      productOrVariationID: .product(id: model.productID),
+                                      isLocalID: true),
+                           originalStatuses: model.imageStatuses)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -38,10 +38,11 @@ final class ProductDownloadListViewController: UIViewController {
         self.product = product
         viewModel = ProductDownloadListViewModel(product: product)
         onCompletion = completion
-        productImageActionHandler = productImageUploader.actionHandler(siteID: product.siteID,
-                                                                       productID: product.productID,
-                                                                       isLocalID: !product.existsRemotely,
-                                                                       originalStatuses: product.imageStatuses)
+        productImageActionHandler = productImageUploader
+            .actionHandler(key: .init(siteID: product.siteID,
+                                      productOrVariationID: .product(id: product.productID),
+                                      isLocalID: !product.existsRemotely),
+                           originalStatuses: product.imageStatuses)
         super.init(nibName: type(of: self).nibName, bundle: nil)
 
         onDeviceMediaLibraryPickerCompletion = { [weak self] assets in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -131,9 +131,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             self.viewModel.updateImages(productImageStatuses.images)
         }
 
-        productImageUploader.stopEmittingErrors(siteID: viewModel.productModel.siteID,
-                                                       productID: viewModel.productModel.productID,
-                                                       isLocalID: !viewModel.productModel.existsRemotely)
+        productImageUploader.stopEmittingErrors(key: .init(siteID: viewModel.productModel.siteID,
+                                                           productOrVariationID: productOrVariationID(),
+                                                           isLocalID: !viewModel.productModel.existsRemotely))
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -142,9 +142,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         view.endEditing(true)
 
         if isBeingDismissedInAnyWay {
-            productImageUploader.startEmittingErrors(siteID: viewModel.productModel.siteID,
-                                                            productID: viewModel.productModel.productID,
-                                                            isLocalID: !viewModel.productModel.existsRemotely)
+            productImageUploader.startEmittingErrors(key: .init(siteID: viewModel.productModel.siteID,
+                                                                productOrVariationID: productOrVariationID(),
+                                                                isLocalID: !viewModel.productModel.existsRemotely))
         }
     }
 
@@ -1484,6 +1484,16 @@ private extension ProductFormViewController {
             viewModel.updateProductVariations(from: updatedProduct)
         }
         show(variationsViewController, sender: self)
+    }
+}
+
+private extension ProductFormViewController {
+    func productOrVariationID() -> ProductOrVariationID {
+        if let viewModel = viewModel as? ProductVariationFormViewModel {
+            return .variation(productID: viewModel.productModel.productID, variationID: viewModel.productModel.productVariation.productVariationID)
+        } else {
+            return .product(id: viewModel.productModel.productID)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -28,6 +28,14 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         viewModel.password
     }
 
+    private var productOrVariationID: ProductOrVariationID {
+        if let viewModel = viewModel as? ProductVariationFormViewModel {
+            return .variation(productID: viewModel.productModel.productID, variationID: viewModel.productModel.productVariation.productVariationID)
+        } else {
+            return .product(id: viewModel.productModel.productID)
+        }
+    }
+
     private var tableViewModel: ProductFormTableViewModel
     private var tableViewDataSource: ProductFormTableViewDataSource {
         didSet {
@@ -132,7 +140,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         }
 
         productImageUploader.stopEmittingErrors(key: .init(siteID: viewModel.productModel.siteID,
-                                                           productOrVariationID: productOrVariationID(),
+                                                           productOrVariationID: productOrVariationID,
                                                            isLocalID: !viewModel.productModel.existsRemotely))
     }
 
@@ -143,7 +151,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
         if isBeingDismissedInAnyWay {
             productImageUploader.startEmittingErrors(key: .init(siteID: viewModel.productModel.siteID,
-                                                                productOrVariationID: productOrVariationID(),
+                                                                productOrVariationID: productOrVariationID,
                                                                 isLocalID: !viewModel.productModel.existsRemotely))
         }
     }
@@ -1484,16 +1492,6 @@ private extension ProductFormViewController {
             viewModel.updateProductVariations(from: updatedProduct)
         }
         show(variationsViewController, sender: self)
-    }
-}
-
-private extension ProductFormViewController {
-    func productOrVariationID() -> ProductOrVariationID {
-        if let viewModel = viewModel as? ProductVariationFormViewModel {
-            return .variation(productID: viewModel.productModel.productID, variationID: viewModel.productModel.productVariation.productVariationID)
-        } else {
-            return .product(id: viewModel.productModel.productID)
-        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -202,10 +202,11 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
             return product != originalProduct || productImageActionHandler.productImageStatuses.hasPendingUpload || password != originalPassword
         }
         let hasProductChangesExcludingImages = product.product.copy(images: []) != originalProduct.product.copy(images: [])
-        let hasImageChanges = productImagesUploader.hasUnsavedChangesOnImages(siteID: product.siteID,
-                                                                              productID: product.productID,
-                                                                              isLocalID: !product.existsRemotely,
-                                                                              originalImages: originalProduct.images)
+        let hasImageChanges = productImagesUploader
+            .hasUnsavedChangesOnImages(key: .init(siteID: product.siteID,
+                                                  productOrVariationID: .product(id: product.productID),
+                                                  isLocalID: !product.existsRemotely),
+                                       originalImages: originalProduct.images)
         return hasProductChangesExcludingImages || hasImageChanges || password != originalPassword
     }
 }
@@ -478,15 +479,16 @@ extension ProductFormViewModel {
 private extension ProductFormViewModel {
     func replaceProductID(productIDBeforeSave: Int64) {
         productImagesUploader.replaceLocalID(siteID: product.siteID,
-                                             localProductID: productIDBeforeSave,
-                                             remoteProductID: product.productID)
+                                             localID: .product(id: productIDBeforeSave),
+                                             remoteID: product.productID)
     }
 
     func saveProductImagesWhenNoneIsPendingUploadAnymore() {
-        productImagesUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: product.siteID,
-                                                                              productID: product.productID,
-                                                                              isLocalID: !product.existsRemotely) { [weak self] result in
-            guard let self = self else { return }
+        productImagesUploader
+            .saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: product.siteID,
+                                                                        productOrVariationID: .product(id: product.productID),
+                                                                        isLocalID: !product.existsRemotely)) { [weak self] result in
+                guard let self = self else { return }
             switch result {
             case .success(let images):
                 let currentProduct = self.product

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -10,7 +10,7 @@ final class ProductImageActionHandler {
     typealias OnAssetUpload = (PHAsset, Result<ProductImage, Error>) -> Void
 
     private let siteID: Int64
-    private let productID: ProductOrVariationID
+    private var productOrVariationID: ProductOrVariationID
 
     /// The queue where internal states like `allStatuses` and `observations` are updated on to maintain thread safety.
     private let queue: DispatchQueue
@@ -47,7 +47,7 @@ final class ProductImageActionHandler {
     ///   - stores: stores that dispatch image upload action.
     init(siteID: Int64, productID: ProductOrVariationID, imageStatuses: [ProductImageStatus], queue: DispatchQueue = .main, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
-        self.productID = productID
+        self.productOrVariationID = productID
         self.queue = queue
         self.stores = stores
         self.allStatuses = (productImageStatuses: imageStatuses, error: nil)
@@ -181,7 +181,7 @@ final class ProductImageActionHandler {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             let productOrVariationID: Int64 = {
-                switch self.productID {
+                switch self.productOrVariationID {
                 case .product(let id):
                     return id
                 case .variation(_, variationID: let variationID):
@@ -197,8 +197,8 @@ final class ProductImageActionHandler {
     ///
     /// Used for updating the product ID during create product flow. i.e. To replace the local product ID with the remote product ID.
     ///
-    func updateProductID(_ remoteProductID: Int64) {
-        self.productID = remoteProductID
+    func updateProductID(_ remoteProductID: ProductOrVariationID) {
+        self.productOrVariationID = remoteProductID
     }
 
     func deleteProductImage(_ productImage: ProductImage) {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -184,15 +184,7 @@ final class ProductImageActionHandler {
     private func uploadMediaAssetToSiteMediaLibrary(asset: PHAsset, onCompletion: @escaping (Result<Media, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            let productOrVariationID: Int64 = {
-                switch self.productOrVariationID {
-                case .product(let id):
-                    return id
-                case .variation(_, variationID: let variationID):
-                    return variationID
-                }
-            }()
-            let action = MediaAction.uploadMedia(siteID: self.siteID, productID: productOrVariationID, mediaAsset: asset, onCompletion: onCompletion)
+            let action = MediaAction.uploadMedia(siteID: self.siteID, productID: self.productOrVariationID.id, mediaAsset: asset, onCompletion: onCompletion)
             self.stores.dispatch(action)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -45,7 +45,11 @@ final class ProductImageActionHandler {
     ///   - imageStatuses: the current image statuses of the product.
     ///   - queue: the queue where the update callbacks are called on. Default to be the main queue.
     ///   - stores: stores that dispatch image upload action.
-    init(siteID: Int64, productID: ProductOrVariationID, imageStatuses: [ProductImageStatus], queue: DispatchQueue = .main, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64,
+         productID: ProductOrVariationID,
+         imageStatuses: [ProductImageStatus],
+         queue: DispatchQueue = .main,
+         stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.productOrVariationID = productID
         self.queue = queue

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
@@ -17,12 +17,12 @@ final class ProductImagesSaver {
     private var assetUploadSubscription: AnyCancellable?
 
     private let siteID: Int64
-    private let productID: Int64
+    private let productOrVariationID: ProductOrVariationID
     private let stores: StoresManager
 
-    init(siteID: Int64, productID: Int64, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64, productOrVariationID: ProductOrVariationID, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
-        self.productID = productID
+        self.productOrVariationID = productOrVariationID
         self.stores = stores
     }
 
@@ -58,21 +58,27 @@ private extension ProductImagesSaver {
     }
 
     func saveProductImages(_ images: [ProductImage], onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
-        let action = ProductAction.updateProductImages(siteID: siteID,
-                                                       productID: productID,
-                                                       images: images) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let product):
-                onProductSave(.success(product.images))
-            case .failure(let error):
-                onProductSave(.failure(error))
+        switch productOrVariationID {
+        case .product(let productID):
+            let action = ProductAction.updateProductImages(siteID: siteID,
+                                                           productID: productID,
+                                                           images: images) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let product):
+                    onProductSave(.success(product.images))
+                case .failure(let error):
+                    onProductSave(.failure(error))
+                }
+                self.imageStatusesToSave = []
+                self.assetUploadSubscription = nil
+                self.uploadStatusesSubscription = nil
             }
-            self.imageStatusesToSave = []
-            self.assetUploadSubscription = nil
-            self.uploadStatusesSubscription = nil
+            stores.dispatch(action)
+        case .variation(_, _):
+            // TODO: 7021 - update variation images action with a different endpoint
+            return
         }
-        stores.dispatch(action)
     }
 
     func observeAssetUploadsToUpdateImageStatuses(imageActionHandler: ProductImageActionHandler) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -33,10 +33,11 @@ private extension ProductDetailsFactory {
                                productImageUploader: ProductImageUploaderProtocol) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
-        let productImageActionHandler = productImageUploader.actionHandler(siteID: product.siteID,
-                                                                           productID: productModel.productID,
-                                                                           isLocalID: false,
-                                                                           originalStatuses: productModel.imageStatuses)
+        let productImageActionHandler = productImageUploader
+            .actionHandler(key: .init(siteID: product.siteID,
+                                      productOrVariationID: .product(id: productModel.productID),
+                                      isLocalID: false),
+                           originalStatuses: productModel.imageStatuses)
         let formType: ProductFormType = isEditProductsEnabled ? .edit: .readonly
         let viewModel = ProductFormViewModel(product: productModel,
                                              formType: formType,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -39,10 +39,11 @@ private extension ProductVariationDetailsFactory {
         let productVariationModel = EditableProductVariationModel(productVariation: productVariation,
                                                                   allAttributes: parentProduct.attributes,
                                                                   parentProductSKU: parentProduct.sku)
-        let productImageActionHandler = productImageUploader.actionHandler(siteID: productVariation.siteID,
-                                                                           productID: productVariationModel.productID,
-                                                                           isLocalID: !productVariationModel.existsRemotely,
-                                                                           originalStatuses: productVariationModel.imageStatuses)
+        let productImageActionHandler = productImageUploader
+            .actionHandler(key: .init(siteID: productVariation.siteID,
+                                      productOrVariationID: .variation(productID: productVariation.productID, variationID: productVariation.productVariationID),
+                                      isLocalID: !productVariationModel.existsRemotely),
+                           originalStatuses: productVariationModel.imageStatuses)
         let formType: ProductFormType = isEditProductsEnabled ? .edit: .readonly
         let viewModel = ProductVariationFormViewModel(productVariation: productVariationModel,
                                                       allAttributes: parentProduct.attributes,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -522,10 +522,11 @@ private extension ProductVariationsViewController {
 
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let productImageActionHandler = productImageUploader.actionHandler(key: .init(siteID: productVariation.siteID,
-                                                                                      productOrVariationID: .variation(productID: productVariation.productID, variationID: productVariation.productVariationID),
-                                                                                      isLocalID: !model.existsRemotely),
-                                                                           originalStatuses: model.imageStatuses)
+        let productImageActionHandler = productImageUploader
+            .actionHandler(key: .init(siteID: productVariation.siteID,
+                                      productOrVariationID: .variation(productID: productVariation.productID, variationID: productVariation.productVariationID),
+                                      isLocalID: !model.existsRemotely),
+                           originalStatuses: model.imageStatuses)
 
         let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                       allAttributes: allAttributes,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -522,9 +522,9 @@ private extension ProductVariationsViewController {
 
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let productImageActionHandler = productImageUploader.actionHandler(siteID: productVariation.siteID,
-                                                                           productID: model.productID,
-                                                                           isLocalID: !model.existsRemotely,
+        let productImageActionHandler = productImageUploader.actionHandler(key: .init(siteID: productVariation.siteID,
+                                                                                      productOrVariationID: .variation(productID: productVariation.productID, variationID: productVariation.productVariationID),
+                                                                                      isLocalID: !model.existsRemotely),
                                                                            originalStatuses: model.imageStatuses)
 
         let viewModel = ProductVariationFormViewModel(productVariation: model,

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -20,14 +20,12 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
         replaceLocalIDWasCalled = true
     }
 
-    func saveProductImagesWhenNoneIsPendingUploadAnymore(
-        key: ProductImageUploaderKey,
-        onProductSave: @escaping (Result<[Yosemite.ProductImage], Error>) -> Void
-    ) {
+    func saveProductImagesWhenNoneIsPendingUploadAnymore(key: ProductImageUploaderKey,
+                                                         onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
         saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = true
     }
 
-    func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> WooCommerce.ProductImageActionHandler {
+    func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
         ProductImageActionHandler(siteID: 0, productID: .product(id: 0), imageStatuses: [])
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -16,30 +16,30 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
         self.errors = errors
     }
 
-    func replaceLocalID(siteID: Int64, localProductID: Int64, remoteProductID: Int64) {
+    func replaceLocalID(siteID: Int64, localID: ProductOrVariationID, remoteID: Int64) {
         replaceLocalIDWasCalled = true
     }
 
-    func saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: Int64,
-                                                         productID: Int64,
-                                                         isLocalID: Bool,
-                                                         onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
+    func saveProductImagesWhenNoneIsPendingUploadAnymore(
+        key: ProductImageUploaderKey,
+        onProductSave: @escaping (Result<[Yosemite.ProductImage], Error>) -> Void
+    ) {
         saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = true
     }
 
-    func actionHandler(siteID: Int64, productID: Int64, isLocalID: Bool, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
-        ProductImageActionHandler(siteID: 0, productID: 0, imageStatuses: [])
+    func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> WooCommerce.ProductImageActionHandler {
+        ProductImageActionHandler(siteID: 0, productID: .product(id: 0), imageStatuses: [])
     }
 
-    func startEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func startEmittingErrors(key: ProductImageUploaderKey) {
         startEmittingErrorsWasCalled = true
     }
 
-    func stopEmittingErrors(siteID: Int64, productID: Int64, isLocalID: Bool) {
+    func stopEmittingErrors(key: ProductImageUploaderKey) {
         stopEmittingErrorsWasCalled = true
     }
 
-    func hasUnsavedChangesOnImages(siteID: Int64, productID: Int64, isLocalID: Bool, originalImages: [ProductImage]) -> Bool {
+    func hasUnsavedChangesOnImages(key: ProductImageUploaderKey, originalImages: [ProductImage]) -> Bool {
         false
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -287,7 +287,7 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // When
         statusUpdates.send(.init(siteID: 134,
-                                 productID: 606,
+                                 productOrVariationID: .product(id: 606),
                                  productImageStatuses: [],
                                  error: .failedUploadingImage(error: NSError(domain: "", code: 8))))
 
@@ -319,7 +319,7 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // When
         statusUpdates.send(.init(siteID: 134,
-                                 productID: 606,
+                                 productOrVariationID: .product(id: 606),
                                  productImageStatuses: [],
                                  error: .failedSavingProductAfterImageUpload(error: NSError(domain: "", code: 18))))
 
@@ -351,7 +351,10 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // When
         let error = NSError(domain: "", code: 8)
-        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: .failedUploadingImage(error: error)))
+        statusUpdates.send(.init(siteID: 134,
+                                 productOrVariationID: .product(id: 606),
+                                 productImageStatuses: [],
+                                 error: .failedUploadingImage(error: error)))
         let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
         notice.actionHandler?()
 
@@ -389,7 +392,10 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // When
         let error = NSError(domain: "", code: 8)
-        statusUpdates.send(.init(siteID: 134, productID: 606, productImageStatuses: [], error: .failedUploadingImage(error: error)))
+        statusUpdates.send(.init(siteID: 134,
+                                 productOrVariationID: .product(id: 606),
+                                 productImageStatuses: [],
+                                 error: .failedUploadingImage(error: error)))
 
         // Then
         XCTAssertEqual(noticePresenter.queuedNotices.count, 0)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
@@ -20,7 +20,7 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
 
     func test_triggering_viewDidLoad_invokes_stopEmittingErrors() throws {
         // Given
-        let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
+        let actionHandler = ProductImageActionHandler(siteID: 134, productID: .product(id: 256), imageStatuses: [])
         let productImageUploader = MockProductImageUploader()
 
         // When
@@ -41,7 +41,7 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
 
     func test_dismissing_product_form_invokes_startEmittingErrors() throws {
         // Given
-        let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
+        let actionHandler = ProductImageActionHandler(siteID: 134, productID: .product(id: 256), imageStatuses: [])
         let productImageUploader = MockProductImageUploader()
         let productForm = ProductFormViewController(viewModel:
                                                         ProductFormViewModel(product: .init(product: .fake()),
@@ -69,7 +69,7 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
 
     func test_popping_product_form_invokes_startEmittingErrors() throws {
         // Given
-        let actionHandler = ProductImageActionHandler(siteID: 134, productID: 256, imageStatuses: [])
+        let actionHandler = ProductImageActionHandler(siteID: 134, productID: .product(id: 256), imageStatuses: [])
         let productImageUploader = MockProductImageUploader()
         let productForm = ProductFormViewController(viewModel:
                                                         ProductFormViewModel(product: .init(product: .fake()),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -340,6 +340,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
 
 extension ProductImageActionHandler {
     convenience init(siteID: Int64, product: ProductFormDataModel) {
-        self.init(siteID: siteID, productID: product.productID, imageStatuses: product.imageStatuses)
+        self.init(siteID: siteID, productID: .product(id: product.productID), imageStatuses: product.imageStatuses)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -13,10 +13,16 @@ final class ProductImageUploaderTests: XCTestCase {
     func test_hasUnsavedChangesOnImages_becomes_false_after_uploading_and_saving() throws {
         // Given
         let imageUploader = ProductImageUploader()
-        let actionHandler = imageUploader.actionHandler(siteID: siteID, productID: productID, isLocalID: false, originalStatuses: [])
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: false),
+                                                        originalStatuses: [])
         let asset = PHAsset()
 
-        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(siteID: siteID, productID: productID, isLocalID: false, originalImages: []))
+        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                          productOrVariationID: .product(id: productID),
+                                                                          isLocalID: false),
+                                                               originalImages: []))
 
         // When
         actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: asset)
@@ -26,18 +32,29 @@ final class ProductImageUploaderTests: XCTestCase {
             }
         }
         XCTAssertTrue(statuses.productImageStatuses.hasPendingUpload)
-        XCTAssertTrue(imageUploader.hasUnsavedChangesOnImages(siteID: siteID, productID: productID, isLocalID: false, originalImages: []))
-        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: siteID, productID: productID, isLocalID: false) { _ in }
+        XCTAssertTrue(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                         productOrVariationID: .product(id: productID),
+                                                                         isLocalID: false),
+                                                              originalImages: []))
+        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: siteID,
+                                                                                 productOrVariationID: .product(id: productID),
+                                                                                 isLocalID: false)) { _ in }
 
         // Then
-        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(siteID: siteID, productID: productID, isLocalID: false, originalImages: []))
+        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                          productOrVariationID: .product(id: productID),
+                                                                          isLocalID: false),
+                                                               originalImages: []))
     }
 
     func test_hasUnsavedChangesOnImages_stays_false_after_uploading_and_saving_successfully() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID, productID: productID, isLocalID: false, originalStatuses: [])
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: false),
+                                                        originalStatuses: [])
         let asset = PHAsset()
 
         let uploadedMedia = Media.fake().copy(mediaID: 645)
@@ -52,7 +69,10 @@ final class ProductImageUploaderTests: XCTestCase {
             }
         }
 
-        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(siteID: siteID, productID: productID, isLocalID: false, originalImages: []))
+        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                          productOrVariationID: .product(id: productID),
+                                                                          isLocalID: false),
+                                                               originalImages: []))
 
         // When
         actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: asset)
@@ -62,17 +82,22 @@ final class ProductImageUploaderTests: XCTestCase {
             }
         }
         XCTAssertTrue(statuses.productImageStatuses.hasPendingUpload)
-        XCTAssertTrue(imageUploader.hasUnsavedChangesOnImages(siteID: siteID, productID: productID, isLocalID: false, originalImages: []))
+        XCTAssertTrue(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                         productOrVariationID: .product(id: productID),
+                                                                         isLocalID: false),
+                                                              originalImages: []))
         let resultOfSavedImages = waitFor { promise in
-            imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: self.siteID, productID: self.productID, isLocalID: false) { result in
+            imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: self.siteID,
+                                                                                     productOrVariationID: .product(id: self.productID),
+                                                                                     isLocalID: false)) { result in
                 promise(result)
             }
         }
 
         // Then
-        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(siteID: siteID,
-                                                               productID: productID,
-                                                               isLocalID: false,
+        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                          productOrVariationID: .product(id: productID),
+                                                                          isLocalID: false),
                                                                originalImages: [.fake().copy(imageID: 645)]))
         XCTAssertTrue(resultOfSavedImages.isSuccess)
         let images = try XCTUnwrap(resultOfSavedImages.get())
@@ -83,7 +108,10 @@ final class ProductImageUploaderTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID, productID: productID, isLocalID: false, originalStatuses: [])
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: false),
+                                                        originalStatuses: [])
         let asset = PHAsset()
 
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -92,7 +120,10 @@ final class ProductImageUploaderTests: XCTestCase {
             }
         }
 
-        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(siteID: siteID, productID: productID, isLocalID: false, originalImages: []))
+        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                          productOrVariationID: .product(id: productID),
+                                                                          isLocalID: false),
+                                                               originalImages: []))
 
         // When
         // Uploads an image and waits for the image upload completion closure to be called later.
@@ -105,10 +136,15 @@ final class ProductImageUploaderTests: XCTestCase {
             actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: asset)
         }
 
-        XCTAssertTrue(imageUploader.hasUnsavedChangesOnImages(siteID: siteID, productID: productID, isLocalID: false, originalImages: []))
+        XCTAssertTrue(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                         productOrVariationID: .product(id: productID),
+                                                                         isLocalID: false), originalImages: []))
 
         // The first save.
-        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: self.siteID, productID: self.productID, isLocalID: false) { result in
+        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key:
+                .init(siteID: self.siteID,
+                      productOrVariationID: .product(id: self.productID),
+                      isLocalID: false)) { result in
             XCTFail("The product save callback should not be triggered after another save request.")
         }
 
@@ -122,7 +158,10 @@ final class ProductImageUploaderTests: XCTestCase {
 
         let resultOfSavedImages: Result<[ProductImage], Error> = waitFor { promise in
             // The second save.
-            imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: self.siteID, productID: self.productID, isLocalID: false) { result in
+            imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key:
+                    .init(siteID: self.siteID,
+                          productOrVariationID: .product(id: self.productID),
+                          isLocalID: false)) { result in
                 promise(result)
             }
             // Triggers success from image upload.
@@ -130,9 +169,9 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // Then
-        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(siteID: siteID,
-                                                               productID: productID,
-                                                               isLocalID: false,
+        XCTAssertFalse(imageUploader.hasUnsavedChangesOnImages(key: .init(siteID: siteID,
+                                                                          productOrVariationID: .product(id: productID),
+                                                                          isLocalID: false),
                                                                originalImages: [.fake().copy(imageID: 606), .fake().copy(imageID: 645)]))
         XCTAssertTrue(resultOfSavedImages.isSuccess)
         let images = try XCTUnwrap(resultOfSavedImages.get())
@@ -147,28 +186,28 @@ final class ProductImageUploaderTests: XCTestCase {
         let originalStatuses: [ProductImageStatus] = [.remote(image: ProductImage.fake()),
                                                       .uploading(asset: PHAsset()),
                                                       .uploading(asset: PHAsset())]
-        _ = imageUploader.actionHandler(siteID: siteID,
-                                        productID: localProductID,
-                                        isLocalID: true,
+        _ = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                   productOrVariationID: .product(id: localProductID),
+                                                   isLocalID: true),
                                         originalStatuses: originalStatuses)
 
         // Before replacing product ID
 
         // Pass empty statuses to get the `actionHandler`, and validate that `actionHandler` with `originalStatuses` is returned.
-        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(siteID: siteID,
-                                                                     productID: localProductID,
-                                                                     isLocalID: true,
+        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                                productOrVariationID: .product(id: localProductID),
+                                                                                isLocalID: true),
                                                                      originalStatuses: []).productImageStatuses)
 
         // When
-        imageUploader.replaceLocalID(siteID: siteID, localProductID: localProductID, remoteProductID: remoteProductID)
+        imageUploader.replaceLocalID(siteID: siteID, localID: .product(id: localProductID), remoteID: remoteProductID)
 
         // After replacing local product ID with remote product ID
 
         // Pass empty statuses and `remoteProductID` to get the `actionHandler`, and validate that `actionHandler` with `originalStatuses` is returned.
-        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(siteID: siteID,
-                                                                     productID: remoteProductID,
-                                                                     isLocalID: false,
+        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                                productOrVariationID: .product(id: remoteProductID),
+                                                                                isLocalID: false),
                                                                      originalStatuses: []).productImageStatuses)
     }
 
@@ -181,19 +220,19 @@ final class ProductImageUploaderTests: XCTestCase {
         let originalStatuses: [ProductImageStatus] = [.remote(image: ProductImage.fake()),
                                                       .uploading(asset: PHAsset()),
                                                       .uploading(asset: PHAsset())]
-        _ = imageUploader.actionHandler(siteID: siteID,
-                                        productID: localProductID,
-                                        isLocalID: true,
+        _ = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                   productOrVariationID: .product(id: localProductID),
+                                                   isLocalID: true),
                                         originalStatuses: originalStatuses)
 
         // When
-        imageUploader.replaceLocalID(siteID: siteID, localProductID: nonExistentProductID, remoteProductID: remoteProductID)
+        imageUploader.replaceLocalID(siteID: siteID, localID: .product(id: nonExistentProductID), remoteID: remoteProductID)
 
         // Then
         // Ensure that trying to replace a non-existent product ID does nothing.
-        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(siteID: siteID,
-                                                                     productID: localProductID,
-                                                                     isLocalID: true,
+        XCTAssertEqual(originalStatuses, imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                                productOrVariationID: .product(id: localProductID),
+                                                                                isLocalID: true),
                                                                      originalStatuses: []).productImageStatuses)
     }
 
@@ -203,9 +242,9 @@ final class ProductImageUploaderTests: XCTestCase {
         let mockProductIDUpdater = MockProductImagesProductIDUpdater()
         let imageUploader = ProductImageUploader(stores: stores,
                                                  imagesProductIDUpdater: mockProductIDUpdater)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: productID,
-                                                        isLocalID: false,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: false),
                                                         originalStatuses: [])
 
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
@@ -229,9 +268,9 @@ final class ProductImageUploaderTests: XCTestCase {
             }
         }
 
-        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: siteID,
-                                                                      productID: productID,
-                                                                      isLocalID: false) { result in }
+        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: siteID,
+                                                                                 productOrVariationID: .product(id: productID),
+                                                                                 isLocalID: false)) { result in }
 
         // Then
         waitUntil {
@@ -245,9 +284,9 @@ final class ProductImageUploaderTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: productID,
-                                                        isLocalID: true,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: true),
                                                         originalStatuses: [])
         let error = NSError(domain: "", code: 6)
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
@@ -268,7 +307,7 @@ final class ProductImageUploaderTests: XCTestCase {
 
         // Then
         assertEqual([.init(siteID: siteID,
-                           productID: productID,
+                           productOrVariationID: .product(id: productID),
                            productImageStatuses: [],
                            error: ProductImageUploaderError.failedUploadingImage(error: error))],
                     errors)
@@ -278,7 +317,10 @@ final class ProductImageUploaderTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID, productID: productID, isLocalID: false, originalStatuses: [])
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: false),
+                                                        originalStatuses: [])
 
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
             if case let .uploadMedia(_, _, _, onCompletion) = action {
@@ -299,9 +341,9 @@ final class ProductImageUploaderTests: XCTestCase {
                 promise(())
             }
         }
-        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(siteID: siteID,
-                                                                      productID: productID,
-                                                                      isLocalID: false) { result in }
+        imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: siteID,
+                                                                                 productOrVariationID: .product(id: productID),
+                                                                                 isLocalID: false)) { result in }
         var errors: [ProductImageUploadErrorInfo] = []
         let _: Void = waitFor { promise in
             self.errorsSubscription = imageUploader.errors.sink { error in
@@ -312,7 +354,7 @@ final class ProductImageUploaderTests: XCTestCase {
 
         // Then
         assertEqual([.init(siteID: siteID,
-                           productID: productID,
+                           productOrVariationID: .product(id: productID),
                            productImageStatuses: [.uploading(asset: asset)],
                            error: .failedSavingProductAfterImageUpload(error: ProductUpdateError.unexpected))],
                     errors)
@@ -322,9 +364,9 @@ final class ProductImageUploaderTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: productID,
-                                                        isLocalID: true,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: true),
                                                         originalStatuses: [])
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
             if case let .uploadMedia(_, _, _, onCompletion) = action {
@@ -350,9 +392,9 @@ final class ProductImageUploaderTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: productID,
-                                                        isLocalID: true,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: true),
                                                         originalStatuses: [])
         let error = NSError(domain: "", code: 6)
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
@@ -362,7 +404,9 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // When
-        imageUploader.stopEmittingErrors(siteID: siteID, productID: 9999, isLocalID: true)
+        imageUploader.stopEmittingErrors(key: .init(siteID: siteID,
+                                                    productOrVariationID: .product(id: 9999),
+                                                    isLocalID: true))
 
         var errors: [ProductImageUploadErrorInfo] = []
         let _: Void = waitFor { promise in
@@ -374,16 +418,20 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // Then
-        assertEqual([.init(siteID: siteID, productID: productID, productImageStatuses: [], error: .failedUploadingImage(error: error))], errors)
+        assertEqual([.init(siteID: siteID,
+                           productOrVariationID: .product(id: productID),
+                           productImageStatuses: [],
+                           error: .failedUploadingImage(error: error))],
+                    errors)
     }
 
     func test_error_is_not_emitted_after_stopEmittingErrors_when_image_upload_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: productID,
-                                                        isLocalID: true,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: true),
                                                         originalStatuses: [])
         let error = NSError(domain: "", code: 6)
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
@@ -393,7 +441,9 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // When
-        imageUploader.stopEmittingErrors(siteID: siteID, productID: productID, isLocalID: true)
+        imageUploader.stopEmittingErrors(key: .init(siteID: siteID,
+                                                    productOrVariationID: .product(id: productID),
+                                                    isLocalID: true))
 
         var errors: [ProductImageUploadErrorInfo] = []
         errorsSubscription = imageUploader.errors.sink { error in
@@ -413,14 +463,18 @@ final class ProductImageUploaderTests: XCTestCase {
         let localProductID: Int64 = 0
         let nonExistentProductID: Int64 = 999
         let remoteProductID = productID
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: localProductID,
-                                                        isLocalID: true,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: localProductID),
+                                                                   isLocalID: true),
                                                         originalStatuses: [])
 
         // When
-        imageUploader.stopEmittingErrors(siteID: siteID, productID: localProductID, isLocalID: true)
-        imageUploader.replaceLocalID(siteID: siteID, localProductID: nonExistentProductID, remoteProductID: remoteProductID)
+        imageUploader.stopEmittingErrors(key: .init(siteID: siteID,
+                                                    productOrVariationID: .product(id: localProductID),
+                                                    isLocalID: true))
+        imageUploader.replaceLocalID(siteID: siteID,
+                                     localID: .product(id: nonExistentProductID),
+                                     remoteID: remoteProductID)
 
         var errors: [ProductImageUploadErrorInfo] = []
         _ = imageUploader.errors.sink { error in
@@ -444,9 +498,9 @@ final class ProductImageUploaderTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: productID,
-                                                        isLocalID: true,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: true),
                                                         originalStatuses: [])
         let error = NSError(domain: "", code: 6)
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
@@ -456,8 +510,12 @@ final class ProductImageUploaderTests: XCTestCase {
         }
 
         // When
-        imageUploader.stopEmittingErrors(siteID: siteID, productID: productID, isLocalID: true)
-        imageUploader.startEmittingErrors(siteID: siteID, productID: productID, isLocalID: true)
+        imageUploader.stopEmittingErrors(key: .init(siteID: siteID,
+                                                    productOrVariationID: .product(id: productID),
+                                                    isLocalID: true))
+        imageUploader.startEmittingErrors(key: .init(siteID: siteID,
+                                                     productOrVariationID: .product(id: productID),
+                                                     isLocalID: true))
 
         var errors: [ProductImageUploadErrorInfo] = []
         let _: Void = waitFor { promise in
@@ -470,7 +528,7 @@ final class ProductImageUploaderTests: XCTestCase {
 
         // Then
         assertEqual([.init(siteID: siteID,
-                           productID: productID,
+                           productOrVariationID: .product(id: productID),
                            productImageStatuses: [],
                            error: ProductImageUploaderError.failedUploadingImage(error: error))],
                     errors)
@@ -482,9 +540,9 @@ final class ProductImageUploaderTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
-        let actionHandler = imageUploader.actionHandler(siteID: siteID,
-                                                        productID: productID,
-                                                        isLocalID: true,
+        let actionHandler = imageUploader.actionHandler(key: .init(siteID: siteID,
+                                                                   productOrVariationID: .product(id: productID),
+                                                                   isLocalID: true),
                                                         originalStatuses: [])
         stores.whenReceivingAction(ofType: MediaAction.self) { action in
             if case let .uploadMedia(_, _, _, onCompletion) = action {
@@ -518,7 +576,7 @@ final class ProductImageUploaderTests: XCTestCase {
 extension ProductImageUploadErrorInfo: Equatable {
     public static func == (lhs: ProductImageUploadErrorInfo, rhs: ProductImageUploadErrorInfo) -> Bool {
         return lhs.siteID == rhs.siteID &&
-        lhs.productID == rhs.productID &&
+        lhs.productOrVariationID == rhs.productOrVariationID &&
         lhs.productImageStatuses == rhs.productImageStatuses &&
         lhs.error == rhs.error
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
@@ -11,9 +11,9 @@ final class ProductImagesSaverTests: XCTestCase {
     func test_image_status_with_upload_error_is_removed_from_imageStatusesToSave() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let actionHandler = ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: [], stores: stores)
+        let actionHandler = ProductImageActionHandler(siteID: siteID, productID: .product(id: productID), imageStatuses: [], stores: stores)
         let asset = PHAsset()
-        let imagesSaver = ProductImagesSaver(siteID: siteID, productID: productID, stores: stores)
+        let imagesSaver = ProductImagesSaver(siteID: siteID, productOrVariationID: .product(id: productID), stores: stores)
 
         // Uploads an image and waits for the image upload completion closure to be called later.
         let imageUploadCompletion: ((Result<Media, Error>) -> Void) = waitFor { promise in
@@ -41,9 +41,9 @@ final class ProductImagesSaverTests: XCTestCase {
     func test_imageStatusesToSave_stays_empty_after_saving_product_successfully() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let actionHandler = ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: [], stores: stores)
+        let actionHandler = ProductImageActionHandler(siteID: siteID, productID: .product(id: productID), imageStatuses: [], stores: stores)
         let asset = PHAsset()
-        let imagesSaver = ProductImagesSaver(siteID: siteID, productID: productID, stores: stores)
+        let imagesSaver = ProductImagesSaver(siteID: siteID, productOrVariationID: .product(id: productID), stores: stores)
 
         // Mocks successful product images update.
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -97,9 +97,9 @@ final class ProductImagesSaverTests: XCTestCase {
     func test_imageStatusesToSave_stays_empty_after_saving_product_fails() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let actionHandler = ProductImageActionHandler(siteID: siteID, productID: productID, imageStatuses: [], stores: stores)
+        let actionHandler = ProductImageActionHandler(siteID: siteID, productID: .product(id: productID), imageStatuses: [], stores: stores)
         let asset = PHAsset()
-        let imagesSaver = ProductImagesSaver(siteID: siteID, productID: productID, stores: stores)
+        let imagesSaver = ProductImagesSaver(siteID: siteID, productOrVariationID: .product(id: productID), stores: stores)
 
         // Mocks product images update failure.
         stores.whenReceivingAction(ofType: ProductAction.self) { action in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of variation support in #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In order to support background image upload for product variations, the product ID in the existing product image upload interface isn't sufficient to identify a variation. A product variation has two IDs, its parent product ID and variation ID. Also, the endpoint for saving a variation with the uploaded image is different from that for a product.

This PR only focused on updating the interface with the intention of not affecting existing functionality for product image upload. Background image upload already doesn't work for variations, and the support for variations will be in follow-up PR(s). I apologize that I didn't wrap the various identifying properties of a product into a struct earlier, and thus the 500+ diffs in this PR 🙇🏻‍♀️

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please do a confidence test on background image upload for product creation and editing:

#### Product creation

- Launch the app
- Navigate to the Products tab and tap on + button on top right to create a product
- In the product creation form, enter a product title and add one or more images
- Tap "Publish" to save the product remotely
- Leave the product form quickly before the image(s) is uploaded --> after a bit, make sure the image(s) is uploaded and attached to the new product. On web `wp-admin/upload.php`, make sure the image(s) are associated with the new product

#### Product editing

- Launch the app
- Navigate to the Products tab and tap on an editable product
- In the product creation form, update the product title and add one or more images
- Tap "Save" to save the product remotely
- Leave the product form quickly before the image(s) is uploaded --> after a bit, make sure the image(s) is uploaded and attached to the product. On web `wp-admin/upload.php`, make sure the image(s) are associated with the product


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
