### PR TITLE
Add contentShape to NavigationRow component

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/NavigationRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/NavigationRow.swift
@@ -39,6 +39,7 @@ struct NavigationRow<Content: View>: View {
             .padding()
             .padding(.horizontal, insets: safeAreaInsets)
             .frame(minHeight: Layout.minHeight)
+            .contentShape(Rectangle())
         }
         .disabled(!selectable)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7274 


### Description
At the moment, when using the SwiftUI `NavigationRow` reusable component, taps that do not happen directly within other components (Images, Text, Disclosure Indicator, etc, ...) in `content` do not trigger the tap gesture action. This is expected as neither the HStack nor Spacer themselves are tappable by default.

This PR addresses this issue by adding `.contentShape(Rectangle())` to the HStack inside the Button view, which makes the NavigationRow tappable.

| Before: Non-tappable areas | After: The whole NavigationRow is tappable |
|---|---|
|<img width="327" alt="Screenshot 2022-07-12 at 12 19 47" src="https://user-images.githubusercontent.com/3812076/178414557-1f7bc3ff-d44e-4554-8fb7-34bcc863b528.png"> |<img width="334" alt="Screenshot 2022-07-12 at 12 20 27" src="https://user-images.githubusercontent.com/3812076/178414578-8c276fcd-8c01-4cef-a2f2-35d39207dacc.png">|



### Testing instructions
- Login in a store that has In-Person Payments enabled
- Go to Settings > In-Person Payments > Card Reader Manuals
- Attempt to tap in the empty areas, see that the button reacts now and prompts a web view

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
