### PR TITLE
Appstore screenshot: Update copies and screenshots

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
@@ -11,12 +11,17 @@ public final class PeriodStatsTable: ScreenObject {
         $0.cells["period-data-thisWeek-tab"]
     }
 
+    private let monthsTabGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["period-data-thisMonth-tab"]
+    }
+
     private let yearsTabGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["period-data-thisYear-tab"]
     }
 
     private var daysTab: XCUIElement { daysTabGetter(app) }
     private var weeksTab: XCUIElement { weeksTabGetter(app) }
+    private var monthsTab: XCUIElement { monthsTabGetter(app) }
     private var yearsTab: XCUIElement { yearsTabGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
@@ -33,10 +38,16 @@ public final class PeriodStatsTable: ScreenObject {
     }
 
     @discardableResult
-       func switchToWeeksTab() -> Self {
-           weeksTab.tap()
-           return self
-       }
+    func switchToWeeksTab() -> Self {
+        weeksTab.tap()
+        return self
+    }
+
+    @discardableResult
+    public func switchToMonthsTab() -> Self {
+        monthsTab.tap()
+        return self
+    }
 
     @discardableResult
     public func switchToYearsTab() -> Self {

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
@@ -3,55 +3,55 @@ import XCTest
 
 public final class PeriodStatsTable: ScreenObject {
 
-    private let daysTabGetter: (XCUIApplication) -> XCUIElement = {
+    private let todayTabGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["period-data-today-tab"]
     }
 
-    private let weeksTabGetter: (XCUIApplication) -> XCUIElement = {
+    private let thisWeekTabGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["period-data-thisWeek-tab"]
     }
 
-    private let monthsTabGetter: (XCUIApplication) -> XCUIElement = {
+    private let thisMonthTabGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["period-data-thisMonth-tab"]
     }
 
-    private let yearsTabGetter: (XCUIApplication) -> XCUIElement = {
+    private let thisYearTabGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["period-data-thisYear-tab"]
     }
 
-    private var daysTab: XCUIElement { daysTabGetter(app) }
-    private var weeksTab: XCUIElement { weeksTabGetter(app) }
-    private var monthsTab: XCUIElement { monthsTabGetter(app) }
-    private var yearsTab: XCUIElement { yearsTabGetter(app) }
+    private var todayTab: XCUIElement { todayTabGetter(app) }
+    private var thisWeekTab: XCUIElement { thisWeekTabGetter(app) }
+    private var thisMonthTab: XCUIElement { thisMonthTabGetter(app) }
+    private var thisYearTab: XCUIElement { thisYearTabGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [daysTabGetter, weeksTabGetter, yearsTabGetter],
+            expectedElementGetters: [todayTabGetter, thisWeekTabGetter, thisYearTabGetter],
             app: app
         )
     }
 
     @discardableResult
     func switchToDaysTab() -> Self {
-        daysTab.tap()
+        todayTab.tap()
         return self
     }
 
     @discardableResult
     func switchToWeeksTab() -> Self {
-        weeksTab.tap()
+        thisWeekTab.tap()
         return self
     }
 
     @discardableResult
     public func switchToMonthsTab() -> Self {
-        monthsTab.tap()
+        thisMonthTab.tap()
         return self
     }
 
     @discardableResult
     public func switchToYearsTab() -> Self {
-        yearsTab.tap()
+        thisYearTab.tap()
         return self
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -190,7 +190,13 @@ public final class NewOrderScreen: ScreenObject {
     /// - Returns: Orders Screen object.
     @discardableResult
     public func cancelOrderCreation() throws -> OrdersScreen {
-        cancelButton.tap()
+        // This cancel button exists only if the feature flag `.splitViewInOrdersTab` is on.
+        // For taking app store screenshot, the beta feature is turned off so we should pop to get out of this screen.
+        if cancelButton.exists {
+            cancelButton.tap()
+        } else {
+            pop()
+        }
         return try OrdersScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -33,13 +33,6 @@ public final class ProductsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func tapOutside() -> Self {
-        let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
-        coordinate.tap()
-        return self
-    }
-
-    @discardableResult
     public func collapseTopBannerIfNeeded() -> Self {
 
         /// Without the info label, we don't need to collapse the top banner

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -23,6 +23,23 @@ public final class ProductsScreen: ScreenObject {
     }
 
     @discardableResult
+    public func selectAddProduct() -> Self {
+        guard app.buttons["product-add-button"].waitForExistence(timeout: 3) else {
+            return self
+        }
+
+        app.buttons["product-add-button"].tap()
+        return self
+    }
+
+    @discardableResult
+    public func tapOutside() -> Self {
+        let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        coordinate.tap()
+        return self
+    }
+
+    @discardableResult
     public func collapseTopBannerIfNeeded() -> Self {
 
         /// Without the info label, we don't need to collapse the top banner

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -47,7 +47,6 @@ class WooCommerceScreenshots: XCTestCase {
         .tabBar.goToProductsScreen()
         .selectAddProduct()
         .thenTakeScreenshot(named: "product-add")
-        .tapOutside()
     }
 
     private let loop = try! SelectorEventLoop(selector: try! KqueueSelector())

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -46,7 +46,7 @@ class WooCommerceScreenshots: XCTestCase {
         // Products
         .tabBar.goToProductsScreen()
         .selectAddProduct()
-        .thenTakeScreenshot(named: "create-product")
+        .thenTakeScreenshot(named: "product-add")
         .tapOutside()
     }
 

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -34,7 +34,7 @@ class WooCommerceScreenshots: XCTestCase {
 
         // My Store
         .dismissTopBannerIfNeeded()
-        .then { ($0 as! MyStoreScreen).periodStatsTable.switchToYearsTab() }
+        .then { ($0 as! MyStoreScreen).periodStatsTable.switchToMonthsTab() }
         .thenTakeScreenshot(named: "order-dashboard")
 
         // Orders

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -32,37 +32,22 @@ class WooCommerceScreenshots: XCTestCase {
 
         try MyStoreScreen()
 
-            // My Store
-            .dismissTopBannerIfNeeded()
-            .then { ($0 as! MyStoreScreen).periodStatsTable.switchToYearsTab() }
-            .thenTakeScreenshot(named: "order-dashboard")
+        // My Store
+        .dismissTopBannerIfNeeded()
+        .then { ($0 as! MyStoreScreen).periodStatsTable.switchToYearsTab() }
+        .thenTakeScreenshot(named: "order-dashboard")
 
-            // Orders
-            .tabBar.goToOrdersScreen()
-            .thenTakeScreenshot(named: "order-list")
-            .selectOrder(atIndex: 0)
-            .thenTakeScreenshot(named: "order-detail")
-            .goBackToOrdersScreen()
+        // Orders
+        .tabBar.goToOrdersScreen()
+        .startOrderCreation()
+        .thenTakeScreenshot(named: "order-creation")
+        .cancelOrderCreation()
 
-            .openSearchPane()
-            .thenTakeScreenshot(named: "order-search")
-            .cancel()
-
-            // Products
-            .tabBar.goToProductsScreen()
-            .collapseTopBannerIfNeeded()
-            .thenTakeScreenshot(named: "product-list")
-            .selectProduct(atIndex: 1)
-            .thenTakeScreenshot(named: "product-details")
-            .goBackToProductList()
-
-            // Reviews
-            .tabBar.goToMenuScreen()
-            .goToReviewsScreen()
-            .thenTakeScreenshot(named: "review-list")
-            .selectReview(atIndex: 3)
-            .thenTakeScreenshot(named: "review-details")
-            .goBackToReviewsScreen()
+        // Products
+        .tabBar.goToProductsScreen()
+        .selectAddProduct()
+        .thenTakeScreenshot(named: "create-product")
+        .tapOutside()
     }
 
     private let loop = try! SelectorEventLoop(selector: try! KqueueSelector())

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -32,8 +32,7 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 store.upsertStoredOrderStats(readOnlyStats: objectGraph.thisMonthOrderStats, timeRange: timeRange)
                 onCompletion(.success(()))
             case .thisYear:
-                store.upsertStoredOrderStats(readOnlyStats: objectGraph.thisYearOrderStats, timeRange: timeRange)
-                onCompletion(.success(()))
+                success(onCompletion)
         }
     }
 
@@ -49,8 +48,7 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisMonthVisitStats, timeRange: timeRange)
                 onCompletion(.success(()))
             case .thisYear:
-                store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisYearVisitStats, timeRange: timeRange)
-                onCompletion(.success(()))
+                success(onCompletion)
         }
     }
 
@@ -66,8 +64,7 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisMonthTopProducts)
                 onCompletion(.success(()))
             case .thisYear:
-                store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisYearTopProducts)
-                onCompletion(.success(()))
+                success(onCompletion)
         }
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -29,7 +29,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
             case .thisWeek:
                 success(onCompletion)
             case .thisMonth:
