### PR TITLE
Background image upload: analytics events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ImageUpload.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ImageUpload.swift
@@ -1,0 +1,68 @@
+extension WooAnalyticsEvent {
+    enum ImageUpload {
+        /// Common event keys.
+        private enum Keys {
+            /// The type of the product - product or variation.
+            static let productOrVariation = "type"
+        }
+
+        enum ProductOrVariation {
+            case product
+            case variation
+        }
+
+        /// Tracked when the product or variation is saved after none of the images are pending upload in the background.
+        /// - Parameter productOrVariation: whether the save action is for a product or variation.
+        static func savingProductAfterBackgroundImageUploadSuccess(productOrVariation: ProductOrVariation) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .savingProductAfterBackgroundImageUploadSuccess,
+                              properties: [Keys.productOrVariation: productOrVariation.analyticsValue])
+        }
+
+        /// Tracked when the product cannot be saved after none of the images are pending upload in the background.
+        /// - Parameter productOrVariation: whether the save action is for a product or variation.
+        static func savingProductAfterBackgroundImageUploadFailed(productOrVariation: ProductOrVariation, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .savingProductAfterBackgroundImageUploadFailed,
+                              properties: [Keys.productOrVariation: productOrVariation.analyticsValue],
+                              error: error)
+        }
+
+        /// Tracked when a notice is shown from failure saving product after image upload in the background.
+        /// - Parameter productOrVariation: whether the save action is for a product or variation.
+        static func failureSavingProductAfterImageUploadNoticeShown(productOrVariation: ProductOrVariation) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .failureSavingProductAfterImageUploadNoticeShown,
+                              properties: [Keys.productOrVariation: productOrVariation.analyticsValue])
+        }
+
+        /// Tracked when the user taps on a notice to view product details from failure saving product after image upload in the background.
+        /// - Parameter productOrVariation: whether the save action is for a product or variation.
+        static func failureSavingProductAfterImageUploadNoticeTapped(productOrVariation: ProductOrVariation) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .failureSavingProductAfterImageUploadNoticeTapped,
+                              properties: [Keys.productOrVariation: productOrVariation.analyticsValue])
+        }
+
+        /// Tracked when a notice is shown from failure uploading an image in the background.
+        /// - Parameter productOrVariation: whether the save action is for a product or variation.
+        static func failureUploadingImageNoticeShown(productOrVariation: ProductOrVariation) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .failureUploadingImageNoticeShown,
+                              properties: [Keys.productOrVariation: productOrVariation.analyticsValue])
+        }
+
+        /// Tracked when the user taps on a notice to view product details from failure uploading an image in the background.
+        /// - Parameter productOrVariation: whether the save action is for a product or variation.
+        static func failureUploadingImageNoticeTapped(productOrVariation: ProductOrVariation) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .failureUploadingImageNoticeTapped,
+                              properties: [Keys.productOrVariation: productOrVariation.analyticsValue])
+        }
+    }
+}
+
+private extension WooAnalyticsEvent.ImageUpload.ProductOrVariation {
+    var analyticsValue: String {
+        switch self {
+        case .product:
+            return "product"
+        case .variation:
+            return "variation"
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -424,6 +424,12 @@ public enum WooAnalyticsStat: String {
     case productImageSettingsAddImagesSourceTapped = "product_image_settings_add_images_source_tapped"
     case productImageSettingsDeleteImageButtonTapped = "product_image_settings_delete_image_button_tapped"
     case productImageUploadFailed = "product_image_upload_failed"
+    case savingProductAfterBackgroundImageUploadSuccess = "saving_product_after_background_image_upload_success"
+    case savingProductAfterBackgroundImageUploadFailed = "saving_product_after_background_image_upload_failed"
+    case failureSavingProductAfterImageUploadNoticeShown = "failure_saving_product_after_image_upload_notice_shown"
+    case failureSavingProductAfterImageUploadNoticeTapped = "failure_saving_product_after_image_upload_notice_tapped"
+    case failureUploadingImageNoticeShown = "failure_uploading_image_notice_shown"
+    case failureUploadingImageNoticeTapped = "failure_uploading_image_notice_tapped"
 
     // Product Categories Events
     //

--- a/WooCommerce/Classes/ServiceLocator/NoticePresenter.swift
+++ b/WooCommerce/Classes/ServiceLocator/NoticePresenter.swift
@@ -6,7 +6,11 @@ protocol NoticePresenter {
 
     /// Enqueues the specified Notice for display.
     ///
-    func enqueue(notice: Notice)
+    /// - Parameter notice: the info to be displayed in the notice.
+    /// - Returns: a boolean that indicates whether the notice can be displayed
+    ///            (e.g. a notice of the same content isn't already displayed or enqueued).
+    @discardableResult
+    func enqueue(notice: Notice) -> Bool
 
     /// UIViewController to be used as Notice(s) Presenter
     ///

--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -30,15 +30,17 @@ class DefaultNoticePresenter: NoticePresenter {
 
     /// Enqueues the specified Notice for display.
     ///
-    func enqueue(notice: Notice) {
+    @discardableResult
+    func enqueue(notice: Notice) -> Bool {
         guard
             noticeOnScreen != notice, // Ignore if we are already presenting this notice.
             !notices.contains(notice) // Ignore if this notice is already enqueued and waiting for presentation.
         else {
-            return
+            return false
         }
         notices.append(notice)
         presentNextNoticeIfPossible()
+        return true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -611,9 +611,11 @@ private extension MainTabBarController {
                     .failureSavingProductAfterImageUploadNoticeTapped(productOrVariation: error.productOrVariationEventProperty))
             }
         })
-        noticePresenter.enqueue(notice: notice)
-        analytics.track(event: .ImageUpload
-            .failureSavingProductAfterImageUploadNoticeShown(productOrVariation: error.productOrVariationEventProperty))
+        let canNoticeBeDisplayed = noticePresenter.enqueue(notice: notice)
+        if canNoticeBeDisplayed {
+            analytics.track(event: .ImageUpload
+                .failureSavingProductAfterImageUploadNoticeShown(productOrVariation: error.productOrVariationEventProperty))
+        }
     }
 
     func handleErrorUploadingImage(_ error: ProductImageUploadErrorInfo) {
@@ -631,9 +633,11 @@ private extension MainTabBarController {
                     .failureUploadingImageNoticeTapped(productOrVariation: error.productOrVariationEventProperty))
             }
         })
-        noticePresenter.enqueue(notice: notice)
-        analytics.track(event: .ImageUpload
-            .failureUploadingImageNoticeShown(productOrVariation: error.productOrVariationEventProperty))
+        let canNoticeBeDisplayed = noticePresenter.enqueue(notice: notice)
+        if canNoticeBeDisplayed {
+            analytics.track(event: .ImageUpload
+                .failureUploadingImageNoticeShown(productOrVariation: error.productOrVariationEventProperty))
+        }
     }
 
     func showProductDetails(for error: ProductImageUploadErrorInfo) async {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -110,6 +110,7 @@ final class MainTabBarController: UITabBarController {
     private let noticePresenter: NoticePresenter
     private let productImageUploader: ProductImageUploaderProtocol
     private let stores: StoresManager = ServiceLocator.stores
+    private let analytics: Analytics
 
     private var productImageUploadErrorsSubscription: AnyCancellable?
 
@@ -120,10 +121,12 @@ final class MainTabBarController: UITabBarController {
     init?(coder: NSCoder,
           featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
           noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
-          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
+          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+          analytics: Analytics = ServiceLocator.analytics) {
         self.featureFlagService = featureFlagService
         self.noticePresenter = noticePresenter
         self.productImageUploader = productImageUploader
+        self.analytics = analytics
         super.init(coder: coder)
     }
 
@@ -131,6 +134,7 @@ final class MainTabBarController: UITabBarController {
         self.featureFlagService = ServiceLocator.featureFlagService
         self.noticePresenter = ServiceLocator.noticePresenter
         self.productImageUploader = ServiceLocator.productImageUploader
+        self.analytics = ServiceLocator.analytics
         super.init(coder: coder)
     }
 
@@ -603,9 +607,13 @@ private extension MainTabBarController {
             guard let self = self else { return }
             Task { @MainActor in
                 await self.showProductDetails(for: error)
+                self.analytics.track(event: .ImageUpload
+                    .failureSavingProductAfterImageUploadNoticeTapped(productOrVariation: error.productOrVariationEventProperty))
             }
         })
         noticePresenter.enqueue(notice: notice)
+        analytics.track(event: .ImageUpload
+            .failureSavingProductAfterImageUploadNoticeShown(productOrVariation: error.productOrVariationEventProperty))
     }
 
     func handleErrorUploadingImage(_ error: ProductImageUploadErrorInfo) {
@@ -619,9 +627,13 @@ private extension MainTabBarController {
             guard let self = self else { return }
             Task { @MainActor in
                 await self.showProductDetails(for: error)
+                self.analytics.track(event: .ImageUpload
+                    .failureUploadingImageNoticeTapped(productOrVariation: error.productOrVariationEventProperty))
             }
         })
         noticePresenter.enqueue(notice: notice)
+        analytics.track(event: .ImageUpload
+            .failureUploadingImageNoticeShown(productOrVariation: error.productOrVariationEventProperty))
     }
 
     func showProductDetails(for error: ProductImageUploadErrorInfo) async {
@@ -664,5 +676,16 @@ extension MainTabBarController {
         static let imageUploadFailureNoticeActionTitle =
         NSLocalizedString("View",
                           comment: "Title of the action to view product details from a notice about an image upload failure in the background.")
+    }
+}
+
+private extension ProductImageUploadErrorInfo {
+    var productOrVariationEventProperty: WooAnalyticsEvent.ImageUpload.ProductOrVariation {
+        switch productOrVariationID {
+        case .product:
+            return .product
+        case .variation:
+            return .variation
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -605,7 +605,8 @@ private extension MainTabBarController {
                             actionTitle: Localization.imageUploadFailureNoticeActionTitle,
                             actionHandler: { [weak self] in
             guard let self = self else { return }
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
                 await self.showProductDetails(for: error)
                 self.analytics.track(event: .ImageUpload
                     .failureSavingProductAfterImageUploadNoticeTapped(productOrVariation: error.productOrVariationEventProperty))
@@ -627,7 +628,8 @@ private extension MainTabBarController {
                             actionTitle: Localization.imageUploadFailureNoticeActionTitle,
                             actionHandler: { [weak self] in
             guard let self = self else { return }
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
                 await self.showProductDetails(for: error)
                 self.analytics.track(event: .ImageUpload
                     .failureUploadingImageNoticeTapped(productOrVariation: error.productOrVariationEventProperty))

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -127,7 +127,8 @@ extension EditAttributesViewController {
             progressViewController.dismiss(animated: true)
 
             guard let (product, variation) = try? result.get() else {
-                return noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
+                noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
+                return
             }
 
             onVariationCreation?(product, variation)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */; };
 		0247F50E286E6CCD009C177E /* MockProductImageActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */; };
 		0247F510286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247F50F286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift */; };
+		0247F512286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247F511286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift */; };
 		02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */; };
 		02482A8C237BE8C7007E73ED /* LinkSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */; };
 		02482A8E237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */; };
@@ -1928,6 +1929,7 @@
 		0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatterTests.swift; sourceTree = "<group>"; };
 		0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImageActionHandler.swift; sourceTree = "<group>"; };
 		0247F50F286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+ImageUploaderTests.swift"; sourceTree = "<group>"; };
