### PR TITLE
Background image upload: product variation support

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -585,7 +585,15 @@ private extension MainTabBarController {
     }
 
     func handleErrorSavingProductAfterImageUpload(_ error: ProductImageUploadErrorInfo) {
-        let notice = Notice(title: Localization.imagesSavingFailureNoticeTitle,
+        let noticeTitle: String = {
+            switch error.productOrVariationID {
+            case .product:
+                return Localization.productImagesSavingFailureNoticeTitle
+            case .variation:
+                return Localization.variationImageSavingFailureNoticeTitle
+            }
+        }()
+        let notice = Notice(title: noticeTitle,
                             subtitle: nil,
                             message: nil,
                             feedbackType: .error,
@@ -647,9 +655,12 @@ extension MainTabBarController {
         static let imageUploadFailureNoticeTitle =
         NSLocalizedString("An image failed to upload",
                           comment: "Title of the notice about an image upload failure in the background.")
-        static let imagesSavingFailureNoticeTitle =
+        static let productImagesSavingFailureNoticeTitle =
         NSLocalizedString("Error saving product images",
                           comment: "Title of the notice about an error saving images uploaded in the background to a product.")
+        static let variationImageSavingFailureNoticeTitle =
+        NSLocalizedString("Error saving variation image",
+                          comment: "Title of the notice about an error saving an image uploaded in the background to a product variation.")
         static let imageUploadFailureNoticeActionTitle =
         NSLocalizedString("View",
                           comment: "Title of the action to view product details from a notice about an image upload failure in the background.")

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -2,9 +2,37 @@ import Combine
 import Photos
 import Yosemite
 
+/// Interface of `ProductImageActionHandler` to allow mocking in unit tests.
+protocol ProductImageActionHandlerProtocol {
+    typealias AllStatuses = (productImageStatuses: [ProductImageStatus], error: Error?)
+    typealias OnAllStatusesUpdate = (AllStatuses) -> Void
+    typealias OnAssetUpload = (PHAsset, Result<ProductImage, Error>) -> Void
+
+    var productImageStatuses: [ProductImageStatus] { get }
+
+    @discardableResult
+    func addUpdateObserver<T: AnyObject>(_ observer: T,
+                                         onUpdate: @escaping OnAllStatusesUpdate) -> AnyCancellable
+
+    func addAssetUploadObserver<T: AnyObject>(_ observer: T,
+                                              onAssetUpload: @escaping OnAssetUpload) -> AnyCancellable
+
+    func addSiteMediaLibraryImagesToProduct(mediaItems: [Media])
+
+    func uploadMediaAssetToSiteMediaLibrary(asset: PHAsset)
+
+    func updateProductID(_ remoteProductID: ProductOrVariationID)
+
+    func deleteProductImage(_ productImage: ProductImage)
+
+    func resetProductImages(to product: ProductFormDataModel)
+
+    func updateProductImageStatusesAfterReordering(_ productImageStatuses: [ProductImageStatus])
+}
+
 /// Encapsulates the implementation of Product images actions from the UI.
 ///
-final class ProductImageActionHandler {
+final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
     typealias AllStatuses = (productImageStatuses: [ProductImageStatus], error: Error?)
     typealias OnAllStatusesUpdate = (AllStatuses) -> Void
     typealias OnAssetUpload = (PHAsset, Result<ProductImage, Error>) -> Void

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
@@ -70,9 +70,7 @@ private extension ProductImagesSaver {
                 case .failure(let error):
                     onProductSave(.failure(error))
                 }
-                self.imageStatusesToSave = []
-                self.assetUploadSubscription = nil
-                self.uploadStatusesSubscription = nil
+                self.reset()
             }
             stores.dispatch(action)
         case .variation(let productID, let variationID):
@@ -91,12 +89,16 @@ private extension ProductImagesSaver {
                 case .failure(let error):
                     onProductSave(.failure(error))
                 }
-                self.imageStatusesToSave = []
-                self.assetUploadSubscription = nil
-                self.uploadStatusesSubscription = nil
+                self.reset()
             }
             stores.dispatch(action)
         }
+    }
+
+    func reset() {
+        imageStatusesToSave = []
+        assetUploadSubscription = nil
+        uploadStatusesSubscription = nil
     }
 
     func observeAssetUploadsToUpdateImageStatuses(imageActionHandler: ProductImageActionHandlerProtocol) {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
@@ -30,7 +30,7 @@ final class ProductImagesSaver {
     /// - Parameters:
     ///   - imageActionHandler: action handler that provides the latest image statuses and image asset upload subscription.
     ///   - onProductSave: called after the product is updated remotely with the uploaded images.
-    func saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: ProductImageActionHandler,
+    func saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: ProductImageActionHandlerProtocol,
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
         let imageStatuses = imageActionHandler.productImageStatuses
         guard imageStatuses.hasPendingUpload else {
@@ -75,13 +75,31 @@ private extension ProductImagesSaver {
                 self.uploadStatusesSubscription = nil
             }
             stores.dispatch(action)
-        case .variation(_, _):
-            // TODO: 7021 - update variation images action with a different endpoint
-            return
+        case .variation(let productID, let variationID):
+            // Product variation only has up to one image.
+            guard let image = images.first else {
+                return
+            }
+            let action = ProductVariationAction.updateProductVariationImage(siteID: siteID,
+                                                                            productID: productID,
+                                                                            variationID: variationID,
+                                                                            image: image) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let productVariation):
+                    onProductSave(.success(productVariation.image.map { [$0] } ?? []))
+                case .failure(let error):
+                    onProductSave(.failure(error))
+                }
+                self.imageStatusesToSave = []
+                self.assetUploadSubscription = nil
+                self.uploadStatusesSubscription = nil
+            }
+            stores.dispatch(action)
         }
     }
 
