### PR TITLE
Background image upload: fix downloadable product & enable feature flag for all users

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -40,7 +40,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .unifiedOrderEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backgroundProductImageUpload:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .consolidatedCardReaderManuals:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .appleIDAccountDeletion:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Login: Display the Jetpack requirement error after login is successful.
 - [*] In-Person Payments: Publicize the Card Present Payments feature on the Payment Method screen [https://github.com/woocommerce/woocommerce-ios/pull/7225]
 - [*] In-Person Payments: Add blog_id to IPP transaction description to match WCPay [https://github.com/woocommerce/woocommerce-ios/pull/7221]
+- [*] Product form: after uploading an image, the product can now be saved immediately while the image is being uploaded in the background. When no images are pending upload for the saved product, the images are added to the product. Testing instructions: https://github.com/woocommerce/woocommerce-ios/pull/7196. [https://github.com/woocommerce/woocommerce-ios/pull/7254]
 
 9.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -33,16 +33,15 @@ final class ProductDownloadListViewController: UIViewController {
                                           backgroundColor: UIColor.black.withAlphaComponent(0.4))
 
     init(product: ProductFormDataModel,
-         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+         stores: StoresManager = ServiceLocator.stores,
          completion: @escaping Completion) {
         self.product = product
         viewModel = ProductDownloadListViewModel(product: product)
         onCompletion = completion
-        productImageActionHandler = productImageUploader
-            .actionHandler(key: .init(siteID: product.siteID,
-                                      productOrVariationID: .product(id: product.productID),
-                                      isLocalID: !product.existsRemotely),
-                           originalStatuses: product.imageStatuses)
+        productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
+                                                              productID: .product(id: product.productID),
+                                                              imageStatuses: [],
+                                                              stores: stores)
         super.init(nibName: type(of: self).nibName, bundle: nil)
 
         onDeviceMediaLibraryPickerCompletion = { [weak self] assets in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7021 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As the last subtask of the background image upload feature #7021, I tested the latest `trunk` with a downloadable product and added some images to its downloadable files. I noticed one issue where the "Save" CTA remains visible after saving the downloadable product after uploading an image. This is because the uploaded image(s) is tracked for the product in `ProductImageUploader`, while we don't support background image upload for downloadable files since the UX is quite different, less used, and it's out of scope.

This PR fixed the issue by instantiating a `ProductImageActionHandler` instead of using one for the product from `ProductImageUploader.actionHandler`. The feature flag is now also enabled for all in release 9.6.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

It'd be great to test downloadable products:

- Go to the products tab
- Tap on an editable & downloadable product
- Tap "Downloadable files" row
- Tap "Add File" and upload an image
- After the image is uploaded (when the activity indicator is no longer shown), tap "Add"
- Tap "Done" to go back to the product form
- Tap "Save" to save the downloadable image --> after the product is saved, the image should be saved as the product's downloadable file and the "Save" CTA should not be shown anymore

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
