### PR TITLE
[Unified Order Editing] Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -366,6 +366,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductAdd, properties: [Keys.flow: flow.rawValue])
         }
 
+        static func orderProductQuantityChange(flow: Flow) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderProductQuantityChange, properties: [Keys.flow: flow.rawValue])
+        }
+
         static func orderCustomerAdd(flow: Flow, hasDifferentShippingDetails: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCustomerAdd, properties: [
                 Keys.flow: flow.rawValue,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -401,8 +401,11 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderShippingMethodRemove, properties: [Keys.flow: flow.rawValue])
         }
 
-        static func orderCustomerNoteAdd(flow: Flow) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderNoteAdd, properties: [Keys.flow: flow.rawValue])
+        static func orderCustomerNoteAdd(flow: Flow, orderID: Int64, orderStatus: OrderStatusEnum) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderNoteAdd, properties: [Keys.flow: flow.rawValue,
+                                                                    "parent_id": orderID,
+                                                                    "status": orderStatus.rawValue,
+                                                                    "type": "customer"])
         }
 
         static func orderStatusChange(flow: Flow, orderID: Int64?, from oldStatus: OrderStatusEnum, to newStatus: OrderStatusEnum) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -436,8 +436,9 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderSyncFailed(errorContext: String, errorDescription: String) -> WooAnalyticsEvent {
+        static func orderSyncFailed(flow: Flow, errorContext: String, errorDescription: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderSyncFailed, properties: [
+                Keys.flow: flow.rawValue,
                 Keys.errorContext: errorContext,
                 Keys.errorDescription: errorDescription
             ])

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -393,6 +393,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderShippingMethodAdd, properties: [Keys.flow: flow.rawValue])
         }
 
+        static func orderShippingMethodRemove(flow: Flow) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderShippingMethodRemove, properties: [Keys.flow: flow.rawValue])
+        }
+
         static func orderCustomerNoteAdd(flow: Flow) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderNoteAdd, properties: [Keys.flow: flow.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -370,6 +370,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductQuantityChange, properties: [Keys.flow: flow.rawValue])
         }
 
+        static func orderProductRemove(flow: Flow) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderProductRemove, properties: [Keys.flow: flow.rawValue])
+        }
+
         static func orderCustomerAdd(flow: Flow, hasDifferentShippingDetails: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCustomerAdd, properties: [
                 Keys.flow: flow.rawValue,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -385,6 +385,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderFeeAdd, properties: [Keys.flow: flow.rawValue])
         }
 
+        static func orderFeeRemove(flow: Flow) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderFeeRemove, properties: [Keys.flow: flow.rawValue])
+        }
+
         static func orderShippingMethodAdd(flow: Flow) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderShippingMethodAdd, properties: [Keys.flow: flow.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -362,6 +362,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderAddNew, properties: [:])
         }
 
+        static func orderEditButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderEditButtonTapped, properties: [:])
+        }
+
         static func orderProductAdd(flow: Flow) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductAdd, properties: [Keys.flow: flow.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -356,14 +356,19 @@ extension WooAnalyticsEvent {
             static let to = "to"
             static let from = "from"
             static let orderID = "id"
+            static let hasMultipleShippingLines = "has_multiple_shipping_lines"
+            static let hasMultipleFeeLines = "has_multiple_fee_lines"
         }
 
         static func orderAddNew() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderAddNew, properties: [:])
         }
 
