### PR TITLE
Send test analytics to dedicated suites for unit, UI iOS, and UI iPadOS

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -eu
 
-TEST_NAME=$1
+CONFIGURATION=$1
 DEVICE=$2
 IOS_VERSION=$3
 
-echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
+echo "Running UI test on $DEVICE for iOS/iPadOS $IOS_VERSION using $CONFIGURATION configuration"
 
 # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
@@ -24,17 +24,11 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
-echo "--- Configure Test Analytics"
-# Collect data separately for iPhone and iPad
-if [[ $DEVICE =~ ^iPhone ]]; then
-  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE
-else
-  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
-fi
-
-echo "BUILDKITE_ANALYTICS_TOKEN starts with $(echo $BUILDKITE_ANALYTICS_TOKEN | cut -c1-5)"
-
 echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
-bundle exec fastlane test_without_building name:"$TEST_NAME" device:"$DEVICE" ios_version:"$IOS_VERSION"
+bundle exec fastlane test_without_building \
+  name:UITests \
+  configuration:"$CONFIGURATION" \
+  device:"$DEVICE" \
+  ios_version:"$IOS_VERSION"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -24,6 +24,14 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
+echo "--- Configure Test Analytics"
+# Collect data separately for iPhone and iPad
+if [[ $DEVICE =~ ^iPhone ]]; then
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE
+else
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
+fi
+
 echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -32,6 +32,8 @@ else
   export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
 fi
 
+echo "BUILDKITE_ANALYTICS_TOKEN starts with $(echo $BUILDKITE_ANALYTICS_TOKEN | cut -c1-5)"
+
 echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,45 +23,6 @@ steps:
     notify:
       - github_commit_status:
           context: "Build"
-
-  #################
-  # Create Installable Build
-  #################
-  - label: "🛠 Installable Build"
-    command: ".buildkite/commands/installable-build.sh"
-    env: *common_env
-    plugins: *common_plugins
-    if: build.pull_request.id != null
-    notify:
-      - github_commit_status:
-          context: "Installable Build"
-
-  #################
-  # Run Unit Tests
-  #################
-  - label: "🔬 Unit Tests"
-    command: ".buildkite/commands/run-unit-tests.sh"
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    notify:
-      - github_commit_status:
-          context: "Unit Tests"
-
-  #################
-  # Lint Translations
-  #################
-  - label: "🧹 Lint Translations"
-    command: "gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot"
-    plugins:
-      - docker#v3.8.0:
-          image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-    agents:
-      queue: "default"
-    notify:
-      - github_commit_status:
-          context: "Lint Translations"
-
   #################
   # UI Tests
   #################
@@ -75,14 +36,3 @@ steps:
     notify:
       - github_commit_status:
           context: "UI Tests (iPhone)"
-
-  - label: "🔬 UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Air (4th generation)" 15.0
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/"
-    notify:
-      - github_commit_status:
-          context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,45 @@ steps:
     notify:
       - github_commit_status:
           context: "Build"
+
+  #################
+  # Create Installable Build
+  #################
+  - label: "🛠 Installable Build"
+    command: ".buildkite/commands/installable-build.sh"
+    env: *common_env
+    plugins: *common_plugins
+    if: build.pull_request.id != null
+    notify:
+      - github_commit_status:
+          context: "Installable Build"
+
+  #################
+  # Run Unit Tests
+  #################
+  - label: "🔬 Unit Tests"
+    command: ".buildkite/commands/run-unit-tests.sh"
+    depends_on: "build"
+    env: *common_env
+    plugins: *common_plugins
+    notify:
+      - github_commit_status:
+          context: "Unit Tests"
+
+  #################
+  # Lint Translations
+  #################
+  - label: "🧹 Lint Translations"
+    command: "gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot"
+    plugins:
+      - docker#v3.8.0:
+          image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
+    agents:
+      queue: "default"
+    notify:
+      - github_commit_status:
+          context: "Lint Translations"
+
   #################
   # UI Tests
   #################
@@ -36,3 +75,14 @@ steps:
     notify:
       - github_commit_status:
           context: "UI Tests (iPhone)"
