### PR TITLE
IPP: pass formatted amount with currency symbol from `OrderDetailsViewModel` to `PaymentMethodsViewModel`

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -11,6 +11,7 @@ import enum Networking.DotcomError
 final class OrderDetailsViewModel {
 
     private let stores: StoresManager
+    private let currencyFormatter: CurrencyFormatter
 
     private(set) var order: Order
 
@@ -22,9 +23,12 @@ final class OrderDetailsViewModel {
         return lookUpOrderStatus(for: order)
     }
 
-    init(order: Order, stores: StoresManager = ServiceLocator.stores) {
+    init(order: Order,
+         stores: StoresManager = ServiceLocator.stores,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.order = order
         self.stores = stores
+        self.currencyFormatter = currencyFormatter
     }
 
     func update(order newOrder: Order) {
@@ -148,11 +152,12 @@ final class OrderDetailsViewModel {
     }
 
     var paymentMethodsViewModel: PaymentMethodsViewModel {
-        PaymentMethodsViewModel(siteID: order.siteID,
-                                orderID: order.orderID,
-                                paymentLink: order.paymentURL,
-                                formattedTotal: order.total,
-                                flow: .orderPayment)
+        let formattedTotal = currencyFormatter.formatAmount(order.total, with: order.currency) ?? String()
+        return PaymentMethodsViewModel(siteID: order.siteID,
+                                       orderID: order.orderID,
+                                       paymentLink: order.paymentURL,
+                                       formattedTotal: formattedTotal,
+                                       flow: .orderPayment)
     }
 
     /// Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -108,13 +108,13 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_paymentMethodsViewModel_title_contains_formatted_order_amount() {
         // Given
-        let order = Order.fake().copy(currency: "USD", total: "10.0")
+        let order = Order.fake().copy(currency: "EUR", total: "10.0")
 
         // When
         let currencyFormatter = CurrencyFormatter(currencySettings: .init())
         let title = OrderDetailsViewModel(order: order, currencyFormatter: currencyFormatter).paymentMethodsViewModel.title
 
         // Then
-        XCTAssertTrue(title.contains("$10.0"))
+        XCTAssertTrue(title.contains("\u{20AC}10.0"))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -1,3 +1,4 @@
+import WooFoundation
 import XCTest
 import Yosemite
 
@@ -103,5 +104,17 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Then
         let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
         XCTAssertFalse(actionButtonIDs.contains(.editOrder))
+    }
+
+    func test_paymentMethodsViewModel_title_contains_formatted_order_amount() {
+        // Given
+        let order = Order.fake().copy(currency: "USD", total: "10.0")
+
+        // When
+        let currencyFormatter = CurrencyFormatter(currencySettings: .init())
+        let title = OrderDetailsViewModel(order: order, currencyFormatter: currencyFormatter).paymentMethodsViewModel.title
+
+        // Then
+        XCTAssertTrue(title.contains("$10.0"))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7263 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From @itsmeichigo's screenshots work https://github.com/woocommerce/woocommerce-ios/pull/7217, we noticed that the order amount in the collect payment alert doesn't contain a currency symbol. It's because the `formattedTotal` just uses `order.total` without formatting with a currency formatter. This PR updated the `PaymentMethodsViewModel` initialization in `OrderDetailsViewModel` to pass a formatted amount from `order.total` and `order.currency`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Steps to reproduce the behavior:
- Make sure your store is eligible for in-person payment
- Select an order that is pending for payment
- Select Collect Payment --> the payment method selector screen title should contain the formatted order amount
- Select the Card payment method and complete the onboarding steps if needed --> when the Collect Payment alert is displayed, the amount should be formatted with the order currency

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | before | after
-- | -- | --
the title now includes the currency | ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-08 at 13 52 34](https://user-images.githubusercontent.com/1945542/178044790-2305e076-7d9c-4c9c-9d65-1b22f62e5726.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-08 at 13 51 29](https://user-images.githubusercontent.com/1945542/178044698-d7acf862-d200-4197-b463-f258e209c7e4.png)
collect payment alert | ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-08 at 13 52 42](https://user-images.githubusercontent.com/1945542/178044791-a257fce7-ac06-46e8-ab4a-48fbf85bdfa2.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-08 at 13 52 06](https://user-images.githubusercontent.com/1945542/178044701-bea91871-f067-4ec5-90c9-87841d1a7a80.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
