### PR TITLE
[Mobile Payments] Enable Payment Gateway Selection for all builds

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -36,7 +36,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .shippingLabelsOnboardingM1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inPersonPaymentGatewaySelection:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .unifiedOrderEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backgroundProductImageUpload:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
The Make Cha-ching Not War project is complete, and we want to allow all our merchants to select a payment gateway for IPP if they have multiple supported plugins active on their store.

This enables the feature flag for all builds.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Use a release build to test this

On a US store with both WCpay and Stripe activated:

1. Tap Menu > ⚙️ > In-Person Payments > Payment Gateway
2. Observe that you can select a payment gateway

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
