### PR TITLE
[Order Details] Show a note "Awaiting payment" for unpaid orders

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -404,8 +404,6 @@ private extension OrderDetailsDataSource {
             configureRefund(cell: cell, at: indexPath)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .netAmount:
             configureNetAmount(cell: cell)
-        case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .awaitingForPayment:
-            configureAwaitingForPaymentInfo(cell: cell)
         case let cell as WooBasicTableViewCell where row == .shippingLabelProducts:
             configureShippingLabelProducts(cell: cell, at: indexPath)
         case let cell as ProductDetailsTableViewCell where row == .aggregateOrderItem:
@@ -640,13 +638,6 @@ private extension OrderDetailsDataSource {
             self?.onCellAction?(.collectPayment, indexPath)
         }
         cell.hideSeparator()
-    }
-
-    private func configureAwaitingForPaymentInfo(cell: TwoColumnHeadlineFootnoteTableViewCell) {
-        let paymentViewModel = OrderPaymentDetailsViewModel(order: order)
-        cell.leftText = Titles.paidByCustomer
-        cell.rightText = order.paymentTotal
-        cell.updateFootnoteText(paymentViewModel.awaitingPayment)
     }
 
     private func configureCreateShippingLabelButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
@@ -1187,9 +1178,7 @@ extension OrderDetailsDataSource {
         let payment: Section = {
             var rows: [Row] = [.payment]
 
-            if shouldShowCustomerPaidRow {
-                rows.append(.customerPaid)
-            }
+            rows.append(.customerPaid)
 
             if condensedRefunds.isNotEmpty {
                 let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
@@ -1198,7 +1187,6 @@ extension OrderDetailsDataSource {
             }
 
             if isEligibleForPayment {
-                rows.append(.awaitingForPayment)
                 rows.append(.collectCardPaymentButton)
             }
 
@@ -1566,7 +1554,6 @@ extension OrderDetailsDataSource {
         case shippingMethod
         case billingDetail
         case payment
-        case awaitingForPayment
         case customerPaid
         case seeReceipt
         case refund
@@ -1611,8 +1598,6 @@ extension OrderDetailsDataSource {
                 return WooBasicTableViewCell.reuseIdentifier
             case .payment:
                 return LedgerTableViewCell.reuseIdentifier
-            case .awaitingForPayment:
-                return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
             case .customerPaid:
                 return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
             case .seeReceipt:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -404,6 +404,8 @@ private extension OrderDetailsDataSource {
             configureRefund(cell: cell, at: indexPath)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .netAmount:
             configureNetAmount(cell: cell)
+        case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .awaitingForPayment:
+            configureAwaitingForPaymentInfo(cell: cell)
         case let cell as WooBasicTableViewCell where row == .shippingLabelProducts:
             configureShippingLabelProducts(cell: cell, at: indexPath)
         case let cell as ProductDetailsTableViewCell where row == .aggregateOrderItem:
@@ -638,6 +640,13 @@ private extension OrderDetailsDataSource {
             self?.onCellAction?(.collectPayment, indexPath)
         }
         cell.hideSeparator()
+    }
+
+    private func configureAwaitingForPaymentInfo(cell: TwoColumnHeadlineFootnoteTableViewCell) {
+        let paymentViewModel = OrderPaymentDetailsViewModel(order: order)
+        cell.leftText = Titles.paidByCustomer
+        cell.rightText = order.paymentTotal
+        cell.updateFootnoteText(paymentViewModel.awaitingPayment)
     }
 
     private func configureCreateShippingLabelButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
@@ -1189,6 +1198,7 @@ extension OrderDetailsDataSource {
             }
 
             if isEligibleForPayment {
+                rows.append(.awaitingForPayment)
                 rows.append(.collectCardPaymentButton)
             }
 
@@ -1556,6 +1566,7 @@ extension OrderDetailsDataSource {
         case shippingMethod
         case billingDetail
         case payment
+        case awaitingForPayment
         case customerPaid
         case seeReceipt
         case refund
@@ -1600,6 +1611,8 @@ extension OrderDetailsDataSource {
                 return WooBasicTableViewCell.reuseIdentifier
             case .payment:
                 return LedgerTableViewCell.reuseIdentifier
+            case .awaitingForPayment:
+                return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
             case .customerPaid:
                 return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
             case .seeReceipt:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -111,6 +111,19 @@ final class OrderPaymentDetailsViewModel {
         return String.localizedStringWithFormat(template, styleDate, order.paymentMethodTitle)
     }
 
+    /// Awaiting payment
+    ///
+    var awaitingPayment: String? {
+        if order.paymentMethodTitle.isEmpty {
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Awaiting payment", comment: "Awaiting payment"))
+        }
+        return String.localizedStringWithFormat(
+            NSLocalizedString("Awaiting payment via %@",
+                              comment: "Awaiting payment via (payment method title)"),
+            order.paymentMethodTitle)
+    }
+
     /// Refund Summary
     /// - returns: A full sentence summary of the date the refund was created, which payment gateway it was refunded to, and a link to the detailed refund.
     /// Example: Oct 28, 2019 via Credit Card (Stripe)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -97,10 +97,7 @@ final class OrderPaymentDetailsViewModel {
         }
 
         guard let datePaid = order.datePaid else {
-            return String.localizedStringWithFormat(
-                NSLocalizedString("Awaiting payment via %@",
-                                  comment: "Awaiting payment via (payment method title)"),
-                order.paymentMethodTitle)
+            return nil
         }
 
         let styleDate = datePaid.toString(dateStyle: .medium, timeStyle: .none)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -88,15 +88,16 @@ final class OrderPaymentDetailsViewModel {
     /// - returns: A full sentence summary of how much (if any) was paid, when, and using what method.
     ///
     /// It reads: `Awaiting payment via Credit Card (Stripe)`
-    /// or: `Nov 19, 2019 via Credit Card (Stripe)`
-    /// or is left blank by returning nil.
+    /// or: `Payment on Nov 19, 2019 via Credit Card (Stripe)`
+    /// or is left blank if is paid, but has no payment method title associated.
     ///
     var paymentSummary: String? {
-        if order.paymentMethodTitle.isEmpty {
-            return nil
-        }
 
         guard let datePaid = order.datePaid else {
+            return awaitingPayment
+        }
+
+        if order.paymentMethodTitle.isEmpty {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -94,7 +94,7 @@ final class OrderPaymentDetailsViewModel {
     var paymentSummary: String? {
 
         guard let datePaid = order.datePaid else {
-            return awaitingPayment
+            return awaitingPaymentTitle
         }
 
         if order.paymentMethodTitle.isEmpty {
@@ -111,14 +111,16 @@ final class OrderPaymentDetailsViewModel {
 
     /// Awaiting payment
     ///
-    var awaitingPayment: String? {
+    private var awaitingPaymentTitle: String? {
         if order.paymentMethodTitle.isEmpty {
             return String.localizedStringWithFormat(
-                NSLocalizedString("Awaiting payment", comment: "Awaiting payment"))
+                NSLocalizedString("Awaiting payment", comment: "The title on the payment row of the Order Details screen when the payment is still pending"))
         }
         return String.localizedStringWithFormat(
             NSLocalizedString("Awaiting payment via %@",
-                              comment: "Awaiting payment via (payment method title)"),
+                              comment: "The title on the payment row of the Order Details screen" +
+                              "when the payment for a specific payment method is still pending." +
+                              "Reads like: Awaiting payment via Stripe."),
             order.paymentMethodTitle)
     }
 

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -54,6 +54,13 @@ final class MockOrders {
         makeOrder(fees: sampleFeeLines())
     }
 
+    func orderPaidWithNoPaymentMethod() -> Order {
+        return Order.fake().copy(
+            datePaid: DateFormatter.dateFromString(with: "2018-04-03T23:05:14"),
+            paymentMethodID: "",
+            paymentMethodTitle: "")
+    }
+
     func orderWithAPIRefunds() -> Order {
         makeOrder(refunds: refundsWithNegativeValue())
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -12,11 +12,13 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     private var brokenOrder: Order!
     private var anotherBrokenOrder: Order!
     private var orderWithFees: Order!
+    private var orderPaidWithNoPaymentMethod: Order!
     private var orderWithAPIRefunds: Order!
     private var orderWithTransientRefunds: Order!
     private var brokenOrderViewModel: OrderPaymentDetailsViewModel!
     private var anotherBrokenOrderViewModel: OrderPaymentDetailsViewModel!
     private var orderWithFeesViewModel: OrderPaymentDetailsViewModel!
+    private var orderPaidWithNoPaymentMethodViewModel: OrderPaymentDetailsViewModel!
     private var orderWithAPIRefundsViewModel: OrderPaymentDetailsViewModel!
     private var orderWithTransientRefundsViewModel: OrderPaymentDetailsViewModel!
 
@@ -33,6 +35,9 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
 
         orderWithFees = MockOrders().orderWithFees()
         orderWithFeesViewModel = OrderPaymentDetailsViewModel(order: orderWithFees, currencySettings: CurrencySettings())
+
+        orderPaidWithNoPaymentMethod = MockOrders().orderPaidWithNoPaymentMethod()
+        orderPaidWithNoPaymentMethodViewModel = OrderPaymentDetailsViewModel(order: orderPaidWithNoPaymentMethod)
 
         orderWithAPIRefunds = MockOrders().orderWithAPIRefunds()
         orderWithAPIRefundsViewModel = OrderPaymentDetailsViewModel(order: orderWithAPIRefunds, refund: MockRefunds.sampleRefund())
@@ -120,12 +125,12 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     }
 
     /// Test the `paymentSummary` calculated property
-    /// returns nil if the payment method title is an empty string
+    /// returns nil if the order is paid but the payment method title is an empty string
     ///
-    func test_order_payment_method_title_returns_nil_if_payment_method_title_is_blank() {
+    func test_order_payment_method_title_returns_nil_when_order_paid_and_payment_method_title_is_blank() {
         let expected = ""
-        XCTAssertEqual(brokenOrder.paymentMethodTitle, expected)
-        XCTAssertNil(brokenOrderViewModel.paymentSummary)
+        XCTAssertEqual(orderPaidWithNoPaymentMethod.paymentMethodTitle, expected)
+        XCTAssertNil(orderPaidWithNoPaymentMethodViewModel.paymentSummary)
     }
 
     /// The `paymentMethodTitle` is used in the `paymentSummary`.
@@ -141,11 +146,14 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.paymentSummary)
     }
 
-    func test_payment_summary_returns_nil_when_date_paid_is_nil() {
-        guard let _ = order.datePaid else {
-            XCTAssertNil(anotherBrokenOrderViewModel.paymentSummary)
-            return
-        }
+    func test_payment_summary_returns_awaiting_payment_message_when_date_paid_is_nil() {
+        XCTAssertNil(brokenOrder.datePaid)
+        XCTAssertNotNil(anotherBrokenOrderViewModel.paymentSummary)
+    }
+
+    func test_payment_summary_returns_payment_summary_message_when_date_paid_is_not_nil() {
+        XCTAssertNotNil(order.datePaid)
+        XCTAssertNotNil(viewModel.paymentSummary)
     }
 
     func test_awaitingPayment_returns_no_payment_method_title_when_paymentMethodTitle_is_empty() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -141,26 +141,27 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.paymentSummary)
     }
 
-    func test_payment_summary_contains_awaiting_payment_message_when_date_paid_is_null() {
-        let awaitingPayment = String.localizedStringWithFormat(
-            NSLocalizedString(
-                "Awaiting payment via %@",
-                comment: "A unit test string. It reads: " +
-                "Awaiting payment via <payment method title>." +
-                "A payment method example is: 'Credit Card (Stripe)'"
-            ),
-            anotherBrokenOrder.paymentMethodTitle
-        )
-
-        XCTAssertEqual(anotherBrokenOrder.paymentMethodTitle, "Cash on Delivery")
-        XCTAssertNil(anotherBrokenOrder.datePaid)
-
-        guard let paymentSummary = anotherBrokenOrderViewModel.paymentSummary else {
-            XCTFail("The payment summary should not be nil or blank.")
+    func test_payment_summary_returns_nil_when_date_paid_is_nil() {
+        guard let _ = order.datePaid else {
+            XCTAssertNil(anotherBrokenOrderViewModel.paymentSummary)
             return
         }
+    }
 
-        XCTAssertTrue(paymentSummary.contains(awaitingPayment))
+    func test_awaitingPayment_returns_no_payment_method_title_when_paymentMethodTitle_is_empty() {
+        guard brokenOrder.paymentMethodTitle.isEmpty else {
+            XCTFail("Expected paymentMethodTitle to be empty")
+            return
+        }
+        XCTAssertEqual(brokenOrderViewModel.awaitingPayment, "Awaiting payment")
+    }
+
+    func test_awaitingPayment_returns_payment_method_title_when_paymentMethodTitle_is_not_empty() {
+        guard order.paymentMethodTitle.isNotEmpty else {
+            XCTFail("Expected paymentMethodTitle to not be empty")
+            return
+        }
+        XCTAssertEqual(viewModel.awaitingPayment, "Awaiting payment via Credit Card (Stripe)")
     }
 
     func test_coupon_lines_matches_expectation() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -161,7 +161,7 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
             XCTFail("Expected paymentMethodTitle to be empty")
             return
         }
-        XCTAssertEqual(brokenOrderViewModel.awaitingPayment, "Awaiting payment")
+        XCTAssertEqual(brokenOrderViewModel.paymentSummary, "Awaiting payment")
     }
 
     func test_awaitingPayment_returns_payment_method_title_when_paymentMethodTitle_is_not_empty() {
@@ -169,7 +169,7 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
             XCTFail("Expected paymentMethodTitle to not be empty")
             return
         }
-        XCTAssertEqual(viewModel.awaitingPayment, "Awaiting payment via Credit Card (Stripe)")
+        XCTAssertEqual(anotherBrokenOrderViewModel.paymentSummary, "Awaiting payment via Cash on Delivery")
     }
 
     func test_coupon_lines_matches_expectation() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -64,7 +64,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertEqual(actualTitles, expectedTitles)
     }
 
-    func test_reloadSections_when_there_is_no_paid_date_then_customer_paid_row_is_hidden() throws {
+    func test_reloadSections_when_there_is_no_paid_date_then_customer_paid_row_is_visible() throws {
         // Given
         let order = Order.fake()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -75,7 +75,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         let customerPaidRow = row(row: .customerPaid, in: paymentSection)
-        XCTAssertNil(customerPaidRow)
+        XCTAssertNotNil(customerPaidRow)
     }
 
     func test_reloadSections_when_there_is_a_paid_date_then_customer_paid_row_is_visible() throws {


### PR DESCRIPTION
Closes: #7206 

### Description
This PR adds a new row for unpaid orders, just above the "Collect Payment" button, that shows "Paid: order.paymentTotal" with an "Awaiting payment" footnote message, so the merchant is aware that the order has not been paid for yet. Context: p91TBi-8P0-p2#comment-10421

<img width="322" alt="Screenshot 2022-07-19 at 22 19 10" src="https://user-images.githubusercontent.com/3812076/179787107-cc289c9a-eb91-4c19-9b13-876b41457e8e.png">


At the moment this is rendered when [isEligibleForPayment](https://github.com/woocommerce/woocommerce-ios/blob/6f764e09814bbf8ac1eef4089638efd6b438e8da/WooCommerce/Classes/ViewModels/Order%20Details/OrderDetailsDataSource.swift#L49) is true, so all orders that render the "Collect Payment" button will also render this row.

| Paid orders | Unpaid orders |
|---|---|
|![_7206_awaiting_payment_1st_iteration_paid_order](https://user-images.githubusercontent.com/3812076/179774094-01edb2cc-4969-4e94-a9d2-058453575683.png)| ![_7206_awaiting_payment_1st_iteration_pending_payment](https://user-images.githubusercontent.com/3812076/179774113-5fcda125-267c-480b-9863-0ca34baba8a5.png)|

### Changes:
- Add `awaitingForPayment` case and row to the `OrderDetailsDataSource`
- Add `cell` and `configureAwaitingForPaymentInfo` method to configure its rendering
- Removed the case where `order.datePaid` is nil in `paymentSummary`, so it only takes care of the message rendering for paid orders.
- Added `awaitingPayment` to `OrderPaymentDetailsViewModel`, which takes care of the message rendering for unpaid orders.
- Updated unit tests
- I haven't found a way to create the case for "_Awaiting payment via %@_", where we have both a non-empty `order.paymentMethodTitle` while the `order.datePaid == nil` as involving an automatic payment method will set a paid date to the order, but I added it for consistency to cover both scenarios while we modify this behavior on a different [issue](https://github.com/woocommerce/woocommerce-ios/issues/7296).

### Testing instructions
- Go to Orders > Tap "+" > Fill out the necessary information > Set order status as `Pending Payment` > Tap `Create`
- See the "Paid" and "Awaiting payment" in the order details, above the "Collect Payment" button
- Tap `Collect Payment` > Select a payment method > process the payment.
- See the "Awaiting payment" message no longer appears, and "Paid" displays the updated value.


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
