### PR TITLE
Improve AddEditCouponViewModelTests with amount validation scenarios

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -163,9 +163,13 @@ final class AddEditCouponViewModel: ObservableObject {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let currencySettings: CurrencySettings
-    private let couponAmountInputFormatter: CouponAmountInputFormatter
     private let inputWarningDurationInSeconds: Double
     let timezone: TimeZone
+
+    /// Sets the amount of time that an invalid amount percent input must stay
+    /// visible to the user before adjusting the value.
+    ///
+    private let couponAmountInputFormatter: CouponAmountInputFormatter
 
     /// When an invalid percentage amount is set a debouncing warning timer is triggered.
     ///

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -164,6 +164,7 @@ final class AddEditCouponViewModel: ObservableObject {
     private let storageManager: StorageManagerType
     private let currencySettings: CurrencySettings
     private let couponAmountInputFormatter: CouponAmountInputFormatter
+    private let inputWarningDurationInSeconds: Double
     let timezone: TimeZone
 
     /// When an invalid percentage amount is set a debouncing warning timer is triggered.
@@ -206,6 +207,7 @@ final class AddEditCouponViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          couponAmountInputFormatter: CouponAmountInputFormatter = CouponAmountInputFormatter(),
+         inputWarningDurationInSeconds: Double = 3,
          timezone: TimeZone = .siteTimezone,
          onSuccess: @escaping (Coupon) -> Void) {
         self.siteID = siteID
@@ -215,6 +217,7 @@ final class AddEditCouponViewModel: ObservableObject {
         self.storageManager = storageManager
         self.currencySettings = currencySettings
         self.couponAmountInputFormatter = couponAmountInputFormatter
+        self.inputWarningDurationInSeconds = inputWarningDurationInSeconds
         self.timezone = timezone
         self.onSuccess = onSuccess
 
@@ -240,6 +243,7 @@ final class AddEditCouponViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          couponAmountInputFormatter: CouponAmountInputFormatter = CouponAmountInputFormatter(),
+         inputWarningDurationInSeconds: Double = 3,
          timezone: TimeZone = .siteTimezone,
          onSuccess: @escaping (Coupon) -> Void) {
         siteID = existingCoupon.siteID
@@ -250,6 +254,7 @@ final class AddEditCouponViewModel: ObservableObject {
         self.storageManager = storageManager
         self.currencySettings = currencySettings
         self.couponAmountInputFormatter = couponAmountInputFormatter
+        self.inputWarningDurationInSeconds = inputWarningDurationInSeconds
         self.timezone = timezone
         self.onSuccess = onSuccess
 
@@ -329,12 +334,14 @@ final class AddEditCouponViewModel: ObservableObject {
 
     private func debounceWarningState() {
         isDisplayingAmountWarning = true
-        amountWarningTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { [weak self] timer in
-            timer.invalidate()
-            self?.amountWarningTimer = nil
-            self?.isDisplayingAmountWarning = false
-            self?.amountField = "100"
-        }
+        amountWarningTimer = Timer.scheduledTimer(
+            withTimeInterval: inputWarningDurationInSeconds,
+            repeats: false) { [weak self] timer in
+                timer.invalidate()
+                self?.amountWarningTimer = nil
+                self?.isDisplayingAmountWarning = false
+                self?.amountField = "100"
+            }
     }
 
     func completeCouponAddEdit(coupon: Coupon, onUpdateFinished: @escaping () -> Void) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -282,7 +282,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "20000", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
-                inputWarningDurationInSeconds: 0.1,
+                inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
         XCTAssertFalse(viewModel.isDisplayingAmountWarning)
@@ -294,7 +294,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isDisplayingAmountWarning)
 
         waitFor { promise in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
                 promise(())
             }
         }
@@ -307,7 +307,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "invalid", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
-                inputWarningDurationInSeconds: 0.1,
+                inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
 
@@ -324,7 +324,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
-                inputWarningDurationInSeconds: 0.1,
+                inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
 
@@ -340,7 +340,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
-                inputWarningDurationInSeconds: 0.1,
+                inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
 
@@ -357,7 +357,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "invalid", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
-                inputWarningDurationInSeconds: 0.1,
+                inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
 
@@ -373,7 +373,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .fixedCart)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
-                inputWarningDurationInSeconds: 0.1,
+                inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
 
@@ -390,7 +390,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "100", discountType: .fixedCart)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
-                inputWarningDurationInSeconds: 0.1,
+                inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -336,7 +336,20 @@ final class AddEditCouponViewModelTests: XCTestCase {
     }
     
     func test_validatePercentageAmountInput_returns_error_when_set_for_no_warning() {
-        
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .percent)
+        let viewModel = AddEditCouponViewModel(
+                existingCoupon: coupon,
+                inputWarningDurationInSeconds: 0.1,
+                onSuccess: { _ in }
+        )
+
+        // When
+        let error = viewModel.validatePercentageAmountInput(withWarning: false)
+
+        // Then
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error, .couponPercentAmountInvalid)
     }
     
     func test_validatePercentageAmountInput_correctly_updates_the_amount() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -276,6 +276,30 @@ final class AddEditCouponViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.hasChangesMade)
     }
