### PR TITLE
Appstore screenshot: Simulate push notification for screenshot

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -128,6 +128,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
         // Games should use this method to pause the game.
+        if ProcessConfiguration.shouldSimulatePushNotification {
+            let content = UNMutableNotificationContent()
+            content.title = "You have a new order! 🎉"
+            content.body = "New order for $13.98 on Your WooCommerce Store"
+            content.sound = UNNotificationSound.default
+
+            // show this notification seconds from now
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+
+            // choose a random identifier
+            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+
+            // add our notification request
+            UNUserNotificationCenter.current().add(request)
+        }
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
@@ -327,6 +342,10 @@ private extension AppDelegate {
 
             /// Trick found at: https://twitter.com/twannl/status/1232966604142653446
             UIApplication.shared.currentKeyWindow?.layer.speed = 100
+        }
+
+        if ProcessConfiguration.shouldSimulatePushNotification {
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { _, _ in }
         }
     }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -132,10 +132,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let content = UNMutableNotificationContent()
             content.title = "You have a new order! 🎉"
             content.body = "New order for $13.98 on Your WooCommerce Store"
-            content.sound = UNNotificationSound.default
 
             // show this notification seconds from now
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1.5, repeats: false)
 
             // choose a random identifier
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -130,8 +130,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Games should use this method to pause the game.
         if ProcessConfiguration.shouldSimulatePushNotification {
             let content = UNMutableNotificationContent()
-            content.title = "You have a new order! 🎉"
-            content.body = "New order for $13.98 on Your WooCommerce Store"
+            content.title = NSLocalizedString("You have a new order! 🎉", comment: "Title for the mocked order notification needed for the AppStore listing screenshot")
+            content.body = NSLocalizedString(
+                "New order for $13.98 on Your WooCommerce Store",
+                comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +
+                "'Your WooCommerce Store' is the name of the mocked store." 
+            )
 
             // show this notification seconds from now
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1.5, repeats: false)

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -137,7 +137,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             content.body = NSLocalizedString(
                 "New order for $13.98 on Your WooCommerce Store",
                 comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +
-                "'Your WooCommerce Store' is the name of the mocked store." 
+                "'Your WooCommerce Store' is the name of the mocked store."
             )
 
             // show this notification seconds from now

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -130,7 +130,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Games should use this method to pause the game.
         if ProcessConfiguration.shouldSimulatePushNotification {
             let content = UNMutableNotificationContent()
-            content.title = NSLocalizedString("You have a new order! 🎉", comment: "Title for the mocked order notification needed for the AppStore listing screenshot")
+            content.title = NSLocalizedString(
+                "You have a new order! 🎉",
+                comment: "Title for the mocked order notification needed for the AppStore listing screenshot"
+            )
             content.body = NSLocalizedString(
                 "New order for $13.98 on Your WooCommerce Store",
                 comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -123,11 +123,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state.
-        // This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message)
-        // or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
-        // Games should use this method to pause the game.
+        // Simulate push notification for capturing snapshot.
+        // This is supposed to be called only by the WooCommerceScreenshots target.
         if ProcessConfiguration.shouldSimulatePushNotification {
             let content = UNMutableNotificationContent()
             content.title = NSLocalizedString(

--- a/WooCommerce/Classes/System/ProcessConfiguration.swift
+++ b/WooCommerce/Classes/System/ProcessConfiguration.swift
@@ -16,4 +16,9 @@ struct ProcessConfiguration {
     static var shouldDisableAnimations: Bool {
         ProcessInfo.processInfo.arguments.contains("disable-animations")
     }
+
+    /// Returns `true` when wishing to simulate push notifications.
+    static var shouldSimulatePushNotification: Bool {
+        ProcessInfo.processInfo.arguments.contains("-mocks-push-notification")
+    }
 }

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -141,7 +141,7 @@ open class Snapshot: NSObject {
 
     open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
         if timeout > 0 {
-            waitForLoadingIndicatorToDisappear(within: timeout)
+//            waitForLoadingIndicatorToDisappear(within: timeout)
         }
 
         NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -141,7 +141,7 @@ open class Snapshot: NSObject {
 
     open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
         if timeout > 0 {
-//            waitForLoadingIndicatorToDisappear(within: timeout)
+            waitForLoadingIndicatorToDisappear(within: timeout)
         }
 
         NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -158,7 +158,7 @@ extension ScreenObject {
     @discardableResult
     func lockScreen() -> Self {
         // This is a hack from https://stackoverflow.com/a/57356929
-        // ☠️ Beware of break changes in future updates ☠️
+        // ☠️ Beware of breaking changes in future updates ☠️
         XCUIDevice.shared.perform(NSSelectorFromString("pressLockButton"))
         sleep(2)
         return self

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -145,7 +145,7 @@ extension BaseScreen {
         let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(screenshotCount)-\(mode)-\(title)"
 
-        snapshot(filename)
+        snapshot(filename, timeWaitingForIdle: 0)
 
         return self
     }
@@ -167,7 +167,7 @@ extension ScreenObject {
         let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(screenshotCount)-\(mode)-\(title)"
 
-        snapshot(filename)
+        snapshot(filename, timeWaitingForIdle: 0)
 
         return self
     }

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -32,6 +32,7 @@ class WooCommerceScreenshots: XCTestCase {
 
         app.launch()
 
+        // Automates allowing local notification if needed
         let app2 = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let button = app2.alerts.firstMatch.buttons["Allow"]
         if button.waitForExistence(timeout: 5) {
@@ -65,6 +66,7 @@ class WooCommerceScreenshots: XCTestCase {
         .selectAddProduct()
         .thenTakeScreenshot(named: "product-add")
 
+        // Push notification
         .lockScreen()
         .thenTakeScreenshot(named: "order-notification")
     }

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -157,6 +157,8 @@ extension ScreenObject {
 
     @discardableResult
     func lockScreen() -> Self {
+        // This is a hack from https://stackoverflow.com/a/57356929
+        // ☠️ Beware of break changes in future updates ☠️
         XCUIDevice.shared.perform(NSSelectorFromString("pressLockButton"))
         sleep(2)
         return self

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -27,9 +27,16 @@ class WooCommerceScreenshots: XCTestCase {
         app.launchArguments.append("-simulate-stripe-card-reader")
         app.launchArguments.append("disable-animations")
         app.launchArguments.append("-mocks-port")
+        app.launchArguments.append("-mocks-push-notification")
         app.launchArguments.append("\(server.listenAddress.port)")
 
         app.launch()
+
+        let app2 = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let button = app2.alerts.firstMatch.buttons["Allow"]
+        if button.waitForExistence(timeout: 5) {
+            button.tap()
+        }
 
         try MyStoreScreen()
 
@@ -57,6 +64,9 @@ class WooCommerceScreenshots: XCTestCase {
         .tabBar.goToProductsScreen()
         .selectAddProduct()
         .thenTakeScreenshot(named: "product-add")
+
+        .lockScreen()
+        .thenTakeScreenshot(named: "order-notification")
     }
 
     private let loop = try! SelectorEventLoop(selector: try! KqueueSelector())
@@ -142,6 +152,13 @@ extension BaseScreen {
 }
 
 extension ScreenObject {
+
+    @discardableResult
+    func lockScreen() -> Self {
+        XCUIDevice.shared.perform(NSSelectorFromString("pressLockButton"))
+        sleep(2)
+        return self
+    }
 
     @discardableResult
     func thenTakeScreenshot(named title: String) -> Self {

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -32,12 +32,12 @@ class WooCommerceScreenshots: XCTestCase {
 
         app.launch()
 
-        // Automates allowing local notification if needed
-        let app2 = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        let button = app2.alerts.firstMatch.buttons["Allow"]
-        if button.waitForExistence(timeout: 5) {
-            button.tap()
+        addUIInterruptionMonitor(withDescription: "System Dialog") {
+            (alert) -> Bool in
+            alert.buttons["Allow"].tap()
+            return true
         }
+        app.tap()
 
         try MyStoreScreen()
 


### PR DESCRIPTION
⚠️ Please make sure that #7216 and #7217 are reviewed and merged first! ⚠️ 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues updating the automated script for taking screenshots for App Store. We want to capture push notifications on the app, so the trick is to use the local notification API:
- Added a new process argument and requested permission for notification upon launch when this argument is enabled.
- To capture the screenshot for the notification, lock the device screen and sleep for 2 seconds before taking a screenshot. In the meantime, schedule a local notification in 1 second when the app is about to be sent to the background. This way the lock screen can be captured with the notification coming in.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn off the feature flag `.splitViewInOrdersTab` in `DefaultFeatureFlagService`.
- Select target WooCommerceScreenshots. Run the `testScreenshots()` UI test.
- Confirm that the test succeeds.

You can find the screenshots in the path `~/Library/Caches/tools.fastlane/screenshots`. It's likely that the folder `screenshots` hasn't been created yet, so you might need to create one yourself.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