-        static func orderEditButtonTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderEditButtonTapped, properties: [:])
+        static func orderEditButtonTapped(hasMultipleShippingLines: Bool, hasMultipleFeeLines: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderEditButtonTapped, properties: [
+                Keys.hasMultipleShippingLines: hasMultipleShippingLines,
+                Keys.hasMultipleFeeLines: hasMultipleFeeLines
+            ])
         }
 
         static func orderProductAdd(flow: Flow) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -222,6 +222,7 @@ public enum WooAnalyticsStat: String {
     case orderCreationFailed = "order_creation_failed"
     case orderContactAction = "order_contact_action"
     case orderCustomerAdd = "order_customer_add"
+    case orderEditButtonTapped = "order_edit_button_tapped"
     case ordersListFilter = "orders_list_filter"
     case ordersListSearch = "orders_list_search"
     case ordersListLoaded = "orders_list_loaded"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -227,6 +227,7 @@ public enum WooAnalyticsStat: String {
     case ordersListLoaded = "orders_list_loaded"
     case orderProductAdd = "order_product_add"
     case orderProductQuantityChange = "order_product_quantity_change"
+    case orderProductRemove = "order_product_remove"
     case orderStatusChange = "order_status_change"
     case orderStatusChangeSuccess = "order_status_change_success"
     case orderStatusChangeFailed = "order_status_change_failed"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -243,6 +243,7 @@ public enum WooAnalyticsStat: String {
     case orderFeeAdd = "order_fee_add"
     case orderFeeRemove = "order_fee_remove"
     case orderShippingMethodAdd = "order_shipping_method_add"
+    case orderShippingMethodRemove = "order_shipping_method_remove"
     case orderSyncFailed = "order_sync_failed"
     case collectPaymentTapped = "payments_flow_order_collect_payment_tapped"
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -241,6 +241,7 @@ public enum WooAnalyticsStat: String {
     case orderTrackingDeleteSuccess = "order_tracking_delete_success"
     case orderTrackingProvidersLoaded = "order_tracking_providers_loaded"
     case orderFeeAdd = "order_fee_add"
+    case orderFeeRemove = "order_fee_remove"
     case orderShippingMethodAdd = "order_shipping_method_add"
     case orderSyncFailed = "order_sync_failed"
     case collectPaymentTapped = "payments_flow_order_collect_payment_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -226,6 +226,7 @@ public enum WooAnalyticsStat: String {
     case ordersListSearch = "orders_list_search"
     case ordersListLoaded = "orders_list_loaded"
     case orderProductAdd = "order_product_add"
+    case orderProductQuantityChange = "order_product_quantity_change"
     case orderStatusChange = "order_status_change"
     case orderStatusChangeSuccess = "order_status_change_success"
     case orderStatusChangeFailed = "order_status_change_failed"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
@@ -17,14 +17,16 @@ struct CustomerNoteSection: View {
             .sheet(
                 isPresented: $showEditNotesView,
                 onDismiss: {
+                    // reset note content when modal is dismissed with swipe down gesture
                     viewModel.noteViewModel.userDidCancelFlow()
-                    viewModel.updateCustomerNote()
                 },
                 content: {
                     EditCustomerNote(
+                        onSave: {
+                            viewModel.updateCustomerNote()
+                        },
                         dismiss: {
                             showEditNotesView.toggle()
-                            viewModel.updateCustomerNote()
                         },
                         viewModel: viewModel.noteViewModel
                     )

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -231,6 +231,8 @@ final class EditableOrderViewModel: ObservableObject {
 
         if feeLine != nil {
             analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: flow.analyticsFlow))
+        } else {
+            analytics.track(event: WooAnalyticsEvent.Orders.orderFeeRemove(flow: flow.analyticsFlow))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -402,7 +402,10 @@ final class EditableOrderViewModel: ObservableObject {
     func updateOrderStatus(newStatus: OrderStatusEnum) {
         let oldStatus = orderSynchronizer.order.status
         orderSynchronizer.setStatus.send(newStatus)
-        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: flow.analyticsFlow, orderID: nil, from: oldStatus, to: newStatus))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: flow.analyticsFlow,
+                                                                          orderID: orderSynchronizer.order.orderID,
+                                                                          from: oldStatus,
+                                                                          to: newStatus))
     }
 
     /// Deletes the order if it has been synced remotely, and removes it from local storage.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -807,7 +807,9 @@ private extension EditableOrderViewModel {
     ///
     func trackCustomerNoteAdded() {
         guard customerNoteDataViewModel.customerNote.isNotEmpty else { return }
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCustomerNoteAdd(flow: flow.analyticsFlow))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCustomerNoteAdd(flow: flow.analyticsFlow,
+                                                                             orderID: orderSynchronizer.order.orderID,
+                                                                             orderStatus: currentOrderStatus))
     }
 
     /// Tracks when the create order button is tapped.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -19,6 +19,15 @@ final class EditableOrderViewModel: ObservableObject {
     enum Flow: Equatable {
         case creation
         case editing(initialOrder: Order)
+
+        var analyticsFlow: WooAnalyticsEvent.Orders.Flow {
+            switch self {
+            case .creation:
+                return .creation
+            case .editing:
+                return .editing
+            }
+        }
     }
 
     /// Current flow. For editing stores existing order state prior to applying any edits.
@@ -210,7 +219,7 @@ final class EditableOrderViewModel: ObservableObject {
         orderSynchronizer.setShipping.send(shippingLine)
 
         if shippingLine != nil {
-            analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: .creation))
+            analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow))
         }
     }
 
