### PR TITLE
Yosemite and Networking support for updating a product variation's image

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -17,6 +17,11 @@ public protocol ProductVariationsRemoteProtocol {
                                 newVariation: CreateProductVariation,
                                 completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void)
+    func updateProductVariationImage(siteID: Int64,
+                                     productID: Int64,
+                                     variationID: Int64,
+                                     image: ProductImage,
+                                     completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func updateProductVariations(siteID: Int64,
                                  productID: Int64,
                                  productVariations: [ProductVariation],
@@ -118,6 +123,31 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         }
     }
 
+    /// Updates the image of a specific `ProductVariation`.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site which will hosts the ProductVariation.
+    ///   - productID: Identifier of the Product.
+    ///   - variationID: Identifier of the ProductVariation.
+    ///   - image: Image to be set to the ProductVariation.
+    ///   - completion: Closure to be executed upon completion.
+    public func updateProductVariationImage(siteID: Int64,
+                                            productID: Int64,
+                                            variationID: Int64,
+                                            image: ProductImage,
+                                            completion: @escaping (Result<ProductVariation, Error>) -> Void) {
+        do {
+            let parameters = try ([ParameterKey.image: image]).toDictionary()
+            let path = "\(Path.products)/\(productID)/variations/\(variationID)"
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let mapper = ProductVariationMapper(siteID: siteID, productID: productID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
     /// Updates the provided `ProductVariations`.
     ///
     /// - Parameters:
@@ -178,5 +208,6 @@ public extension ProductVariationsRemote {
         static let page: String       = "page"
         static let perPage: String    = "per_page"
         static let contextKey: String = "context"
+        static let image: String = "image"
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -276,6 +276,50 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(result).isFailure)
     }
 
+    /// Verifies that `updateProductVariationImage` properly parses the `product-variation-update` sample response.
+    ///
+    func test_updateProductVariationImage_properly_returns_parsed_product() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let sampleProductVariationID: Int64 = 2783
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations/\(sampleProductVariationID)", filename: "product-variation-update")
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductVariationImage(siteID: self.sampleSiteID,
+                                               productID: self.sampleProductID,
+                                               variationID: sampleProductVariationID,
+                                               image: .fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let productVariation = try XCTUnwrap(result.get())
+        XCTAssertEqual(productVariation.image?.imageID, 2432)
+    }
+
+    /// Verifies that `updateProductVariationImage` properly relays Networking Layer errors.
+    ///
+    func test_updateProductVariationImage_properly_relays_networking_error() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let sampleProductVariationID: Int64 = 2783
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductVariationImage(siteID: self.sampleSiteID,
+                                               productID: self.sampleProductID,
+                                               variationID: sampleProductVariationID,
+                                               image: .fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     // MARK: - Delete ProductVariation
 
     /// Verifies that deleteProductVariation properly parses the `product-variation` sample response.

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -25,6 +25,13 @@ public enum ProductVariationAction: Action {
     ///
     case updateProductVariation(productVariation: ProductVariation, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)
 
+    /// Updates the image of the specified ProductVariation.
+    case updateProductVariationImage(siteID: Int64,
+                                     productID: Int64,
+                                     variationID: Int64,
+                                     image: ProductImage,
+                                     completion: (Result<ProductVariation, ProductUpdateError>) -> Void)
+
     /// Updates the provided ProductVariations.
     ///
     case updateProductVariations(siteID: Int64,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -144,7 +144,11 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
         }
     }
 
-    func updateProductVariationImage(siteID: Int64, productID: Int64, variationID: Int64, image: ProductImage, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
+    func updateProductVariationImage(siteID: Int64,
+                                     productID: Int64,
+                                     variationID: Int64,
+                                     image: ProductImage,
+                                     completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {
                 return

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -19,6 +19,9 @@ final class MockProductVariationsRemote {
     /// The results to return based on the given arguments in `updateProductVariation`
     private var productVariationUpdateResults = [ResultKey: Result<ProductVariation, Error>]()
 
+    /// The results to return based on the given arguments in `updateProductVariationImage`
+    private var productVariationImageUpdateResults = [ResultKey: Result<ProductVariation, Error>]()
+
     /// The results to return based on the given arguments in `updateProductVariations`
     private var productVariationsUpdateResults = [ResultKey: Result<[ProductVariation], Error>]()
 
@@ -44,6 +47,13 @@ final class MockProductVariationsRemote {
     func whenUpdatingProductVariation(siteID: Int64, productID: Int64, productVariationID: Int64, thenReturn result: Result<ProductVariation, Error>) {
         let key = ResultKey(siteID: siteID, productID: productID, productVariationIDs: [productVariationID])
         productVariationUpdateResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `updateProductVariationImage()` is called.
+    ///
+    func whenUpdatingProductVariationImage(siteID: Int64, productID: Int64, productVariationID: Int64, thenReturn result: Result<ProductVariation, Error>) {
+        let key = ResultKey(siteID: siteID, productID: productID, productVariationIDs: [productVariationID])
+        productVariationImageUpdateResults[key] = result
     }
 
     /// Set the value passed to the `completion` block if `updateProductVariations()` is called.
@@ -127,6 +137,23 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
                                 productID: productVariation.productID,
                                 productVariationIDs: [productVariation.productVariationID])
             if let result = self.productVariationUpdateResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func updateProductVariationImage(siteID: Int64, productID: Int64, variationID: Int64, image: ProductImage, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let key = ResultKey(siteID: siteID,
+                                productID: productID,
+                                productVariationIDs: [variationID])
+            if let result = self.productVariationImageUpdateResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -559,6 +559,85 @@ final class ProductVariationStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
     }
 
+    // MARK: - ProductVariationAction.updateProductVariationImage
+
+    /// Verifies that `ProductVariationAction.updateProductVariationImage` effectively persists the returned product variation.
+    ///
+    func test_updateProductVariationImage_with_success_persists_returned_variation() throws {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let productVariationID: Int64 = 17
+        let expectedProductVariation = ProductVariation.fake().copy(siteID: sampleSiteID,
+                                                                    productID: sampleProductID,
+                                                                    productVariationID: productVariationID,
+                                                                    image: ProductImage.fake(),
+                                                                    // `stockQuantity` is set to non-nil in storage.
+                                                                    stockQuantity: 0)
+        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID,
+                                                            productID: sampleProductID,
+                                                            productVariationID: productVariationID)
+        remote.whenUpdatingProductVariationImage(siteID: sampleSiteID,
+                                                 productID: sampleProductID,
+                                                 productVariationID: productVariationID,
+                                                 thenReturn: .success(expectedProductVariation))
+
+        // Saves an existing ProductVariation into storage.
+        // Note: at least one field of `ProductVariation` before and after the update should be different.
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 1)
+
+        // When
+        let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
+            let action = ProductVariationAction.updateProductVariationImage(siteID: self.sampleSiteID,
+                                                                            productID: self.sampleProductID,
+                                                                            variationID: productVariationID,
+                                                                            image: .fake()) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let updatedProductVariation = try XCTUnwrap(result.get())
+        assertEqual(expectedProductVariation, updatedProductVariation)
+
+        let storedProductVariation = viewStorage.loadProductVariation(siteID: sampleSiteID, productVariationID: productVariationID)
+        assertEqual(expectedProductVariation, storedProductVariation?.toReadOnly())
+    }
+
+    func test_updateProductImages_with_failure_returns_error() {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let productVariationID: Int64 = 17
+        let networkError = NSError(domain: "", code: 400, userInfo: nil)
+        remote.whenUpdatingProductVariationImage(siteID: sampleSiteID,
+                                                 productID: sampleProductID,
+                                                 productVariationID: productVariationID,
+                                                 thenReturn: .failure(networkError))
+        // Saves an existing ProductVariation into storage.
+        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID, productID: sampleProductID, productVariationID: productVariationID)
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 1)
+
+        // When
+        let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
+            let action = ProductVariationAction.updateProductVariationImage(siteID: self.sampleSiteID,
+                                                                            productID: self.sampleProductID,
+                                                                            variationID: productVariationID,
+                                                                            image: .fake()) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure, .init(error: networkError))
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 1)
+    }
+
     // MARK: `requestMissingVariations`
 
     func test_requestMissingVariations_only_completes_when_all_missing_variations_are_returned() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

- [x] ⚠️ Make sure https://github.com/woocommerce/woocommerce-ios/pull/7179 is merged before merging this PR ⚠️ 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To support background image upload for product variations, we need to use a different endpoint from the one for products. This PR just implemented the Yosemite and Networking changes for this new endpoint `products/\(productID)/variations/\(variationID)` with a parameter `image: \(image)`. The use of this new endpoint will be in a followup PR to integrate with this PR and its base https://github.com/woocommerce/woocommerce-ios/pull/7179.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The new action isn't used yet, just CI passing is sufficient!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
