### PR TITLE
[Orders] Use Color Studio Blue 5 for Completed order status

### DIFF
--- a/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
@@ -27,7 +27,7 @@ extension UILabel {
     ///
     private func applyBackground(for statusEnum: OrderStatusEnum) {
         switch statusEnum {
-        case .autoDraft, .pending, .completed, .cancelled, .refunded, .custom:
+        case .autoDraft, .pending, .cancelled, .refunded, .custom:
             backgroundColor = .gray(.shade5)
         case .onHold:
             backgroundColor = .withColorStudio(.orange, shade: .shade5)
@@ -35,6 +35,8 @@ extension UILabel {
             backgroundColor = .withColorStudio(.green, shade: .shade5)
         case .failed:
             backgroundColor = .withColorStudio(.red, shade: .shade5)
+        case .completed:
+            backgroundColor = .withColorStudio(.blue, shade: .shade5)
         }
 
         textColor = .black

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -417,7 +417,7 @@ extension EditableOrderViewModel {
             title = orderStatus.name ?? orderStatus.slug
             color = {
                 switch orderStatus.status {
-                case .autoDraft, .pending, .completed, .cancelled, .refunded, .custom:
+                case .autoDraft, .pending, .cancelled, .refunded, .custom:
                     return .gray(.shade5)
                 case .onHold:
                     return .withColorStudio(.orange, shade: .shade5)
@@ -425,6 +425,8 @@ extension EditableOrderViewModel {
                     return .withColorStudio(.green, shade: .shade5)
                 case .failed:
                     return .withColorStudio(.red, shade: .shade5)
+                case .completed:
+                    return .withColorStudio(.blue, shade: .shade5)
                 }
             }()
         }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue0.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue0.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "239",
           "alpha" : "1.000",
           "blue" : "247",
-          "green" : "243"
+          "green" : "243",
+          "red" : "239"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.937",
-          "alpha" : "1.000",
-          "blue" : "0.969",
-          "green" : "0.953"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue10.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue10.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "155",
           "alpha" : "1.000",
           "blue" : "241",
-          "green" : "199"
+          "green" : "199",
+          "red" : "155"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.937",
-          "alpha" : "1.000",
-          "blue" : "0.969",
-          "green" : "0.953"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue100.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue100.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0",
           "alpha" : "1.000",
           "blue" : "28",
-          "green" : "19"
+          "green" : "19",
+          "red" : "0"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.016",
-          "alpha" : "1.000",
-          "blue" : "0.349",
-          "green" : "0.224"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue20.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue20.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "116",
           "alpha" : "1.000",
           "blue" : "232",
-          "green" : "176"
+          "green" : "176",
+          "red" : "116"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.776",
-          "alpha" : "1.000",
-          "blue" : "0.965",
-          "green" : "0.871"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue30.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue30.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "82",
           "alpha" : "1.000",
           "blue" : "219",
-          "green" : "154"
+          "green" : "154",
+          "red" : "82"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.608",
-          "alpha" : "1.000",
-          "blue" : "0.945",
-          "green" : "0.780"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue40.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue40.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "54",
           "alpha" : "1.000",
           "blue" : "200",
-          "green" : "133"
+          "green" : "133",
+          "red" : "54"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.455",
-          "alpha" : "1.000",
-          "blue" : "0.910",
-          "green" : "0.690"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue5.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue5.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "198",
           "alpha" : "1.000",
           "blue" : "246",
-          "green" : "222"
+          "green" : "222",
+          "red" : "198"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.937",
-          "alpha" : "1.000",
-          "blue" : "0.969",
-          "green" : "0.953"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue50.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue50.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "34",
           "alpha" : "1.000",
           "blue" : "177",
-          "green" : "113"
+          "green" : "113",
+          "red" : "34"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.322",
-          "alpha" : "1.000",
-          "blue" : "0.859",
-          "green" : "0.604"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue60.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue60.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "19",
           "alpha" : "1.000",
           "blue" : "150",
-          "green" : "94"
+          "green" : "94",
+          "red" : "19"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.212",
-          "alpha" : "1.000",
-          "blue" : "0.784",
-          "green" : "0.522"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue70.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue70.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "10",
           "alpha" : "1.000",
           "blue" : "120",
-          "green" : "75"
+          "green" : "75",
+          "red" : "10"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.133",
-          "alpha" : "1.000",
-          "blue" : "0.694",
-          "green" : "0.443"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue80.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue80.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "4",
           "alpha" : "1.000",
           "blue" : "89",
-          "green" : "57"
+          "green" : "57",
+          "red" : "4"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.075",
-          "alpha" : "1.000",
-          "blue" : "0.588",
-          "green" : "0.369"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WooCommerce/Resources/ColorPalette.xcassets/Blue90.colorset/Contents.json
+++ b/WooCommerce/Resources/ColorPalette.xcassets/Blue90.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "1",
           "alpha" : "1.000",
           "blue" : "58",
-          "green" : "38"
+          "green" : "38",
+          "red" : "1"
         }
-      }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.039",
-          "alpha" : "1.000",
-          "blue" : "0.471",
-          "green" : "0.294"
-        }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }


### PR DESCRIPTION
Closes: #7192

## Description

A recent App Store review pointed out that we use the same color for completed order status and cancelled order status, whereas wp-admin uses separate colors. This PR addresses this by changing completed status to Color Studio Blue 5, as discussed here: p1656692062233029-slack-CGPNUU63E

## Changes

* Updates `UILabel+OrderStatus` to set the background color for the `completed` status to Blue 5.
* Updates `EditableOrderViewModel.StatusBadgeViewModel` (used in Order Creation/Editing) to set the background color for the `completed` status to Blue 5.
* Updates the `ColorPalette` assets to use the same color blue for light and dark mode. Previously, the Blue colors had a different dark mode color defined, so the Color Studio shades were not consistent across light and dark modes.

## Screenshots

Light|Dark
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 33 55](https://user-images.githubusercontent.com/8658164/176946259-fb09fbd8-3538-43c4-8201-c08bbdf866bc.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 34 00](https://user-images.githubusercontent.com/8658164/176946270-826a665a-a5f5-43c4-9c77-01baa66e4d5e.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 44 22](https://user-images.githubusercontent.com/8658164/176946282-375f18a1-fd4c-4042-988d-16020ccf176c.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 44 26](https://user-images.githubusercontent.com/8658164/176946290-2d3050bf-1875-4d96-9aad-dca8ea3e214e.png)

Other instances of Color Studio Blue:

Light|Dark
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 55 30](https://user-images.githubusercontent.com/8658164/176946605-de4b08d3-7587-4120-9fad-2775f14cc2ee.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 55 34](https://user-images.githubusercontent.com/8658164/176946615-89dd6998-e276-4a02-a498-bfbe798ed306.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 55 42](https://user-images.githubusercontent.com/8658164/176946625-7b9a196d-9e59-4a4c-aab8-40b53988b79c.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-07-01 at 18 55 51](https://user-images.githubusercontent.com/8658164/176946634-f0d39877-39c7-4943-8004-20da5bf5a1c3.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.