### PR TITLE
[Unified Order Editing] Inform About Multiple Lines

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -978,13 +978,13 @@ private extension EditableOrderViewModel {
                           comment: "Recovery suggestion when we fail to update an address when creating or editing an order")
 
         static let multipleShippingLines = NSLocalizedString("Shipping details are incomplete.\n" +
-                                                             "To edit all shipping details, browse the order in your WooCommerce store admin.",
+                                                             "To edit all shipping details, view the order in your WooCommerce store admin.",
                                                              comment: "Info message shown when the order contains multiple shipping lines")
         static let multipleFeeLines = NSLocalizedString("Fees are incomplete.\n" +
-                                                        "To edit all fees, browse the order in your WooCommerce store admin.",
+                                                        "To edit all fees, view the order in your WooCommerce store admin.",
                                                         comment: "Info message shown when the order contains multiple fee lines")
         static let multipleFeesAndShippingLines = NSLocalizedString("Fees & Shipping details are incomplete.\n" +
-                                                                    "To edit all the details, browse the order in your WooCommerce store admin.",
+                                                                    "To edit all the details, view the order in your WooCommerce store admin.",
                                                                     comment: "Info message shown when the order contains multiple fees and shipping lines")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -744,7 +744,7 @@ private extension EditableOrderViewModel {
                     return Localization.multipleFeeLines
                 case (.editing, 2...Int.max, 2...Int.max): // Multiple shipping & fee lines
                     return Localization.multipleFeesAndShippingLines
-                case (.editing, _, _): // Negative count - Should not happen!
+                case (.editing, _, _): // Single/nil shipping & fee lines
                     return nil
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -104,6 +104,10 @@ final class EditableOrderViewModel: ObservableObject {
     /// Defines if the non editable indicators (banners, locks, fields) should be shown.
     @Published private(set) var shouldShowNonEditableIndicators: Bool = false
 
+    /// Defines the multiple lines info message to show.
+    ///
+    @Published private(set) var multipleLinesMessage: String? = nil
+
     /// Status Results Controller.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
@@ -266,6 +270,7 @@ final class EditableOrderViewModel: ObservableObject {
         configurePaymentDataViewModel()
         configureCustomerNoteDataViewModel()
         configureNonEditableIndicators()
+        configureMultipleLinesMessage()
         resetAddressForm()
     }
 
@@ -725,6 +730,29 @@ private extension EditableOrderViewModel {
             .assign(to: &$shouldShowNonEditableIndicators)
     }
 
+    /// Binds the order state to the `multipleLineMessage` property.
+    ///
+    func configureMultipleLinesMessage() {
+        Publishers.CombineLatest(orderSynchronizer.orderPublisher, Just(flow))
+            .map { order, flow -> String? in
+                switch (flow, order.shippingLines.count, order.fees.count) {
+                case (.creation, _, _):
+                    return nil
+                case (.editing, 2...Int.max, 0...1): // Multiple shipping lines
+                    return Localization.multipleShippingLines
+                case (.editing, 0...1, 2...Int.max): // Multiple fee lines
+                    return Localization.multipleFeeLines
+                case (.editing, 2...Int.max, 2...Int.max): // Multiple shipping & fee lines
+                    return Localization.multipleFeesAndShippingLines
+                case (.editing, _, _): // Negative count - Should not happen!
+                    return nil
+                }
+            }
+            .assign(to: &$multipleLinesMessage)
+    }
+
+
+
     /// Tracks when customer details have been added
     ///
     func trackCustomerDetailsAdded() {
@@ -948,5 +976,15 @@ private extension EditableOrderViewModel {
         static let invalidBillingSuggestion =
         NSLocalizedString("Please make sure you are running the latest version of WooCommerce and try again later.",
                           comment: "Recovery suggestion when we fail to update an address when creating or editing an order")
+
+        static let multipleShippingLines = NSLocalizedString("Shipping details are incomplete.\n" +
+                                                             "To edit all shipping details, browse the order in your WooCommerce store admin.",
+                                                             comment: "Info message shown when the order contains multiple shipping lines")
+        static let multipleFeeLines = NSLocalizedString("Fees are incomplete.\n" +
+                                                        "To edit all fees, browse the order in your WooCommerce store admin.",
+                                                        comment: "Info message shown when the order contains multiple fee lines")
+        static let multipleFeesAndShippingLines = NSLocalizedString("Fees & Shipping details are incomplete.\n" +
+                                                                    "To edit all the details, browse the order in your WooCommerce store admin.",
+                                                                    comment: "Info message shown when the order contains multiple fees and shipping lines")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -123,8 +123,15 @@ struct OrderForm: View {
 
                         Spacer(minLength: Layout.sectionSpacing)
 
-                        OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
-                            .disabled(viewModel.shouldShowNonEditableIndicators)
+                        Group {
+                            if let title = viewModel.multipleLinesMessage {
+                                MultipleLinesMessage(title: title)
+                                Spacer(minLength: Layout.sectionSpacing)
+                            }
+
+                            OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
+                                .disabled(viewModel.shouldShowNonEditableIndicators)
+                        }
 
                         Spacer(minLength: Layout.sectionSpacing)
 
@@ -171,6 +178,39 @@ struct OrderForm: View {
         }
         .wooNavigationBarStyle()
         .notice($viewModel.notice, autoDismiss: false)
+    }
+}
+
+/// Represents an information message to indicate about multiple shipping or fee lines.
+///
+private struct MultipleLinesMessage: View {
+
+    /// Message to display.
+    ///
+    let title: String
+
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: OrderForm.Layout.noSpacing) {
+            Divider()
+
+            HStack(spacing: OrderForm.Layout.sectionSpacing) {
+
+                Image(uiImage: .infoImage)
+                    .foregroundColor(Color(.brand))
+
+                Text(title)
+                    .bodyStyle()
+            }
+            .padding()
+            .padding(.horizontal, insets: safeAreaInsets)
+
+            Divider()
+        }
+        .background(Color(.listForeground))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1195,6 +1195,61 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.shouldShowNonEditableIndicators)
     }
+
+    func test_zero_fees_and_shipping_lines_order_displays_nil_message() {
+        // Given
+        let order = Order.fake()
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
+
+        // Then
+        XCTAssertNil(viewModel.multipleLinesMessage)
+    }
+
+    func test_one_shipping_and_fee_line_order_displays_nil_message() {
+        // Given
+        let order = Order.fake().copy(shippingLines: [.fake()], fees: [.fake()])
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
+
+        // Then
+        XCTAssertNil(viewModel.multipleLinesMessage)
+    }
+
+    func test_multiple_shipping_line_order_displays_info_message() {
+        // Given
+        let order = Order.fake().copy(shippingLines: [.fake(), .fake()])
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
+
+        // Then
+        XCTAssertNotNil(viewModel.multipleLinesMessage)
+    }
+
+    func test_multiple_fee_line_order_displays_info_message() {
+        // Given
+        let order = Order.fake().copy(fees: [.fake(), .fake()])
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
+
+        // Then
+        XCTAssertNotNil(viewModel.multipleLinesMessage)
+    }
+
+    func test_multiple_shipping_and_fee_line_order_displays_info_message() {
+        // Given
+        let order = Order.fake().copy(shippingLines: [.fake(), .fake()], fees: [.fake(), .fake()])
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
+
+        // Then
+        XCTAssertNotNil(viewModel.multipleLinesMessage)
+    }
 }
 
 private extension MockStorageManager {


### PR DESCRIPTION
Closes: #7181

# Why

As we have decided to only support one shipping line and one fee line for the time being, we need to inform the merchant when an order has multiple lines.

# How

- Updated `ViewModel` to properly compute the correct information message depending on the order state.

- Added a new `MultipleLinesMessage` view that is rendered only when the view model multiple lines message is not nil.

# Screenshots
Multiple Shipping | Multiple Fees | Multiple Shipping & Fees
--- | --- | ---
![multiple-shipping](https://user-images.githubusercontent.com/562080/176988245-8c9c7053-ee13-48b3-a865-97c9b39ebee2.png) | ![multiple-fees](https://user-images.githubusercontent.com/562080/176988243-975c694c-113d-47bc-a53e-70854afc1420.png) | ![multiple-both](https://user-images.githubusercontent.com/562080/176988247-9c40b778-0b70-458c-88d8-66a65fe5e129.png) |

# Testing Steps

- Create an order on Core with multiple shipping lines
- Go to edit that order on the app
- See that the correct info message is shown.

----

- Create an order on Core with multiple fee lines
- Go to edit that order on the app
- See that the correct info message is shown.

----

- Create an order on Core with multiple shipping & fee lines
- Go to edit that order on the app
- See that the correct info message is shown.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