-    func observeAssetUploadsToUpdateImageStatuses(imageActionHandler: ProductImageActionHandler) {
+    func observeAssetUploadsToUpdateImageStatuses(imageActionHandler: ProductImageActionHandlerProtocol) {
         assetUploadSubscription = imageActionHandler.addAssetUploadObserver(self) { [weak self] asset, result in
             guard let self = self else { return }
             guard let index = self.imageStatusesToSave.firstIndex(where: { status -> Bool in

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		0245465F24EE9106004F531C /* ProductVariationFormEventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0245465E24EE9106004F531C /* ProductVariationFormEventLogger.swift */; };
 		0246405F258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0246405E258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift */; };
 		0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */; };
+		0247F50E286E6CCD009C177E /* MockProductImageActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */; };
 		02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */; };
 		02482A8C237BE8C7007E73ED /* LinkSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */; };
 		02482A8E237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */; };
@@ -1924,6 +1925,7 @@
 		0245465E24EE9106004F531C /* ProductVariationFormEventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormEventLogger.swift; sourceTree = "<group>"; };
 		0246405E258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelCoordinatorTests.swift; sourceTree = "<group>"; };
 		0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatterTests.swift; sourceTree = "<group>"; };
+		0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImageActionHandler.swift; sourceTree = "<group>"; };
 		02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSettingsViewController.swift; sourceTree = "<group>"; };
 		02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkSettingsViewController.xib; sourceTree = "<group>"; };
 		02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecLinkFormatBarCommand.swift; sourceTree = "<group>"; };
@@ -5877,6 +5879,7 @@
 				02BF9BAE2851E7EA008CE2DD /* MockAppleIDCredentialChecker.swift */,
 				EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */,
 				EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */,
+				0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10130,6 +10133,7 @@
 				748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */,
 				02524A5D252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift in Sources */,
 				028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */,
