### PR TITLE
[Order Metadata] Add support for order metadata in Networking Layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -350,7 +350,8 @@ extension Order {
             coupons: .fake(),
             refunds: .fake(),
             fees: .fake(),
-            taxes: .fake()
+            taxes: .fake(),
+            customFields: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -311,7 +311,8 @@ extension Order {
         coupons: CopiableProp<[OrderCouponLine]> = .copy,
         refunds: CopiableProp<[OrderRefundCondensed]> = .copy,
         fees: CopiableProp<[OrderFeeLine]> = .copy,
-        taxes: CopiableProp<[OrderTaxLine]> = .copy
+        taxes: CopiableProp<[OrderTaxLine]> = .copy,
+        customFields: CopiableProp<[OrderMetaData]> = .copy
     ) -> Order {
         let siteID = siteID ?? self.siteID
         let orderID = orderID ?? self.orderID
@@ -346,6 +347,7 @@ extension Order {
         let refunds = refunds ?? self.refunds
         let fees = fees ?? self.fees
         let taxes = taxes ?? self.taxes
+        let customFields = customFields ?? self.customFields
 
         return Order(
             siteID: siteID,
@@ -380,7 +382,8 @@ extension Order {
             coupons: coupons,
             refunds: refunds,
             fees: fees,
-            taxes: taxes
+            taxes: taxes,
+            customFields: customFields
         )
     }
 }
@@ -493,7 +496,7 @@ extension OrderItemRefund {
         name: CopiableProp<String> = .copy,
         productID: CopiableProp<Int64> = .copy,
         variationID: CopiableProp<Int64> = .copy,
-        refundedItemID: CopiableProp<String> = .copy,
+        refundedItemID: NullableCopiableProp<String> = .copy,
         quantity: CopiableProp<Decimal> = .copy,
         price: CopiableProp<NSDecimalNumber> = .copy,
         sku: NullableCopiableProp<String> = .copy,

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -46,6 +46,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
     public let fees: [OrderFeeLine]
     public let taxes: [OrderTaxLine]
 
+    public let customFields: [OrderMetaData]
+
     /// Order struct initializer.
     ///
     public init(siteID: Int64,
@@ -80,7 +82,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                 coupons: [OrderCouponLine],
                 refunds: [OrderRefundCondensed],
                 fees: [OrderFeeLine],
-                taxes: [OrderTaxLine]) {
+                taxes: [OrderTaxLine],
+                customFields: [OrderMetaData]) {
 
         self.siteID = siteID
         self.orderID = orderID
@@ -119,6 +122,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         self.refunds = refunds
         self.fees = fees
         self.taxes = taxes
+
+        self.customFields = customFields
     }
 
 
@@ -194,6 +199,9 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         // https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1561
         let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? false
 
+        // Filter out meta data if its key is prefixed with an underscore (internal meta keys)
+        let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") }) ?? []
+
         self.init(siteID: siteID,
                   orderID: orderID,
                   parentID: parentID,
@@ -226,7 +234,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   coupons: coupons,
                   refunds: refunds,
                   fees: fees,
-                  taxes: taxes)
+                  taxes: taxes,
+                  customFields: customFields)
     }
 
     public static var empty: Order {
@@ -262,7 +271,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   coupons: [],
                   refunds: [],
                   fees: [],
-                  taxes: [])
+                  taxes: [],
+                  customFields: [])
     }
 }
 

--- a/Networking/Networking/Model/OrderMetaData.swift
+++ b/Networking/Networking/Model/OrderMetaData.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents the metadata within an Order
 /// Currently only handles `String` metadata values
 ///
