### PR TITLE
Login Onboarding: add a feature flag and onboarding UI

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -49,6 +49,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .orderCustomFields:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .loginPrologueOnboarding:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -97,4 +97,8 @@ public enum FeatureFlag: Int {
     /// Enable the Order Custom Fields button in Order Details
     ///
     case orderCustomFields
+
+    /// Onboarding experiment on the login prologue screen
+    ///
+    case loginPrologueOnboarding
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -3,8 +3,8 @@ import UIKit
 /// Contains a feature carousel with buttons that end up on the login prologue screen.
 final class LoginOnboardingViewController: UIViewController {
     private let stackView: UIStackView = .init()
-    private lazy var pageViewController: LoginProloguePageViewController =
-    LoginProloguePageViewController(pageTypes: [.stats, .orderManagement, .products], showsSubtitle: true)
+    private lazy var pageViewController = LoginProloguePageViewController(pageTypes: [.stats, .orderManagement, .products],
+                                                                          showsSubtitle: true)
     private let onDismiss: () -> Void
 
     init(onDismiss: @escaping () -> Void) {
@@ -84,10 +84,10 @@ private extension LoginOnboardingViewController {
     func configureStackViewSubviews() {
         let carousel = createFeatureCarousel()
 
-        let continueButton = createContinueButton()
+        let nextButton = createNextButton()
         let skipButton = createSkipButton()
         let buttonStackView: UIStackView = {
-            let stackView = UIStackView(arrangedSubviews: [continueButton, skipButton])
+            let stackView = UIStackView(arrangedSubviews: [nextButton, skipButton])
             stackView.spacing = Constants.buttonStackViewSpacing
             stackView.axis = .vertical
             return stackView
@@ -100,16 +100,17 @@ private extension LoginOnboardingViewController {
         pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
         addChild(pageViewController)
+        pageViewController.didMove(toParent: self)
         return pageViewController.view
     }
 
-    func createContinueButton() -> UIButton {
+    func createNextButton() -> UIButton {
         let button = UIButton(frame: .zero)
         button.applyPrimaryButtonStyle()
         button.setTitle(Localization.continueButtonTitle, for: .normal)
         button.on(.touchUpInside) { [weak self] _ in
             guard let self = self else { return }
-            guard self.pageViewController.goToNextPage() else {
+            guard self.pageViewController.goToNextPageIfPossible() else {
                 return self.onDismiss()
             }
         }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -1,0 +1,136 @@
+import UIKit
+
+/// Contains a feature carousel with buttons that end up on the login prologue screen.
+final class LoginOnboardingViewController: UIViewController {
+    private let stackView: UIStackView = .init()
+    private let onDismiss: () -> Void
+
+    init(onDismiss: @escaping () -> Void) {
+        self.onDismiss = onDismiss
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureMainView()
+        configureCurvedImageView()
+        configureWooLogo()
+        configureStackView()
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIDevice.isPad() ? .all : .portrait
+    }
+}
+
+private extension LoginOnboardingViewController {
+    func configureMainView() {
+        view.backgroundColor = .basicBackground
+
+        let bottomView = UIView(frame: .zero)
+        bottomView.backgroundColor = .authPrologueBottomBackgroundColor
+        bottomView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bottomView)
+        NSLayoutConstraint.activate([
+            bottomView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor),
+            bottomView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor),
+            bottomView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.3),
+            bottomView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    func configureCurvedImageView() {
+        let imageView = UIImageView(image: .curvedRectangle)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: view.safeTopAnchor, constant: 52),
+            imageView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.7)
+        ])
+    }
+
+    func configureWooLogo() {
+        let imageView = UIImageView(image: .wooLogoPrologueImage)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 176),
+            imageView.heightAnchor.constraint(equalToConstant: 36),
+            imageView.topAnchor.constraint(equalTo: view.safeTopAnchor, constant: 28)
+        ])
+    }
+
+    func configureStackView() {
+        configureStackViewSubviews()
+
+        stackView.axis = .vertical
+        stackView.spacing = Constants.stackViewSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+        view.pinSubviewToSafeArea(stackView, insets: Constants.stackViewInsets)
+    }
+
+    func configureStackViewSubviews() {
+        let carousel = createFeatureCarousel()
+
+        let continueButton = createContinueButton()
+        let skipButton = createSkipButton()
+        let buttonStackView: UIStackView = {
+            let stackView = UIStackView(arrangedSubviews: [continueButton, skipButton])
+            stackView.spacing = Constants.buttonStackViewSpacing
+            stackView.axis = .vertical
+            return stackView
+        }()
+
+        stackView.addArrangedSubviews([carousel, buttonStackView])
+    }
+
+    func createFeatureCarousel() -> UIView {
+        let carousel = LoginProloguePageViewController()
+        carousel.view.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(carousel)
+        return carousel.view
+    }
+
+    func createContinueButton() -> UIButton {
+        let button = UIButton(frame: .zero)
+        button.applyPrimaryButtonStyle()
+        button.setTitle(Localization.continueButtonTitle, for: .normal)
+        button.on(.touchUpInside) { [weak self] _ in
+            self?.onDismiss()
+        }
+        return button
+    }
+
+    func createSkipButton() -> UIButton {
+        let button = UIButton(frame: .zero)
+        button.applyLinkButtonStyle()
+        button.setTitle(Localization.skipButtonTitle, for: .normal)
+        button.on(.touchUpInside) { [weak self] _ in
+            self?.onDismiss()
+        }
+        return button
+    }
+}
+
+private extension LoginOnboardingViewController {
+    enum Localization {
+        static let continueButtonTitle = NSLocalizedString("Next", comment: "The button title on the login onboarding screen to continue to the next step.")
+        static let skipButtonTitle = NSLocalizedString("Skip", comment: "The button title on the login onboarding screen to skip to the prologue screen.")
+    }
+
+    enum Constants {
+        static let stackViewInsets: UIEdgeInsets = .init(top: 0, left: 16, bottom: 20, right: 16)
+        static let stackViewSpacing: CGFloat = 40
+        static let buttonStackViewSpacing: CGFloat = 16
+    }
+}

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -47,7 +47,8 @@ private extension LoginOnboardingViewController {
     }
 
     func configureCurvedImageView() {
-        let imageView = UIImageView(image: .curvedRectangle)
+        let imageView = UIImageView(image: .curvedRectangle.withRenderingMode(.alwaysTemplate))
+        imageView.tintColor = .authPrologueBottomBackgroundColor
         imageView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(imageView)
         NSLayoutConstraint.activate([

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 /// Contains a feature carousel with buttons that end up on the login prologue screen.
 final class LoginOnboardingViewController: UIViewController {
     private let stackView: UIStackView = .init()
+    private lazy var pageViewController: LoginProloguePageViewController = LoginProloguePageViewController(pageTypes: [.stats, .orderManagement, .products])
     private let onDismiss: () -> Void
 
     init(onDismiss: @escaping () -> Void) {
@@ -94,11 +95,10 @@ private extension LoginOnboardingViewController {
     }
 
     func createFeatureCarousel() -> UIView {
-        let carousel = LoginProloguePageViewController()
-        carousel.view.translatesAutoresizingMaskIntoConstraints = false
+        pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
-        addChild(carousel)
-        return carousel.view
+        addChild(pageViewController)
+        return pageViewController.view
     }
 
     func createContinueButton() -> UIButton {
@@ -106,7 +106,10 @@ private extension LoginOnboardingViewController {
         button.applyPrimaryButtonStyle()
         button.setTitle(Localization.continueButtonTitle, for: .normal)
         button.on(.touchUpInside) { [weak self] _ in
-            self?.onDismiss()
+            guard let self = self else { return }
+            guard self.pageViewController.goToNextPage() else {
+                return self.onDismiss()
+            }
         }
         return button
     }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -3,7 +3,8 @@ import UIKit
 /// Contains a feature carousel with buttons that end up on the login prologue screen.
 final class LoginOnboardingViewController: UIViewController {
     private let stackView: UIStackView = .init()
-    private lazy var pageViewController: LoginProloguePageViewController = LoginProloguePageViewController(pageTypes: [.stats, .orderManagement, .products])
+    private lazy var pageViewController: LoginProloguePageViewController =
+    LoginProloguePageViewController(pageTypes: [.stats, .orderManagement, .products], showsSubtitle: true)
     private let onDismiss: () -> Void
 
     init(onDismiss: @escaping () -> Void) {
@@ -132,8 +133,8 @@ private extension LoginOnboardingViewController {
     }
 
     enum Constants {
-        static let stackViewInsets: UIEdgeInsets = .init(top: 0, left: 16, bottom: 20, right: 16)
-        static let stackViewSpacing: CGFloat = 40
+        static let stackViewInsets: UIEdgeInsets = .init(top: 52, left: 16, bottom: 20, right: 16)
+        static let stackViewSpacing: CGFloat = 30
         static let buttonStackViewSpacing: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -118,6 +118,7 @@ private extension LoginOnboardingViewController {
 
     func createSkipButton() -> UIButton {
         let button = UIButton(frame: .zero)
+        button.accessibilityIdentifier = "Login Onboarding Skip Button"
         button.applyLinkButtonStyle()
         button.setTitle(Localization.skipButtonTitle, for: .normal)
         button.on(.touchUpInside) { [weak self] _ in

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
@@ -26,6 +26,24 @@ final class LoginProloguePageViewController: UIPageViewController {
             setViewControllers([firstPage], direction: .forward, animated: false)
         }
 
+        configureUIBasedOnPageCount()
+    }
+
+    /// Shows the next page of content if it is not on the last page.
+    /// - Returns: Whether it can go to the next page, if it has not reached the last page.
+    func goToNextPageIfPossible() -> Bool {
+        let currentPage = pageControl.currentPage
+        guard currentPage < pages.count - 1 else {
+            return false
+        }
+        pageControl.currentPage = currentPage + 1
+        handlePageControlValueChanged(sender: pageControl)
+        return true
+    }
+}
+
+private extension LoginProloguePageViewController {
+    func configureUIBasedOnPageCount() {
         if pages.count > 1 {
             addPageControl()
         } else {
@@ -36,7 +54,7 @@ final class LoginProloguePageViewController: UIPageViewController {
 
     // MARK: Page Control Setup
     //
-    private func addPageControl() {
+    func addPageControl() {
         pageControl.currentPageIndicatorTintColor = .gray(.shade5)
         pageControl.pageIndicatorTintColor = .wooCommercePurple(.shade50)
         pageControl.transform = CGAffineTransform(scaleX: Constants.pageControlScale, y: Constants.pageControlScale)
@@ -53,19 +71,7 @@ final class LoginProloguePageViewController: UIPageViewController {
         pageControl.addTarget(self, action: #selector(handlePageControlValueChanged(sender:)), for: .valueChanged)
     }
 
-    /// Show the next page of content.
-    /// - Returns: Whether there is next page.
-    func goToNextPage() -> Bool {
-        let currentPage = pageControl.currentPage
-        guard currentPage < pages.count - 1 else {
-            return false
-        }
-        pageControl.currentPage = currentPage + 1
-        handlePageControlValueChanged(sender: pageControl)
-        return true
-    }
-
-    @objc private func handlePageControlValueChanged(sender: UIPageControl) {
+    @objc func handlePageControlValueChanged(sender: UIPageControl) {
         guard let currentPage = viewControllers?.first,
               let currentIndex = pages.firstIndex(of: currentPage) else {
             return

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
@@ -8,8 +8,8 @@ final class LoginProloguePageViewController: UIPageViewController {
 
     private let pageControl = UIPageControl()
 
-    init(pageTypes: [LoginProloguePageType] = LoginProloguePageType.allCases) {
-        self.pages = pageTypes.map { LoginProloguePageTypeViewController(pageType: $0) }
+    init(pageTypes: [LoginProloguePageType] = LoginProloguePageType.allCases, showsSubtitle: Bool = false) {
+        self.pages = pageTypes.map { LoginProloguePageTypeViewController(pageType: $0, showsSubtitle: showsSubtitle) }
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal)
     }
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
@@ -4,13 +4,12 @@ import UIKit
 ///
 final class LoginProloguePageViewController: UIPageViewController {
 
-    private let pages: [UIViewController] = {
-        LoginProloguePageType.allCases.map { LoginProloguePageTypeViewController(pageType: $0) }
-    }()
+    private let pages: [UIViewController]
 
     private let pageControl = UIPageControl()
 
-    init() {
+    init(pageTypes: [LoginProloguePageType] = LoginProloguePageType.allCases) {
+        self.pages = pageTypes.map { LoginProloguePageTypeViewController(pageType: $0) }
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal)
     }
 
@@ -49,7 +48,19 @@ final class LoginProloguePageViewController: UIPageViewController {
         pageControl.addTarget(self, action: #selector(handlePageControlValueChanged(sender:)), for: .valueChanged)
     }
 
-    @objc func handlePageControlValueChanged(sender: UIPageControl) {
+    /// Show the next page of content.
+    /// - Returns: Whether there is next page.
+    func goToNextPage() -> Bool {
+        let currentPage = pageControl.currentPage
+        guard currentPage < pages.count - 1 else {
+            return false
+        }
+        pageControl.currentPage = currentPage + 1
+        handlePageControlValueChanged(sender: pageControl)
+        return true
+    }
+
+    @objc private func handlePageControlValueChanged(sender: UIPageControl) {
         guard let currentPage = viewControllers?.first,
               let currentIndex = pages.firstIndex(of: currentPage) else {
             return

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
@@ -26,7 +26,12 @@ final class LoginProloguePageViewController: UIPageViewController {
             setViewControllers([firstPage], direction: .forward, animated: false)
         }
 
-        addPageControl()
+        if pages.count > 1 {
+            addPageControl()
+        } else {
+            // Sets data source to `nil` to disable scrolling.
+            dataSource = nil
+        }
     }
 
     // MARK: Page Control Setup

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -31,6 +31,22 @@ enum LoginProloguePageType: CaseIterable {
         }
     }
 
+    var subtitle: String? {
+        switch self {
+        case .stats:
+            return NSLocalizedString("We know it’s essential to your business.",
+                                     comment: "Subtitle displayed in promotional screens shown during the login flow.")
+        case .orderManagement:
+            return NSLocalizedString("You can manage quickly and easily.",
+                                     comment: "Subtitle displayed in promotional screens shown during the login flow.")
+        case .products:
+            return NSLocalizedString("We make it fast and easy to process effortlessly.",
+                                     comment: "Subtitle displayed in promotional screens shown during the login flow.")
+        default:
+            return nil
+        }
+    }
+
     var image: UIImage {
         switch self {
         case .stats:
@@ -49,15 +65,18 @@ enum LoginProloguePageType: CaseIterable {
 
 /// Simple container for each page of the login prologue carousel.
 ///
-class LoginProloguePageTypeViewController: UIViewController {
+final class LoginProloguePageTypeViewController: UIViewController {
     private let stackView = UIStackView()
     private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
     private let imageView = UIImageView()
 
-    private var pageType: LoginProloguePageType
+    private let pageType: LoginProloguePageType
+    private let showsSubtitle: Bool
 
-    init(pageType: LoginProloguePageType) {
+    init(pageType: LoginProloguePageType, showsSubtitle: Bool) {
         self.pageType = pageType
+        self.showsSubtitle = showsSubtitle
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -73,9 +92,14 @@ class LoginProloguePageTypeViewController: UIViewController {
         configureStackView()
         configureImage()
         configureTitle()
+        if showsSubtitle {
+            configureSubtitle()
+        }
     }
+}
 
-    private func configureStackView() {
+private extension LoginProloguePageTypeViewController {
+    func configureStackView() {
         view.addSubview(stackView)
 
         // Stack view layout
@@ -97,7 +121,7 @@ class LoginProloguePageTypeViewController: UIViewController {
         ])
     }
 
-    private func configureImage() {
+    func configureImage() {
         stackView.addArrangedSubview(imageView)
 
         // Image style & layout
@@ -112,11 +136,11 @@ class LoginProloguePageTypeViewController: UIViewController {
         imageView.image = pageType.image
     }
 
-    private func configureTitle() {
+    func configureTitle() {
         stackView.addArrangedSubview(titleLabel)
 
         // Label style & layout
-        titleLabel.font = .body
+        titleLabel.font = showsSubtitle ? .font(forStyle: .title2, weight: .semibold): .body
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textColor = .text
         titleLabel.textAlignment = .center
@@ -132,7 +156,28 @@ class LoginProloguePageTypeViewController: UIViewController {
         titleLabel.text = pageType.title
     }
 
-    private enum Constants {
+    func configureSubtitle() {
+        stackView.addArrangedSubview(subtitleLabel)
+
+        // Label style & layout
+        subtitleLabel.font = .body
+        subtitleLabel.adjustsFontForContentSizeCategory = true
+        subtitleLabel.textColor = .textSubtle
+        subtitleLabel.textAlignment = .center
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.setContentHuggingPriority(.required, for: .vertical)
+        subtitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        NSLayoutConstraint.activate([
+            subtitleLabel.widthAnchor.constraint(equalToConstant: Constants.labelWidth)
+        ])
+
+        subtitleLabel.text = pageType.subtitle
+    }
+}
+
+private extension LoginProloguePageTypeViewController {
+    enum Constants {
         static let stackSpacing: CGFloat = 40 // Space between image and text
         static let stackVerticalOffset: CGFloat = 103
         static let stackBottomMargin: CGFloat = -57 // Minimum margin between stack view and login buttons, including space required for UIPageControl

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -9,6 +9,7 @@ enum LoginProloguePageType: CaseIterable {
     case orderManagement
     case products
     case reviews
+    case getStarted
 
     var title: String {
         switch self {
@@ -24,6 +25,9 @@ enum LoginProloguePageType: CaseIterable {
         case .reviews:
             return NSLocalizedString("Monitor and approve your product reviews",
                                      comment: "Caption displayed in promotional screens shown during the login flow.")
+        case .getStarted:
+            return NSLocalizedString("Let’s get started!",
+                                     comment: "Caption displayed in the prologue screen shown after onboarding during the login flow.")
         }
     }
 
@@ -35,7 +39,7 @@ enum LoginProloguePageType: CaseIterable {
             return UIImage.prologueOrdersImage
         case .products:
             return UIImage.prologueProductsImage
-        case .reviews:
+        case .reviews, .getStarted:
             return UIImage.prologueReviewsImage
         }
     }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -90,7 +90,8 @@ private extension LoginPrologueViewController {
     /// This is contained in a child view so that this view's background doesn't scroll.
     ///
     func setupCarousel(isNewToWooCommerceButtonShown: Bool) {
-        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureEnabled ? [.getStarted]: LoginProloguePageType.allCases
+        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureEnabled ?
+        [.getStarted]: [.stats, .orderManagement, .products, .reviews]
         let carousel = LoginProloguePageViewController(pageTypes: pageTypes, showsSubtitle: isOnboardingFeatureEnabled)
         carousel.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -8,6 +8,7 @@ import Experiments
 ///
 final class LoginPrologueViewController: UIViewController {
     private let isNewToWooCommerceButtonShown: Bool
+    private let isOnboardingFeatureEnabled: Bool
     private let analytics: Analytics
 
     /// Background View, to be placed surrounding the bottom area.
@@ -37,6 +38,7 @@ final class LoginPrologueViewController: UIViewController {
     init(analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         isNewToWooCommerceButtonShown = featureFlagService.isFeatureFlagEnabled(.newToWooCommerceLinkInLoginPrologue)
+        self.isOnboardingFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding)
         self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
     }
@@ -88,7 +90,8 @@ private extension LoginPrologueViewController {
     /// This is contained in a child view so that this view's background doesn't scroll.
     ///
     func setupCarousel(isNewToWooCommerceButtonShown: Bool) {
-        let carousel = LoginProloguePageViewController()
+        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureEnabled ? [.getStarted]: LoginProloguePageType.allCases
+        let carousel = LoginProloguePageViewController(pageTypes: pageTypes)
         carousel.view.translatesAutoresizingMaskIntoConstraints = false
 
         addChild(carousel)

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -38,7 +38,7 @@ final class LoginPrologueViewController: UIViewController {
     init(analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         isNewToWooCommerceButtonShown = featureFlagService.isFeatureFlagEnabled(.newToWooCommerceLinkInLoginPrologue)
-        self.isOnboardingFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding)
+        isOnboardingFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding)
         self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
     }
@@ -90,8 +90,7 @@ private extension LoginPrologueViewController {
     /// This is contained in a child view so that this view's background doesn't scroll.
     ///
     func setupCarousel(isNewToWooCommerceButtonShown: Bool) {
-        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureEnabled ?
-        [.getStarted]: [.stats, .orderManagement, .products, .reviews]
+        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureEnabled ? [.getStarted] : [.stats, .orderManagement, .products, .reviews]
         let carousel = LoginProloguePageViewController(pageTypes: pageTypes, showsSubtitle: isOnboardingFeatureEnabled)
         carousel.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -91,7 +91,7 @@ private extension LoginPrologueViewController {
     ///
     func setupCarousel(isNewToWooCommerceButtonShown: Bool) {
         let pageTypes: [LoginProloguePageType] = isOnboardingFeatureEnabled ? [.getStarted]: LoginProloguePageType.allCases
-        let carousel = LoginProloguePageViewController(pageTypes: pageTypes)
+        let carousel = LoginProloguePageViewController(pageTypes: pageTypes, showsSubtitle: isOnboardingFeatureEnabled)
         carousel.view.translatesAutoresizingMaskIntoConstraints = false
 
         addChild(carousel)

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -976,6 +976,12 @@ extension UIImage {
         return im2.imageWithTintColor(tintColor)
     }
 
+    /// Woo logo that is displayed on the login prologue.
+    ///
+    static var wooLogoPrologueImage: UIImage {
+        UIImage(named: "prologue-logo")!
+    }
+
     /// Waiting for Customers Image
     ///
     static var waitingForCustomersImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -109,7 +109,7 @@ private extension AppCoordinator {
 
     /// Presents onboarding on top of the authentication UI under certain criteria.
     func presentLoginOnboarding() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) else  {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) else {
             return
         }
         let onboardingViewController = LoginOnboardingViewController { [weak self] in
@@ -208,7 +208,8 @@ private extension AppCoordinator {
     /// Sets the app window's root view controller, with animation only if the root view controller is previously non-nil.
     /// - Parameters:
     ///   - rootViewController: view controller to be set as the window's root view controller.
-    ///   - onCompletion: called after the root view controller is set after animation if needed. The boolean value indicates whether or not the animations actually finished before the completion handler was called.
+    ///   - onCompletion: called after the root view controller is set after animation if needed.
+    ///                   The boolean value indicates whether or not the animations actually finished before the completion handler was called.
     func setWindowRootViewControllerAndAnimateIfNeeded(_ rootViewController: UIViewController, onCompletion: @escaping (Bool) -> Void = { _ in }) {
         // Animates window transition only if the root view controller is non-nil originally.
         let shouldAnimate = window.rootViewController != nil

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -101,8 +101,23 @@ private extension AppCoordinator {
         setWindowRootViewControllerAndAnimateIfNeeded(authenticationUI) { [weak self] _ in
             guard let self = self else { return }
             self.tabBarController.removeViewControllers()
+
+            self.presentLoginOnboarding()
         }
         ServiceLocator.analytics.track(.openedLogin)
+    }
+
+    /// Presents onboarding on top of the authentication UI under certain criteria.
+    func presentLoginOnboarding() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) else  {
+            return
+        }
+        let onboardingViewController = LoginOnboardingViewController { [weak self] in
+            self?.window.rootViewController?.dismiss(animated: true)
+        }
+        onboardingViewController.modalPresentationStyle = .fullScreen
+        onboardingViewController.modalTransitionStyle = .crossDissolve
+        window.rootViewController?.present(onboardingViewController, animated: false)
     }
 
     /// Displays logged in tab bar UI.
@@ -190,12 +205,18 @@ private extension AppCoordinator {
 }
 
 private extension AppCoordinator {
+    /// Sets the app window's root view controller, with animation only if the root view controller is previously non-nil.
+    /// - Parameters:
+    ///   - rootViewController: view controller to be set as the window's root view controller.
+    ///   - onCompletion: called after the root view controller is set after animation if needed. The boolean value indicates whether or not the animations actually finished before the completion handler was called.
     func setWindowRootViewControllerAndAnimateIfNeeded(_ rootViewController: UIViewController, onCompletion: @escaping (Bool) -> Void = { _ in }) {
         // Animates window transition only if the root view controller is non-nil originally.
         let shouldAnimate = window.rootViewController != nil
         window.rootViewController = rootViewController
         if shouldAnimate {
             UIView.transition(with: window, duration: Constants.animationDuration, options: .transitionCrossDissolve, animations: {}, completion: onCompletion)
+        } else {
+            onCompletion(false)
         }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginOnboardingScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginOnboardingScreen.swift
@@ -1,0 +1,16 @@
+import ScreenObject
+import XCTest
+
+public final class LoginOnboardingScreen: ScreenObject {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetter: { $0.buttons["Login Onboarding Skip Button"] },
+            app: app
+        )
+    }
+
+    public func skipOnboarding() throws -> PrologueScreen {
+        app.buttons["Login Onboarding Skip Button"].tap()
+        return try PrologueScreen()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 		02DD81FC242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02DD81F8242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib */; };
 		02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */; };
 		02DE5CAB279F8754007CBEF3 /* Double+RoundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */; };
+		02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */; };
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9B284743A40010B254 /* ProductImageUploader.swift */; };
 		02E19B9E284745210010B254 /* LegacyProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9D284745210010B254 /* LegacyProductImageUploader.swift */; };
@@ -2181,6 +2182,7 @@
 		02DD81F8242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WordPressMediaLibraryImagePickerViewController.xib; sourceTree = "<group>"; };
 		02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Rounding.swift"; sourceTree = "<group>"; };
 		02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+RoundingTests.swift"; sourceTree = "<group>"; };
+		02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingScreen.swift; sourceTree = "<group>"; };
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E19B9B284743A40010B254 /* ProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageUploader.swift; sourceTree = "<group>"; };
 		02E19B9D284745210010B254 /* LegacyProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyProductImageUploader.swift; sourceTree = "<group>"; };
@@ -8209,6 +8211,7 @@
 				D8F3A972258862BE0085859B /* PrologueScreen.swift */,
 				D8F3A9782588659E0085859B /* GetStartedScreen.swift */,
 				D8F3A97E258865BD0085859B /* PasswordScreen.swift */,
+				02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -8948,6 +8951,7 @@
 				80C3626B27704EE1005CEAD3 /* ProductDataStructs.swift in Sources */,
 				80C3627127745737005CEAD3 /* ReviewDataStructs.swift in Sources */,
 				CC1AB56827FC5822003DEF43 /* OrderStatusScreen.swift in Sources */,
+				02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */,
 				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
 				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		02F6800325807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */; };
 		02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800825807CD300C3BAD2 /* GridStackView.swift */; };
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
+		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
@@ -2218,6 +2219,7 @@
 		02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionListView.swift; sourceTree = "<group>"; };
 		02F6800825807CD300C3BAD2 /* GridStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridStackView.swift; sourceTree = "<group>"; };
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
+		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		03180BE52763AA8F00B938A8 /* Woo-Release-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Release-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE62763AA8F00B938A8 /* Woo-Alpha-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha-macOS.entitlements"; sourceTree = "<group>"; };
@@ -6681,6 +6683,7 @@
 				B5A8F8AE20B88DCC00D211DE /* LoginPrologueViewController.xib */,
 				CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */,
 				CC69236126010946002FB669 /* LoginProloguePages.swift */,
+				02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */,
 			);
 			path = Prologue;
 			sourceTree = "<group>";
@@ -9021,6 +9024,7 @@
 				025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */,
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				456AB0E7283E610500019CFF /* WCShipInstallTableViewCell.swift in Sources */,
+				02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */,
 				D89FAF4E2795BDFF00D8DA66 /* InPersonPaymentsPluginConflictAdminView.swift in Sources */,
 				E15F163126C5117300D3059B /* InPersonPaymentsNoConnectionView.swift in Sources */,
 				456CB50D2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -499,6 +499,10 @@ final class IconsTests: XCTestCase {
         XCTAssertEqual(size, image!.size)
     }
 
+    func test_wooLogoPrologueImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.wooLogoPrologueImage)
+    }
+
     func testWaitingForCustomersImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.waitingForCustomersImage)
     }

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -13,14 +13,16 @@ class WooAnalyticsTests: XCTestCase {
 
     /// CredentialsStorage Unit-Testing Instance
     ///
-    private var testingProvider: MockAnalyticsProvider?
+    private var testingProvider: MockAnalyticsProvider? {
+        analytics.analyticsProvider as? MockAnalyticsProvider
+    }
 
 
     // MARK: - Overridden Methods
 
     override func setUp() {
         super.setUp()
-        testingProvider = analytics.analyticsProvider as? MockAnalyticsProvider
+        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())
     }
 
     /// Verifies basic events are received by the AnalyticsProvider

--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -5,7 +5,8 @@ class LoginFlow {
 
     @discardableResult
     static func logInWithWPcom() throws -> MyStoreScreen {
-       return try PrologueScreen().selectContinueWithWordPress()
+       return try LoginOnboardingScreen().skipOnboarding()
+            .selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
             .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -16,7 +16,8 @@ final class LoginTests: XCTestCase {
     func skipped_test_site_address_login_logout() throws {
         try skipTillSettingsFixed()
 
-        let prologue = try PrologueScreen().selectSiteAddress()
+        let prologue = try LoginOnboardingScreen().skipOnboarding()
+            .selectSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
@@ -54,7 +55,8 @@ final class LoginTests: XCTestCase {
     }
 
     func test_WordPress_unsuccessfull_login() throws {
-        _ = try PrologueScreen().selectContinueWithWordPress()
+        _ = try LoginOnboardingScreen().skipOnboarding()
+            .selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7284 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For the onboarding experiment, we're presenting a screen that has the first 3 pages of the pre-existing feature carousel with 2 CTAs at the bottom - "Next" which shows the next feature until the end and goes to the prologue, and "Skip" which just goes to the prologue directly. The onboarding is currently behind a new feature flag `loginPrologueOnboarding`, and the feature flag check will be updated to use an app setting as a future subtask.

On the onboarding screen, a new subtitle is shown in the feature carousel (`LoginProloguePageViewController`/`LoginProloguePageTypeViewController`). The copy on the onboarding screen might change after marketing confirmation in pe5sF9-dj-p2#comment-276.

I chose to implement `LoginOnboardingViewController` in UIKit with pure layout code for the following reasons:
- The child view controller `LoginProloguePageViewController` for the feature carousel is in UIKit
- The layout is pretty simple with two image views and two stack views, and if we ever need to convert this to a SwiftUI view it's easier to find the style configurations in code (it was hard for me to locate all the styles in `LoginPrologueViewController`
- It's faster for me to implement UI in code than using a xib with a bunch of IBOutlet's, though the Auto Layout constraints code is a bit verbose 😅 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Feature flag enabled

- Log out from the app if needed
- Relaunch the app --> an onboarding screen should be shown as in the screencast below with two CTAs - "Next" and "Skip"
- Tap "Next" or manually swipe to the next feature in the carousel --> at the last feature, tapping "Next" should go back to the prologue screen with just "Get started" above the login CTAs
- Relaunch the app
- Tap "Skip" --> it should go to the prologue screen with just "Get started" above the login CTAs

#### Feature flag disabled

- In code, return `false` for `loginPrologueOnboarding` feature flag in `DefaultFeatureFlagService`
- Log out from the app if needed
- Relaunch the app --> the prologue screen should look the same as production: 4 feature pages and without subtitle

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

onboarding screen | prologue screen
-- | --
![Simulator Screen Shot - iPhone 13 - 2022-07-14 at 13 29 34](https://user-images.githubusercontent.com/1945542/179046214-124055b3-e1c3-4153-87e4-4251f39d1dbc.png) | ![Simulator Screen Shot - iPhone 13 - 2022-07-14 at 13 29 45](https://user-images.githubusercontent.com/1945542/179046219-a181f8a3-4a51-4c3f-8689-0cc3f69594ee.png)

Example screencast:

https://user-images.githubusercontent.com/1945542/179046220-c3709f68-a720-498c-869a-67711fcd4c2c.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->