### PR TITLE
Add new feature flag for IPP reader manuals consolidation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -41,6 +41,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backgroundProductImageUpload:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .consolidatedCardReaderManuals:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .appleIDAccountDeletion:
             return true
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -82,6 +82,10 @@ public enum FeatureFlag: Int {
     ///
     case backgroundProductImageUpload
 
+    /// Enable IPP reader manuals consolidation screen
+    ///
+    case consolidatedCardReaderManuals
+
     /// Apple ID account deletion
     ///
     case appleIDAccountDeletion


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7183 

### Description
Adds a new feature flag so that we can hide the work in progress for the new reader manual consolidation views behind it.
Ref: p91TBi-7SX-p2

### Testing instructions
Nothing yet!

### Screenshots
None either!