@@ -221,7 +230,7 @@ final class EditableOrderViewModel: ObservableObject {
         orderSynchronizer.setFee.send(feeLine)
 
         if feeLine != nil {
-            analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: .creation))
+            analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: flow.analyticsFlow))
         }
     }
 
@@ -379,7 +388,7 @@ final class EditableOrderViewModel: ObservableObject {
     func updateOrderStatus(newStatus: OrderStatusEnum) {
         let oldStatus = orderSynchronizer.order.status
         orderSynchronizer.setStatus.send(newStatus)
-        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .creation, orderID: nil, from: oldStatus, to: newStatus))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: flow.analyticsFlow, orderID: nil, from: oldStatus, to: newStatus))
     }
 
     /// Deletes the order if it has been synced remotely, and removes it from local storage.
@@ -635,7 +644,7 @@ private extension EditableOrderViewModel {
         let input = OrderSyncProductInput(product: .product(product), quantity: 1)
         orderSynchronizer.setProduct.send(input)
 
-        analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: .creation))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: flow.analyticsFlow))
     }
 
     /// Adds a selected product variation (from the product list) to the order.
@@ -648,7 +657,7 @@ private extension EditableOrderViewModel {
         let input = OrderSyncProductInput(product: .variation(variation), quantity: 1)
         orderSynchronizer.setProduct.send(input)
 
-        analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: .creation))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: flow.analyticsFlow))
     }
 
     /// Configures product row view models for each item in `orderDetails`.
@@ -777,14 +786,14 @@ private extension EditableOrderViewModel {
             }
             return billingAddress != shippingAddress
         }()
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCustomerAdd(flow: .creation, hasDifferentShippingDetails: areAddressesDifferent))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCustomerAdd(flow: flow.analyticsFlow, hasDifferentShippingDetails: areAddressesDifferent))
     }
 
     /// Tracks when customer note have been added
     ///
     func trackCustomerNoteAdded() {
         guard customerNoteDataViewModel.customerNote.isNotEmpty else { return }
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCustomerNoteAdd(flow: .creation))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCustomerNoteAdd(flow: flow.analyticsFlow))
     }
 
     /// Tracks when the create order button is tapped.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -841,8 +841,9 @@ private extension EditableOrderViewModel {
     /// Tracks an order remote sync failure
     ///
     func trackSyncOrderFailure(error: Error) {
-        analytics.track(event: WooAnalyticsEvent.Orders.orderSyncFailed(errorContext: String(describing: error),
-                                                                            errorDescription: error.localizedDescription))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderSyncFailed(flow: flow.analyticsFlow,
+                                                                        errorContext: String(describing: error),
+                                                                        errorDescription: error.localizedDescription))
     }
 
     /// Creates an `OrderSyncAddressesInput` type from a `NewOrderAddressData` type.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -296,6 +296,8 @@ final class EditableOrderViewModel: ObservableObject {
     func removeItemFromOrder(_ item: OrderItem) {
         guard let input = createUpdateProductInput(item: item, quantity: 0) else { return }
         orderSynchronizer.setProduct.send(input)
+
+        analytics.track(event: WooAnalyticsEvent.Orders.orderProductRemove(flow: flow.analyticsFlow))
     }
 
     /// Creates a view model for the `ProductRow` corresponding to an order item.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -314,6 +314,10 @@ final class EditableOrderViewModel: ObservableObject {
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
                                        displayMode: .attributes(attributes),
