### PR TITLE
[Reader Manuals Consolidation] Extract CardReaderManualRowView and model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualRowView.swift
@@ -1,17 +1,18 @@
 import SwiftUI
 
 struct CardReaderManualRowView: View {
+    // Environment safe areas
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
-    /// Environment safe areas
-    ///
-    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+    @State var webViewPresented = false
 
     let manual: Manual
 
     var body: some View {
-        NavigationLink(destination: SafariView(url: URL(string: manual.urlString)!)) {
+        NavigationRow(content: {
             HStack {
                 Image(uiImage: manual.image)
                     .resizable()
@@ -19,19 +20,22 @@ struct CardReaderManualRowView: View {
                     .frame(width: Constants.imageSize * scale, height: Constants.imageSize * scale, alignment: .center)
                 Text(manual.name)
                 .font(.body)
-                Spacer()
-                DisclosureIndicator()
             }
-            .padding()
-            .padding(.horizontal, insets: safeAreaInsets)
-        }
-        .buttonStyle(PlainButtonStyle())
+            .sheet(isPresented: $webViewPresented, onDismiss: {
+                webViewPresented = false
+            }, content: {
+                SafariSheetView(url: URL(string: manual.urlString)!)
+            })
+        }, action: {
+            webViewPresented.toggle()
+        })
+            .buttonStyle(PlainButtonStyle())
     }
 }
 
 struct CardReaderManualRowView_Previews: PreviewProvider {
     static var previews: some View {
-        CardReaderManualRowView(manual: Manual(id: 0, image: .cardReaderManualIcon, name: "empty", urlString: "empty"))
+        CardReaderManualRowView(manual: Manual(id: 0, image: .cardReaderManualIcon, name: "", urlString: ""))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualRowView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct CardReaderManualRowView: View {
+    // Tracks the scale of the view due to accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    /// Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
+    let manual: Manual
+
+    var body: some View {
+        NavigationLink(destination: SafariView(url: URL(string: manual.urlString)!)) {
+            HStack {
+                Image(uiImage: manual.image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: Constants.imageSize * scale, height: Constants.imageSize * scale, alignment: .center)
+                Text(manual.name)
+                .font(.body)
+                Spacer()
+                DisclosureIndicator()
+            }
+            .padding()
+            .padding(.horizontal, insets: safeAreaInsets)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+struct CardReaderManualRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        CardReaderManualRowView(manual: Manual(id: 0, image: .cardReaderManualIcon, name: "empty", urlString: "empty"))
+    }
+}
+
+private extension CardReaderManualRowView {
+    enum Constants {
+        static let imageSize: CGFloat = 64
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsView.swift
@@ -35,12 +35,3 @@ private extension CardReaderManualsView {
                                                         comment: "Navigation title at the top of the Card reader manuals screen")
     }
 }
-
-private extension CardReaderManualsView {
-    enum Constants {
-        static let iconSize: CGFloat = 16
-        static let imageSize: CGFloat = 64
-        static let imageSizeMultiplier: CGFloat = 0.2
-        static let textSizeMultiplier: CGFloat = 0.6
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsView.swift
@@ -3,8 +3,6 @@ import SwiftUI
 /// A view to be displayed on Card Reader Manuals screen
 ///
 struct CardReaderManualsView: View {
-    // Tracks the scale of the view due to accessibility changes
-    @ScaledMetric private var scale: CGFloat = 1.0
 
     let viewModel = CardReaderManualsViewModel()
     var manuals: [Manual] {
@@ -12,30 +10,16 @@ struct CardReaderManualsView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(manuals, id: \.name) { manual in
-                        Divider()
-                        NavigationLink(destination: SafariView(url: URL(string: manual.urlString)!)) {
-                                Image(uiImage: manual.image)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: Constants.imageSize * scale, height: Constants.imageSize * scale, alignment: .center)
-                                    .frame(width: geometry.size.width * Constants.imageSizeMultiplier)
-                                Text(manual.name)
-                                .frame(width: geometry.size.width * Constants.textSizeMultiplier, alignment: .leading)
-                                .font(.body)
-                                DisclosureIndicator()
-                                .frame(width: geometry.size.width * Constants.imageSizeMultiplier)
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                    }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(manuals, id: \.name) { manual in
                     Divider()
+                    CardReaderManualRowView(manual: manual)
                 }
+                Divider()
             }
-            .navigationBarTitle(Localization.navigationTitle, displayMode: .inline)
         }
+        .navigationBarTitle(Localization.navigationTitle, displayMode: .inline)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Yosemite
 
 struct Manual: Identifiable {
     let id: Int
@@ -11,28 +12,7 @@ struct Manual: Identifiable {
 final class CardReaderManualsViewModel {
     let manuals: [Manual]
 
-    init(manuals: [Manual] = [bbposChipper2XBT, stripeM2, wisepad3]) {
-        self.manuals = manuals
+    init(cardReaders: [CardReaderType] = [.chipper, .stripeM2, .wisepad3]) {
+        self.manuals = cardReaders.map { $0.manual }
     }
-}
-
-extension CardReaderManualsViewModel {
-    static let bbposChipper2XBT = Manual(
-        id: 0,
-        image: .cardReaderImageBBPOSChipper,
-        name: "BBPOS Chipper 2X BT",
-        urlString: "https://stripe.com/files/docs/terminal/c2xbt_product_sheet.pdf"
-    )
-    static let stripeM2 = Manual(
-        id: 1,
-        image: .cardReaderImageM2,
-        name: "Stripe Reader M2",
-        urlString: "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"
-    )
-    static let wisepad3 = Manual(
-        id: 2,
-        image: .cardReaderImageWisepad3,
-        name: "Wisepad 3",
-        urlString: "https://stripe.com/files/docs/terminal/wp3_product_sheet.pdf"
-    )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Yosemite
+
+extension CardReaderType {
+
+    var manual: Manual {
+        switch self {
+        case .chipper:
+            return Manual(
+                id: 0,
+                image: .cardReaderImageBBPOSChipper,
+                name: "BBPOS Chipper 2X BT",
+                urlString: "https://stripe.com/files/docs/terminal/c2xbt_product_sheet.pdf"
+            )
+        case .stripeM2:
+            return Manual(
+                id: 1,
+                image: .cardReaderImageM2,
+                name: "Stripe Reader M2",
+                urlString: "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"
+            )
+        case .wisepad3:
+            return Manual(
+                id: 2,
+                image: .cardReaderImageWisepad3,
+                name: "Wisepad 3",
+                urlString: "https://stripe.com/files/docs/terminal/wp3_product_sheet.pdf"
+            )
+        case .other:
+            return Manual(id: 5, image: .cardReaderManualIcon, name: "", urlString: "")
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -952,6 +952,7 @@
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
 		68E952CC287536010095A23D /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CB287536010095A23D /* SafariView.swift */; };
 		68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */; };
+		68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
 		740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740987B221B87760000E4C80 /* FancyAnimatedButton+Woo.swift */; };
@@ -2716,6 +2717,7 @@
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
 		68E952CB287536010095A23D /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
+		68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderType+Manual.swift"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
 		740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LargeImageTableViewCell.xib; sourceTree = "<group>"; };
@@ -8075,6 +8077,7 @@
 				684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */,
 				68E952CB287536010095A23D /* SafariView.swift */,
 				68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */,
+				68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -9088,6 +9091,7 @@
 				B5AA7B3F20ED81C2004DA14F /* UserDefaults+Woo.swift in Sources */,
 				318477E527A33C650058C7E9 /* CardPresentModalConnectingFailedChargeReader.swift in Sources */,
 				DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */,
+				68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */,
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -951,6 +951,7 @@
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
 		68E952CC287536010095A23D /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CB287536010095A23D /* SafariView.swift */; };
+		68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
 		740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740987B221B87760000E4C80 /* FancyAnimatedButton+Woo.swift */; };
@@ -2714,6 +2715,7 @@
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
 		68E952CB287536010095A23D /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
+		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
 		740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LargeImageTableViewCell.xib; sourceTree = "<group>"; };
@@ -7199,7 +7201,6 @@
 				DEC51B05276B3F3C009F3DF4 /* Int64+Helpers.swift */,
 				02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */,
 				02645D8727BA2E820065DC68 /* NSAttributedString+Attributes.swift */,
-				B9B6DEEE283F8B9F00901FB7 /* Site+PluginsURL.swift */,
 				450C6EE9286F4334002DB168 /* SitePlugin+Woo.swift */,
 				B9B6DEEE283F8B9F00901FB7 /* Site+URL.swift */,
 				021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */,
@@ -8073,6 +8074,7 @@
 				684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */,
 				684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */,
 				68E952CB287536010095A23D /* SafariView.swift */,
+				68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -9560,6 +9562,7 @@
 				020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */,
 				B5A56BF5219F5AB20065A902 /* NSNotificationName+Woo.swift in Sources */,
 				D449C51B26DE6B5000D75B02 /* ReportList.swift in Sources */,
+				68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */,
 				CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */,
 				029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */,
 				DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */,


### PR DESCRIPTION
Closes: #7193 

### Description
This PR is a continuation of #7199, it addresses the following items:

- From [this review](https://github.com/woocommerce/woocommerce-ios/pull/7199#discussion_r913666836): Extracts a new `CardReaderManualRowView` component from `CardReaderManualsView`, using the existing SwiftUI reusable components `NavigationRow` and `SafariSheetView`.
- From [this review](https://github.com/woocommerce/woocommerce-ios/pull/7199#discussion_r913671666): Extracts the Manuals model into a `CardReaderType+Manual` extension

### Testing instructions

- Go to Settings > In-Person Payments
- Tap on `Card Reader manuals` and see 3 options:
- See how each option redirects to the online documentation for that specific manual.

### Screenshots

![Simulator Screen Recording - iPhone 11 Pro Max - 2022-07-06 at 19 22 04](https://user-images.githubusercontent.com/3812076/177549217-c5526c74-2af4-41f6-a15d-f5250a2347d1.gif)

