### PR TITLE
Payment Gateway Selection Screen: Make it scrollable in landscape

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -47,45 +47,42 @@ struct InPersonPaymentsSelectPluginView: View {
     let onPluginSelected: (CardPresentPaymentsPlugin) -> Void
 
     var body: some View {
-        GeometryReader { reader in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    Image(uiImage: .creditCardGiveIcon)
-                        .foregroundColor(Color(.primary))
-                        .accessibilityHidden(true)
+        ScrollableVStack(padding: 0) {
+            VStack(alignment: .leading, spacing: 16) {
+                Image(uiImage: .creditCardGiveIcon)
+                    .foregroundColor(Color(.primary))
+                    .accessibilityHidden(true)
 
-                    VStack(alignment: .leading, spacing: 32) {
-                        Text(Localization.title)
-                            .font(.largeTitle.bold())
-                            .fixedSize(horizontal: false, vertical: true)
-                        Text(Localization.prompt)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .bodyStyle()
+                VStack(alignment: .leading, spacing: 32) {
+                    Text(Localization.title)
+                        .font(.largeTitle.bold())
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(Localization.prompt)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .bodyStyle()
 
-                        VStack(alignment: .leading, spacing: 16) {
-                            InPersonPaymentsSelectPluginRow(icon: .wcpayIcon, name: "WooCommerce Payments", selected: selectedPlugin == .wcPay)
-                                .onTapGesture {
-                                    selectedPlugin = .wcPay
-                                }
-                            InPersonPaymentsSelectPluginRow(icon: .stripeIcon, name: "Stripe", selected: selectedPlugin == .stripe)
-                                .onTapGesture {
-                                    selectedPlugin = .stripe
-                                }
-                        }
+                    VStack(alignment: .leading, spacing: 16) {
+                        InPersonPaymentsSelectPluginRow(icon: .wcpayIcon, name: "WooCommerce Payments", selected: selectedPlugin == .wcPay)
+                            .onTapGesture {
+                                selectedPlugin = .wcPay
+                            }
+                        InPersonPaymentsSelectPluginRow(icon: .stripeIcon, name: "Stripe", selected: selectedPlugin == .stripe)
+                            .onTapGesture {
+                                selectedPlugin = .stripe
+                            }
                     }
-
-                    Spacer()
-
-                    Button(Localization.confirm, action: confirmPluginSelection)
-                    .disabled(selectedPlugin == nil)
-                    .buttonStyle(PrimaryButtonStyle())
                 }
-                .padding(.top, 32)
-                .padding(.horizontal, 16)
-                .padding(.bottom, 24)
-                .background(Color(.tertiarySystemBackground).ignoresSafeArea())
-                .frame(minHeight: reader.size.height)
+
+                Spacer()
+
+                Button(Localization.confirm, action: confirmPluginSelection)
+                .disabled(selectedPlugin == nil)
+                .buttonStyle(PrimaryButtonStyle())
             }
+            .padding(.top, 32)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+            .background(Color(.tertiarySystemBackground).ignoresSafeArea())
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -47,41 +47,46 @@ struct InPersonPaymentsSelectPluginView: View {
     let onPluginSelected: (CardPresentPaymentsPlugin) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Image(uiImage: .creditCardGiveIcon)
-                .foregroundColor(Color(.primary))
-                .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 32) {
-                Text(Localization.title)
-                    .font(.largeTitle.bold())
-                    .fixedSize(horizontal: false, vertical: true)
-                Text(Localization.prompt)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .bodyStyle()
-
+        GeometryReader { reader in
+            ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    InPersonPaymentsSelectPluginRow(icon: .wcpayIcon, name: "WooCommerce Payments", selected: selectedPlugin == .wcPay)
-                        .onTapGesture {
-                            selectedPlugin = .wcPay
+                    Image(uiImage: .creditCardGiveIcon)
+                        .foregroundColor(Color(.primary))
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 32) {
+                        Text(Localization.title)
+                            .font(.largeTitle.bold())
+                            .fixedSize(horizontal: false, vertical: true)
+                        Text(Localization.prompt)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .bodyStyle()
+
+                        VStack(alignment: .leading, spacing: 16) {
+                            InPersonPaymentsSelectPluginRow(icon: .wcpayIcon, name: "WooCommerce Payments", selected: selectedPlugin == .wcPay)
+                                .onTapGesture {
+                                    selectedPlugin = .wcPay
+                                }
+                            InPersonPaymentsSelectPluginRow(icon: .stripeIcon, name: "Stripe", selected: selectedPlugin == .stripe)
+                                .onTapGesture {
+                                    selectedPlugin = .stripe
+                                }
                         }
-                    InPersonPaymentsSelectPluginRow(icon: .stripeIcon, name: "Stripe", selected: selectedPlugin == .stripe)
-                        .onTapGesture {
-                            selectedPlugin = .stripe
-                        }
+                    }
+
+                    Spacer()
+
+                    Button(Localization.confirm, action: confirmPluginSelection)
+                    .disabled(selectedPlugin == nil)
+                    .buttonStyle(PrimaryButtonStyle())
                 }
+                .padding(.top, 32)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 24)
+                .background(Color(.tertiarySystemBackground).ignoresSafeArea())
+                .frame(minHeight: reader.size.height)
             }
-
-            Spacer()
-
-            Button(Localization.confirm, action: confirmPluginSelection)
-            .disabled(selectedPlugin == nil)
-            .buttonStyle(PrimaryButtonStyle())
         }
-        .padding(.top, 32)
-        .padding(.horizontal, 16)
-        .padding(.bottom, 24)
-        .background(Color(.tertiarySystemBackground).ignoresSafeArea())
     }
 
     private func confirmPluginSelection() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
@@ -4,15 +4,18 @@ import SwiftUI
 ///
 struct ScrollableVStack<Content: View>: View {
     let alignment: HorizontalAlignment
+    let padding: CGFloat
     let spacing: CGFloat?
     let content: Content
 
     init(
         alignment: HorizontalAlignment = .center,
+        padding: CGFloat = 24,
         spacing: CGFloat? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.alignment = alignment
+        self.padding = padding
         self.spacing = spacing
         self.content = content()
     }
@@ -23,7 +26,7 @@ struct ScrollableVStack<Content: View>: View {
                 VStack(alignment: alignment, spacing: spacing) {
                     content
                 }
-                .padding(24)
+                .padding(padding)
                 .frame(minWidth: geometry.size.width, minHeight: geometry.size.height)
             }
         }


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: ##7286
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When changing the device orientation to landscape the Confirm Payment Method in the Payment Gateway Selection screen was hidden, thus making this screen unusable. With this PR we embed the view into a scroll view, so the user can scroll and access the button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisites: Have both WooCommerce Payments and Stripe plugins installed and active in an American store.

1. Go To Settings
2. Open In-Person Payments
3. The Payment Gateway Selection screen should be shown. Rotate to landscape, scroll down, and tap the button.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1864060/179953432-b9b6f74b-58ed-4ac7-8db1-b646dc3ec574.mp4



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
