### PR TITLE
[Mobile Payments] Add blog_id to IPP transaction description

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [**] Order Details: All unpaid orders have a Collect Payment button, which shows a payment method selection screen. Choices are Cash, Card, and Payment Link. [https://github.com/woocommerce/woocommerce-ios/pull/7111]
 - [*] Coupons: Removed the redundant animation when reloading the coupon list. [https://github.com/woocommerce/woocommerce-ios/pull/7137]
+- [*] In-Person Payments: Add blog_id to IPP transaction description to match WCPay [https://github.com/woocommerce/woocommerce-ios/pull/7221]
 
 9.5
 -----

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -254,13 +254,15 @@ private extension PaymentCaptureOrchestrator {
     }
 
     func receiptDescription(orderNumber: String) -> String? {
-        guard let storeName = stores.sessionManager.defaultSite?.name else {
+        guard let storeName = stores.sessionManager.defaultSite?.name,
+              let blogId = stores.sessionManager.defaultSite?.siteID else {
             return nil
         }
 
         return String.localizedStringWithFormat(Localization.receiptDescription,
                                                 orderNumber,
-                                                storeName)
+                                                storeName,
+                                                String(blogId))
     }
 
     func celebrate() {
@@ -284,11 +286,10 @@ private extension PaymentCaptureOrchestrator {
 
 private extension PaymentCaptureOrchestrator {
     enum Localization {
-        static let receiptDescription = NSLocalizedString("In-Person Payment for Order #%1$@ for %2$@",
-                                                          comment: "Message included in emailed receipts. "
-                                                            + "Reads as: In-Person Payment for "
-                                                            + "Order @{number} for @{store name} "
-                                                            + "Parameters: %1$@ - order number, "
-                                                            + "%2$@ - store name")
+        static let receiptDescription = NSLocalizedString(
+            "In-Person Payment for Order #%1$@ for %2$@ blog_id %3$@",
+            comment: "Message included in emailed receipts. " +
+            "Reads as: In-Person Payment for Order @{number} for @{store name} blog_id @{blog id} " +
+            "Parameters: %1$@ - order number, %2$@ - store name, %3$@ - blog ID number")
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -255,14 +255,14 @@ private extension PaymentCaptureOrchestrator {
 
     func receiptDescription(orderNumber: String) -> String? {
         guard let storeName = stores.sessionManager.defaultSite?.name,
-              let blogId = stores.sessionManager.defaultSite?.siteID else {
+              let blogID = stores.sessionManager.defaultSite?.siteID else {
             return nil
         }
 
         return String.localizedStringWithFormat(Localization.receiptDescription,
                                                 orderNumber,
                                                 storeName,
-                                                String(blogId))
+                                                String(blogID))
     }
 
     func celebrate() {
@@ -289,7 +289,7 @@ private extension PaymentCaptureOrchestrator {
         static let receiptDescription = NSLocalizedString(
             "In-Person Payment for Order #%1$@ for %2$@ blog_id %3$@",
             comment: "Message included in emailed receipts. " +
-            "Reads as: In-Person Payment for Order @{number} for @{store name} blog_id @{blog id} " +
+            "Reads as: In-Person Payment for Order @{number} for @{store name} blog_id @{blog ID} " +
             "Parameters: %1$@ - order number, %2$@ - store name, %3$@ - blog ID number")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7214 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates description of IPP so the text matches WCPay - `In-Person Payment for Order #[ORDER_ID] for [SITE NAME] blog_id [BLOG_ID]`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open Order List
2. Tap on +
3. Create a simple payment
4. Enter an amount
5. Click on Next
6. Tap on Card
7. Finish the IPP flow
8. Open Stripe Dashboard and locate the payment
9. Notice the payment descriptions matches `In-Person Payment for Order #[ORDER_ID] for [SITE NAME] blog_id [BLOG_ID]`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Stripe dashboard transactions with old and updated descriptions](https://user-images.githubusercontent.com/2472348/177501005-1f56a3c8-70a5-4762-b026-79c84f2cae28.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
