### PR TITLE
Login: update "New to WooCommerce" URL to point to our own doc

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -131,8 +131,7 @@ private extension LoginPrologueViewController {
 private extension LoginPrologueViewController {
     enum Constants {
         static let spacingBetweenCarouselAndNewToWooCommerceButton: CGFloat = 20
-        // TODO: 7231 - update URL if needed
-        static let newToWooCommerceURL = "https://woocommerce.com/guides/new-store"
+        static let newToWooCommerceURL = "https://woocommerce.com/document/woocommerce-features"
     }
 
     enum Localization {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7231 

⚠️ This PR targets the frozen release 9.6 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To comply with App Store guidelines to not include any signup or payment links in a web doc, we created [our own doc](https://woocommerce.com/document/woocommerce-features/) to fork the content from [Woo features](https://woocommerce.com/woocommerce-features/). I'll update the content of the doc later today to remove signup links and enhance the layout in tablet sizes, but the PR is ready for review to be included in the frozen release 9.6.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log out of the app if needed --> on the login prologue screen, there should be a button that says "New to WooCommerce?" above the 2 login buttons. tapping on it should open a webview to [this doc](https://woocommerce.com/document/woocommerce-features)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1945542/178506713-aa3b24a0-534b-47ce-ba5b-b540638456ec.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