+				0247F50E286E6CCD009C177E /* MockProductImageActionHandler.swift in Sources */,
 				AEA3F91527BEC96B00B9F555 /* PriceFieldFormatterTests.swift in Sources */,
 				02BC5AA824D2802B00C43326 /* MockProductVariationStoresManager.swift in Sources */,
 				E1C6535C27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		0246405F258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0246405E258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift */; };
 		0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */; };
 		0247F50E286E6CCD009C177E /* MockProductImageActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */; };
+		0247F510286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247F50F286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift */; };
 		02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */; };
 		02482A8C237BE8C7007E73ED /* LinkSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */; };
 		02482A8E237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */; };
@@ -1926,6 +1927,7 @@
 		0246405E258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelCoordinatorTests.swift; sourceTree = "<group>"; };
 		0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatterTests.swift; sourceTree = "<group>"; };
 		0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImageActionHandler.swift; sourceTree = "<group>"; };
+		0247F50F286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+ImageUploaderTests.swift"; sourceTree = "<group>"; };
 		02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSettingsViewController.swift; sourceTree = "<group>"; };
 		02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkSettingsViewController.xib; sourceTree = "<group>"; };
 		02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecLinkFormatBarCommand.swift; sourceTree = "<group>"; };
@@ -3678,6 +3680,7 @@
 				0215C6FB2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift */,
 				2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */,
 				022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */,
+				0247F50F286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -10203,6 +10206,7 @@
 				0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */,
 				EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */,
 				7E7C5F8B2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift in Sources */,