+		0247F511286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ImageUpload.swift"; sourceTree = "<group>"; };
 		02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSettingsViewController.swift; sourceTree = "<group>"; };
 		02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkSettingsViewController.xib; sourceTree = "<group>"; };
 		02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecLinkFormatBarCommand.swift; sourceTree = "<group>"; };
@@ -5897,6 +5899,7 @@
 				747AA08A2107CF8D0047A89B /* TracksProvider.swift */,
 				5783FB3E25D7369F00B9984B /* WooAnalyticsEventPropertyType.swift */,
 				02C3FACD282A93020095440A /* WooAnalyticsEvent+Dashboard.swift */,
+				0247F511286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -9334,6 +9337,7 @@
 				028E1F702833DD0A001F8829 /* DashboardViewModel.swift in Sources */,
 				2602A63D27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift in Sources */,
 				CC4B252B27CFCEE2008D2E6E /* OrderTotalsCalculator.swift in Sources */,
+				0247F512286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				45DB70602614C7E80064A6CF /* ShippingLabelPackageDetailsResultsControllers.swift in Sources */,
 				027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockNoticePresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockNoticePresenter.swift
@@ -11,7 +11,8 @@ final class MockNoticePresenter: NoticePresenter {
 
     private(set) var queuedNotices = [Notice]()
 
-    func enqueue(notice: Notice) {
+    func enqueue(notice: Notice) -> Bool {
         queuedNotices.append(notice)
+        return true
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
@@ -8,6 +8,23 @@ final class ProductImagesSaverTests: XCTestCase {
     private let siteID: Int64 = 134
     private let productID: Int64 = 606
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+
+        super.tearDown()
+    }
+
     func test_image_status_with_upload_error_is_removed_from_imageStatusesToSave() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -162,6 +179,68 @@ final class ProductImagesSaverTests: XCTestCase {
         XCTAssertEqual(imagesSaver.imageStatusesToSave, [])
         let savedImages = try XCTUnwrap(result.get())
         XCTAssertEqual(savedImages, [image])
+    }
+
+    // MARK: - Analytics
+
+    func test_savingProductAfterBackgroundImageUploadSuccess_is_tracked_on_variation_update_success() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let variationID: ProductOrVariationID = .variation(productID: productID, variationID: 134)
+        let imagesSaver = ProductImagesSaver(siteID: siteID, productOrVariationID: variationID, stores: stores, analytics: analytics)
+        let asset = PHAsset()
+        let actionHandler = MockProductImageActionHandler(productImageStatuses: [.uploading(asset: asset)])
+        let image = ProductImage.fake()
+        actionHandler.assetUploadResults = (asset: asset, result: .success(image))
+
+        // Mocks successful variation image update.
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            if case let .updateProductVariationImage(_, _, _, image, completion) = action {
+                completion(.success(.fake().copy(image: image)))
+            }
+        }
+
+        // When
+        waitFor { promise in
+            // Saves product images.
+            imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: actionHandler) { result in
+                promise(())
+            }
+        }
+
+        // Then
+        assertEqual([WooAnalyticsStat.savingProductAfterBackgroundImageUploadSuccess.rawValue], analyticsProvider.receivedEvents)
+        assertEqual("variation", analyticsProvider.receivedProperties.first?["type"] as? String)
+    }
+
+    func test_savingProductAfterBackgroundImageUploadFailed_is_tracked_on_product_update_failure() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imagesSaver = ProductImagesSaver(siteID: siteID, productOrVariationID: .product(id: 648), stores: stores, analytics: analytics)
+        let asset = PHAsset()
+        let actionHandler = MockProductImageActionHandler(productImageStatuses: [.uploading(asset: asset)])
+        let image = ProductImage.fake()
+        actionHandler.assetUploadResults = (asset: asset, result: .success(image))
+
+        // Mocks successful variation image update.
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .updateProductImages(_, _, _, completion) = action {
+                completion(.failure(.unexpected))
+            }
+        }
+
+        // When
+        waitFor { promise in
+            // Saves product images.
+            imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: actionHandler) { result in
+                promise(())
+            }
+        }
+
+        // Then
+        assertEqual([WooAnalyticsStat.savingProductAfterBackgroundImageUploadFailed.rawValue], analyticsProvider.receivedEvents)
+        assertEqual("product", analyticsProvider.receivedProperties.first?["type"] as? String)
+        assertEqual("Yosemite.ProductUpdateError", analyticsProvider.receivedProperties.first?["error_domain"] as? String)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

