### PR TITLE
[Order Details] Change refund lines to be shown chronologically

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 9.7
 -----
-
+- [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]
 
 9.6
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -210,7 +210,7 @@ final class OrderDetailsDataSource: NSObject {
     /// All the condensed refunds in an order
     ///
     var condensedRefunds: [OrderRefundCondensed] {
-        return order.refunds.sorted(by: { $0.refundID > $1.refundID })
+        return order.refunds.sorted(by: { $0.refundID < $1.refundID })
     }
 
     /// Notes of an Order


### PR DESCRIPTION
Closes: #7060

### Description
This PR modifies the order in which items on `[OrderRefundCondensed]` are sorted, so when we have multiple partial refunds in the same Order, they appear Chronologically (newest at the top, older at the bottom) in the Order Details screen. 

The reason for using the `refundID` to sort these is to keep it simple as this auto incremental field in Woo Core, when a new refund is created, a new incremental post_ID is assigned.

Ref: p91TBi-8P0-p2#line-items-in-the-payment-section

### Testing instructions
- Create an Order with multiple items, or an Order with one item, fee, and shipping fees.
- Mark the Order as completed.
- Refund various of the elements in the Order separately. You can add a note to "Refund reason:" like "refund 1, refund 2, etc, .. " so is easier to keep track of their ordering.
- Check the Order details and see how these appear chronologically, with the first performed refund (oldest) at the top, and the last performed refund at the end (newest).

### Screenshots
| Before | After |
|--|--|
| ![_refund order default 2022-07-14](https://user-images.githubusercontent.com/3812076/178903078-52b54b8f-1be5-4815-bd53-ddb9904ac04a.png) | ![_refund order updated 2022-07-14](https://user-images.githubusercontent.com/3812076/178903222-a466e58c-e861-40ae-897a-bec6b37ccee9.png) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
