### PR TITLE
Coupons: Check changes in coupon creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -151,7 +151,7 @@ struct AddEditCoupon: View {
                             .padding(.bottom, Constants.verticalSpacing)
 
                             Button {
-                                viewModel.generateRandomCouponCode()
+                                viewModel.updateCodeFieldWithRandomCode()
                             } label: {
                                 Text(Localization.regenerateCouponCodeButton)
                             }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -427,32 +427,32 @@ final class AddEditCouponViewModel: ObservableObject {
     }
 
     /// Default coupon when coupon creation is initiated
-    var defaultCoupon: Coupon {
-        Coupon(siteID: siteID,
-               couponID: -1,
-               code: initialCouponCode,
-               amount: "0.00",
-               dateCreated: Date(),
-               dateModified: Date(),
-               discountType: initialDiscountType,
-               description: "",
-               dateExpires: nil,
-               usageCount: 0,
-               individualUse: false,
-               productIds: [],
-               excludedProductIds: [],
-               usageLimit: nil,
-               usageLimitPerUser: nil,
-               limitUsageToXItems: nil,
-               freeShipping: false,
-               productCategories: [],
-               excludedProductCategories: [],
-               excludeSaleItems: false,
-               minimumAmount: "",
-               maximumAmount: "",
-               emailRestrictions: [],
-               usedBy: [])
-    }
+    private lazy var defaultCoupon: Coupon = {
+        .init(siteID: siteID,
+              couponID: -1,
+              code: initialCouponCode,
+              amount: "0.00",
+              dateCreated: Date(),
+              dateModified: Date(),
+              discountType: initialDiscountType,
+              description: "",
+              dateExpires: nil,
+              usageCount: 0,
+              individualUse: false,
+              productIds: [],
+              excludedProductIds: [],
+              usageLimit: nil,
+              usageLimitPerUser: nil,
+              limitUsageToXItems: nil,
+              freeShipping: false,
+              productCategories: [],
+              excludedProductCategories: [],
+              excludeSaleItems: false,
+              minimumAmount: "",
+              maximumAmount: "",
+              emailRestrictions: [],
+              usedBy: [])
+    }()
 
     /// Coupon generated from input
     var populatedCoupon: Coupon {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -147,7 +147,6 @@ final class AddEditCouponViewModel: ObservableObject {
     }
 
     var hasChangesMade: Bool {
-        guard editingOption == .editing else { return true }
         let coupon = populatedCoupon
         return checkDiscountTypeUpdated(for: coupon) ||
         checkAmountUpdated(for: coupon) ||
@@ -414,6 +413,35 @@ final class AddEditCouponViewModel: ObservableObject {
         stores.dispatch(action)
     }
 
+    /// Default coupon when coupon creation is initiated
+    var defaultCoupon: Coupon {
+        Coupon(siteID: siteID,
+               couponID: -1,
+               code: codeField,
+               amount: "0.00",
+               dateCreated: Date(),
+               dateModified: Date(),
+               discountType: .percent,
+               description: "",
+               dateExpires: nil,
+               usageCount: 0,
+               individualUse: false,
+               productIds: [],
+               excludedProductIds: [],
+               usageLimit: nil,
+               usageLimitPerUser: nil,
+               limitUsageToXItems: nil,
+               freeShipping: false,
+               productCategories: [],
+               excludedProductCategories: [],
+               excludeSaleItems: false,
+               minimumAmount: "",
+               maximumAmount: "",
+               emailRestrictions: [],
+               usedBy: [])
+    }
+
+    /// Coupon generated from input
     var populatedCoupon: Coupon {
         let emailRestrictions: [String] = {
             if couponRestrictionsViewModel.allowedEmails.isEmpty {
@@ -478,9 +506,7 @@ final class AddEditCouponViewModel: ObservableObject {
 //
 private extension AddEditCouponViewModel {
     func checkDiscountTypeUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         return coupon.discountType != initialCoupon.discountType
     }
 
@@ -498,9 +524,7 @@ private extension AddEditCouponViewModel {
     }
 
     func checkUsageRestrictionsUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         let amountFormatter = CouponAmountInputFormatter()
 
         return amountFormatter.value(from: coupon.maximumAmount) != amountFormatter.value(from: initialCoupon.maximumAmount) ||
@@ -516,9 +540,7 @@ private extension AddEditCouponViewModel {
     }
 
     func checkExpiryDateUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         // since we're trimming time on the new date, we should also trim the time on the old date
         // as a workaround for the edge case where the date was created with different time zones.
         guard let oldDate = initialCoupon.dateExpires?.startOfDay(timezone: timezone),
@@ -529,38 +551,28 @@ private extension AddEditCouponViewModel {
     }
 
     func checkCouponCodeUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         return coupon.code.lowercased() != initialCoupon.code.lowercased()
     }
 
     func checkAmountUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         let amountFormatter = CouponAmountInputFormatter()
         return amountFormatter.value(from: coupon.amount) != amountFormatter.value(from: initialCoupon.amount)
     }
 
     func checkDescriptionUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         return coupon.description != initialCoupon.description
     }
 
     func checkAllowedProductsAndCategoriesUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         return coupon.productIds != initialCoupon.productIds || coupon.productCategories != initialCoupon.productCategories
     }
 
     func checkFreeShippingUpdated(for coupon: Coupon) -> Bool {
-        guard let initialCoupon = self.coupon else {
-            return false
-        }
+        let initialCoupon = self.coupon ?? defaultCoupon
         return coupon.freeShipping != initialCoupon.freeShipping
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -202,6 +202,12 @@ final class AddEditCouponViewModel: ObservableObject {
 
     private var subscriptions: Set<AnyCancellable> = []
 
+    /// Keeping track of the initial discount type to check for changes
+    private let initialDiscountType: Coupon.DiscountType
+
+    /// Keeping track of the initial coupon code to check for changes
+    private let initialCouponCode: String
+
     /// Init method for coupon creation
     ///
     init(siteID: Int64,
@@ -235,7 +241,9 @@ final class AddEditCouponViewModel: ObservableObject {
         couponRestrictionsViewModel = CouponRestrictionsViewModel(siteID: siteID)
         productOrVariationIDs = []
         categoryIDs = []
-        generateRandomCouponCode()
+        initialCouponCode = Self.generateRandomCouponCode()
+        codeField = initialCouponCode
+        initialDiscountType = discountType
         configureWarningBehavior()
     }
 
@@ -273,6 +281,8 @@ final class AddEditCouponViewModel: ObservableObject {
         couponRestrictionsViewModel = CouponRestrictionsViewModel(coupon: existingCoupon)
         productOrVariationIDs = existingCoupon.productIds
         categoryIDs = existingCoupon.productCategories
+        initialCouponCode = existingCoupon.code
+        initialDiscountType = existingCoupon.discountType
 
         configureWarningBehavior()
     }
@@ -282,7 +292,7 @@ final class AddEditCouponViewModel: ObservableObject {
     /// We will loop to select 8 characters from the set `ABCDEFGHJKMNPQRSTUVWXYZ23456789` at random using `arc4random_uniform` for randomness.
     /// https://github.com/woocommerce/woocommerce/blob/2e60d47a019a6e35f066f3ef43a56c0e761fc8e3/includes/admin/class-wc-admin-assets.php#L295
     ///
-    func generateRandomCouponCode() {
+    private static func generateRandomCouponCode() -> String {
         let dictionary: [String] = "ABCDEFGHJKMNPQRSTUVWXYZ23456789".map { String($0) }
         let generatedCodeLength = 8
 
@@ -290,8 +300,7 @@ final class AddEditCouponViewModel: ObservableObject {
         for _ in 0 ..< generatedCodeLength {
             code += dictionary.randomElement() ?? ""
         }
-
-        codeField = code
+        return code
     }
 
     private func configureWarningBehavior() {
@@ -314,6 +323,10 @@ final class AddEditCouponViewModel: ObservableObject {
                 }
             }
             .store(in: &subscriptions)
+    }
+
+    func updateCodeFieldWithRandomCode() {
+        codeField = Self.generateRandomCouponCode()
     }
 
     @discardableResult
@@ -417,11 +430,11 @@ final class AddEditCouponViewModel: ObservableObject {
     var defaultCoupon: Coupon {
         Coupon(siteID: siteID,
                couponID: -1,
-               code: codeField,
+               code: initialCouponCode,
                amount: "0.00",
                dateCreated: Date(),
                dateModified: Date(),
-               discountType: .percent,
+               discountType: initialDiscountType,
                description: "",
                dateExpires: nil,
                usageCount: 0,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -139,7 +139,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    func test_hasChangesMade_is_correct_for_discount_type() {
+    func test_hasChangesMade_is_correct_when_updating_discount_type() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(discountType: .percent)
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -152,7 +152,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_coupon_code() {
+    func test_hasChangesMade_is_correct_when_updating_coupon_code() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(code: "ABCDEF")
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -165,7 +165,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_amount() {
+    func test_hasChangesMade_is_correct_when_updating_amount() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "11.22")
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -178,7 +178,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_expiry_date() {
+    func test_hasChangesMade_is_correct_when_updating_expiry_date() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(dateExpires: Date())
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -191,7 +191,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_nil_expiry_date() {
+    func test_hasChangesMade_is_correct_when_updating_nil_expiry_date() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(dateExpires: Date())
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -204,7 +204,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_updated_product_restrictions() {
+    func test_hasChangesMade_is_correct_when_updating_product_restrictions() {
         // Given
         let coupon = Coupon.sampleCoupon
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -217,7 +217,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_updated_category_restrictions() {
+    func test_hasChangesMade_is_correct_when_updating_category_restrictions() {
         // Given
         let coupon = Coupon.sampleCoupon
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -230,7 +230,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_description() {
+    func test_hasChangesMade_is_correct_when_updating_description() {
         // Given
         let coupon = Coupon.sampleCoupon
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -243,7 +243,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_free_shipping() {
+    func test_hasChangesMade_is_correct_when_updating_free_shipping() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(freeShipping: false)
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -256,7 +256,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_correct_for_updated_usage_restrictions() {
+    func test_hasChangesMade_is_correct_when_updating_usage_restrictions() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(usageLimit: 100)
         let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
@@ -269,9 +269,118 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChangesMade)
     }
 
-    func test_hasChangesMade_is_always_true_when_is_in_creation_mode() {
+    func test_hasChangesMade_is_false_when_creation_is_initiated() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: {_ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_discount_type_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.discountType = .fixedProduct
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_coupon_code_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.codeField = "1d23rds3"
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_amount_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.amountField = "10.00"
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_expiry_date_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.expiryDateField = Date().adding(days: 12, seconds: 0, using: .current)
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_product_restrictions_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.productOrVariationIDs = [1, 21, 33]
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_category_restrictions_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.categoryIDs = [12, 2]
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_description_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.descriptionField = "lorem ipsum"
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_free_shipping_from_creation_flow() {
+        // Given
+        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.freeShipping = true
+
+        // Then
+        XCTAssertTrue(viewModel.hasChangesMade)
+    }
+
+    func test_hasChangesMade_is_correct_when_updating_usage_restrictions_from_creation_flow() {
+        // Given
+        let coupon = Coupon.sampleCoupon.copy(usageLimit: 100)
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        XCTAssertFalse(viewModel.hasChangesMade) // confidence check
+
+        // When
+        viewModel.couponRestrictionsViewModel.usageLimitPerCoupon = "1000"
 
         // Then
         XCTAssertTrue(viewModel.hasChangesMade)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -21,7 +21,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.codeField, "")
 
         // When
-        viewModel.generateRandomCouponCode()
+        viewModel.updateCodeFieldWithRandomCode()
 
         // Then
         let dictionary = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7203
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the way changes are checked in the coupon creation flow.

Previously we were considering changes are made no matter what in coupon creation flow. This actually doesn't make sense since a user should be able to drag to dismiss the flow without any prompt if they haven't changed anything in the form.

The solution is to keep a default coupon as generated when the coupon creation is initiated and use it to compare when checking if changes are made.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have coupon management enabled in Settings > Experimental features.
- Navigate to Menu > Coupons. Select "+" button on the top right to start coupon creation.
- In the creation form, swipe down the modal and notice that the modal can be dismissed instantly.
- Repeat step 2, then change any detail in the form before attempting to swipe to dismiss the modal again. Notice that there's an alert asking for confirmation to discard the changes.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/177139032-e53ac3de-4db3-404a-8c1f-75f38f00da49.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