- [x] TODO: add events to the spreadsheet after the PR is approved
- [x] TODO: add an issue to Android for tracking new events that are applicable https://github.com/woocommerce/woocommerce-android/issues/6872

Part of #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implemented the analytics events as in p91TBi-8Gx-p2#comment-10778:

event name | trigger | props
-- | -- | --
*_saving_product_after_background_image_upload_failed | When the product cannot be saved after none of the images are pending upload in the background. | error, type:product\|variation
*_saving_product_after_background_image_upload_success | When the product or variation is saved after none of the images are pending upload in the background. | type:product\|variation
*_failure_saving_product_after_image_upload_notice_shown | A notice is shown from failure saving product after image upload in the background. |  type:product\|variation
*_failure_saving_product_after_image_upload_notice_tapped | The user taps on a notice to view product details from failure saving product after image upload in the background. |  type:product\|variation
*_failure_uploading_image_notice_shown | A notice is shown from failure uploading an image in the background. |  type:product\|variation
*_failure_uploading_image_notice_tapped | The user taps on a notice to view product details from failure uploading an image in the background. | type:product\|variation

<br class="Apple-interchange-newline">

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Product image upload success

- Launch the app
- In the product form, add one or more images
- Tap "Save" to save the product while the images are still being uploaded
- Leave the product form quickly, and feel free to do anything in the app --> after all the images are uploaded and the product is saved, an event should be tracked like: `🔵 Tracked saving_product_after_background_image_upload_success, properties: [AnyHashable("type"): "product", ...]`

