### PR TITLE
[Mobile Payments] Remove unused property in PaymentMethodsViewModel

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -76,16 +76,6 @@ final class PaymentMethodsViewModel: ObservableObject {
     ///
     private let flow: WooAnalyticsEvent.PaymentsFlow.Flow
 
-    /// Stored payment gateways accounts.
-    /// We will care about the first one because only one is supported right now.
-    ///
-    private lazy var gatewayAccountResultsController: ResultsController<StoragePaymentGatewayAccount> = {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
-        let controller = ResultsController<StoragePaymentGatewayAccount>(storageManager: storage, matching: predicate, sortedBy: [])
-        try? controller.performFetch()
-        return controller
-    }()
-
     /// Stored orders.
     /// We need to fetch this from our storage layer because we are only provide IDs as dependencies
     /// To keep previews/UIs decoupled from our business logic.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: N/A
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a leftover from https://github.com/woocommerce/woocommerce-ios/pull/7130, we do not need `gatewayAccountResultsController` because we are retrieving the gateway account from the store anyways.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
You can double-check that everything works fine without this property by creating a test payment. 

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
