### PR TITLE
Dashboard: Fix leak of continuation by calling onCompletion before early returns

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -114,6 +114,7 @@ private extension StoreStatsAndTopPerformersViewController {
 
     func syncStats(forced: Bool, viewControllerToSync: StoreStatsAndTopPerformersPeriodViewController, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         guard !isSyncing else {
+            onCompletion?(.success(()))
             return
         }
 
@@ -149,11 +150,13 @@ private extension StoreStatsAndTopPerformersViewController {
 
         [viewControllerToSync].forEach { [weak self] vc in
             guard let self = self else {
+                onCompletion?(.success(()))
                 return
             }
 
             if !forced, let lastFullSyncTimestamp = vc.lastFullSyncTimestamp, Date().timeIntervalSince(lastFullSyncTimestamp) < vc.minimalIntervalBetweenSync {
                 // data refresh is not required
+                onCompletion?(.success(()))
                 return
             }
 


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
While working on the screenshots last week, I noticed some warnings in Xcode console about a leaked continuation of Swift Task:
```
SWIFT TASK CONTINUATION MISUSE: reloadData(forced:) leaked its continuation!
```

Looking at `StoreStatsAndTopPerformersViewController`, it seems that we're having a few early returns in the `syncAllStats(forced:)` method that don't trigger the `onCompletion` closure. The `reloadData(forced:)` method uses checked continuation and waits for the `onCompletion` closure to resume, so in cases that the method is returned without the `onCompletion` closure, the continuation is leaked.

The quick fix is to trigger the `onCompletion` closure before returning early - this helps avoiding continuation leaks.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build and run the app, make sure that the My Store tab still works as before.
- Pay attention to Xcode console, make sure that the warning about continuation leak is no longer there.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