+                                       quantityUpdatedCallback: { [weak self] _ in
+                guard let self = self else { return }
+                self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductQuantityChange(flow: self.flow.analyticsFlow))
+            },
                                        removeProductIntent: { [weak self] in
                 self?.selectOrderItem(item.itemID) })
         } else {
@@ -321,6 +325,10 @@ final class EditableOrderViewModel: ObservableObject {
                                        product: product,
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
+                                       quantityUpdatedCallback: { [weak self] _ in
+                guard let self = self else { return }
+                self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductQuantityChange(flow: self.flow.analyticsFlow))
+            },
                                        removeProductIntent: { [weak self] in
                 self?.selectOrderItem(item.itemID) })
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -220,6 +220,8 @@ final class EditableOrderViewModel: ObservableObject {
 
         if shippingLine != nil {
             analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow))
+        } else {
+            analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodRemove(flow: flow.analyticsFlow))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -39,6 +39,10 @@ final class EditCustomerNoteHostingController<ViewModel: EditCustomerNoteViewMod
 ///
 struct EditCustomerNote<ViewModel: EditCustomerNoteViewModelProtocol>: View {
 
+    /// Callback closure called when the note is updated and successfully saved.
+    ///
+    var onSave: (() -> Void) = {}
+
     /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
     ///
     var dismiss: (() -> Void) = {}
@@ -80,6 +84,7 @@ struct EditCustomerNote<ViewModel: EditCustomerNoteViewModelProtocol>: View {
             Button(Localization.done) {
                 viewModel.updateNote { success in
                     if success {
+                        onSave()
                         dismiss()
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -341,6 +341,8 @@ private extension OrderDetailsViewController {
         let viewController = OrderFormHostingController(viewModel: viewModel)
         let navController = UINavigationController(rootViewController: viewController)
         present(navController, animated: true)
+
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderEditButtonTapped())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -342,7 +342,10 @@ private extension OrderDetailsViewController {
         let navController = UINavigationController(rootViewController: viewController)
         present(navController, animated: true)
 
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderEditButtonTapped())
+        let hasMultipleShippingLines = self.viewModel.order.shippingLines.count > 1
+        let hasMultipleFeeLines = self.viewModel.order.fees.count > 1
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderEditButtonTapped(hasMultipleShippingLines: hasMultipleShippingLines,
+                                                                                             hasMultipleFeeLines: hasMultipleFeeLines))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -126,6 +126,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         quantity < minimumQuantity
     }
 
+    /// Closure to run when the quantity is changed.
+    ///
+    var quantityUpdatedCallback: (Decimal) -> Void
+
     /// Closure to run when the quantity is decremented below the minimum quantity.
     ///
     var removeProductIntent: () -> Void
@@ -153,6 +157,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          variationDisplayMode: VariationDisplayMode? = nil,
          selectedState: ProductRow.SelectedState = .notSelected,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
          removeProductIntent: @escaping (() -> Void) = {}) {
         self.id = id ?? Int64(UUID().uuidString.hashValue)
         self.selectedState = selectedState
@@ -169,6 +174,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.currencyFormatter = currencyFormatter
         self.numberOfVariations = numberOfVariations
         self.variationDisplayMode = variationDisplayMode
+        self.quantityUpdatedCallback = quantityUpdatedCallback
         self.removeProductIntent = removeProductIntent
     }
 
@@ -180,6 +186,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      canChangeQuantity: Bool,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                     quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
                      removeProductIntent: @escaping (() -> Void) = {}) {
         // Don't show any price for variable products; price will be shown for each product variation.
         let price: String?
@@ -203,6 +210,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   numberOfVariations: product.variations.count,
                   selectedState: selectedState,
                   currencyFormatter: currencyFormatter,
+                  quantityUpdatedCallback: quantityUpdatedCallback,
                   removeProductIntent: removeProductIntent)
     }
 