-struct OrderMetaData: Decodable {
+public struct OrderMetaData: Decodable {
     public let key: String
     public let value: String
 

--- a/Networking/Networking/Model/OrderMetaData.swift
+++ b/Networking/Networking/Model/OrderMetaData.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents the metadata within an Order
 /// Currently only handles `String` metadata values
 ///
-public struct OrderMetaData: Decodable {
+public struct OrderMetaData: Decodable, Equatable {
     public let key: String
     public let value: String
 

--- a/Networking/Networking/Model/OrderMetaData.swift
+++ b/Networking/Networking/Model/OrderMetaData.swift
@@ -5,12 +5,14 @@ import Codegen
 /// Currently only handles `String` metadata values
 ///
 public struct OrderMetaData: Decodable, Equatable {
+    public let metadataID: Int64
     public let key: String
     public let value: String
 
     /// OrderMetaData struct initializer.
     ///
-    public init(key: String, value: String) {
+    public init(metadataID: Int64, key: String, value: String) {
+        self.metadataID = metadataID
         self.key = key
         self.value = value
     }
@@ -19,10 +21,11 @@ public struct OrderMetaData: Decodable, Equatable {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        let metadataID = try container.decode(Int64.self, forKey: .metadataID)
         let key = try container.decode(String.self, forKey: .key)
         let value = container.failsafeDecodeIfPresent(String.self, forKey: .value) ?? ""
 
-        self.init(key: key, value: value)
+        self.init(metadataID: metadataID, key: key, value: value)
     }
 }
 
@@ -30,6 +33,7 @@ public struct OrderMetaData: Decodable, Equatable {
 ///
 private extension OrderMetaData {
     enum CodingKeys: String, CodingKey {
+        case metadataID = "id"
         case key
         case value
     }

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -327,6 +327,26 @@ final class OrderMapperTests: XCTestCase {
 
         XCTAssertEqual(order.chargeID, "ch_3KMuym2EdyGr1FMV0uQZeFqm")
     }
+
+    func test_order_custom_fields_correctly_remove_internal_metadata() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadFullyRefundedOrderResponse())
+
+        // Then
+        XCTAssertEqual(order.customFields.count, 4)
+    }
+
+    func test_order_custom_fields_are_parsed_correctly() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadFullyRefundedOrderResponse())
+
+        // When
+        let customField = try XCTUnwrap(order.customFields.first)
+
+        // Then
+        let expectedCustomField = OrderMetaData(key: "Viewed Currency", value: "USD")
+        XCTAssertEqual(customField, expectedCustomField)
+    }
 }
 
 

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -344,7 +344,7 @@ final class OrderMapperTests: XCTestCase {
         let customField = try XCTUnwrap(order.customFields.first)
 
         // Then
-        let expectedCustomField = OrderMetaData(key: "Viewed Currency", value: "USD")
+        let expectedCustomField = OrderMetaData(metadataID: 18148, key: "Viewed Currency", value: "USD")
         XCTAssertEqual(customField, expectedCustomField)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -458,7 +458,8 @@ struct EditAddressForm_Previews: PreviewProvider {
                                    coupons: [],
                                    refunds: [],
                                    fees: [],
-                                   taxes: [])
+                                   taxes: [],
+                                   customFields: [])
 
     static let sampleAddress = Address(firstName: "Johnny",
                                        lastName: "Appleseed",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -474,7 +474,8 @@ extension ShippingLabelPackagesFormViewModel {
                      coupons: sampleCoupons(),
                      refunds: [],
                      fees: [],
-                     taxes: [])
+                     taxes: [],
+                     customFields: [])
     }
 
     static func sampleAddress() -> Address {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -38,7 +38,8 @@ enum ShippingLabelSampleData {
                      coupons: sampleCoupons(),
                      refunds: [],
                      fees: [],
-                     taxes: [])
+                     taxes: [],
+                     customFields: [])
     }
 
     static func samplePackageDetails() -> ShippingLabelPackagesResponse {

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -242,7 +242,8 @@ extension MockObjectGraph {
             coupons: [],
             refunds: [],
             fees: [],
-            taxes: []
+            taxes: [],
+            customFields: []
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -109,7 +109,8 @@ extension Storage.Order: ReadOnlyConvertible {
                      coupons: orderCoupons,
                      refunds: orderRefunds,
                      fees: orderFeeLines,
-                     taxes: orderTaxLines)
+                     taxes: orderTaxLines,
+                     customFields: []) // TODO: Handle custom fields (order meta data)
 
     }
 

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -40,7 +40,8 @@ public enum OrderFactory {
               coupons: [],
               refunds: [],
               fees: [simplePaymentFee(feeID: 0, amount: amount, taxable: taxable)],
-              taxes: [])
+              taxes: [],
+              customFields: [])
     }
 
     /// Creates a fee line suitable to be used within a simple payments order.


### PR DESCRIPTION
Closes: #7232

## Description

The Networking layer already supports decoding order metadata (as the `OrderMetaData` entity) from the order details API response: `GET /wc/v3/orders/{ORDER_ID}`.

This PR adds support in the Networking Layer for setting non-internal order metadata (metadata that doesn't have a key prefixed with an underscore) on a new `customFields` property on the `Order` entity.

Note: I decided to call this property `customFields` because we're not including ALL metadata and it corresponds with how wp-admin presents this metadata. (WordPress generally refers to post metadata as [custom fields](https://wordpress.org/support/article/custom-fields/).) Let me know if you think some other naming would be clearer here!

## Changes

* Updates the `Order` entity with a new `customFields` property. When decoding an order from the API, any non-internal metadata (metadata that doesn't have a key prefixed with an underscore) is saved in `customFields`.
* Adds the `customFields` property everywhere `Order` is used, including in the generated `fake()` and `copy()` methods. (`Order+ReadOnlyConvertible` will be updated to handle custom fields as part of #7234.)
* Updates the `OrderMetaData` entity:
   * It is now public (since that entity is now used for a property on orders, and not just internally when decoding order responses) and `Equatable` (for unit testing).
   * It now includes a `metadataID` property. This ensures the metadata has a unique ID property, in case the keys are missing or not unique for some metadata.
* Adds unit tests to check that the order metadata filters out internal metadata and parses the order metadata as expected.

## Testing

The new `customFields` property isn't used yet, so a quick smoke test should be sufficient to confirm that the order list still loads on the Orders tab and orders can be opened to view the order details.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
