### PR TITLE
Remove unnecessary method and calls

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -626,7 +626,6 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        insertSamplePaymentGateway(siteID: order.siteID)
 
         // When
         let chargeFetched: Bool = waitFor { promise in
@@ -655,7 +654,6 @@ final class IssueRefundViewModelTests: XCTestCase {
         ]
         let order = MockOrders().makeOrder(items: items).copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        insertSamplePaymentGateway(siteID: order.siteID)
         stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
             if case let .fetchWCPayCharge(siteID: _, chargeID: _, onCompletion: onCompletion) = action {
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
@@ -678,7 +676,6 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
@@ -691,7 +688,6 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: nil)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
@@ -704,7 +700,6 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
@@ -717,7 +712,6 @@ final class IssueRefundViewModelTests: XCTestCase {
         // The order has a chargeID
         let order = MockOrders().sampleOrder().copy(chargeID: "ch_id")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        insertSamplePaymentGateway(siteID: order.siteID)
 
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: CurrencySettings(), stores: stores, storage: storageManager)
 
@@ -727,26 +721,6 @@ final class IssueRefundViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonAnimating)
-    }
-}
-
-private extension IssueRefundViewModelTests {
-    func insertSamplePaymentGateway(siteID: Int64) {
-        let paymentGatewayAccount = PaymentGatewayAccount
-            .fake()
-            .copy(
-                siteID: siteID,
-                gatewayID: "woocommerce-payments",
-                status: "complete",
-                hasPendingRequirements: false,
-                hasOverdueRequirements: false,
-                isCardPresentEligible: true,
-                isLive: true,
-                isInTestMode: false
-            )
-        storageManager.reset()
-        let newAccount = storageManager.viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
-        newAccount.update(with: paymentGatewayAccount)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7099
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After reviewing the code that reads `PaymentGatewayAccount` directly, I found this helper method with its calls in `IssueRefundViewModelTests`. It actually does nothing because `IssueRefundViewModel` doesn't read `PaymentGatewayAccount` directly, so we can remove them.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Make sure that `IssueRefundViewModelTests` passes all its tests successfully.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
