### PR TITLE
[Mobile Payments] Fix payment methods landscape UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -28,53 +28,55 @@ struct PaymentMethodsView: View {
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Layout.noSpacing) {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Layout.noSpacing) {
 
-            Text(Localization.header)
-                .subheadlineStyle()
-                .padding()
-                .padding(.horizontal, insets: safeAreaInsets)
+                Text(Localization.header)
+                    .subheadlineStyle()
+                    .padding()
+                    .padding(.horizontal, insets: safeAreaInsets)
 
-            Divider()
+                Divider()
 
-            VStack(alignment: .leading, spacing: 8) {
-                VStack(alignment: .leading, spacing: Layout.noSpacing) {
-                    MethodRow(icon: .priceImage, title: Localization.cash) {
-                        showingCashAlert = true
-                        viewModel.trackCollectByCash()
-                    }
+                VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: Layout.noSpacing) {
+                        MethodRow(icon: .priceImage, title: Localization.cash) {
+                            showingCashAlert = true
+                            viewModel.trackCollectByCash()
+                        }
 
-                    if viewModel.showPayWithCardRow {
-                        Divider()
+                        if viewModel.showPayWithCardRow {
+                            Divider()
 
-                        MethodRow(icon: .creditCardImage, title: Localization.card) {
-                            viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
+                            MethodRow(icon: .creditCardImage, title: Localization.card) {
+                                viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
+                            }
+                        }
+
+                        if viewModel.showPaymentLinkRow {
+                            Divider()
+
+                            MethodRow(icon: .linkImage, title: Localization.link) {
+                                sharingPaymentLink = true
+                                viewModel.trackCollectByPaymentLink()
+                            }
                         }
                     }
+                    .padding(.horizontal)
+                    .background(Color(.listForeground))
 
-                    if viewModel.showPaymentLinkRow {
-                        Divider()
-
-                        MethodRow(icon: .linkImage, title: Localization.link) {
-                            sharingPaymentLink = true
-                            viewModel.trackCollectByPaymentLink()
-                        }
+                    if viewModel.showUpsellCardReaderFeatureBanner {
+                        FeatureAnnouncementCardView(viewModel: viewModel.cardUpsellAnnouncementViewModel,
+                                                    dismiss: nil,
+                                                    callToAction: {
+                            showingPurchaseCardReaderView = true
+                        })
                     }
                 }
-                .padding(.horizontal)
-                .background(Color(.listForeground))
 
-                if viewModel.showUpsellCardReaderFeatureBanner {
-                    FeatureAnnouncementCardView(viewModel: viewModel.cardUpsellAnnouncementViewModel,
-                                            dismiss: nil,
-                                            callToAction: {
-                        showingPurchaseCardReaderView = true
-                    })
-                }
+                // Pushes content to the top
+                Spacer()
             }
-
-            // Pushes content to the top
-            Spacer()
         }
         .ignoresSafeArea(edges: .horizontal)
         .disabled(viewModel.disableViewActions)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -14,6 +14,8 @@ struct FeatureAnnouncementCardView: View {
         self.callToAction = callToAction
     }
 
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
@@ -55,10 +57,12 @@ struct FeatureAnnouncementCardView: View {
             }
             .padding(.top, Layout.smallSpacing)
             .padding(.leading, Layout.padding)
-        }.background(Color(.listForeground))
-            .onAppear {
-                viewModel.onAppear()
-            }
+        }
+        .padding(.horizontal, insets: safeAreaInsets)
+        .background(Color(.listForeground).ignoresSafeArea())
+        .onAppear {
+            viewModel.onAppear()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7246 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, a maximum of three rows were displayed on the `PaymentMethod` screen, and they were all standard height. This meant there was no situation when that screen would need to scroll. 

Recently, we added a feature announcement card, which did not completely fit on smaller devices in landscape. Additionally, on newer devices this new announcement card was partially obscured by the notch.

This adds a scrollview to the PaymentMethod screen, correctly respecting `safeAreaInsets`, to enable users to see the full content of that screen, including when they are in landscape.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a store in the US or Canada:

1. Launch the app and go to the Orders tab
2. Tap `+` and select `Simple Payment` or `Create Order
3. Set up the payment/order and go through to the payment method selection screen.
4. Change the orientation to landscape
5. Observe that the table is scrollable, and the banner's content is not obscured by the notch

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/177786581-dedd76cc-2fea-4a01-bdc3-22066ae7d73a.mp4

![PaymentMethods in landscape on notched screen](https://user-images.githubusercontent.com/2472348/177786726-962b1483-ba55-40cc-8ca9-127de6576c67.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
