### PR TITLE
[Unified Order Editing] Disable edit menu only during intial order load

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -183,10 +183,6 @@ extension OrderDetailsViewModel {
     func syncEverything(onReloadSections: (() -> ())? = nil, onCompletion: (() -> ())? = nil) {
         let group = DispatchGroup()
 
-        /// Update state to syncing
-        ///
-        syncState = .syncing
-
         group.enter()
         syncOrder { [weak self] _ in
             defer {
@@ -630,7 +626,6 @@ private extension OrderDetailsViewModel {
     ///
     enum SyncState {
         case notSynced
-        case syncing
         case synced
     }
 }


### PR DESCRIPTION
Closes: #7301.

## Description

This PR updates the "•••" button in navbar to be disabled only when the order is loading for the first time. On subsequent syncs it should remain enabled.

## How

By removing `syncing` case and its assignment we will have `notSynced` -> `synced` transition on first load, staying in `synced` on any additional updates. `SyncState` is only used in `moreActionsButtons` logic.

## Testing

1. Go to the Orders tab, open the order.
2. Check for "•••" in right side navbar. It should be disabled (grey color) until the order is loaded.
3. Wait until order fully loads.
4. Tap "Billing details" to navigate on different screen.
5. Tap back button and confirm that menu button in navbar ("•••") is still enabled.
6. Tap "•••" in navbar. Select "Edit".
7. Confirm that editing flow opens fine.

## Video

https://user-images.githubusercontent.com/3132438/179800597-672578c0-d110-40ef-b7ed-560ece4126d5.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.