+				0247F510286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift in Sources */,
 				020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */,
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,
 				579CDF01274D811D00E8903D /* StoreStatsUsageTracksEventEmitterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageActionHandler.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageActionHandler.swift
@@ -1,0 +1,62 @@
+import Combine
+import Photos
+@testable import WooCommerce
+import struct Yosemite.Media
+import struct Yosemite.ProductImage
+
+final class MockProductImageActionHandler: ProductImageActionHandlerProtocol {
+    typealias AllStatuses = (productImageStatuses: [ProductImageStatus], error: Error?)
+    typealias OnAssetUpload = (PHAsset, Result<ProductImage, Error>) -> Void
+
+    var productImageStatuses: [ProductImageStatus] {
+        allStatuses.productImageStatuses
+    }
+
+    // Can be set externally to be emitted in `addUpdateObserver`.
+    @Published var allStatuses: AllStatuses
+
+    // Can be set externally to be emitted in `addAssetUploadObserver`.
+    @Published var assetUploadResults: (asset: PHAsset, result: Result<ProductImage, Error>)?
+
+    init(productImageStatuses: [ProductImageStatus]) {
+        self.allStatuses = (productImageStatuses: productImageStatuses, error: nil)
+    }
+
+    func addUpdateObserver<T>(_ observer: T, onUpdate: @escaping OnAllStatusesUpdate) -> AnyCancellable where T: AnyObject {
+        return $allStatuses.sink { statuses in
+            onUpdate(statuses)
+        }
+    }
+
+    func addAssetUploadObserver<T>(_ observer: T, onAssetUpload: @escaping OnAssetUpload) -> AnyCancellable where T: AnyObject {
+        return $assetUploadResults
+            .compactMap { $0 }
+            .sink { result in
+                onAssetUpload(result.asset, result.result)
+            }
+    }
+
+    func addSiteMediaLibraryImagesToProduct(mediaItems: [Media]) {
+        // no-op
+    }
+
+    func uploadMediaAssetToSiteMediaLibrary(asset: PHAsset) {
+        // no-op
+    }
+
+    func updateProductID(_ remoteProductID: ProductOrVariationID) {
+        // no-op
+    }
+
+    func deleteProductImage(_ productImage: ProductImage) {
+        // no-op
+    }
+
+    func resetProductImages(to product: ProductFormDataModel) {
+        // no-op
+    }
+
+    func updateProductImageStatusesAfterReordering(_ productImageStatuses: [ProductImageStatus]) {
+        // no-op
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -2,7 +2,7 @@ import Combine
 @testable import Yosemite
 @testable import WooCommerce
 
-final class MockProductImageUploader: ProductImageUploaderProtocol {
+final class MockProductImageUploader {
     let errors: AnyPublisher<ProductImageUploadErrorInfo, Never>
 
     var replaceLocalIDWasCalled = false
@@ -11,11 +11,24 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
     var stopEmittingErrorsWasCalled = false
     var resetWasCalled = false
 
+    private var onProductSaveResult: Result<[ProductImage], Error>?
+    private var hasUnsavedChangesOnImages = false
+
     init(errors: AnyPublisher<ProductImageUploadErrorInfo, Never> =
          Empty<ProductImageUploadErrorInfo, Never>().eraseToAnyPublisher()) {
         self.errors = errors
     }
 
+    func whenProductIsSaved(thenReturn result: Result<[ProductImage], Error>) {
+        onProductSaveResult = result
+    }
+
+    func whenHasUnsavedChangesOnImagesIsCalled(thenReturn hasUnsavedChangesOnImages: Bool) {
+        self.hasUnsavedChangesOnImages = hasUnsavedChangesOnImages
+    }
+}
+
+extension MockProductImageUploader: ProductImageUploaderProtocol {
     func replaceLocalID(siteID: Int64, localID: ProductOrVariationID, remoteID: Int64) {
         replaceLocalIDWasCalled = true
     }
@@ -23,6 +36,9 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
     func saveProductImagesWhenNoneIsPendingUploadAnymore(key: ProductImageUploaderKey,
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
         saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled = true
+        if let result = onProductSaveResult {
+            onProductSave(result)
+        }
     }
 
     func actionHandler(key: ProductImageUploaderKey, originalStatuses: [ProductImageStatus]) -> ProductImageActionHandler {
@@ -38,7 +54,7 @@ final class MockProductImageUploader: ProductImageUploaderProtocol {
     }
 
     func hasUnsavedChangesOnImages(key: ProductImageUploaderKey, originalImages: [ProductImage]) -> Bool {
-        false
+        hasUnsavedChangesOnImages
     }
 
     func reset() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -5,8 +5,6 @@ import Yosemite
 
 /// Unit tests for `ProductFormViewModel`'s `saveProductRemotely`
 final class ProductFormViewModel_SaveTests: XCTestCase {
-    private let defaultSiteID: Int64 = 134
-
     private var storesManager: MockStoresManager!
 
     override func setUp() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -193,13 +193,17 @@ extension EditableProductVariationModel {
 extension ProductVariationFormViewModel {
     convenience init(productVariation: EditableProductVariationModel,
                      formType: ProductFormType = .edit,
-                     productImageActionHandler: ProductImageActionHandler,
-                     storesManager: StoresManager = ServiceLocator.stores) {
+                     productImageActionHandler: ProductImageActionHandlerProtocol,
+                     storesManager: StoresManager = ServiceLocator.stores,
+                     productImagesUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+                     isBackgroundImageUploadEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload)) {
         self.init(productVariation: productVariation,
                   allAttributes: [],
                   parentProductSKU: nil,
                   formType: formType,
                   productImageActionHandler: productImageActionHandler,
-                  storesManager: storesManager)
+                  storesManager: storesManager,
+                  productImagesUploader: productImagesUploader,
+                  isBackgroundImageUploadEnabled: isBackgroundImageUploadEnabled)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ImageUploaderTests.swift
@@ -1,0 +1,156 @@
+import Combine
+import Photos
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+
+final class ProductVariationFormViewModel_ImageUploaderTests: XCTestCase {
+    private var storesManager: MockStoresManager!
+    private var subscriptions: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: SessionManager.testingInstance)
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        super.tearDown()
+    }
+
+    func test_isUpdateEnabled_is_false_after_saving_a_variation_while_an_image_is_uploading() throws {
+        // Given
+        let productVariation = ProductVariation.fake().copy(status: .published)
+        let model = EditableProductVariationModel(productVariation: productVariation)
+        let productImageActionHandler = MockProductImageActionHandler(productImageStatuses: [.uploading(asset: PHAsset())])
+        let viewModel = ProductVariationFormViewModel(productVariation: model,
+                                                      productImageActionHandler: productImageActionHandler,
+                                                      storesManager: storesManager,
+                                                      isBackgroundImageUploadEnabled: true)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            if case let ProductVariationAction.updateProductVariation(productVariation, onCompletion) = action {
+                onCompletion(.success(productVariation))
+            }
+        }
+
+        var isUpdateEnabledValues: [Bool] = []
+        viewModel.isUpdateEnabled.removeDuplicates().sink { isUpdateEnabled in
+            isUpdateEnabledValues.append(isUpdateEnabled)
+        }.store(in: &subscriptions)
+        XCTAssertEqual(isUpdateEnabledValues, [])
+
+        // When
+        waitFor { promise in
+            viewModel.saveProductRemotely(status: .published) { result in
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertEqual(isUpdateEnabledValues, [false])
+    }
+
+    func test_isUpdateEnabled_becomes_false_after_saving_a_variation_from_image_upload() throws {
+        // Given
+        let originalImage = ProductImage.fake().copy(imageID: 7)
+        let productVariation = ProductVariation.fake().copy(image: originalImage, status: .published)
+        let model = EditableProductVariationModel(productVariation: productVariation)
+        let productImageActionHandler = MockProductImageActionHandler(productImageStatuses: [])
+        let productImageUploader = MockProductImageUploader()
+        let image = ProductImage.fake().copy(imageID: 6)
+        productImageUploader.whenProductIsSaved(thenReturn: .success([image]))
+        productImageUploader.whenHasUnsavedChangesOnImagesIsCalled(thenReturn: true)
+        let viewModel = ProductVariationFormViewModel(productVariation: model,
+                                                      productImageActionHandler: productImageActionHandler,
+                                                      storesManager: storesManager,
+                                                      productImagesUploader: productImageUploader,
+                                                      isBackgroundImageUploadEnabled: true)
+
+        var isUpdateEnabledValues: [Bool] = []
+        viewModel.isUpdateEnabled.removeDuplicates().sink { isUpdateEnabled in
+            isUpdateEnabledValues.append(isUpdateEnabled)
+        }.store(in: &subscriptions)
+        XCTAssertEqual(isUpdateEnabledValues, [])
+
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            if case let ProductVariationAction.updateProductVariation(productVariation, completion) = action {
+                completion(.success(productVariation))
+            }
+        }
+
+        XCTAssertEqual(viewModel.originalProductModel.images, [originalImage])
+        XCTAssertEqual(viewModel.productModel.images, [originalImage])
+
+        // When
+        // Adds an image to the variation.
+        viewModel.updateImages([image])
+        XCTAssertEqual(isUpdateEnabledValues, [true])
+
+        let _: Void = waitFor { promise in
+            productImageUploader.whenHasUnsavedChangesOnImagesIsCalled(thenReturn: false)
+            viewModel.saveProductRemotely(status: .published) { result in
+                promise(())
+            }
+            XCTAssertEqual(isUpdateEnabledValues, [true, false])
+        }
+
+        // Then
+        XCTAssertEqual(isUpdateEnabledValues, [true, false])
+        XCTAssertEqual(viewModel.originalProductModel.images, [image])
+        XCTAssertEqual(viewModel.productModel.images, [image])
+    }
+
+    func test_isUpdateEnabled_is_always_false_when_image_was_saved_previously() throws {
+        // Given
+        let originalImage = ProductImage.fake().copy(imageID: 7)
+        let productVariation = ProductVariation.fake().copy(image: originalImage, status: .published)
+        let model = EditableProductVariationModel(productVariation: productVariation)
+        let productImageActionHandler = MockProductImageActionHandler(productImageStatuses: [])
+        let productImageUploader = MockProductImageUploader()
+        let image = ProductImage.fake().copy(imageID: 6)
+        productImageUploader.whenProductIsSaved(thenReturn: .success([image]))
+
+        // Sets `hasUnsavedChangesOnImages` to `false` to simulate the scenario when an image was saved previously
+        // and thus no unsaved changes on the variation image.
+        productImageUploader.whenHasUnsavedChangesOnImagesIsCalled(thenReturn: false)
+
+        let viewModel = ProductVariationFormViewModel(productVariation: model,
+                                                      productImageActionHandler: productImageActionHandler,
+                                                      storesManager: storesManager,
+                                                      productImagesUploader: productImageUploader,
+                                                      isBackgroundImageUploadEnabled: true)
+
+        var isUpdateEnabledValues: [Bool] = []
+        viewModel.isUpdateEnabled.removeDuplicates().sink { isUpdateEnabled in
+            isUpdateEnabledValues.append(isUpdateEnabled)
+        }.store(in: &subscriptions)
+        XCTAssertEqual(isUpdateEnabledValues, [])
+
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            if case let ProductVariationAction.updateProductVariation(productVariation, completion) = action {
+                completion(.success(productVariation))
+            }
+        }
+
+        XCTAssertEqual(viewModel.originalProductModel.images, [originalImage])
+        XCTAssertEqual(viewModel.productModel.images, [originalImage])
+
+        // When
+        // Adds an image to the variation.
+        viewModel.updateImages([image])
+        XCTAssertEqual(isUpdateEnabledValues, [false])
+
+        let _: Void = waitFor { promise in
+            viewModel.saveProductRemotely(status: .published) { result in
+                promise(())
+            }
+            XCTAssertEqual(isUpdateEnabledValues, [false])
+        }
+
+        // Then
+        XCTAssertEqual(isUpdateEnabledValues, [false])
+        XCTAssertEqual(viewModel.originalProductModel.images, [image])
+        XCTAssertEqual(viewModel.productModel.images, [image])
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7021
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After testing the latest work for background image upload, we still need to invoke `ProductImageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore` to track background image upload progress and also call a different endpoint in `ProductImagesSaver` for updating a variation's image (a variation can only have up to one image in core). 

This PR added support for product variation image upload & update in the background, and also created a protocol `ProductImageActionHandlerProtocol` for mocking `ProductImageActionHandler` in unit tests. The main changes are in `ProductVariationFormViewModel` (similar to `ProductFormViewModel`) and in `ProductImagesSaver`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Variation update success

- Launch the app
- Go to the products tab
- Tap on an editable variable product
- Tap the Variations row
- Tap on a variation, or generate one if needed
- In the variation form, add or replace the image
- Tap "Save" to save the variation while the image is still being uploaded
- Leave the variation form quickly, and feel free to do anything in the app --> the image should be uploaded and the variation's image should be saved. in the wp-admin media library, the uploaded image is also attached to the variation

#### Variation update error

One way to test variation image update failure is by updating the [variation image update endpoint](https://github.com/woocommerce/woocommerce-ios/blob/5c4ff120fb40d37c1dc4403c3fbb8eac69eea230/Networking/Networking/Remote/ProductVariationsRemote.swift#L141) to an invalid one like adding some extra character at the end. You can also put `sleep(numberOfSeconds)` to simulate a longer response time.

- Launch the app
- Go to the products tab
- Tap on an editable variable product
- Tap the Variations row
- Tap on a variation, or generate one if needed
- In the variation form, add or replace the image
- Tap "Save" to save the variation while the image is still being uploaded
- Leave the variation form quickly, and feel free to do anything in the app including switching stores --> when the image is uploaded but the variation's image cannot be saved, an in-app notice (snackbar) should be shown with a title `Error saving variation image` and an action `View` (if you are viewing a modal when the failure occurs, the notice is shown after dismissing the modal)
- Tap on "View" to view variation details --> it should switch to the original store if needed, and present the variation form. There should not be a "Save" CTA in the product form

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Variation update failure notice:

<img src="https://user-images.githubusercontent.com/1945542/176948253-a4ac357a-6e80-4349-97eb-310f62671fd0.png" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
