### PR TITLE
[Order Metadata] Update Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -358,6 +358,14 @@ extension WooAnalyticsEvent {
             static let orderID = "id"
         }
 
+        static func orderOpen(order: Order) -> WooAnalyticsEvent {
+            let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
+            return WooAnalyticsEvent(statName: .orderOpen, properties: ["id": order.orderID,
+                                                                        "status": order.status.rawValue,
+                                                                        "custom_fields_count": Int64(order.customFields.count),
+                                                                        "custom_fields_size": Int64(customFieldsSize)])
+        }
+
         static func orderAddNew() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderAddNew, properties: [:])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -243,6 +243,7 @@ public enum WooAnalyticsStat: String {
     case orderShippingMethodAdd = "order_shipping_method_add"
     case orderSyncFailed = "order_sync_failed"
     case collectPaymentTapped = "payments_flow_order_collect_payment_tapped"
+    case orderViewCustomFieldsTapped = "order_view_custom_fields_tapped"
 
     // MARK: Order List Sorting/Filtering
     //

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -391,6 +391,7 @@ extension OrderDetailsViewModel {
             let billingInformationViewController = BillingInformationViewController(order: order, editingEnabled: !isUnifiedEditingEnabled)
             viewController.navigationController?.pushViewController(billingInformationViewController, animated: true)
         case .customFields:
+            ServiceLocator.analytics.track(.orderViewCustomFieldsTapped)
             let customFields = order.customFields.map {
                 OrderCustomFieldsViewModel(metadata: $0)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -591,8 +591,11 @@ extension OrderListViewController: UITableViewDelegate {
 
         selectedIndexPath = indexPath
         let order = orderDetailsViewModel.order
+        let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
-                                                                    "status": order.status.rawValue])
+                                                                    "status": order.status.rawValue,
+                                                                    "custom_fields_count": order.customFields.count,
+                                                                    "custom_fields_size": customFieldsSize])
         selectedOrderID = order.orderID
 
         if isSplitViewInOrdersTabEnabled {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -591,11 +591,7 @@ extension OrderListViewController: UITableViewDelegate {
 
         selectedIndexPath = indexPath
         let order = orderDetailsViewModel.order
-        let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
-        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
-                                                                    "status": order.status.rawValue,
-                                                                    "custom_fields_count": order.customFields.count,
-                                                                    "custom_fields_size": customFieldsSize])
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
         selectedOrderID = order.orderID
 
         if isSplitViewInOrdersTabEnabled {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -386,7 +386,11 @@ private extension OrdersRootViewController {
             show(orderViewController, sender: self)
         }
 
-        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID, "status": order.status.rawValue])
+        let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
+        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
+                                                                    "status": order.status.rawValue,
+                                                                    "custom_fields_count": order.customFields.count,
+                                                                    "custom_fields_size": customFieldsSize])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -386,11 +386,7 @@ private extension OrdersRootViewController {
             show(orderViewController, sender: self)
         }
 
-        let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
-        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
-                                                                    "status": order.status.rawValue,
-                                                                    "custom_fields_count": order.customFields.count,
-                                                                    "custom_fields_size": customFieldsSize])
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
     }
 }
 


### PR DESCRIPTION
Closes: #7273

## Description/Changes

Adds and updates the following analytics events:

* `order_open` updated to use a `WooAnalyticsEvent` method and add new properties:
  * `custom_fields_count: $total-metadata-count`
  * `custom_fields_size: $metadata-size-in-bytes`
* `order_view_custom_fields_tapped` added (965-gh-Automattic/tracks-events-registration)

## Testing

1. Go to the Orders tab and select an order with custom fields.
2. Confirm the `order_open` event is tracked with all of its expected properties.
3. Tap the "View Custom Fields" button and confirm the `order_view_custom_fields_tapped` event is tracked.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.