### PR TITLE
[Order Metadata] Release "View custom fields" feature in order details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -45,8 +45,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .newToWooCommerceLinkInLoginPrologue:
             return true
-        case .orderCustomFields:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .loginPrologueOnboarding:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -94,10 +94,6 @@ public enum FeatureFlag: Int {
     ///
     case newToWooCommerceLinkInLoginPrologue
 
-    /// Enable the Order Custom Fields button in Order Details
-    ///
-    case orderCustomFields
-
     /// Onboarding experiment on the login prologue screen
     ///
     case loginPrologueOnboarding

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,10 +4,10 @@
 ----
 - [***] Orders: Orders can now be edited within the app. [https://github.com/woocommerce/woocommerce-ios/pull/7300]
 - [*] In-Person Payments: Card Reader Manuals now appear based on country availability, consolidated into an unique view [https://github.com/woocommerce/woocommerce-ios/pull/7178]
------
 - [*] In-Person Payments: The purchase card reader information card can be dismissed [https://github.com/woocommerce/woocommerce-ios/pull/7260]
 - [*] In-Person Payments: When dismissing the purchase card reader information card, the user can choose to be reminded in 14 days. [https://github.com/woocommerce/woocommerce-ios/pull/7271]
 - [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]
+- [**] Orders: You can now view the Custom Fields for an order in the Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/7310]
 
 9.6
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1064,9 +1064,7 @@ extension OrderDetailsDataSource {
         }()
 
         let customFields: Section? = {
-            guard featureFlags.isFeatureFlagEnabled(.orderCustomFields),
-                  order.customFields.isNotEmpty
-            else {
+            guard order.customFields.isNotEmpty else {
                 return nil
             }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -11,7 +11,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let inPersonPaymentGatewaySelection: Bool
     private let isAppleIDAccountDeletionEnabled: Bool
     private let isBackgroundImageUploadEnabled: Bool
-    private let isOrderCustomFieldsEnabled: Bool
 
     init(isJetpackConnectionPackageSupportOn: Bool = false,
          isHubMenuOn: Bool = false,
@@ -21,8 +20,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          shippingLabelsOnboardingM1: Bool = false,
          inPersonPaymentGatewaySelection: Bool = false,
          isAppleIDAccountDeletionEnabled: Bool = false,
-         isBackgroundImageUploadEnabled: Bool = false,
-         isOrderCustomFieldsEnabled: Bool = false) {
+         isBackgroundImageUploadEnabled: Bool = false) {
         self.isJetpackConnectionPackageSupportOn = isJetpackConnectionPackageSupportOn
         self.isHubMenuOn = isHubMenuOn
         self.isInboxOn = isInboxOn
@@ -32,7 +30,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.inPersonPaymentGatewaySelection = inPersonPaymentGatewaySelection
         self.isAppleIDAccountDeletionEnabled = isAppleIDAccountDeletionEnabled
         self.isBackgroundImageUploadEnabled = isBackgroundImageUploadEnabled
-        self.isOrderCustomFieldsEnabled = isOrderCustomFieldsEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -55,8 +52,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isAppleIDAccountDeletionEnabled
         case .backgroundProductImageUpload:
             return isBackgroundImageUploadEnabled
-        case .orderCustomFields:
-            return isOrderCustomFieldsEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -34,15 +34,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_payment_section_is_shown_right_after_the_products_and_refunded_products_sections() {
         // Given
         let order = makeOrder()
-        let mockFeatureFlagService = MockFeatureFlagService(isOrderCustomFieldsEnabled: false)
 
         insert(refund: makeRefund(orderID: order.orderID, siteID: order.siteID))
 
         let dataSource = OrderDetailsDataSource(
             order: order,
             storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration,
-            featureFlags: mockFeatureFlagService
+            cardPresentPaymentsConfiguration: Mocks.configuration
         )
 
         dataSource.configureResultsControllers { }
@@ -483,14 +481,12 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_custom_fields_button_is_visible() throws {
         // Given
-        let mockFeatureFlagService = MockFeatureFlagService(isOrderCustomFieldsEnabled: true)
         let order = MockOrders().makeOrder(customFields: [
             OrderMetaData(metadataID: 123, key: "Key", value: "Value")
         ])
         let dataSource = OrderDetailsDataSource(
             order: order, storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration,
-            featureFlags: mockFeatureFlagService
+            cardPresentPaymentsConfiguration: Mocks.configuration
         )
 
         // When
@@ -503,32 +499,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_custom_fields_button_is_hidden_when_order_contains_no_custom_fields_to_display() throws {
         // Given
-        let mockFeatureFlagService = MockFeatureFlagService(isOrderCustomFieldsEnabled: true)
         let order = MockOrders().makeOrder(customFields: [])
         let dataSource = OrderDetailsDataSource(
             order: order, storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration,
-            featureFlags: mockFeatureFlagService
-        )
-
-        // When
-        dataSource.reloadSections()
-
-        // Then
-        let customFieldSection = section(withCategory: .customFields, from: dataSource)
-        XCTAssertNil(customFieldSection)
-    }
-
-    func test_custom_fields_button_is_hidden_when_feature_flag_is_disabled() throws {
-        // Given
-        let mockFeatureFlagService = MockFeatureFlagService(isOrderCustomFieldsEnabled: false)
-        let order = MockOrders().makeOrder(customFields: [
-            OrderMetaData(metadataID: 123, key: "Key", value: "Value")
-        ])
-        let dataSource = OrderDetailsDataSource(
-            order: order, storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration,
-            featureFlags: mockFeatureFlagService
+            cardPresentPaymentsConfiguration: Mocks.configuration
         )
 
         // When


### PR DESCRIPTION
Closes: #7272

## Description

This PR removes the Order Custom Fields feature flag to release the feature. This adds a "View Custom Fields" button to order details when an order contains custom field metadata. Tapping this button opens a list of the custom field keys and values, with tappable URLs if the URL scheme can be opened by an app on the device.

## Changes

* Removes the `orderCustomFields` feature flag from the UI and unit tests.

Note: I removed the feature flag entirely, instead of just updating its value in `DefaultFeatureFlagService`, so we don't have to do further cleanup later. If we change our mind about releasing this feature, we can revert the changes in this PR to reinstate it.

## Testing

Note: This feature has been tested with these steps prior to this release PR. I'm including these steps for reference during beta testing.

### Scenario 1
1. Go to the Orders section of the app and select an order that contains Custom Fields (e.g. added by the [Checkout Field Editor](https://woocommerce.com/products/woocommerce-checkout-field-editor/) plugin).
2. Verify in the Order Details of the selected order that now a `View Custom Fields` button is displayed between the Products and Payments sections.
3. Tap on the `View Custom Fields` button and verify that the Custom Fields view displays correctly all expected data.

### Scenario 2
1. Go to the Orders section of the app and select an order that **DOES NOT** contain Custom Fields.
2. Verify in the Order Details of the selected order that the `View Custom Fields` button is hidden and there is no viable way to call the Custom Fields view.

## Screenshots

Order Details|Custom Fields
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-07-20 at 10 38 31](https://user-images.githubusercontent.com/8658164/179966117-e30114a2-045c-46c9-af13-1caf78b1b589.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-07-20 at 10 38 35](https://user-images.githubusercontent.com/8658164/179966129-89e67741-ee1e-4a56-958b-8a90d3c5117c.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
