### PR TITLE
[Order Creation] Add unit test coverage for view models in the Customer section

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
@@ -24,6 +24,19 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         subscriptions.removeAll()
     }
 
+    func test_view_model_inits_with_expected_values() {
+        // Given
+        let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,
+                                                        addressData: .init(billingAddress: nil, shippingAddress: nil),
+                                                        onAddressUpdate: nil)
+
+        // Then
+        XCTAssertTrue(viewModel.showEmailField)
+        XCTAssertFalse(viewModel.showAlternativeUsageToggle)
+        XCTAssertNil(viewModel.alternativeUsageToggleTitle)
+        XCTAssertTrue(viewModel.showDifferentAddressToggle)
+    }
+
     func test_input_of_identical_addresses_disables_different_address_toggle() {
         // Given
         let viewModel = CreateOrderAddressFormViewModel(siteID: sampleSiteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -936,6 +936,24 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(hasDifferentShippingDetailsProperty)
     }
 
+    func test_customer_details_tracked_when_only_billing_address_added() throws {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.addressFormViewModel.fields.address1 = sampleAddress1().address1
+        viewModel.addressFormViewModel.saveAddress(onFinish: { _ in })
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderCustomerAdd.rawValue])
+
+        let flowProperty = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
+        let hasDifferentShippingDetailsProperty = try XCTUnwrap(analytics.receivedProperties.first?["has_different_shipping_details"] as? Bool)
+        XCTAssertEqual(flowProperty, "creation")
+        XCTAssertFalse(hasDifferentShippingDetailsProperty)
+    }
+
     func test_customer_details_not_tracked_when_removed() {
         // Given
         let analytics = MockAnalyticsProvider()


### PR DESCRIPTION
Closes: #6510

## Description

This PR adds unit tests to fill in gaps in unit test coverage for view models in the Customer section of order creation/editing.

## Changes

* Adds a unit test for `EditableOrderViewModel` to confirm that `trackCustomerDetailsAdded` correctly tracks customer details when only a billing address is entered (especially that it provides the correct value for the property `has_different_shipping_details`).
* Adds a unit test for `CreateOrderAddressFormViewModel`, to confirm the view model properties have the expected values when it is initialized. (It doesn't check properties that only return localized strings, since those are low risk and not used for logic.)

## Testing

Confirm unit tests pass.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
