### PR TITLE
[Unified Order Editing] Improve edit button accessibility

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -134,14 +134,12 @@ private extension OrderDetailsViewController {
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
 
         // Actions menu
-        if viewModel.moreActionsButtons.isNotEmpty {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(image: .moreImage,
-                                                                style: .plain,
-                                                                target: self,
-                                                                action: #selector(presentActionMenuSheet(_:)))
-        } else {
-            navigationItem.rightBarButtonItem = nil
-        }
+        let menuButton = UIBarButtonItem(image: .moreImage,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(presentActionMenuSheet(_:)))
+        menuButton.isEnabled = viewModel.moreActionsButtons.isNotEmpty
+        navigationItem.rightBarButtonItem = menuButton
     }
 
     /// Setup: EntityListener

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -138,6 +138,7 @@ private extension OrderDetailsViewController {
                                          style: .plain,
                                          target: self,
                                          action: #selector(presentActionMenuSheet(_:)))
+        menuButton.accessibilityLabel = Localization.ActionsMenu.accessibilityLabel
         menuButton.isEnabled = viewModel.moreActionsButtons.isNotEmpty
         navigationItem.rightBarButtonItem = menuButton
     }
@@ -843,6 +844,7 @@ private extension OrderDetailsViewController {
         }
 
         enum ActionsMenu {
+            static let accessibilityLabel = NSLocalizedString("Order actions", comment: "Accessibility label for button triggering more actions menu sheet.")
             static let cancelAction = NSLocalizedString("Cancel", comment: "Cancel the main more actions menu sheet.")
         }
     }


### PR DESCRIPTION
Closes: #7290.

## Description

This PR updates the "•••" button in navbar to be disabled instead of hidden until the order is completely loaded.
It also adds simple accessibility label to the same button.

## Testing

1. Go to the Orders tab, open the order.
2. Check for "•••" in right side navbar. It should be always displayed, but disabled (grey color) until the order is loaded.
3. Wait until order fully loads. Tap "•••" in navbar. Select "Edit".
4. Confirm that editing flow opens fine.

## Screenshots

before | after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/179512189-cd437cf0-370e-4d6f-919f-e2d6f88acc3a.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/179512196-d42bd09b-e393-4617-a5fa-2a9e25ba5da2.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.