### PR TITLE
Login Prologue: add a "New to WooCommerce?" button for new users behind a feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -45,6 +45,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .appleIDAccountDeletion:
             return true
+        case .newToWooCommerceLinkInLoginPrologue:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -89,4 +89,8 @@ public enum FeatureFlag: Int {
     /// Apple ID account deletion
     ///
     case appleIDAccountDeletion
+
+    /// Showing a "New to WooCommerce" link in the login prologue screen
+    ///
+    case newToWooCommerceLinkInLoginPrologue
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -9,16 +9,18 @@ final class LoginPrologueViewController: UIViewController {
 
     /// Background View, to be placed surrounding the bottom area.
     ///
-    @IBOutlet var backgroundView: UIView!
+    @IBOutlet private var backgroundView: UIView!
 
     /// Container View: Holds up the Button + bottom legend.
     ///
-    @IBOutlet var containerView: UIView!
+    @IBOutlet private var containerView: UIView!
 
     /// Curved Rectangle: Background shape with curved top edge
     ///
-    @IBOutlet weak var curvedRectangle: UIImageView!
+    @IBOutlet private weak var curvedRectangle: UIImageView!
 
+    /// Button for users who are new to WooCommerce to learn more about WooCommerce.
+    @IBOutlet private weak var newToWooCommerceButton: UIButton!
 
     // MARK: - Overridden Properties
 
@@ -37,6 +39,7 @@ final class LoginPrologueViewController: UIViewController {
         setupContainerView()
         setupCurvedRectangle()
         setupCarousel()
+        setupNewToWooCommerceButton()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -76,6 +79,38 @@ private extension LoginPrologueViewController {
 
         addChild(carousel)
         view.addSubview(carousel.view)
-        view.pinSubviewToAllEdges(carousel.view)
+        NSLayoutConstraint.activate([
+            carousel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            carousel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            carousel.view.topAnchor.constraint(equalTo: view.topAnchor),
+            carousel.view.bottomAnchor.constraint(equalTo: newToWooCommerceButton.topAnchor),
+        ])
+    }
+
+    func setupNewToWooCommerceButton() {
+        newToWooCommerceButton.setTitle(Localization.newToWooCommerce, for: .normal)
+        newToWooCommerceButton.applyLinkButtonStyle()
+        newToWooCommerceButton.titleLabel?.numberOfLines = 0
+        newToWooCommerceButton.on(.touchUpInside) { _ in
+            // TODO: 7231 - analytics
+
+            guard let url = URL(string: Constants.newToWooCommerceURL) else {
+                return assertionFailure("Cannot generate URL.")
+            }
+
+            WebviewHelper.launch(url, with: self)
+        }
+    }
+}
+
+private extension LoginPrologueViewController {
+    enum Constants {
+        // TODO: 7231 - update URL if needed
+        static let newToWooCommerceURL = "https://wordpress.com/support/introduction-to-woocommerce"
+    }
+
+    enum Localization {
+        static let newToWooCommerce = NSLocalizedString("New to WooCommerce?",
+                                                        comment: "Title of button in the login prologue screen for users who are new to WooCommerce.")
     }
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -1,11 +1,13 @@
 import Foundation
 import UIKit
 import WordPressAuthenticator
+import Experiments
 
 
 /// Displays the WooCommerce Prologue UI.
 ///
 final class LoginPrologueViewController: UIViewController {
+    private let isNewToWooCommerceButtonShown: Bool
 
     /// Background View, to be placed surrounding the bottom area.
     ///
@@ -31,6 +33,15 @@ final class LoginPrologueViewController: UIViewController {
 
     // MARK: - Overridden Methods
 
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        isNewToWooCommerceButtonShown = featureFlagService.isFeatureFlagEnabled(.newToWooCommerceLinkInLoginPrologue)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -38,8 +49,8 @@ final class LoginPrologueViewController: UIViewController {
         setupBackgroundView()
         setupContainerView()
         setupCurvedRectangle()
-        setupCarousel()
-        setupNewToWooCommerceButton()
+        setupCarousel(isNewToWooCommerceButtonShown: isNewToWooCommerceButtonShown)
+        setupNewToWooCommerceButton(isNewToWooCommerceButtonShown: isNewToWooCommerceButtonShown)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -73,21 +84,28 @@ private extension LoginPrologueViewController {
     /// Adds a carousel (slider) of screens to promote the main features of the app.
     /// This is contained in a child view so that this view's background doesn't scroll.
     ///
-    func setupCarousel() {
+    func setupCarousel(isNewToWooCommerceButtonShown: Bool) {
         let carousel = LoginProloguePageViewController()
         carousel.view.translatesAutoresizingMaskIntoConstraints = false
 
         addChild(carousel)
         view.addSubview(carousel.view)
-        NSLayoutConstraint.activate([
-            carousel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            carousel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            carousel.view.topAnchor.constraint(equalTo: view.topAnchor),
-            carousel.view.bottomAnchor.constraint(equalTo: newToWooCommerceButton.topAnchor),
-        ])
+        if isNewToWooCommerceButtonShown {
+            NSLayoutConstraint.activate([
+                carousel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                carousel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                carousel.view.topAnchor.constraint(equalTo: view.topAnchor),
+                carousel.view.bottomAnchor.constraint(equalTo: newToWooCommerceButton.topAnchor),
+            ])
+        } else {
+            view.pinSubviewToAllEdges(carousel.view)
+        }
     }
 
-    func setupNewToWooCommerceButton() {
+    func setupNewToWooCommerceButton(isNewToWooCommerceButtonShown: Bool) {
+        guard isNewToWooCommerceButtonShown else {
+            return newToWooCommerceButton.isHidden = true
+        }
         newToWooCommerceButton.setTitle(Localization.newToWooCommerce, for: .normal)
         newToWooCommerceButton.applyLinkButtonStyle()
         newToWooCommerceButton.titleLabel?.numberOfLines = 0

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -91,6 +91,7 @@ private extension LoginPrologueViewController {
         newToWooCommerceButton.setTitle(Localization.newToWooCommerce, for: .normal)
         newToWooCommerceButton.applyLinkButtonStyle()
         newToWooCommerceButton.titleLabel?.numberOfLines = 0
+        newToWooCommerceButton.titleLabel?.textAlignment = .center
         newToWooCommerceButton.on(.touchUpInside) { _ in
             // TODO: 7231 - analytics
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -95,7 +95,8 @@ private extension LoginPrologueViewController {
                 carousel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 carousel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 carousel.view.topAnchor.constraint(equalTo: view.topAnchor),
-                carousel.view.bottomAnchor.constraint(equalTo: newToWooCommerceButton.topAnchor),
+                carousel.view.bottomAnchor.constraint(equalTo: newToWooCommerceButton.topAnchor,
+                                                      constant: -Constants.spacingBetweenCarouselAndNewToWooCommerceButton),
             ])
         } else {
             view.pinSubviewToAllEdges(carousel.view)
@@ -124,6 +125,7 @@ private extension LoginPrologueViewController {
 
 private extension LoginPrologueViewController {
     enum Constants {
+        static let spacingBetweenCarouselAndNewToWooCommerceButton: CGFloat = 20
         // TODO: 7231 - update URL if needed
         static let newToWooCommerceURL = "https://wordpress.com/support/introduction-to-woocommerce"
     }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -127,7 +127,7 @@ private extension LoginPrologueViewController {
     enum Constants {
         static let spacingBetweenCarouselAndNewToWooCommerceButton: CGFloat = 20
         // TODO: 7231 - update URL if needed
-        static let newToWooCommerceURL = "https://wordpress.com/support/introduction-to-woocommerce"
+        static let newToWooCommerceURL = "https://woocommerce.com/guides/new-store"
     }
 
     enum Localization {

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
@@ -42,7 +42,7 @@
                     </constraints>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IUc-Ht-iMk">
-                    <rect key="frame" x="161.66666666666666" y="779" width="67" height="31"/>
+                    <rect key="frame" x="161.66666666666666" y="759" width="67" height="31"/>
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" title="Button"/>
                 </button>
@@ -61,7 +61,7 @@
                 <constraint firstItem="3vu-Xh-Yk9" firstAttribute="top" secondItem="o29-Vv-KDs" secondAttribute="bottom" id="fcK-hC-jRy"/>
                 <constraint firstItem="3vu-Xh-Yk9" firstAttribute="leading" secondItem="V2X-Xj-JeZ" secondAttribute="leading" id="osl-zf-VHk"/>
                 <constraint firstItem="Rhn-8s-tRs" firstAttribute="trailing" secondItem="3oc-0l-uZX" secondAttribute="trailing" id="sli-mX-npW"/>
-                <constraint firstItem="IUc-Ht-iMk" firstAttribute="bottom" secondItem="o29-Vv-KDs" secondAttribute="bottom" id="ukL-9P-uxE"/>
+                <constraint firstItem="IUc-Ht-iMk" firstAttribute="bottom" secondItem="o29-Vv-KDs" secondAttribute="bottom" constant="-20" id="ukL-9P-uxE"/>
                 <constraint firstItem="Rhn-8s-tRs" firstAttribute="leading" secondItem="3oc-0l-uZX" secondAttribute="leading" id="vw2-Lp-6Db"/>
                 <constraint firstItem="IUc-Ht-iMk" firstAttribute="centerX" secondItem="o29-Vv-KDs" secondAttribute="centerX" id="xCS-jP-Lti"/>
                 <constraint firstItem="o29-Vv-KDs" firstAttribute="bottom" secondItem="3oc-0l-uZX" secondAttribute="bottom" id="yj6-tl-g4o"/>

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,6 +13,7 @@
                 <outlet property="backgroundView" destination="3vu-Xh-Yk9" id="SU5-64-Opq"/>
                 <outlet property="containerView" destination="o29-Vv-KDs" id="U7h-cw-w9k"/>
                 <outlet property="curvedRectangle" destination="Rhn-8s-tRs" id="fwI-6M-kbT"/>
+                <outlet property="newToWooCommerceButton" destination="IUc-Ht-iMk" id="nQg-ke-CWf"/>
                 <outlet property="view" destination="V2X-Xj-JeZ" id="Vob-Ki-8K1"/>
             </connections>
         </placeholder>
@@ -40,9 +41,16 @@
                         <constraint firstAttribute="height" constant="36" id="gWf-lm-a4c"/>
                     </constraints>
                 </imageView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IUc-Ht-iMk">
+                    <rect key="frame" x="161.66666666666666" y="779" width="67" height="31"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="3oc-0l-uZX"/>
             <constraints>
+                <constraint firstItem="IUc-Ht-iMk" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="o29-Vv-KDs" secondAttribute="trailing" constant="16" id="5TO-hi-QbE"/>
+                <constraint firstItem="IUc-Ht-iMk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="o29-Vv-KDs" secondAttribute="leading" constant="16" id="B0q-rB-pt3"/>
                 <constraint firstAttribute="bottom" secondItem="3vu-Xh-Yk9" secondAttribute="bottom" id="DQs-9H-0q1"/>
                 <constraint firstItem="o29-Vv-KDs" firstAttribute="leading" secondItem="3oc-0l-uZX" secondAttribute="leading" id="EIM-fi-cgJ"/>
                 <constraint firstItem="3oc-0l-uZX" firstAttribute="trailing" secondItem="o29-Vv-KDs" secondAttribute="trailing" id="LER-Vg-1a4"/>
@@ -53,7 +61,9 @@
                 <constraint firstItem="3vu-Xh-Yk9" firstAttribute="top" secondItem="o29-Vv-KDs" secondAttribute="bottom" id="fcK-hC-jRy"/>
                 <constraint firstItem="3vu-Xh-Yk9" firstAttribute="leading" secondItem="V2X-Xj-JeZ" secondAttribute="leading" id="osl-zf-VHk"/>
                 <constraint firstItem="Rhn-8s-tRs" firstAttribute="trailing" secondItem="3oc-0l-uZX" secondAttribute="trailing" id="sli-mX-npW"/>
+                <constraint firstItem="IUc-Ht-iMk" firstAttribute="bottom" secondItem="o29-Vv-KDs" secondAttribute="bottom" id="ukL-9P-uxE"/>
                 <constraint firstItem="Rhn-8s-tRs" firstAttribute="leading" secondItem="3oc-0l-uZX" secondAttribute="leading" id="vw2-Lp-6Db"/>
+                <constraint firstItem="IUc-Ht-iMk" firstAttribute="centerX" secondItem="o29-Vv-KDs" secondAttribute="centerX" id="xCS-jP-Lti"/>
                 <constraint firstItem="o29-Vv-KDs" firstAttribute="bottom" secondItem="3oc-0l-uZX" secondAttribute="bottom" id="yj6-tl-g4o"/>
                 <constraint firstItem="3vu-Xh-Yk9" firstAttribute="trailing" secondItem="V2X-Xj-JeZ" secondAttribute="trailing" id="zQC-U3-vhG"/>
             </constraints>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7231 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Design reference: p1657132348284999-slack-C0354HSNUJH

This PR added a new CTA on the login prologue screen for users who are new to WooCommerce behind a feature flag. The link is above the existing 2 login CTAs and tapping on it shows a web page (pending decision pe5sF9-2B-p2#comment-54). We might explore AB testing this feature pending discussion p1657093503947079/1657093471.680409-slack-CGPNUU63E.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Feature flag on

- Log out of the app if needed --> on the login prologue screen, there should be a button that says "New to WooCommerce?" above the 2 login buttons. tapping on it should open a webview (currently to [this doc](https://wordpress.com/support/introduction-to-woocommerce/) but we're likely updating it to our own doc)

#### Feature flag off

- Log out of the app if needed --> on the login prologue screen, there should not be a button that says "New to WooCommerce?" above the 2 login buttons (the same as in production)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | dark | light
-- | -- | --
feature flag on | ![Simulator Screen Shot - iPhone 13 - 2022-07-07 at 10 07 22](https://user-images.githubusercontent.com/1945542/177793986-f0ddecaf-5bcf-4e48-8b8b-ab39dc734fd0.png) | ![Simulator Screen Shot - iPhone 13 - 2022-07-07 at 10 08 07](https://user-images.githubusercontent.com/1945542/177793993-4f1bee2f-1dab-47b2-a1b6-292322935d6f.png)
feature flag off | ![Simulator Screen Shot - iPhone 13 - 2022-07-06 at 16 02 23](https://user-images.githubusercontent.com/1945542/177633333-75696b72-355f-4983-904a-08de1772ffe9.png) | ![Simulator Screen Shot - iPhone 13 - 2022-07-06 at 16 01 40](https://user-images.githubusercontent.com/1945542/177633331-e9fd0949-bf60-4b5b-a23f-73b551df06e1.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->