### PR TITLE
[Order Details] Use Order's `needsProcessing` endpoint

### DIFF
--- a/Networking/Networking/Extensions/Order+Fallbacks.swift
+++ b/Networking/Networking/Extensions/Order+Fallbacks.swift
@@ -22,4 +22,11 @@ internal extension Order {
     static func inferIsEditable(status: OrderStatusEnum) -> Bool {
         return status == .pending || status == .onHold || status == .autoDraft
     }
+
+    /// Temporary. Conditions to be copied from:
+    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1567
+    ///
+    static func inferNeedsProcessing(status: OrderStatusEnum) -> Bool {
+        return status == .processing
+    }
 }

--- a/Networking/Networking/Extensions/Order+Fallbacks.swift
+++ b/Networking/Networking/Extensions/Order+Fallbacks.swift
@@ -23,9 +23,9 @@ internal extension Order {
         return status == .pending || status == .onHold || status == .autoDraft
     }
 
-    /// Temporary. Conditions to be copied from:
-    /// https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1567
-    ///
+    /// If the Order Status is not specifically set to "processing", then return false.
+    /// We'll recalculate `needsProcessing` directly in the view model when we actually need to access the property.
+    /// TODO-7302: Improve this part by making `needsProcessing` optional and update Core Data accordingly
     static func inferNeedsProcessing(status: OrderStatusEnum) -> Bool {
         return status == .processing
     }

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -194,10 +194,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         // Properties added on WC 6.6, we provide a local fallback for older stores.
         let isEditable = try container.decodeIfPresent(Bool.self, forKey: .isEditable) ?? Self.inferIsEditable(status: status)
         let needsPayment = try container.decodeIfPresent(Bool.self, forKey: .needsPayment) ?? Self.inferNeedsPayment(status: status, total: total)
-
-        // TODO: Update with local fallback when required.
-        // https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1561
-        let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? false
+        let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? Self.inferNeedsProcessing(status: status)
 
         // Filter out metadata if the key is prefixed with an underscore (internal meta keys) or the value is empty
         let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") && !$0.value.isEmpty }) ?? []

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -24,10 +24,11 @@ final class OrderDetailsDataSource: NSObject {
     ///
     private(set) var sections = [Section]()
 
-    /// Is this order processing?
+    /// Does this order need processing? Payment received (paid). The order is awaiting fulfillment.
+    /// All product orders require processing, except those that only contain products which are both Virtual and Downloadable.
     ///
-    private var isProcessingPayment: Bool {
-        return order.status == OrderStatusEnum.processing
+    private var needsProcessing: Bool {
+        order.needsProcessing
     }
 
     /// Is this order fully refunded?
@@ -1029,7 +1030,7 @@ extension OrderDetailsDataSource {
                 rows.append(.shippingLabelCreateButton)
             }
 
-            if isProcessingPayment {
+            if needsProcessing {
                 if shouldShowShippingLabelCreation {
                     rows.append(.markCompleteButton(style: .secondary, showsBottomSpacing: false))
                     rows.append(.shippingLabelCreationInfo(showsSeparator: false))

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -28,7 +28,14 @@ final class OrderDetailsDataSource: NSObject {
     /// All product orders require processing, except those that only contain products which are both Virtual and Downloadable.
     ///
     private var needsProcessing: Bool {
-        order.needsProcessing
+        if order.needsProcessing {
+            return true
+        } else {
+            let orderContainsOnlyVirtualAndDownloadableProducts = self.products.filter { (product) -> Bool in
+                return items.first(where: { $0.productID == product.productID}) != nil
+            }.allSatisfy { $0.virtual == true && $0.downloadable == true }
+            return !orderContainsOnlyVirtualAndDownloadableProducts
+        }
     }
 
     /// Is this order fully refunded?

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -304,6 +304,8 @@ final class OrderDetailsDataSource: NSObject {
 
     /// Does this order need processing? Payment received (paid). The order is awaiting fulfillment.
     /// All product orders require processing, except those that only contain products which are both Virtual and Downloadable.
+    /// Conditions copied from:
+    ///  https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1567
     ///
     private func needsProcessing() -> Bool {
         order.needsProcessing || !allOrderProductsAreVirtualAndDownloadable()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -156,9 +156,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(issueRefundRow)
     }
 
-    func test_markOrderComplete_button_is_visible_and_primary_style_if_order_is_processing_and_not_eligible_for_shipping_label_creation() throws {
+    func test_markOrderComplete_button_is_visible_and_primary_style_if_order_needs_processing_and_not_eligible_for_shipping_label_creation() throws {
         // Given
-        let order = makeOrder().copy(status: .processing)
+        let order = makeOrder().copy(needsProcessing: true)
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = false
 
@@ -170,9 +170,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row(row: .markCompleteButton(style: .primary, showsBottomSpacing: true), in: productsSection))
     }
 
-    func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() throws {
+    func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_needs_processing_and_eligible_for_shipping_label_creation() throws {
         // Given
-        let order = makeOrder().copy(status: .processing)
+        let order = makeOrder().copy(needsProcessing: true)
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 


### PR DESCRIPTION
Closes: #7296 
Partially fixes: #7207
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When decoding an Order, stores that are on Woo 6.6+ can use new Order properties like `.isEditable`, `.needsPayment`, or `.needsProcessing`. We [implemented two of them already](https://github.com/woocommerce/woocommerce-ios/pull/7066), this PR adds the fallback for `.needsProcessing`.

The logic has been copied from [needsProcessing](https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1567): All product orders require processing, except those that only contain products which are both Virtual and Downloadable.

It seemed preferable to have this logic inside `Networking.Order` directly, but as far as I could gather (reference: 
 p1658117718210059-slack-CGPNUU63E ), it seems that we do not have access to the Product properties so I relied on checking this directly in the `OrderDetailsDataSource`, as is where we'll be using this property to stop relying on `datePaid` to render different button configurations (for example here: [#](https://github.com/woocommerce/woocommerce-ios/issues/7207) or here: [#](https://github.com/woocommerce/woocommerce-ios/issues/7209)). Happy to get any feedback if this has to be implemented differently, or if there would be a better way.

### Changes
- We attempt to decode `Order.needsProcessing` if present (stores on Woo 6.6+), otherwise we fall back to do an Order status check in `inferNeedsProcessing`, which will return true if `OrderStatusEnum.processing`, or false otherwise.
- In the `OrderdetailsDataSource`, we double-check if the order contains only virtual and downloadable products and update the local `needsProcessing` variable.
- Changed the name of `isProcessingPayment` to `needsProcessing` to avoid confusion about what the order status represents, as orders that need processing, the Payment has already been received.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