#### Image upload error

One way to test image upload failure is by updating the [media remote endpoint](https://github.com/woocommerce/woocommerce-ios/blob/0eae2a783db5f68577d613bf58b42cdda73e744f/Networking/Networking/Remote/MediaRemote.swift#L113) to an invalid one like adding some extra character at the end. You can also put `sleep(numberOfSeconds)` to simulate a longer response time.

- Launch the app
- In the product form, add one or more images
- Tap "Save" to save the product while the images are still being uploaded
- Leave the product form quickly, and feel free to do anything in the app including switching stores --> when an image fails to upload, an in-app notice (snackbar) should be shown with an action "View" (if you are viewing a modal when the failure occurs, the notice is shown after dismissing the modal). Two events should be tracked like: `🔵 Tracked failure_uploading_image_notice_shown, properties: [AnyHashable("type"): "product", ...]` and `🔵 Tracked product_image_upload_failed, properties: [AnyHashable("error_domain"): "Yosemite.ProductUpdateError", AnyHashable("type"): "variation", ...]`
- Tap on "View" to view product details --> it should switch to the original store if needed, and present the product form. An event should be tracked like: `🔵 Tracked failure_uploading_image_notice_tapped, properties: [AnyHashable("type"): "product", ...]`

#### Variation update error

One way to test variation image update failure is by updating the [variation image update endpoint](https://github.com/woocommerce/woocommerce-ios/blob/5c4ff120fb40d37c1dc4403c3fbb8eac69eea230/Networking/Networking/Remote/ProductVariationsRemote.swift#L141) to an invalid one like adding some extra character at the end. You can also put `sleep(numberOfSeconds)` to simulate a longer response time.

- Launch the app
- Go to the products tab
- Tap on an editable variable product
- Tap the Variations row
- Tap on a variation, or generate one if needed
- In the variation form, add or replace the image
- Tap "Save" to save the variation while the image is still being uploaded
- Leave the variation form quickly, and feel free to do anything in the app including switching stores --> when the image is uploaded but the variation's image cannot be saved, an in-app notice (snackbar) should be shown with a title `Error saving variation image` and an action `View` (if you are viewing a modal when the failure occurs, the notice is shown after dismissing the modal). Two events should be tracked like: `🔵 Tracked failure_saving_product_after_image_upload_notice_shown, properties: [AnyHashable("type"): "variation", ...]` and `🔵 Tracked saving_product_after_background_image_upload_failed, properties: [AnyHashable("error_domain"): "Yosemite.ProductUpdateError", AnyHashable("type"): "variation", ...]`
- Tap on "View" to view variation details --> it should switch to the original store if needed, and present the variation form. An event should be tracked like: `🔵 Tracked failure_saving_product_after_image_upload_notice_tapped, properties: [AnyHashable("type"): "variation", ...]`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