-                success(onCompletion)
+                store.upsertStoredOrderStats(readOnlyStats: objectGraph.thisMonthOrderStats, timeRange: timeRange)
+                onCompletion(.success(()))
             case .thisYear:
                 store.upsertStoredOrderStats(readOnlyStats: objectGraph.thisYearOrderStats, timeRange: timeRange)
                 onCompletion(.success(()))
@@ -45,7 +46,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
             case .thisWeek:
                 success(onCompletion)
             case .thisMonth:
-                success(onCompletion)
+                store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisMonthVisitStats, timeRange: timeRange)
+                onCompletion(.success(()))
             case .thisYear:
                 store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisYearVisitStats, timeRange: timeRange)
                 onCompletion(.success(()))
@@ -61,7 +63,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
             case .thisWeek:
                 success(onCompletion)
             case .thisMonth:
-                success(onCompletion)
+                store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisMonthTopProducts)
+                onCompletion(.success(()))
             case .thisYear:
                 store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisYearTopProducts)
                 onCompletion(.success(()))

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -80,7 +80,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
             number: 2201,
             customer: Customers.MiraWorkman,
             status: .processing,
-            total: 1310.00,
+            total: 50.00,
             items: [
                 createOrderItem(from: Products.malayaShades, count: 4),
                 createOrderItem(from: Products.blackCoralShades, count: 5),
@@ -91,21 +91,21 @@ struct ScreenshotObjectGraph: MockObjectGraph {
             customer: Customers.LydiaDonin,
             status: .processing,
             daysOld: 3,
-            total: 300
+            total: 73.29
         ),
         createOrder(
             number: 2116,
             customer: Customers.ChanceVicarro,
             status: .processing,
             daysOld: 4,
-            total: 300
+            total: 66.15
         ),
         createOrder(
             number: 2104,
             customer: Customers.MarcusCurtis,
             status: .processing,
             daysOld: 5,
-            total: 420
+            total: 120.00
         ),
         createOrder(
             number: 2087,

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -183,6 +183,26 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         )
     ]
 
