### PR TITLE
[Unified Order Editing] Replace menu with a single edit button

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -146,10 +146,10 @@ final class OrderDetailsViewModel {
 
     private var receipt: CardPresentReceiptParameters? = nil
 
-    /// Returns available action buttons given the internal state.
+    /// Returns edit action availability given the internal state.
     ///
-    var moreActionsButtons: [MoreActionButton] {
-        MoreActionButton.availableButtons(order: order, syncState: syncState)
+    var editButtonIsEnabled: Bool {
+        syncState == .synced
     }
 
     var paymentMethodsViewModel: PaymentMethodsViewModel {
@@ -627,44 +627,5 @@ private extension OrderDetailsViewModel {
     enum SyncState {
         case notSynced
         case synced
-    }
-}
-
-// MARK: More Action Buttons Definition
-extension OrderDetailsViewModel {
-
-    /// Defines an action button that resides inside the more action menu.
-    ///
-    struct MoreActionButton {
-
-        /// Defines all possible more action button types.
-        ///
-        enum ButtonType: CaseIterable {
-            case editOrder
-        }
-
-        /// ID of the button.
-        ///
-        let id: ButtonType
-
-        /// Title of the button.
-        ///
-        let title: String
-
-        fileprivate static func availableButtons(order: Order, syncState: SyncState) -> [MoreActionButton] {
-            ButtonType.allCases.compactMap { buttonType in
-                switch buttonType {
-                case .editOrder:
-                    guard syncState == .synced, ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing) else {
-                        return nil
-                    }
-                    return .init(id: buttonType, title: Localization.editOrder)
-                }
-            }
-        }
-
-        enum Localization {
-            static let editOrder = NSLocalizedString("Edit", comment: "Title to edit an order")
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -102,8 +102,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         let viewModel = OrderDetailsViewModel(order: order)
 
         // Then
-        let actionButtonIDs = viewModel.moreActionsButtons.map { $0.id }
-        XCTAssertFalse(actionButtonIDs.contains(.editOrder))
+        XCTAssertFalse(viewModel.editButtonIsEnabled)
     }
 
     func test_paymentMethodsViewModel_title_contains_formatted_order_amount() {


### PR DESCRIPTION
## Description

This PR replaces the "•••" menu button in navbar with a single "Edit" button.
We don't have any additional options for this menu yet, so it was removed completely for now.

Internal discussion ref: pe5pgL-8B-p2#comment-303

## Testing

1. Go to the Orders tab, open the order.
2. Check for "Edit" button in a right side of navbar. It should be disabled (grey color) until the order is loaded.
3. Wait until order fully loads.
4. Tap "Edit" in navbar.
5. Confirm that editing flow opens fine.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/179994468-ab287bb0-7a73-4c25-b24b-ff4158c4af7c.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/179994483-255cffb7-09e3-4732-af3a-edf646641d8c.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.