+    
+    func test_validatePercentageAmountInput_correctly_control_warning_visibility() {
+        
+    }
+    
+    func test_validatePercentageAmountInput_returns_error_for_invalid_amount() {
+        
+    }
+    
+    func test_validatePercentageAmountInput_returns_error_when_set_for_no_warning() {
+        
+    }
+    
+    func test_validatePercentageAmountInput_correctly_updates_the_amount() {
+        
+    }
+    
+    func test_validatePercentageAmountInput_ignores_validation_when_discountType_is_not_percent() {
+        
+    }
+    
+    func test_validatePercentageAmountInput_returns_nil_if_amount_is_valid() {
+        
+    }
 
     func test_discount_type_changed_to_percent_triggers_amount_adjustment() {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -351,9 +351,21 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertNotNil(error)
         XCTAssertEqual(error, .couponPercentAmountInvalid)
     }
-    
-    func test_validatePercentageAmountInput_correctly_updates_the_amount() {
-        
+
+    func test_validatePercentageAmountInput_with_no_warning_defaults_amount_to_zero() {
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(amount: "invalid", discountType: .percent)
+        let viewModel = AddEditCouponViewModel(
+                existingCoupon: coupon,
+                inputWarningDurationInSeconds: 0.1,
+                onSuccess: { _ in }
+        )
+
+        // When
+        let error = viewModel.validatePercentageAmountInput(withWarning: false)
+
+        // Then
+        XCTAssertEqual(viewModel.amountField, "0")
     }
     
     func test_validatePercentageAmountInput_ignores_validation_when_discountType_is_not_percent() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -276,7 +276,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.hasChangesMade)
     }
-    
+
     func test_validatePercentageAmountInput_correctly_control_warning_visibility() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "20000", discountType: .percent)
@@ -301,7 +301,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
         XCTAssertFalse(viewModel.isDisplayingAmountWarning)
     }
-    
+
     func test_validatePercentageAmountInput_returns_error_for_invalid_amount() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "invalid", discountType: .percent)
@@ -334,7 +334,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         // Then
         XCTAssertNil(error)
     }
-    
+
     func test_validatePercentageAmountInput_returns_error_when_set_for_no_warning() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .percent)
@@ -362,12 +362,12 @@ final class AddEditCouponViewModelTests: XCTestCase {
         )
 
         // When
-        let error = viewModel.validatePercentageAmountInput(withWarning: false)
+        viewModel.validatePercentageAmountInput(withWarning: false)
 
         // Then
         XCTAssertEqual(viewModel.amountField, "0")
     }
-    
+
     func test_validatePercentageAmountInput_ignores_validation_when_discountType_is_not_percent() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .fixedCart)
@@ -384,7 +384,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertNil(error)
         XCTAssertEqual(viewModel.amountField, "200")
     }