@@ -216,6 +224,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      displayMode: VariationDisplayMode,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                     quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
                      removeProductIntent: @escaping (() -> Void) = {}) {
         let imageURL: URL?
         if let encodedImageURLString = productVariation.image?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
@@ -238,6 +247,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   variationDisplayMode: displayMode,
                   selectedState: selectedState,
                   currencyFormatter: currencyFormatter,
+                  quantityUpdatedCallback: quantityUpdatedCallback,
                   removeProductIntent: removeProductIntent)
     }
 
@@ -277,6 +287,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     func incrementQuantity() {
         quantity += 1
+
+        quantityUpdatedCallback(quantity)
     }
 
     /// Decrement the product quantity.
@@ -286,6 +298,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             return removeProductIntent()
         }
         quantity -= 1
+
+        quantityUpdatedCallback(quantity)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1070,7 +1070,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(analytics.receivedEvents.isEmpty)
     }
 
-    func test_sync_failure_tracked_when_sync_fails() {
+    func test_sync_failure_tracked_when_sync_fails() throws {
         // Given
         let analytics = MockAnalyticsProvider()
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -1094,6 +1094,10 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(analytics.receivedEvents.contains(WooAnalyticsStat.orderSyncFailed.rawValue))
+
+        let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.orderSyncFailed.rawValue}))
+        let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["flow"] as? String, "creation")
     }
 
     // MARK: -

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -967,16 +967,21 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(properties, "creation")
     }
 
-    func test_fee_line_not_tracked_when_removed() {
+    func test_fee_line_tracked_when_removed() throws {
         // Given
         let analytics = MockAnalyticsProvider()
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: .fake()),
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
         viewModel.saveFeeLine(nil)
 
         // Then
-        XCTAssertTrue(analytics.receivedEvents.isEmpty)
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderFeeRemove.rawValue])
+
+        let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
+        XCTAssertEqual(properties, "editing")
     }
 
     func test_customer_details_tracked_when_added() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1053,8 +1053,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderNoteAdd.rawValue])
 
-        let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
-        XCTAssertEqual(properties, "creation")
+        let properties = try XCTUnwrap(analytics.receivedProperties.first)
+        XCTAssertEqual(properties["flow"] as? String, "creation")
+        XCTAssertEqual(properties["parent_id"] as? Int64, 0)
+        XCTAssertEqual(properties["status"] as? String, "pending")
+        XCTAssertEqual(properties["type"] as? String, "customer")
     }
 
     func test_customer_note_not_tracked_when_removed() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -939,16 +939,21 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(properties, "creation")
     }
 
-    func test_shipping_method_not_tracked_when_removed() {
+    func test_shipping_method_tracked_when_removed() throws {
         // Given
         let analytics = MockAnalyticsProvider()
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: .fake()),
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
         viewModel.saveShippingLine(nil)
 
         // Then
-        XCTAssertTrue(analytics.receivedEvents.isEmpty)
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodRemove.rawValue])
+
+        let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
+        XCTAssertEqual(properties, "editing")
     }
 
     func test_fee_line_tracked_when_added() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -901,6 +901,28 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(properties, "editing")
     }
 
+    func test_product_is_tracked_when_removed_from_order() throws {
+        // Given
+        let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
+        let storageManager = MockStorageManager()
+        storageManager.insertProducts([product0])
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // Given products are added to order
+        viewModel.addProductViewModel.selectProduct(product0.productID)
+
+        // When
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)
+        viewModel.removeItemFromOrder(itemToRemove)
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderProductAdd.rawValue, WooAnalyticsStat.orderProductRemove.rawValue])
+
+        let properties = try XCTUnwrap(analytics.receivedProperties.last?["flow"] as? String)
+        XCTAssertEqual(properties, "creation")
+    }
+
     func test_shipping_method_tracked_when_added() throws {
         // Given
         let analytics = MockAnalyticsProvider()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -861,6 +861,24 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     // MARK: - Tracking Tests
 
+    func test_product_is_tracked_when_added() throws {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        let storageManager = MockStorageManager()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.addProductViewModel.selectProduct(product.productID)
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderProductAdd.rawValue])
+
+        let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
+        XCTAssertEqual(properties, "creation")
+    }
+
     func test_shipping_method_tracked_when_added() throws {
         // Given
         let analytics = MockAnalyticsProvider()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -939,7 +939,9 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_customer_details_tracked_when_only_billing_address_added() throws {
         // Given
         let analytics = MockAnalyticsProvider()
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: .fake()),
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
         viewModel.addressFormViewModel.fields.address1 = sampleAddress1().address1
@@ -950,7 +952,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         let flowProperty = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
         let hasDifferentShippingDetailsProperty = try XCTUnwrap(analytics.receivedProperties.first?["has_different_shipping_details"] as? Bool)
-        XCTAssertEqual(flowProperty, "creation")
+        XCTAssertEqual(flowProperty, "editing")
         XCTAssertFalse(hasDifferentShippingDetailsProperty)
     }
 


