### PR TITLE
[Order Metadata] Handle complex metadata values

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -199,8 +199,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         // https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1561
         let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? false
 
-        // Filter out meta data if its key is prefixed with an underscore (internal meta keys)
-        let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") }) ?? []
+        // Filter out metadata if the key is prefixed with an underscore (internal meta keys) or the value is empty
+        let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") && !$0.value.isEmpty }) ?? []
 
         self.init(siteID: siteID,
                   orderID: orderID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsDetails.swift
@@ -12,7 +12,8 @@ struct OrderCustomFieldsDetails: View {
                     VStack(alignment: .leading) {
                         ForEach(customFields) { customField in
                             CustomFieldRow(title: customField.title,
-                                           content: customField.content)
+                                           content: customField.content,
+                                           contentURL: customField.contentURL)
                             Divider()
                                 .padding(.leading)
                         }
@@ -49,6 +50,10 @@ private struct CustomFieldRow: View {
     ///
     let content: String
 
+    /// Optional URL to link the content
+    ///
+    let contentURL: URL?
+
     /// URL to display in `SafariSheet` in app
     ///
     @State private var displayedURL: URL?
@@ -63,7 +68,7 @@ private struct CustomFieldRow: View {
                    spacing: Constants.spacing) {
                 Text(title)
 
-                if content.isValidURL(), let url = URL(string: content), UIApplication.shared.canOpenURL(url) { // Display content as a link
+                if let url = contentURL { // Display content as a link if URL is provided
                     Text(content)
                         .font(.footnote)
                         .foregroundColor(Color(.textLink))
@@ -112,7 +117,7 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
     static var previews: some View {
         OrderCustomFieldsDetails(customFields: [
             OrderCustomFieldsViewModel(id: 0, title: "First Title", content: "First Content"),
-            OrderCustomFieldsViewModel(id: 1, title: "Second Title", content: "Second Content")
+            OrderCustomFieldsViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
         ])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsDetails.swift
@@ -11,10 +11,8 @@ struct OrderCustomFieldsDetails: View {
                 ScrollView {
                     VStack(alignment: .leading) {
                         ForEach(customFields) { customField in
-                            TitleAndSubtitleRow(
-                                title: customField.title,
-                                subtitle: customField.content
-                            )
+                            CustomFieldRow(title: customField.title,
+                                           content: customField.content)
                             Divider()
                                 .padding(.leading)
                         }
@@ -42,11 +40,69 @@ struct OrderCustomFieldsDetails: View {
     }
 }
 
+private struct CustomFieldRow: View {
+    /// Custom Field title
+    ///
+    let title: String
+
+    /// Custom Field content
+    ///
+    let content: String
+
+    /// URL to display in `SafariSheet` in app
+    ///
+    @State private var displayedURL: URL?
+
+    /// Action to open URL with system handler
+    ///
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading,
+                   spacing: Constants.spacing) {
+                Text(title)
+
+                if content.isValidURL(), let url = URL(string: content), UIApplication.shared.canOpenURL(url) { // Display content as a link
+                    Text(content)
+                        .font(.footnote)
+                        .foregroundColor(Color(.textLink))
+                        .safariSheet(url: $displayedURL)
+                        .onTapGesture {
+                            switch url.scheme {
+                            case "http", "https":
+                                displayedURL = url // Open in `SafariSheet` in app
+                            default:
+                                openURL(url) // Open in associated app for URL scheme
+                            }
+                        }
+                } else { // Display content as plain text
+                    Text(content)
+                        .footnoteStyle()
+                }
+            }.padding([.leading, .trailing], Constants.vStackPadding)
+
+            Spacer()
+        }
+        .padding([.top, .bottom], Constants.hStackPadding)
+        .frame(minHeight: Constants.height)
+    }
+}
+
 // MARK: - Constants
 //
 extension OrderCustomFieldsDetails {
     enum Localization {
         static let title = NSLocalizedString("Custom Fields", comment: "Title for the order custom fields list")
+    }
+}
+
+private extension CustomFieldRow {
+    enum Constants {
+        static let spacing: CGFloat = 8
+        static let vStackPadding: CGFloat = 16
+        static let hStackPadding: CGFloat = 10
+        static let height: CGFloat = 64
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsViewModel.swift
@@ -18,7 +18,7 @@ struct OrderCustomFieldsViewModel: Identifiable {
     init(id: Int64, title: String, content: String) {
         self.id = id
         self.title = title
-        self.content = content
+        self.content = content.removedHTMLTags
     }
 
     init(metadata: OrderMetaData) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Custom Fields/OrderCustomFieldsViewModel.swift
@@ -15,17 +15,30 @@ struct OrderCustomFieldsViewModel: Identifiable {
     ///
     let content: String
 
-    init(id: Int64, title: String, content: String) {
+    /// Optional URL used for linking the Custom Field content
+    ///
+    let contentURL: URL?
+
+    init(id: Int64, title: String, content: String, contentURL: URL? = nil) {
         self.id = id
         self.title = title
-        self.content = content.removedHTMLTags
+        self.content = content
+        self.contentURL = contentURL
+
     }
 
     init(metadata: OrderMetaData) {
+        // Create a URL out of the metadata value, if it is a valid URL that can be opened on device
+        var contentURL: URL?
+        if metadata.value.isValidURL(), let url = URL(string: metadata.value), UIApplication.shared.canOpenURL(url) {
+            contentURL = url
+        }
+
         self.init(
             id: metadata.metadataID,
             title: metadata.key,
-            content: metadata.value
+            content: metadata.value.removedHTMLTags,
+            contentURL: contentURL
         )
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1306,6 +1306,7 @@
 		CC53FB402759042600C4CA4F /* ProductSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3F2759042600C4CA4F /* ProductSelectorViewModelTests.swift */; };
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
+		CC5BA5F5287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5BA5F4287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift */; };
 		CC5C278727EE19A700B25D2A /* NewOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */; };
 		CC5C278B27EE314F00B25D2A /* orders_3337_create_order.json in Resources */ = {isa = PBXBuildFile; fileRef = CC5C278A27EE314E00B25D2A /* orders_3337_create_order.json */; };
 		CC666F2427F329DC0045AF1E /* View+DiscardChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC666F2327F329DC0045AF1E /* View+DiscardChanges.swift */; };
@@ -3110,6 +3111,7 @@
 		CC53FB3F2759042600C4CA4F /* ProductSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSelectorViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
+		CC5BA5F4287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomFieldsViewModelTests.swift; sourceTree = "<group>"; };
 		CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderScreen.swift; sourceTree = "<group>"; };
 		CC5C278A27EE314E00B25D2A /* orders_3337_create_order.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337_create_order.json; sourceTree = "<group>"; };
 		CC666F2327F329DC0045AF1E /* View+DiscardChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+DiscardChanges.swift"; sourceTree = "<group>"; };
@@ -5800,6 +5802,7 @@
 				26C6E8E126E2D85300C7BB0F /* Addresses */,
 				025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */,
 				578195FB25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift */,
+				CC5BA5F4287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift */,
 			);
 			path = "Order Details";
 			sourceTree = "<group>";
@@ -10139,6 +10142,7 @@
 				D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */,
 				4572641B27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift in Sources */,
 				AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */,
+				CC5BA5F5287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift in Sources */,
 				02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */,
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,
 				0277AEA5256CAA4200F45C4A /* MockShippingLabel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderCustomFieldsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderCustomFieldsViewModelTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+class OrderCustomFieldsViewModelTests: XCTestCase {
+
+    func test_view_model_inits_with_expected_values() throws {
+        // Given
+        let url = URL(string: "https://woocommerce.com/")
+        let viewModel = OrderCustomFieldsViewModel(id: 1, title: "First Metadata", content: "First Content", contentURL: url)
+
+        // Then
+        XCTAssertEqual(viewModel.id, 1)
+        XCTAssertEqual(viewModel.title, "First Metadata")
+        XCTAssertEqual(viewModel.content, "First Content")
+        XCTAssertEqual(viewModel.contentURL, url)
+    }
+
+    func test_init_with_OrderMetaData_strips_HTML_from_metadata_value() throws {
+        // Given
+        let metadata = OrderMetaData(metadataID: 0, key: "HTML Metadata", value: "<strong>Fancy</strong> <a href=\"http://\">Metadata</a>")
+
+        // When
+        let viewModel = OrderCustomFieldsViewModel(metadata: metadata)
+
+        // Then
+        XCTAssertEqual(viewModel.content, "Fancy Metadata")
+    }
+
+    func test_init_with_OrderMetaData_creates_contentURL_from_metadata_value() throws {
+        // Given
+        let urlString = "https://woocommerce.com/"
+        let metadata = OrderMetaData(metadataID: 0, key: "URL Metadata", value: urlString)
+
+        // When
+        let viewModel = OrderCustomFieldsViewModel(metadata: metadata)
+
+        // Then
+        XCTAssertEqual(viewModel.contentURL, URL(string: urlString))
+    }
+
+}


### PR DESCRIPTION
Closes: #7279

## Description

We want to handle certain cases for the values in custom fields in different ways:

- Discard empty values.
- Discard JSON values.
- Strip HTML from strings.
- Detect when the value is a URL and make it tappable, opening the URL in an internal browser.

We already discard JSON values when decoding the metadata from the API response, so this PR adds support for the other handling we need.

## Changes

* When we decode and save the custom fields on the `Order` entity in the Networking layer, we now discard any metadata with empty values.
* When we initialize `OrderCustomFieldsViewModel` with `OrderMetaData`, it now handles complex metadata values:
  * It strips any HTML with our `removedHTMLTags` String extension.
  * If the value if a valid URL that can be opened on the device, it sets the optional `contentURL` property in the view model.
* `OrderCustomFieldDetails` is updated to display linked content. I swapped out the `TitleAndSubtitleRow` for a new `CustomFieldRow` in `OrderCustomFieldsDetails`. If a URL is provided for the row, the content is displayed as a link:
  * URLs with `http`/`https` schemes (which can be opened in Safari) are opened with our `.safariSheet` view modifier.
  * URLs with other schemes are opened with the associated app, using the system's default open URL action. (For example, the Mail app for `mailto` URLs or the phone app for `tel` URLs.)

## Testing

1. Create an order with custom fields that include URLs with different schemes (e.g. `http`/`https`, `mailto`, `tel`).
2. Build and run the app on a device or simulator. (Note that running it on a real device will support more URL schemes, so more metadata values will be linkified.)
3. Go to the Orders section of the app and select the order with custom fields.
4. Tap on "View Custom Fields" to open the Custom Fields list.
5. Confirm that URLs with `http` or `https` schemes are displayed as links (with the accent pink font color), as are any other URLs that have a corresponding app installed that can open them. Confirm that if there _isn't_ an app on the device to open a given URL, it is displayed as plain text instead of a link.
6. Tap on an `http`/`https` URL and confirm it is opened an in-app Safari sheet.
7. Go back to the Custom Fields list and tap on a URL with a different scheme and confirm it is opened in the corresponding app.

## Screenshots


https://user-images.githubusercontent.com/8658164/178579104-700d1f5f-99ae-41aa-8419-572dc47cef2e.mov



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
