### PR TITLE
Split view: Switch to new order if split view is enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -372,6 +372,10 @@ private extension OrdersRootViewController {
     ///
     private func navigateToOrderDetail(_ order: Order) {
         let viewModel = OrderDetailsViewModel(order: order)
+        guard !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
+            return handleSwitchingDetails(viewModel: viewModel)
+        }
+
         let orderViewController = Inject.ViewControllerHost(OrderDetailsViewController(viewModel: viewModel))
 
         // Cleanup navigation (remove new order flow views) before navigating to order details


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #6381 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There's an existing issue of split view in the order creation flow: when a new order is created, it's pushed into the primary column's navigation stack.

This PR fixes that by switching the split view's secondary column to display the new order instead.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn on the `splitViewInOrdersTab` feature flag.
- Build the app to an iPad or large iPhone in landscape mode.
- Create a new order and notice that the new order is displayed on the secondary column.
- Try building the app to an iPhone in portrait mode. Notice that the newly created order is still displayed after creation succeeds.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/177760129-f52c609a-d98b-4ecd-a9f9-c4a2445e85f3.mp4




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