+
+  - label: "🔬 UI Tests (iPad)"
+    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Air (4th generation)" 15.0
+    depends_on: "build"
+    env: *common_env
+    plugins: *common_plugins
+    artifact_paths:
+      - "build/results/"
+    notify:
+      - github_commit_status:
+          context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,7 +66,7 @@ steps:
   # UI Tests
   #################
   - label: "🔬 UI Tests (iPhone)"
-    command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 11' 15.0
+    command: .buildkite/commands/run-ui-tests.sh iOS 'iPhone 11' 15.0
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
@@ -77,7 +77,7 @@ steps:
           context: "UI Tests (iPhone)"
 
   - label: "🔬 UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Air (4th generation)" 15.0
+    command: .buildkite/commands/run-ui-tests.sh iPadOS "iPad Air (4th generation)" 15.0
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,9 +86,9 @@
         "package": "BuildkiteTestCollector",
         "repositoryURL": "https://github.com/buildkite/test-collector-swift",
         "state": {
-          "branch": null,
-          "revision": "87afcecfb58dd017d6e835ec8e88e9eaa18095ba",
-          "version": "0.1.1"
+          "branch": "main",
+          "revision": "6dd8393f7b96150a8956830af72320f5154acb32",
+          "version": null
         }
       },
       {

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,9 +86,9 @@
         "package": "BuildkiteTestCollector",
         "repositoryURL": "https://github.com/buildkite/test-collector-swift",
         "state": {
-          "branch": "main",
-          "revision": "6dd8393f7b96150a8956830af72320f5154acb32",
-          "version": null
+          "branch": null,
+          "revision": "77c7f492f5c1c9ca159f73d18f56bbd1186390b0",
+          "version": "0.3.0"
         }
       },
       {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -11224,8 +11224,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/buildkite/test-collector-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				branch = main;
+				kind = branch;
 			};
 		};
 		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -11224,8 +11224,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/buildkite/test-collector-swift";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.0;
 			};
 		};
 		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce-BuildForTesting.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce-BuildForTesting.xcscheme
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+               BuildableName = "WooCommerce.app"
+               BlueprintName = "WooCommerce"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CodegenTests"
+               BuildableName = "CodegenTests"
+               BlueprintName = "CodegenTests"
+               ReferencedContainer = "container:../CodeGeneration">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0270C08927069A8900FC799F"
+               BuildableName = "ExperimentsTests.xctest"
+               BlueprintName = "ExperimentsTests"
+               ReferencedContainer = "container:../Experiments/Experiments.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TestKitTests"
+               BuildableName = "TestKitTests"
+               BlueprintName = "TestKitTests"
+               ReferencedContainer = "container:../TestKit">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCDC49C923FFFFF4003166BA"
+               BuildableName = "WooCommerceUITests.xctest"
+               BlueprintName = "WooCommerceUITests"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B557D9EB209753AA005962F4"
+               BuildableName = "NetworkingTests.xctest"
+               BlueprintName = "NetworkingTests"
+               ReferencedContainer = "container:../Networking/Networking.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B56DB3DC2049BFAA00D4AA8E"
+               BuildableName = "WooCommerceTests.xctest"
+               BlueprintName = "WooCommerceTests"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B9C9C63D283E703C001B879F"
+               BuildableName = "WooFoundationTests.xctest"
+               BlueprintName = "WooFoundationTests"
+               ReferencedContainer = "container:../WooFoundation/WooFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D88FDB0725DD216B00CB0DBD"
+               BuildableName = "HardwareTests.xctest"
+               BlueprintName = "HardwareTests"
+               ReferencedContainer = "container:../Hardware/Hardware.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5C9DDFD2087FEC0006B910A"
+               BuildableName = "YosemiteTests.xctest"
+               BlueprintName = "YosemiteTests"
+               ReferencedContainer = "container:../Yosemite/Yosemite.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B54CA5A120A4BBA600F38CD1"
+               BuildableName = "StorageTests.xctest"
+               BlueprintName = "StorageTests"
+               ReferencedContainer = "container:../Storage/Storage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:WooCommerceTests/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:WooCommerceUITests/UITests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+            BuildableName = "WooCommerce.app"
+            BlueprintName = "WooCommerce"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+            BuildableName = "WooCommerce.app"
+            BlueprintName = "WooCommerce"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -19,7 +19,7 @@
     "environmentVariableEntries" : [
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
+        "value" : "$(BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS)"
       },
       {
         "key" : "BUILDKITE_BRANCH",

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -54,6 +54,10 @@ final class LoginTests: XCTestCase {
     }
 
     func test_WordPress_unsuccessfull_login() throws {
+        XCTAssertTrue(
+            (ProcessInfo.processInfo.environment["BUILDKITE_ANALYTICS_TOKEN"] ?? "").starts(with: "w4tH")
+        )
+
         _ = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -54,10 +54,6 @@ final class LoginTests: XCTestCase {
     }
 
     func test_WordPress_unsuccessfull_login() throws {
-        XCTAssertTrue(
-            (ProcessInfo.processInfo.environment["BUILDKITE_ANALYTICS_TOKEN"] ?? "").starts(with: "w4tH")
-        )
-
         _ = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -45,8 +45,8 @@
     ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:WooCommerce.xcodeproj",
-      "identifier" : "CCDC49C923FFFFF4003166BA",
-      "name" : "WooCommerceUITests"
+      "identifier" : "B56DB3C52049BFAA00D4AA8E",
+      "name" : "WooCommerce"
     },
     "testRepetitionMode" : "retryOnFailure"
   },

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -2,18 +2,87 @@
   "configurations" : [
     {
       "id" : "DA512AA1-66D1-4829-BC02-EEFD0E226DE7",
-      "name" : "Configuration 1",
+      "name" : "iOS",
       "options" : {
-
+        "environmentVariableEntries" : [
+          {
+            "key" : "BUILDKITE_ANALYTICS_TOKEN",
+            "value" : "$(BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE)"
+          },
+          {
+            "key" : "BUILDKITE_BRANCH",
+            "value" : "$(BUILDKITE_BRANCH)"
+          },
+          {
+            "key" : "BUILDKITE_BUILD_ID",
+            "value" : "$(BUILDKITE_BUILD_ID)"
+          },
+          {
+            "key" : "BUILDKITE_BUILD_NUMBER",
+            "value" : "$(BUILDKITE_BUILD_NUMBER)"
+          },
+          {
+            "key" : "BUILDKITE_BUILD_URL",
+            "value" : "$(BUILDKITE_BUILD_URL)"
+          },
+          {
+            "key" : "BUILDKITE_COMMIT",
+            "value" : "$(BUILDKITE_COMMIT)"
+          },
+          {
+            "key" : "BUILDKITE_JOB_ID",
+            "value" : "$(BUILDKITE_JOB_ID)"
+          },
+          {
+            "key" : "BUILDKITE_MESSAGE",
+            "value" : "$(BUILDKITE_MESSAGE)"
+          }
+        ]
+      }
+    },
+    {
+      "id" : "9B6F0B72-4EBF-4541-926F-C9C95D531FED",
+      "name" : "iPadOS",
+      "options" : {
+        "environmentVariableEntries" : [
+          {
+            "key" : "BUILDKITE_ANALYTICS_TOKEN",
+            "value" : "$(BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD)"
+          },
+          {
+            "key" : "BUILDKITE_BRANCH",
+            "value" : "$(BUILDKITE_BRANCH)"
+          },
+          {
+            "key" : "BUILDKITE_BUILD_ID",
+            "value" : "$(BUILDKITE_BUILD_ID)"
+          },
+          {
+            "key" : "BUILDKITE_BUILD_NUMBER",
+            "value" : "$(BUILDKITE_BUILD_NUMBER)"
+          },
+          {
+            "key" : "BUILDKITE_BUILD_URL",
+            "value" : "$(BUILDKITE_BUILD_URL)"
+          },
+          {
+            "key" : "BUILDKITE_COMMIT",
+            "value" : "$(BUILDKITE_COMMIT)"
+          },
+          {
+            "key" : "BUILDKITE_JOB_ID",
+            "value" : "$(BUILDKITE_JOB_ID)"
+          },
+          {
+            "key" : "BUILDKITE_MESSAGE",
+            "value" : "$(BUILDKITE_MESSAGE)"
+          }
+        ]
       }
     }
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$(BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE)"
-      },
       {
         "key" : "BUILDKITE_BRANCH",
         "value" : "$(BUILDKITE_BRANCH)"

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -53,6 +53,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "OrdersTests",
+        "ProductsTests",
+        "ReviewsTests",
+        "StatsTests",
         "StatsTests\/testStatsScreenLoad()"
       ],
       "target" : {

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -12,7 +12,7 @@
     "environmentVariableEntries" : [
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
+        "value" : "$(BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE)"
       },
       {
         "key" : "BUILDKITE_BRANCH",

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -43,6 +43,11 @@
         "value" : "$(BUILDKITE_MESSAGE)"
       }
     ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:WooCommerce.xcodeproj",
+      "identifier" : "B56DB3C52049BFAA00D4AA8E",
+      "name" : "WooCommerce"
+    },
     "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -12,7 +12,7 @@
     "environmentVariableEntries" : [
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$BUILDKITE_ANALYTICS_TOKEN"
+        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
       },
       {
         "key" : "BUILDKITE_BRANCH",

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -45,8 +45,8 @@
     ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:WooCommerce.xcodeproj",
-      "identifier" : "B56DB3C52049BFAA00D4AA8E",
-      "name" : "WooCommerce"
+      "identifier" : "CCDC49C923FFFFF4003166BA",
+      "name" : "WooCommerceUITests"
     },
     "testRepetitionMode" : "retryOnFailure"
   },

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1054,6 +1054,8 @@ lane :test_without_building do |options|
     result_bundle: true,
     # settins for XML test report generation via `trainer`
     output_types: '',