+    var thisMonthVisitStats: SiteVisitStats {
+        Self.createVisitStats(
+            siteID: 1,
+            granularity: .month,
+            items: [Int](0..<30).map { dayIndex in
+                Self.createVisitStatsItem(
+                    granularity: .day,
+                    periodDate: date.monthStart.addingDays(dayIndex),
+                    visitors: Int.random(in: 10 ... 100)
+                )
+            }
+        )
+    }
+
+    var thisMonthTopProducts: TopEarnerStats = createStats(siteID: 1, granularity: .month, items: [
+        createTopEarningItem(product: Products.akoyaPearlShades, quantity: 17),
+        createTopEarningItem(product: Products.blackCoralShades, quantity: 11),
+        createTopEarningItem(product: Products.coloradoShades, quantity: 5),
+    ])
+
     var thisYearVisitStats: SiteVisitStats {
         Self.createVisitStats(
             siteID: 1,
@@ -191,7 +211,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
                 Self.createVisitStatsItem(
                     granularity: .month,
                     periodDate: date.yearStart.addingMonths(monthIndex),
-                    visitors: Int.random(in: 100 ... 1000)
+                    visitors: Int.random(in: 100 ... 500)
                 )
             }
         )
@@ -209,14 +229,28 @@ struct ScreenshotObjectGraph: MockObjectGraph {
 
     /// The possible value of an order when generating random stats
     ///
-    private let orderValueRange = 100 ..< 500
+    private let orderValueRange = 10 ..< 50
+
+    var thisMonthOrderStats: OrderStatsV4 {
+        Self.createStats(
+            siteID: 1,
+            granularity: .monthly,
+            intervals: thisMonthVisitStats.items!.enumerated().map {
+                Self.createMonthlyInterval(
+                    date: date.monthStart.addingDays($0.offset),
+                    orderCount: Int(Double($0.element.visitors) * Double.random(in: orderProbabilityRange)),
+                    revenue: Decimal($0.element.visitors) * Decimal.random(in: orderValueRange)
+                )
+            }
+        )
+    }
 
     var thisYearOrderStats: OrderStatsV4 {
         Self.createStats(
             siteID: 1,
             granularity: .yearly,
             intervals: thisYearVisitStats.items!.enumerated().map {
-                Self.createInterval(
+                Self.createYearlyInterval(
                     date: date.yearStart.addingMonths($0.offset),
                     orderCount: Int(Double($0.element.visitors) * Double.random(in: orderProbabilityRange)),
                     revenue: Decimal($0.element.visitors) * Decimal.random(in: orderValueRange)

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -191,7 +191,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
                 Self.createVisitStatsItem(
                     granularity: .day,
                     periodDate: date.monthStart.addingDays(dayIndex),
-                    visitors: Int.random(in: 10 ... 100)
+                    visitors: Int.random(in: 0 ... 20)
                 )
             }
         )
@@ -229,7 +229,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
 
     /// The possible value of an order when generating random stats
     ///
-    private let orderValueRange = 10 ..< 50
+    private let orderValueRange = 5 ..< 20
 
     var thisMonthOrderStats: OrderStatsV4 {
         Self.createStats(

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -203,25 +203,6 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         createTopEarningItem(product: Products.coloradoShades, quantity: 5),
     ])
 
-    var thisYearVisitStats: SiteVisitStats {
-        Self.createVisitStats(
-            siteID: 1,
-            granularity: .year,
-            items: [Int](0..<12).map { monthIndex in
-                Self.createVisitStatsItem(
-                    granularity: .month,
-                    periodDate: date.yearStart.addingMonths(monthIndex),
-                    visitors: Int.random(in: 100 ... 500)
-                )
-            }
-        )
-    }
-
-    var thisYearTopProducts: TopEarnerStats = createStats(siteID: 1, granularity: .year, items: [
-        createTopEarningItem(product: Products.akoyaPearlShades, quantity: 17),
-        createTopEarningItem(product: Products.blackCoralShades, quantity: 11),
-        createTopEarningItem(product: Products.coloradoShades, quantity: 5),
-    ])
 
     /// The probability of a sale for each visit when generating random stats
     ///
@@ -238,20 +219,6 @@ struct ScreenshotObjectGraph: MockObjectGraph {
             intervals: thisMonthVisitStats.items!.enumerated().map {
                 Self.createMonthlyInterval(
                     date: date.monthStart.addingDays($0.offset),
-                    orderCount: Int(Double($0.element.visitors) * Double.random(in: orderProbabilityRange)),
-                    revenue: Decimal($0.element.visitors) * Decimal.random(in: orderValueRange)
-                )
-            }
-        )
-    }
-
-    var thisYearOrderStats: OrderStatsV4 {
-        Self.createStats(
-            siteID: 1,
-            granularity: .yearly,
-            intervals: thisYearVisitStats.items!.enumerated().map {
-                Self.createYearlyInterval(
-                    date: date.yearStart.addingMonths($0.offset),
                     orderCount: Int(Double($0.element.visitors) * Double.random(in: orderProbabilityRange)),
                     revenue: Decimal($0.element.visitors) * Decimal.random(in: orderValueRange)
                 )

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -448,11 +448,11 @@ private extension Array where Element == OrderStatsV4Interval {
         let components = Calendar.current.dateComponents(in: .current, from: self)
         return components.month ?? 0
     }
-     
-     var day: Int {
-         let components = Calendar.current.dateComponents(in: .current, from: self)
-         return components.day ?? 0
-     }
+
+    var day: Int {
+        let components = Calendar.current.dateComponents(in: .current, from: self)
+        return components.day ?? 0
+    }
 
     var yearStart: Date {
         let year = Calendar.current.component(.year, from: self)

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -16,10 +16,6 @@ public protocol MockObjectGraph {
     var thisMonthVisitStats: SiteVisitStats { get }
     var thisMonthTopProducts: TopEarnerStats { get }
 
-    var thisYearOrderStats: OrderStatsV4 { get }
-    var thisYearVisitStats: SiteVisitStats { get }
-    var thisYearTopProducts: TopEarnerStats { get }
-
     func accountWithId(id: Int64) -> Account
     func accountSettingsWithUserId(userId: Int64) -> AccountSettings
 
@@ -294,19 +290,6 @@ extension MockObjectGraph {
         )
     }
 
-    static func createYearlyInterval(
-        date: Date,
-        orderCount: Int,
-        revenue: Decimal
-    ) -> OrderStatsV4Interval {
-        OrderStatsV4Interval(
-            interval: String(date.month),
-            dateStart: date.asOrderStatsString,
-            dateEnd: date.monthEnd.asOrderStatsString,
-            subtotals: createTotal(orderCount: orderCount, revenue: revenue)
-        )
-    }
-
     static func createVisitStatsItem(granularity: StatGranularity, periodDate: Date, visitors: Int) -> SiteVisitStatsItem {
         switch granularity {
         case .day, .month:
@@ -356,13 +339,7 @@ extension MockObjectGraph {
                 granularity: .day,
                 items: items
             )
-            case .year:
-            return SiteVisitStats(
-                siteID: siteID,
-                date: Date().asVisitStatsYearString,
-                granularity: .month,
-                items: items
-            )
+            case .year: preconditionFailure("Not implemented")
         }
     }
 

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -369,7 +369,7 @@ extension MockObjectGraph {
     static func createStats(siteID: Int64, granularity: StatGranularity, items: [TopEarnerStatsItem]) -> TopEarnerStats {
         TopEarnerStats(
             siteID: siteID,
-            date: String(Date().year),
+            date: StatsStoreV4.buildDateString(from: Date(), with: granularity),
             granularity: granularity,
             limit: "",
             items: items

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -292,7 +292,7 @@ extension MockObjectGraph {
 
     static func createVisitStatsItem(granularity: StatGranularity, periodDate: Date, visitors: Int) -> SiteVisitStatsItem {
         switch granularity {
-        case .day, .month:
+        case .day:
             return SiteVisitStatsItem(period: periodDate.asVisitStatsMonthString, visitors: visitors)
         default:
             fatalError("Not implemented yet")

--- a/fastlane/appstoreres/metadata/source/description.txt
+++ b/fastlane/appstoreres/metadata/source/description.txt
@@ -1,22 +1,22 @@
-Manage your business on the go with the WooCommerce Mobile App. Create products, process orders, and keep an eye on key stats in real-time. 
+Manage your business on the go with the WooCommerce Mobile App. Add products, create orders, take quick payments, and keep an eye on new sales and key stats in real time.
 
-ADD PRODUCTS
-Create, group, and publish products directly from your iPhone or iPad. Capture your creativity in the moment – turn your ideas into products in seconds, or save them as drafts for later.
+Add and edit products with a touch
+Get started in seconds! Create, group, and publish products directly from your iPhone or iPad. Capture your creativity the moment it strikes – turn your ideas into products immediately, or save them as drafts for later.
 
-GET NOTIFIED
-Never miss an order or a review. Keep that FOMO at bay by enabling real-time alerts – and listen out for that addictive “cha-ching” sound that comes with every new sale!
+Create orders on the fly
+Once you have some products created, it’s simple. Choose items from your catalog, add shipping, and then fill in customer details to quickly create an order that syncs with your inventory.
 
-VIEW AND MODIFY ORDERS
-Scroll the summaries, or search by customer or order specifics. Tap into the details to see itemized billing, begin fulfillment, and change order status. Add notes to the order or email customers directly to follow up.
+Take payments in person
+Collect physical payments using WooCommerce In-Person Payments and a card reader (available in the US and Canada). Start a new order – or find an existing one that’s pending payment – and collect payment using the card reader or a digital wallet, such as Apple Pay.
 
-TRACK YOUR STATS
-See which products are winning at a glance. Keep tabs on overall revenue, order count, and visitor data by week, month, and year. Knowledge = power!
+Get notified of every sale
+Now that you’re actively selling, never miss an order or a review. Keep yourself in the loop by enabling real-time alerts – and listen for that addictive “cha-ching” sound that comes with each new sale!
 
-SWITCH BETWEEN STORES
-For those with more than one, toggle seamlessly between your businesses in seconds.
+Track sales and bestselling products
+See which products are winning at a glance. Keep tabs on your overall revenue, order count, and visitor data by week, month, and year. Knowledge = power.
 
 WooCommerce is the world’s most customizable open-source eCommerce platform. Whether you’re launching a business, taking brick-and-mortar retail online, or developing sites for clients, use WooCommerce for a store that powerfully blends content and commerce.
 
-Requirements: WooCommerce v3.5+, the Jetpack plugin.
+Requirements: WooCommerce v3.5+. Jetpack is also required to receive notifications.
 
 View the Privacy Notice for California users at https://automattic.com/privacy/#california-consumer-privacy-act-ccpa.

--- a/fastlane/appstoreres/metadata/source/description.txt
+++ b/fastlane/appstoreres/metadata/source/description.txt
@@ -17,6 +17,6 @@ See which products are winning at a glance. Keep tabs on your overall revenue, o
 
 WooCommerce is the world’s most customizable open-source eCommerce platform. Whether you’re launching a business, taking brick-and-mortar retail online, or developing sites for clients, use WooCommerce for a store that powerfully blends content and commerce.
 
-Requirements: WooCommerce v3.5+. Jetpack is also required to receive notifications.
+Requirements: WooCommerce v3.5+.
 
 View the Privacy Notice for California users at https://automattic.com/privacy/#california-consumer-privacy-act-ccpa.

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
@@ -1,2 +1,2 @@
-Track sales and high
-performing products
+Track sales and
+bestselling products

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
@@ -1,2 +1,2 @@
-View and manage
-orders on the go
+Create orders
+on the fly

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
@@ -1,2 +1,2 @@
-Review order details
-and payments
+Take payments
+in person

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
@@ -1,2 +1,2 @@
-View products and
-check inventory
+Add and edit products 
+with a touch

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
@@ -1,2 +1,2 @@
-Get notified about
-new reviews
+Get notified of 
+every sale

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -57,7 +57,7 @@
 	],
 	"entries": [
 		// iPhone 11 Pro Max
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-01.png",
@@ -65,41 +65,33 @@
 			"screenshot": "iPhone 11 Pro Max-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 11 Pro Max-2-light-order-list.png",
+			"screenshot": "iPhone 11 Pro Max-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-03.png",
 			"background": "#674399",
-			"screenshot": "iPhone 11 Pro Max-3-dark-order-detail.png",
+			"screenshot": "iPhone 11 Pro Max-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 11 Pro Max-5-light-product-list.png",
+			"screenshot": "iPhone 11 Pro Max-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPhone 11 Pro Max",
-			"filename": "iPhone 11 Pro Max-05.png",
-			"background": "#674399",
-			"screenshot": "iPhone 11 Pro Max-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 		// iPhone 8 Plus
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-01.png",
@@ -107,42 +99,34 @@
 			"screenshot": "iPhone 8 Plus-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 8 Plus-2-light-order-list.png",
+			"screenshot": "iPhone 8 Plus-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-03.png",
 			"background": "#674399",
-			"screenshot": "iPhone 8 Plus-3-dark-order-detail.png",
+			"screenshot": "iPhone 8 Plus-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 8 Plus-5-light-product-list.png",
+			"screenshot": "iPhone 8 Plus-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPhone 8 Plus",
-			"filename": "iPhone 8 Plus-05.png",
-			"background": "#674399",
-			"screenshot": "iPhone 8 Plus-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 
 		/// iPad Pro 12.9 (2nd Generation)
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-01.png",
@@ -150,41 +134,33 @@
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-2-light-order-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-03.png",
 			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-dark-order-detail.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-light-product-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPad Pro 12.9 (2nd Generation)",
-			"filename": "iPad Pro (12.9-inch) (2nd generation)-05.png",
-			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 		/// iPad Pro 12.9 (3rd Generation)
-		// Track sales data and high performing products
+		// Track sales and bestselling products
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-01.png",
@@ -192,37 +168,29 @@
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
-		// View and manage orders on the go
+		// Create orders on the fly
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-02.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-2-light-order-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
-		// Review order details and payments
+		// Take payments in person
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-03.png",
 			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-dark-order-detail.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
-		// View products and check inventory
+		// Add and edit products with a touch
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-light-product-list.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
-		},
-		// Get notified about new reviews
-		{
-			"device": "iPad Pro 12.9 (3rd Generation)",
-			"filename": "iPad Pro (12.9-inch) (3rd generation)-05.png",
-			"background": "#674399",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-7-dark-review-list.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		}
 	]
 }


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As per request from the marketing team (p91TBi-9eM-p2), this PR updates the automation scripts to take requested screenshots:
- Capture the monthly revenue: switch to capture the This Month tab of the My Store screen with mock data for the monthly stats.
- Update script to capture order creation form and product creation bottom sheet.
- Also update copies for app description

Updates for other screenshots will be handled in subsequent PRs.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn off the feature flag `.splitViewInOrdersTab` in `DefaultFeatureFlagService`.
- Select target WooCommerceScreenshots. Run the `testScreenshots()` UI test.
- Confirm that the test succeeds.

For copy updates, these can be checked by comparing with the Google doc in p91TBi-9eM-p2.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
