### PR TITLE
[Mobile Payments] Modify track event for IPP choose payment screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -173,7 +173,6 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"
-    case cardPresentSelectPaymentGatewayShow = "card_present_select_payment_gateway_show"
 
     // MARK: Order View Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -82,12 +82,6 @@ struct InPersonPaymentsSelectPluginView: View {
         .padding(.horizontal, 16)
         .padding(.bottom, 24)
         .background(Color(.tertiarySystemBackground).ignoresSafeArea())
-        .onAppear {
-            ServiceLocator.analytics.track(
-                event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingNotCompleted(
-                    reason: "multiple_payment_provider_conflict",
-                    countryCode: SiteAddress().countryCode ))
-        }
     }
 
     private func confirmPluginSelection() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -83,7 +83,10 @@ struct InPersonPaymentsSelectPluginView: View {
         .padding(.bottom, 24)
         .background(Color(.tertiarySystemBackground).ignoresSafeArea())
         .onAppear {
-            ServiceLocator.analytics.track(.cardPresentSelectPaymentGatewayShow)
+            ServiceLocator.analytics.track(
+                event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingNotCompleted(
+                    reason: "multiple_payment_provider_conflict",
+                    countryCode: SiteAddress().countryCode ))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -98,8 +98,12 @@ final class InPersonPaymentsViewModel: ObservableObject {
 
 private extension InPersonPaymentsViewModel {
     func trackState(_ state: CardPresentPaymentOnboardingState) {
-        guard let reason = state.reasonForAnalytics else {
+        // When we remove this feature flag, we can switch reason to let and remove the state.isSelectPlugin block
+        guard var reason = state.reasonForAnalytics else {
             return
+        }
+        if state.isSelectPlugin && !gatewaySelectionAvailable {
+            reason = "multiple_plugins_installed"
         }
         ServiceLocator.analytics
             .track(event: .InPersonPayments

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -84,7 +84,7 @@ extension CardPresentPaymentOnboardingState {
         case .completed:
             return nil
         case .selectPlugin:
-            return "multiple_payment_provider_conflict"
+            return "multiple_payment_providers_conflict"
         case .pluginShouldBeDeactivated:
             return "plugin_should_be_deactivated"
         case .countryNotSupported(countryCode: _):

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -84,7 +84,7 @@ extension CardPresentPaymentOnboardingState {
         case .completed:
             return nil
         case .selectPlugin:
-            return "multiple_plugins_installed"
+            return "multiple_payment_provider_conflict"
         case .pluginShouldBeDeactivated:
             return "plugin_should_be_deactivated"
         case .countryNotSupported(countryCode: _):


### PR DESCRIPTION
Ref: pdfdoF-Zb#comment-2022-p2

### Description

Within IPP settings, when the “Choose Payment Gateway” screen is shown, we're currently tracking the `.cardPresentSelectPaymentGatewayShow` event when the view appears. 

Through this initial release, we're changing this to be a `.cardPresentOnboardingNotCompleted` existing track event instead, providing the `"multiple_payment_provider_conflict"` reason, and we'll iterate over it in the future.

### Testing instructions
- In the simulator, go to Settings > In-Person payments > Manage Payment Gateway
- Once the selection screen appears, see the following track message in the console:

```
🔵 Tracked card_present_onboarding_not_completed, properties: [AnyHashable("reason"): "multiple_payment_provider_conflict", AnyHashable("blog_id"): 121710041, AnyHashable("country"): "US", AnyHashable("is_wpcom_store"): false]
```
