### PR TITLE
Coupons: Update coupon amount formatter default value to be empty

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/Coupon Text Validators/CouponAmountInputFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/Coupon Text Validators/CouponAmountInputFormatter.swift
@@ -20,7 +20,7 @@ struct CouponAmountInputFormatter: UnitInputFormatter {
 
     func format(input text: String?) -> String {
         guard !text.isNilOrEmpty else {
-            return "0"
+            return ""
         }
 
         return priceInputFormatter.format(input: text)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponAmountInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponAmountInputFormatterTests.swift
@@ -51,7 +51,7 @@ final class CouponAmountInputFormatterTests: XCTestCase {
 
     func test_formatting_empty_input() {
         let input = ""
-        XCTAssertEqual(formatter.format(input: input), "0")
+        XCTAssertEqual(formatter.format(input: input), "")
     }
 
     func test_formatting_zero_input() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7202
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the `CouponAmountInputFormatter` to not format the values to 0 if the content is empty or null.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable coupon management in Settings > Experimental Features.
- Navigate to Menu > Coupons. Select "+" to create a new coupon.
- Notice that on the creation form, the default value for the discount amount and minimum/maximum amounts are empty. Tap on these fields and start typing, you should get the desired number without any trailing zero.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/177697995-fec3a2eb-c855-4d6a-9d7c-b18764db151e.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