-    
+
     func test_validatePercentageAmountInput_returns_nil_if_amount_is_valid() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "100", discountType: .fixedCart)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -303,7 +303,20 @@ final class AddEditCouponViewModelTests: XCTestCase {
     }
     
     func test_validatePercentageAmountInput_returns_error_for_invalid_amount() {
-        
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(amount: "invalid", discountType: .percent)
+        let viewModel = AddEditCouponViewModel(
+                existingCoupon: coupon,
+                inputWarningDurationInSeconds: 0.1,
+                onSuccess: { _ in }
+        )
+
+        // When
+        let error = viewModel.validatePercentageAmountInput(withWarning: true)
+
+        // Then
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error, .couponPercentAmountInvalid)
     }
     
     func test_validatePercentageAmountInput_returns_error_when_set_for_no_warning() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -280,13 +280,17 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_discount_type_changed_to_percent_triggers_amount_adjustment() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "20000")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(
+            existingCoupon: coupon,
+            inputWarningDurationInSeconds: 0.01,
+            onSuccess: { _ in }
+        )
 
         // When
         viewModel.discountType = .percent
 
         waitFor { promise in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
                 promise(())
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -369,7 +369,20 @@ final class AddEditCouponViewModelTests: XCTestCase {
     }
     
     func test_validatePercentageAmountInput_ignores_validation_when_discountType_is_not_percent() {
-        
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .fixedCart)
+        let viewModel = AddEditCouponViewModel(
+                existingCoupon: coupon,
+                inputWarningDurationInSeconds: 0.1,
+                onSuccess: { _ in }
+        )
+
+        // When
+        let error = viewModel.validatePercentageAmountInput(withWarning: false)
+
+        // Then
+        XCTAssertNil(error)
+        XCTAssertEqual(viewModel.amountField, "200")
     }
     
     func test_validatePercentageAmountInput_returns_nil_if_amount_is_valid() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -386,7 +386,20 @@ final class AddEditCouponViewModelTests: XCTestCase {
     }
     
     func test_validatePercentageAmountInput_returns_nil_if_amount_is_valid() {
-        
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(amount: "100", discountType: .fixedCart)
+        let viewModel = AddEditCouponViewModel(
+                existingCoupon: coupon,
+                inputWarningDurationInSeconds: 0.1,
+                onSuccess: { _ in }
+        )
+
+        // When
+        let error = viewModel.validatePercentageAmountInput(withWarning: false)
+
+        // Then
+        XCTAssertNil(error)
+        XCTAssertEqual(viewModel.amountField, "100")
     }
 
     func test_discount_type_changed_to_percent_triggers_amount_adjustment() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -278,7 +278,28 @@ final class AddEditCouponViewModelTests: XCTestCase {
     }
     
     func test_validatePercentageAmountInput_correctly_control_warning_visibility() {
-        
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(amount: "20000", discountType: .percent)
+        let viewModel = AddEditCouponViewModel(
+                existingCoupon: coupon,
+                inputWarningDurationInSeconds: 0.1,
+                onSuccess: { _ in }
+        )
+        XCTAssertFalse(viewModel.isDisplayingAmountWarning)
+
+        // When
+        viewModel.validatePercentageAmountInput(withWarning: true)
+
+        // Then
+        XCTAssertTrue(viewModel.isDisplayingAmountWarning)
+
+        waitFor { promise in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                promise(())
+            }
+        }
+
+        XCTAssertFalse(viewModel.isDisplayingAmountWarning)
     }
     
     func test_validatePercentageAmountInput_returns_error_for_invalid_amount() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -420,6 +420,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
             }
         }
 
+        // Then
         XCTAssertEqual(viewModel.amountField, "100")
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -318,6 +318,22 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertNotNil(error)
         XCTAssertEqual(error, .couponPercentAmountInvalid)
     }
+
+    func test_validatePercentAmountInput_returns_nil_when_set_for_warning_correction() {
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .percent)
+        let viewModel = AddEditCouponViewModel(
+                existingCoupon: coupon,
+                inputWarningDurationInSeconds: 0.1,
+                onSuccess: { _ in }
+        )
+
+        // When
+        let error = viewModel.validatePercentageAmountInput(withWarning: true)
+
+        // Then
+        XCTAssertNil(error)
+    }
     
     func test_validatePercentageAmountInput_returns_error_when_set_for_no_warning() {
         


### PR DESCRIPTION
Summary
==========
Improve test coverage over the introduced changes to the AddEditCouponViewModel in #6837 by adding unit tests for missing coupon amount validation scenarios, but also improve testability by making the warning debounce time an externally injected value, allowing much faster unit tests.

How to Test
==========
Simply play with the AddEditCouponViewModel `validatePercentageAmountInput` function scenarios and see if the unit tests catch any breaking changes, also verify if the new tests make sense or if there are more scenarios that could be added.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.