### PR TITLE
Login Prologue: "New to WooCommerce?" analytics and feature release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -46,7 +46,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .appleIDAccountDeletion:
             return true
         case .newToWooCommerceLinkInLoginPrologue:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Coupons: Removed the redundant animation when reloading the coupon list. [https://github.com/woocommerce/woocommerce-ios/pull/7137]
 - [*] Login: Display "What is WordPress.com?" link in "Continue With WordPress.com" flow. [https://github.com/woocommerce/woocommerce-ios/pull/7213]
 - [*] Login: Display the Jetpack requirement error after login is successful.
+- [*] Login: Display a "New to WooCommerce?" link in the login prologue screen above the login buttons. [https://github.com/woocommerce/woocommerce-ios/pull/7261]
 - [*] In-Person Payments: Publicize the Card Present Payments feature on the Payment Method screen [https://github.com/woocommerce/woocommerce-ios/pull/7225]
 - [*] In-Person Payments: Add blog_id to IPP transaction description to match WCPay [https://github.com/woocommerce/woocommerce-ios/pull/7221]
 - [*] Product form: after uploading an image, the product can now be saved immediately while the image is being uploaded in the background. When no images are pending upload for the saved product, the images are added to the product. Testing instructions: https://github.com/woocommerce/woocommerce-ios/pull/7196. [https://github.com/woocommerce/woocommerce-ios/pull/7254]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -31,6 +31,7 @@ public enum WooAnalyticsStat: String {
     case signedIn = "signed_in"
     case logout = "account_logout"
     case openedLogin = "login_accessed"
+    case loginNewToWooButtonTapped = "login_new_to_woo_button_tapped"
     case loginFailed = "login_failed_to_login"
     case loginAutoFillCredentialsFilled = "login_autofill_credentials_filled"
     case loginAutoFillCredentialsUpdated = "login_autofill_credentials_updated"

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -8,6 +8,7 @@ import Experiments
 ///
 final class LoginPrologueViewController: UIViewController {
     private let isNewToWooCommerceButtonShown: Bool
+    private let analytics: Analytics
 
     /// Background View, to be placed surrounding the bottom area.
     ///
@@ -33,8 +34,10 @@ final class LoginPrologueViewController: UIViewController {
 
     // MARK: - Overridden Methods
 
-    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         isNewToWooCommerceButtonShown = featureFlagService.isFeatureFlagEnabled(.newToWooCommerceLinkInLoginPrologue)
+        self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -111,8 +114,10 @@ private extension LoginPrologueViewController {
         newToWooCommerceButton.applyLinkButtonStyle()
         newToWooCommerceButton.titleLabel?.numberOfLines = 0
         newToWooCommerceButton.titleLabel?.textAlignment = .center
-        newToWooCommerceButton.on(.touchUpInside) { _ in
-            // TODO: 7231 - analytics
+        newToWooCommerceButton.on(.touchUpInside) { [weak self] _ in
+            guard let self = self else { return }
+
+            self.analytics.track(.loginNewToWooButtonTapped)
 
             guard let url = URL(string: Constants.newToWooCommerceURL) else {
                 return assertionFailure("Cannot generate URL.")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7231 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR added an analytics event to track when the "New to WooCommerce?" button is tapped. Also, the feature flag is enabled for all since we're not planning to AB test this for now (ref pe5sF9-6C-p2#comment-168).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log out of the app if needed --> on the login prologue screen, there should be a button that says "New to WooCommerce?" above the 2 login buttons. tapping on it should open a webview (currently to [this doc](https://woocommerce.com/guides/new-store) but we're likely updating it to our own doc later). in the console, an event should be tracked like `🔵 Tracked login_new_to_woo_button_tapped`



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->