### PR TITLE
[Unified Order Editing] Handle multiple fee lines

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -483,13 +483,16 @@ extension EditableOrderViewModel {
         let shouldShowShippingTotal: Bool
         let shippingTotal: String
 
-        // We only support one(the first) shipping line
+        // We only support one (the first) shipping line
         let shippingMethodTitle: String
         let shippingMethodTotal: String
 
         let shouldShowFees: Bool
         let feesBaseAmountForPercentage: Decimal
         let feesTotal: String
+
+        // We only support one (the first) fee line
+        let feeLineTotal: String
 
         let taxesTotal: String
 
@@ -510,6 +513,7 @@ extension EditableOrderViewModel {
              shouldShowFees: Bool = false,
              feesBaseAmountForPercentage: Decimal = 0,
              feesTotal: String = "0",
+             feeLineTotal: String = "0",
              taxesTotal: String = "0",
              orderTotal: String = "0",
              isLoading: Bool = false,
@@ -525,6 +529,7 @@ extension EditableOrderViewModel {
             self.shouldShowFees = shouldShowFees
             self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.feesTotal = currencyFormatter.formatAmount(feesTotal) ?? "0.00"
+            self.feeLineTotal = currencyFormatter.formatAmount(feeLineTotal) ?? "0.00"
             self.taxesTotal = currencyFormatter.formatAmount(taxesTotal) ?? "0.00"
             self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? "0.00"
             self.isLoading = isLoading
@@ -535,7 +540,7 @@ extension EditableOrderViewModel {
                                                                       didSelectSave: saveShippingLineClosure)
             self.feeLineViewModel = FeeLineDetailsViewModel(isExistingFeeLine: shouldShowFees,
                                                             baseAmountForPercentage: feesBaseAmountForPercentage,
-                                                            feesTotal: self.feesTotal,
+                                                            feesTotal: feeLineTotal,
                                                             didSelectSave: saveFeeLineClosure)
         }
     }
@@ -710,6 +715,7 @@ private extension EditableOrderViewModel {
                                             shouldShowFees: order.fees.filter { $0.name != nil }.isNotEmpty,
                                             feesBaseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
                                             feesTotal: orderTotals.feesTotal.stringValue,
+                                            feeLineTotal: order.fees.first?.total ?? "0",
                                             taxesTotal: order.totalTax.isNotEmpty ? order.totalTax : "0",
                                             orderTotal: order.total.isNotEmpty ? order.total : "0",
                                             isLoading: isDataSyncing && !showNonEditableIndicators,


### PR DESCRIPTION
Closes: #6982.

## Description

**Order Creation** let us create only one fee line, but with **Order Edition** we can receive orders that have multiple fee lines.

To support those orders, this PR allows us to edit and delete the first fee line found without modifying the others.

## How

- Update `EditableOrderViewModel` to render the first fee line total, instead of the order total.
- Update `FeesInputTransformer` to edit and delete only the first fee line.

## Testing

1. Create an order with multiple fee lines on Core.
2. Go to the Orders tab, open the order.
3. Wait until order fully loads. Tap "•••" in navbar. Select "Edit".
4. Tap the "Fees" line in "Payment" section.
5. See that only the first fee line is presented and can be edited.
6. Remove that fee line.
7. See that the others fees remain unaltered.

## Video

https://user-images.githubusercontent.com/3132438/177528082-e7099606-c9a1-4a73-bfa3-3150a514eb8d.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.