### PR TITLE
[Order Details] Rely on `needsPayment` property for "Collect Payment" button

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -47,7 +47,7 @@ final class OrderDetailsDataSource: NSObject {
     /// Whether the order is eligible for card present payment.
     ///
     var isEligibleForPayment: Bool {
-        return order.datePaid == nil
+        order.needsPayment
     }
 
     var isEligibleForRefund: Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -214,7 +214,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_reloadSections_when_isEligibleForPayment_is_true_then_collect_payment_button_is_visible() throws {
         //Given
-        let order = makeOrder().copy(datePaid: .some(nil)) // Unpaid orders are eligible for payment
+        let order = makeOrder().copy(needsPayment: true) // Unpaid orders are eligible for payment
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
@@ -295,7 +295,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_create_shipping_label_button_is_not_visible_when_order_is_eligible_for_payment() throws {
         // Given
-        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100")
+        let order = makeOrder().copy(needsPayment: true, status: .processing, total: "100")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 


### PR DESCRIPTION
Partially fixes: #7209 

### Description
At the moment, we check for the `datePaid == nil `to determine that an Order is unpaid and that we should show the "Collect Payment" button. This causes problems in different scenarios, for example:

- If the merchant switches order status manually
- Plugins that modify `datePaid`
- Custom order statuses

This PR changes the Order's `isEligibleForPayment` check to rely on the Order [needsPayment](https://github.com/woocommerce/woocommerce-ios/blob/6f764e09814bbf8ac1eef4089638efd6b438e8da/Networking/Networking/Model/Order.swift#L196) property, rather than on a nil-check for `datePaid`, which checks if an Order status is `.pending` or `.failed` and its `Total > 0`, hence is eligible for payment (needsPayment).


### Testing instructions
- Go to "Orders" > "+" > Fill the necessary details > set the Order as `pending payment` or `failed`
- See the "Collect Payment" button is visible.
- Switch the Order status to a different status, like `processing`, or `complete`
- See the "Collect Payment" button is not visible.

| Status`.pending`: Collect Payment Button is visible | Status`.processing`: Collect Payment Button is hidden |
|--|--|
| ![simulator_screenshot_0D641213-A9C1-494D-B070-A6C16760D824](https://user-images.githubusercontent.com/3812076/179968271-758f83d7-7482-40a8-9978-272d10b251a7.png) | ![simulator_screenshot_31FB3AE9-346A-452A-9A62-F39F8BCF9FC7](https://user-images.githubusercontent.com/3812076/179968423-07f1b8b0-80bf-4203-8221-990e7e130e96.png) |


Modifying `isEligibleForPayment` also affects the logic of whether the button to create shipping labels should be visible, as we only allow Shipping Label creation if the order has been paid.

- Install and activate [WCShipping](https://woocommerce.com/woocommerce-shipping/)
- Go to "Orders" > "+" > Add physical/shippable products to the order > set the Order as `pending payment` or `failed`
- See the "Collect Payment" button is visible, and the "Create Shipping Label" is not visible
- Switch the Order status to a different status, like `processing`, or `complete`
- See the "Collect Payment" button is not visible, and the "Create Shipping Label" is visible

| Status`.pending`: Collect Payment visible & Shipping Label hidden | Status`.processing`: Collect Payment hidden & Shipping Label visible |
|--|--|
| ![simulator_screenshot_965E4B57-F20A-48AA-8F35-B48C987CCFC6](https://user-images.githubusercontent.com/3812076/179968815-3c3c5e4d-4ac1-43ae-9801-5c5960d28354.png) | ![simulator_screenshot_8581795B-9B51-4E04-8708-54E5C3A2B9D5](https://user-images.githubusercontent.com/3812076/179968780-96c56212-d9bd-4e8b-89d1-632e07560113.png) |

---


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
