### PR TITLE
[Mobile Payments] Payment Gateway Selection Screen. Design Review.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -52,6 +52,7 @@ struct InPersonPaymentsSelectPluginView: View {
                     .font(.largeTitle.bold())
                     .fixedSize(horizontal: false, vertical: true)
                 Text(Localization.prompt)
+                    .fixedSize(horizontal: false, vertical: true)
                     .bodyStyle()
 
                 VStack(alignment: .leading, spacing: 16) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -54,14 +54,16 @@ struct InPersonPaymentsSelectPluginView: View {
                 Text(Localization.prompt)
                     .bodyStyle()
 
-                InPersonPaymentsSelectPluginRow(icon: .wcpayIcon, name: "WooCommerce Payments", selected: selectedPlugin == .wcPay)
-                    .onTapGesture {
-                        selectedPlugin = .wcPay
-                    }
-                InPersonPaymentsSelectPluginRow(icon: .stripeIcon, name: "Stripe", selected: selectedPlugin == .stripe)
-                    .onTapGesture {
-                        selectedPlugin = .stripe
-                    }
+                VStack(alignment: .leading, spacing: 16) {
+                    InPersonPaymentsSelectPluginRow(icon: .wcpayIcon, name: "WooCommerce Payments", selected: selectedPlugin == .wcPay)
+                        .onTapGesture {
+                            selectedPlugin = .wcPay
+                        }
+                    InPersonPaymentsSelectPluginRow(icon: .stripeIcon, name: "Stripe", selected: selectedPlugin == .stripe)
+                        .onTapGesture {
+                            selectedPlugin = .stripe
+                        }
+                }
             }
 
             Spacer()
@@ -70,7 +72,7 @@ struct InPersonPaymentsSelectPluginView: View {
             .disabled(selectedPlugin == nil)
             .buttonStyle(PrimaryButtonStyle())
         }
-        .padding(.top, 64)
+        .padding(.top, 32)
         .padding(.horizontal, 16)
         .padding(.bottom, 24)
         .background(Color(.tertiarySystemBackground).ignoresSafeArea())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: ##7100
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add some minor space changes so the view complies with the design:

- Changed top padding from 64 to 32
- Added  the `InPersonPaymentsSelectPluginRow` into a `VStack` so the spacing between them (16) can be different than the original one (32)

The rest of the values stays the same.

@joe-keenan  Unfortunately, I didn't find an easy-clean way to hide the tabs as suggested here https://github.com/woocommerce/woocommerce-ios/issues/7100 Since `InPersonPaymentsSelectPluginView` is embedded into `InPersonPaymentsView` which shows a view depending on the onboarding status, it cannot be pushed as we did for “Manage Card Reader". We could hide the tabs for the whole flow, but since the IPP Settings Menu is part of that view as well, it would hide the tabs for that screen which might not be appropriate. @joshheald maybe you have a good idea for addressing this smoothly. Otherwise, I will create a new issue and tackle that in a future iteration.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Prerequisites
Have WCPay and Stripe active and enabled in the same US Store.

You can see the screen by going to Menu, tapping on the settings icon, and then In-Person Payments.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/1864060/176894547-5f76c334-00e0-424e-8384-4220e015de89.png" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