+    # DEBUG: get full xcodebuild logs to see why we have no UI tests analytics
+    output_style: 'raw',
     fail_build: false
   )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1046,6 +1046,8 @@ lane :test_without_building do |options|
 
   UI.user_error!('Unable to find .xctestrun file') unless !xctestrun_path.nil? && File.exist?((xctestrun_path))
 
+  configurations = options[:test_configuration].nil? ? nil : [options[:test_configuration]]
+
   run_tests(
     workspace: 'WooCommerce.xcworkspace',
     scheme: TEST_SCHEME,
@@ -1053,6 +1055,7 @@ lane :test_without_building do |options|
     deployment_target_version: options[:ios_version],
     test_without_building: true,
     xctestrun: xctestrun_path,
+    only_test_configurations: configurations,
     result_bundle: true,
     # settins for XML test report generation via `trainer`
     output_types: '',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,8 @@ SCREENSHOT_DEVICES = [
 MAIN_BUNDLE_IDENTIFIERS = %w[com.automattic.woocommerce].freeze        # Registered in our main account, for development and AppStore
 ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce].freeze # Registered in our Enterprise account, for App Center / Installable Builds
 
+TEST_SCHEME = 'WooCommerce-BuildForTesting'
+
 # List of `.strings` files manually maintained by developers (as opposed to being automatically extracted from the code)
 # which we will merge into the main `Localizable.strings` file imported by GlotPress, then extract back once we download the translations.
 #
@@ -556,7 +558,7 @@ platform :ios do
   lane :build_for_testing do |options|
     run_tests(
       workspace: 'WooCommerce.xcworkspace',
-      scheme: 'WooCommerce',
+      scheme: TEST_SCHEME,
       derived_data_path: 'DerivedData',
       build_for_testing: true,
       device: options[:device],
@@ -1046,7 +1048,7 @@ lane :test_without_building do |options|
 
   run_tests(
     workspace: 'WooCommerce.xcworkspace',
-    scheme: 'WooCommerce',
+    scheme: TEST_SCHEME,
     device: options[:device],
     deployment_target_version: options[:ios_version],
     test_without_building: true,


### PR DESCRIPTION
(_Supersedes https://github.com/woocommerce/woocommerce-ios/pull/7163_)

### Description

I created three Test Analytics suites for unit, UI iOS, and UI iPadOS tests to collect more granular info. In particular, given the difference in test run time between unit and UI, having them split means we should have more accurate average figures.

### Testing instructions
Verify that analytics have been reported for this build by following the "Test Analytics" link in the [build page](https://buildkite.com/automattic/woocommerce-ios/builds/6498).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->