### PR TITLE
Coupons: Fix issue loading coupon list after creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -154,12 +154,7 @@ final class CouponListViewController: UIViewController, GhostableViewController 
                 snapshot.appendSections([.main])
                 snapshot.appendItems(viewModels, toSection: Section.main)
 
-                if #available(iOS 15.0, *) {
-                    // minimally reloads the list without computing diff or animation
-                    self.dataSource.applySnapshotUsingReloadData(snapshot)
-                } else {
-                    self.dataSource.apply(snapshot)
-                }
+                self.dataSource.apply(snapshot)
             }
             .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -154,7 +154,12 @@ final class CouponListViewController: UIViewController, GhostableViewController 
                 snapshot.appendSections([.main])
                 snapshot.appendItems(viewModels, toSection: Section.main)
 
-                self.dataSource.apply(snapshot)
+                if #available(iOS 15.0, *) {
+                    // minimally reloads the list without computing diff or animation
+                    self.dataSource.applySnapshotUsingReloadData(snapshot)
+                } else {
+                    self.dataSource.apply(snapshot)
+                }
             }
             .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -204,7 +204,11 @@ private extension CouponListViewController {
     /// Triggers the coupon creation flow
     ///
     func startCouponCreation(discountType: Coupon.DiscountType) {
-        let viewModel = AddEditCouponViewModel(siteID: siteID, discountType: discountType, onSuccess: {_ in })
+        let viewModel = AddEditCouponViewModel(siteID: siteID,
+                                               discountType: discountType,
+                                               onSuccess: { [weak self] _ in
+            self?.refreshCouponList()
+        })
         let addEditHostingController = AddEditCouponHostingController(viewModel: viewModel, onDisappear: { [weak self] in
             guard let self = self else { return }
             self.dismiss(animated: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7204 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, after being created, coupons are decoded with the incorrect timezone, causing them not being shown on top of the list.

From my testing, it's the [custom timezone for the encoder](https://github.com/woocommerce/woocommerce-ios/blob/df7ba0e352023517a0d2faa479872d05f258ed73/Networking/Networking/Remote/CouponsRemote.swift#L185-L187) that causes this. I.e, the decoded created date is correct if I comment out those lines, but I don't have a good explanation for this 😓.

Given that we want to keep the custom timezone for the date formatter of the encoder, this PR adds a quick workaround to fix #7204 by reloading the coupon list immediately after a coupon is created. This is not elegant, so please feel free to share any better suggestions if possible.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have coupon management enabled in Settings > Experimental Features.
- Navigate to Menu > Coupons. Select "+" to add a new coupon.
- Add any details to the creation form and tap Save. 
- Dismiss the success modal and notice that the new coupon is on the top of the coupon list.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/177366752-2debc210-0dd3-4f8b-bca3-3eb8e553226f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
