### PR TITLE
[Unified Order Editing] Handle Multiple Shipping Lines

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -477,7 +477,10 @@ extension EditableOrderViewModel {
 
         let shouldShowShippingTotal: Bool
         let shippingTotal: String
+
+        // We only support one(the first) shipping line
         let shippingMethodTitle: String
+        let shippingMethodTotal: String
 
         let shouldShowFees: Bool
         let feesBaseAmountForPercentage: Decimal
@@ -498,6 +501,7 @@ extension EditableOrderViewModel {
              shouldShowShippingTotal: Bool = false,
              shippingTotal: String = "0",
              shippingMethodTitle: String = "",
+             shippingMethodTotal: String = "",
              shouldShowFees: Bool = false,
              feesBaseAmountForPercentage: Decimal = 0,
              feesTotal: String = "0",
@@ -512,6 +516,7 @@ extension EditableOrderViewModel {
             self.shouldShowShippingTotal = shouldShowShippingTotal
             self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? "0.00"
             self.shippingMethodTitle = shippingMethodTitle
+            self.shippingMethodTotal = currencyFormatter.formatAmount(shippingMethodTotal) ?? "0.00"
             self.shouldShowFees = shouldShowFees
             self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? "0.00"
@@ -521,7 +526,7 @@ extension EditableOrderViewModel {
             self.showNonEditableIndicators = showNonEditableIndicators
             self.shippingLineViewModel = ShippingLineDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
                                                                       initialMethodTitle: shippingMethodTitle,
-                                                                      shippingTotal: self.shippingTotal,
+                                                                      shippingTotal: shippingMethodTotal,
                                                                       didSelectSave: saveShippingLineClosure)
             self.feeLineViewModel = FeeLineDetailsViewModel(isExistingFeeLine: shouldShowFees,
                                                             baseAmountForPercentage: feesBaseAmountForPercentage,
@@ -696,6 +701,7 @@ private extension EditableOrderViewModel {
                                             shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
                                             shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
                                             shippingMethodTitle: shippingMethodTitle,
+                                            shippingMethodTotal: order.shippingLines.first?.total ?? "0",
                                             shouldShowFees: order.fees.filter { $0.name != nil }.isNotEmpty,
                                             feesBaseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
                                             feesTotal: orderTotals.feesTotal.stringValue,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -20,8 +20,8 @@ struct ShippingInputTransformer {
             return order.copy(shippingTotal: input.total, shippingLines: [input])
         }
 
-        // Since we only support one shipping line, if we find one, we update our input with the existing `shippingID`.
-        let updatedShippingLine = input.copy(shippingID: existingShippingLine.shippingID)
+        // Since we only support one shipping line, if we find one, we update the existing with the new input values.
+        let updatedShippingLine = existingShippingLine.copy(methodTitle: input.methodTitle, total: input.total)
         return order.copy(shippingTotal: updatedShippingLine.total, shippingLines: [updatedShippingLine])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -8,11 +8,13 @@ struct ShippingInputTransformer {
     /// Adds, deletes, or updates a shipping line input into an existing order.
     ///
     static func update(input: ShippingLine?, on order: Order) -> Order {
-        // If input is `nil`, then we remove any existing shipping line.
+        // If input is `nil`, then we remove the first shipping line.
         // We remove a shipping like by setting its `methodID` to nil.
         guard let input = input else {
-            let linesToRemove = order.shippingLines.map { OrderFactory.deletedShippingLine($0) }
-            return order.copy(shippingTotal: "0", shippingLines: linesToRemove)
+            guard let lineToRemove = order.shippingLines.first.map({ OrderFactory.deletedShippingLine($0) }) else {
+                return order
+            }
+            return order.copy(shippingLines: [lineToRemove])
         }
 
         // If there is no existing shipping lines, we insert the input one.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
@@ -24,10 +24,11 @@ class ShippingInputTransformerTests: XCTestCase {
         XCTAssertEqual(updatedOrder.shippingTotal, input.total)
     }
 
-    func test_new_input_updates_shipping_line_from_order() throws {
+    func test_new_input_updates_first_shipping_line_from_order() throws {
         // Given
         let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
-        let order = Order.fake().copy(shippingLines: [shipping])
+        let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
+        let order = Order.fake().copy(shippingLines: [shipping, shipping2])
 
         // When
         let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "12.00")
@@ -38,13 +39,17 @@ class ShippingInputTransformerTests: XCTestCase {
         XCTAssertEqual(shippingLine.shippingID, shipping.shippingID)
         XCTAssertEqual(shippingLine.methodID, input.methodID)
         XCTAssertEqual(shippingLine.total, input.total)
-        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
+        XCTAssertEqual(updatedOrder.shippingTotal, "24.0")
+
+        let shippingLine2 = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
+        XCTAssertEqual(shipping2, shippingLine2)
     }
 
-    func test_new_input_deletes_shipping_line_from_order() throws {
+    func test_new_input_deletes_first_shipping_line_from_order() throws {
         // Given
         let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
-        let order = Order.fake().copy(shippingLines: [shipping])
+        let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
+        let order = Order.fake().copy(shippingLines: [shipping, shipping2])
 
         // When
         let updatedOrder = ShippingInputTransformer.update(input: nil, on: order)
@@ -54,6 +59,9 @@ class ShippingInputTransformerTests: XCTestCase {
         XCTAssertNil(shippingLine.methodID)
         XCTAssertEqual(shippingLine.shippingID, shipping.shippingID)
         XCTAssertEqual(shippingLine.total, "0")
-        XCTAssertEqual(updatedOrder.shippingTotal, "0")
+        XCTAssertEqual(updatedOrder.shippingTotal, "12.0")
+
+        let shippingLine2 = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
+        XCTAssertEqual(shipping2, shippingLine2)
     }
 }


### PR DESCRIPTION
Closes: #6980 

# Why

**Order Creation** let us create only one shipping line, but with **Order Edition** we can receive orders that have multiple shipping lines. 

To support those orders, this PR allows us to edit and delete the first shipping line found without modifying the others.

# How

- Update `EditableOrderViewModel` to render the first shipping line total, instead of the order total.
- Update `ShippingLinesInputTransformer` to edit and delete only the first shipping line.

# Demo

https://user-images.githubusercontent.com/562080/176975567-2b96e2b9-b179-4937-8620-9cde4a937ce7.mov

# Testing Steps

- Create an order with multiple shipping lines on Core
- Go to the order in the app and edit the shipping lines
- See that only the first shipping line is presented and can be edited.
- Remove that shipping line
- See that the others shipping lines remain unaltered

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