### PR DESCRIPTION
Closes: #7050.

## Description

This PR updates Tracks events for coupon edit and deletion following #7050.

Events updated:
- `order_product_add` 975-gh-Automattic/tracks-events-registration
- `order_customer_add` 976-gh-Automattic/tracks-events-registration
- `order_fee_add` 980-gh-Automattic/tracks-events-registration
- `order_shipping_method_add` 981-gh-Automattic/tracks-events-registration
- `order_note_add` 977-gh-Automattic/tracks-events-registration
- `order_status_change` 978-gh-Automattic/tracks-events-registration
- `order_sync_failed` 979-gh-Automattic/tracks-events-registration

Events added:
- `order_edit_button_tapped` 970-gh-Automattic/tracks-events-registration
- `order_product_quantity_change` 971-gh-Automattic/tracks-events-registration
- `order_product_remove` 972-gh-Automattic/tracks-events-registration
- `order_fee_remove` 973-gh-Automattic/tracks-events-registration
- `order_shipping_method_remove` 974-gh-Automattic/tracks-events-registration

Events added/updated in the spreadsheet.

## Testing

- Go to the Orders tab, open the order.
- Wait until order fully loads. Tap "•••" in navbar. Select "Edit".
  - An event should be tracked like: `🔵 Tracked order_edit_button_tapped, properties: [...]`
- Tap "Edit" in order status section. Select different status.
  - `🔵 Tracked order_status_change, properties: [AnyHashable("flow"): "editing", AnyHashable("from"): "pending", AnyHashable("to"): "on-hold", ...]`
- Tap "Add Product" and select any product.
  - `🔵 Tracked order_product_add, properties: [AnyHashable("flow"): "editing", ...]`
- Increment amount for added product.
  - `🔵 Tracked order_product_quantity_change, properties: [AnyHashable("flow"): "editing", ...]`
- Tap product row and then "Remove Product from Order".
  - `🔵 Tracked order_product_remove, properties: [AnyHashable("flow"): "editing", ...]`
- Tap "Add Shipping", enter amount and tap "Done".
  - `🔵 Tracked order_shipping_method_add, properties: [AnyHashable("flow"): "editing", ...]`
- Tap "Shipping" row and then "Remove Shipping from Order".
  - `🔵 Tracked order_shipping_method_remove, properties: [AnyHashable("flow"): "editing", ...]`
- Tap "Add Fee", enter amount and tap "Done".
  - `🔵 Tracked order_fee_add, properties: [AnyHashable("flow"): "editing", ...]`
- Tap "Fees" row and then "Remove Fee from Order".
  - `🔵 Tracked order_fee_remove, properties: [AnyHashable("flow"): "editing", ...]`
- Tap "Add Customer Details" row, enter first name and tap "Done".
  - `🔵 Tracked order_customer_add, properties: [AnyHashable("flow"): "editing", AnyHashable("has_different_shipping_details"): false, ...]`
- Tap "Add Note", enter text and tap "Done".
  - `🔵 Tracked order_note_add, properties: [AnyHashable("flow"): "editing", ...]`
- Close order, get back on "Orders" tab, tap "+" -> "Create order".
- Tap "Add Product" and select any product.
  - Already checked event from above should have correct flow: `🔵 Tracked order_product_add, properties: [AnyHashable("flow"): "creation", ...]`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.