### PR TITLE
[Reader Manuals Consolidation] Display only supported readers

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsView.swift
@@ -15,11 +15,13 @@ struct CardReaderManualsView: View {
                 ForEach(manuals, id: \.name) { manual in
                     Divider()
                     CardReaderManualRowView(manual: manual)
+                        .background(Color(UIColor.listForeground))
                 }
                 Divider()
             }
         }
         .navigationBarTitle(Localization.navigationTitle, displayMode: .inline)
+        .background(Color(UIColor.listBackground))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 import Yosemite
 
-struct Manual: Identifiable {
+struct Manual: Identifiable, Equatable {
     let id: Int
     let image: UIImage
     let name: String
@@ -10,9 +10,13 @@ struct Manual: Identifiable {
 }
 
 final class CardReaderManualsViewModel {
+    var configurationLoader: CardPresentConfigurationLoader
     let manuals: [Manual]
 
     init(cardReaders: [CardReaderType] = [.chipper, .stripeM2, .wisepad3]) {
-        self.manuals = cardReaders.map { $0.manual }
+        // Initialize the View Model only with the supported readers for a specific Store
+        self.configurationLoader = CardPresentConfigurationLoader()
+        let supportedReaders = configurationLoader.configuration.supportedReaders
+        self.manuals = supportedReaders.map { $0.manual }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
@@ -13,7 +13,7 @@ final class CardReaderManualsViewModel {
     var configurationLoader: CardPresentConfigurationLoader
     let manuals: [Manual]
 
-    init(cardReaders: [CardReaderType] = [.chipper, .stripeM2, .wisepad3]) {
+    init() {
         // Initialize the View Model only with the supported readers for a specific Store
         self.configurationLoader = CardPresentConfigurationLoader()
         let supportedReaders = configurationLoader.configuration.supportedReaders

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -954,6 +954,7 @@
 		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
+		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
 		68E952CC287536010095A23D /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CB287536010095A23D /* SafariView.swift */; };
 		68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */; };
 		68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */; };
@@ -2727,6 +2728,7 @@
 		6856D66A1963092C34D20674 /* Calendar+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Calendar+Extensions.swift"; sourceTree = "<group>"; };
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
+		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
 		68E952CB287536010095A23D /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
 		68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderType+Manual.swift"; sourceTree = "<group>"; };
@@ -7695,6 +7697,7 @@
 				03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */,
 				03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */,
 				02346809282CEA5F00CFC503 /* ReceiptViewModelTests.swift */,
+				6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -10222,6 +10225,7 @@
 				028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */,
 				0247F50E286E6CCD009C177E /* MockProductImageActionHandler.swift in Sources */,
 				AEA3F91527BEC96B00B9F555 /* PriceFieldFormatterTests.swift in Sources */,
+				6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */,
 				02BC5AA824D2802B00C43326 /* MockProductVariationStoresManager.swift in Sources */,
 				E1C6535C27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift in Sources */,
 				2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+class CardReaderManualsViewModelTests: XCTestCase {
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDownWithError() throws {
+        storageManager = nil
+        try super.tearDownWithError()
+    }
+
+    func test_viewModel_not_nil() {
+        // Given
+        let viewModel = CardReaderManualsViewModel()
+
+        // When
+        XCTAssertNotNil(viewModel)
+    }
+
+    func test_viewModel_when_init_then_has_default_manuals() {
+         // Given
+         let viewModel = CardReaderManualsViewModel()
+
+         // When
+         let expectedManuals = viewModel.manuals
+
+         // Then
+         XCTAssertEqual(viewModel.manuals, expectedManuals)
+     }
+
+    func test_viewModel_when_US_store_then_available_card_reader_manuals() {
+        // Given
+        let setting = SiteSetting.fake()
+                    .copy(
+                        siteID: sampleSiteID,
+                        settingID: "woocommerce_default_country",
+                        value: "US:CA"
+                    )
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        let viewModel = CardReaderManualsViewModel()
+
+        // When
+        let availableReaderTypes = [CardReaderType.chipper, CardReaderType.stripeM2]
+        let expectedManuals = availableReaderTypes.map { $0.manual }
+
+        // Then
+        XCTAssertEqual(viewModel.manuals, expectedManuals)
+    }
+
+    func test_viewModel_when_CA_store_then_available_card_reader_manuals() {
+        // Given
+        let setting = SiteSetting.fake()
+                    .copy(
+                        siteID: sampleSiteID,
+                        settingID: "woocommerce_default_country",
+                        value: "CA:NS"
+                    )
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        let viewModel = CardReaderManualsViewModel()
+
+        // When
+        let availableReaderTypes = [CardReaderType.wisepad3]
+        let expectedManuals = availableReaderTypes.map { $0.manual }
+
+        // Then
+        XCTAssertEqual(viewModel.manuals, expectedManuals)
+    }
+
+    func test_viewModel_when_IPP_not_available_country_then_available_card_reader_manuals_is_empty() {
+        // Given
+        let setting = SiteSetting.fake()
+                    .copy(
+                        siteID: sampleSiteID,
+                        settingID: "woocommerce_default_country",
+                        value: "ES"
+                    )
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        let viewModel = CardReaderManualsViewModel()
+
+        // When
+        let availableReaderTypes: [CardReaderType] = []
+        let expectedManuals = availableReaderTypes.map { $0.manual }
+
+        // Then
+        XCTAssertEqual(viewModel.manuals, expectedManuals)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
@@ -4,21 +4,23 @@ import Yosemite
 
 class CardReaderManualsViewModelTests: XCTestCase {
 
-    /// Mock Storage: InMemory
-    ///
     private var storageManager: MockStorageManager!
-
-    /// Dummy Site ID
-    ///
+    private var stores: MockStoresManager!
     private let sampleSiteID: Int64 = 1234
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         storageManager = MockStorageManager()
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.sessionManager.setStoreId(sampleSiteID)
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
     }
 
     override func tearDownWithError() throws {
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings())
+        storageManager.reset()
         storageManager = nil
+        stores = nil
         try super.tearDownWithError()
     }
 
@@ -26,7 +28,7 @@ class CardReaderManualsViewModelTests: XCTestCase {
         // Given
         let viewModel = CardReaderManualsViewModel()
 
-        // When
+        // Then
         XCTAssertNotNil(viewModel)
     }
 
@@ -44,12 +46,14 @@ class CardReaderManualsViewModelTests: XCTestCase {
     func test_viewModel_when_US_store_then_available_card_reader_manuals() {
         // Given
         let setting = SiteSetting.fake()
-                    .copy(
-                        siteID: sampleSiteID,
-                        settingID: "woocommerce_default_country",
-                        value: "US:CA"
-                    )
+            .copy(
+                siteID: sampleSiteID,
+                settingID: "woocommerce_default_country",
+                value: "US:CA",
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
         storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        ServiceLocator.selectedSiteSettings.refresh()
         let viewModel = CardReaderManualsViewModel()
 
         // When
@@ -63,15 +67,17 @@ class CardReaderManualsViewModelTests: XCTestCase {
     func test_viewModel_when_CA_store_then_available_card_reader_manuals() {
         // Given
         let setting = SiteSetting.fake()
-                    .copy(
-                        siteID: sampleSiteID,
-                        settingID: "woocommerce_default_country",
-                        value: "CA:NS"
-                    )
+            .copy(
+                siteID: sampleSiteID,
+                settingID: "woocommerce_default_country",
+                value: "CA:NS",
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
         storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        ServiceLocator.selectedSiteSettings.refresh()
         let viewModel = CardReaderManualsViewModel()
 
-        // When
+        // When:
         let availableReaderTypes = [CardReaderType.wisepad3]
         let expectedManuals = availableReaderTypes.map { $0.manual }
 
@@ -85,10 +91,11 @@ class CardReaderManualsViewModelTests: XCTestCase {
                     .copy(
                         siteID: sampleSiteID,
                         settingID: "woocommerce_default_country",
-                        value: "ES"
+                        value: "ES",
+                        settingGroupKey: SiteSettingGroup.general.rawValue
                     )
         storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
-        let viewModel = CardReaderManualsViewModel()
+        let viewModel = CardReaderManualsViewModel.init()
 
         // When
         let availableReaderTypes: [CardReaderType] = []

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
@@ -32,17 +32,6 @@ class CardReaderManualsViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel)
     }
 
-    func test_viewModel_when_init_then_has_default_manuals() {
-         // Given
-         let viewModel = CardReaderManualsViewModel()
-
-         // When
-         let expectedManuals = viewModel.manuals
-
-         // Then
-         XCTAssertEqual(viewModel.manuals, expectedManuals)
-     }
-
     func test_viewModel_when_US_store_then_available_card_reader_manuals() {
         // Given
         let setting = SiteSetting.fake()


### PR DESCRIPTION
Closes: #7219 

### Description
At the moment we're showing all Manuals in the consolidated view despite not all readers being available to all regions.

This PR modifies the way we initialize `CardReaderManualsViewModel` by checking the supported readers for each region, so we only display the manuals for the supported readers based on the Store country, that's:

- US-based stores will only display the manuals for Chipper and M2.
- CA-based stores will only display the manual for Wisepad 3.


### Testing instructions
- In your US or CA store, go to Settings > In-Person Payments > Card Reader manuals:
-- See manuals for Chipper and M2 in the US store.
-- See the manual for Wisepad 3 in the CA store.

### Screenshots

![RMC 2022-07-11 filter by country](https://user-images.githubusercontent.com/3812076/178209199-5b062ba8-f170-416f-87b6-33576fd4da64.gif)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
