### PR TITLE
Improves BUILDKITE_TOKEN permission explanation in release management prechecks

### DIFF
--- a/Scripts/release-management-prechecks.sh
+++ b/Scripts/release-management-prechecks.sh
@@ -52,7 +52,7 @@ Here is how to retrieve these values:
 
 $P_ENV_GITHUB_TOKEN: https://github.com/settings/tokens (requires 'repo')
 $P_ENV_SENTRY_AUTH_TOKEN: https://sentry.io/settings/account/api/auth-tokens/ (requires 'event:read, member:read, org:read, project:read, project:releases, team:read, event:admin')
-$P_ENV_BUILDKITE_TOKEN: https://buildkite.com/user/api-access-tokens (requires 'read_builds, write_builds')
+$P_ENV_BUILDKITE_TOKEN: https://buildkite.com/user/api-access-tokens (requires: 'Organizations: Automattic' & 'REST Scopes: read_builds, write_builds')
 "
 }
 


### PR DESCRIPTION
### Description
As reported by @kidinov, while generating the `BUILDKITE_TOKEN`, we need to give it access to `Automattic` organization so that our release tooling can trigger builds using this token. This PR simply adds this information to the `release-management-prechecks` script.

### Testing instructions
N/A

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
