### PR TITLE
Login enhancement: Add analytics for the Jetpack setup flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 9.7
 ----
 - [*] In-Person Payments: Card Reader Manuals now appear based on country availability, consolidated into an unique view [https://github.com/woocommerce/woocommerce-ios/pull/7178]
------
+- [*] Login: Jetpack setup flow is now accessible from the Jetpack requirement screen. [https://github.com/woocommerce/woocommerce-ios/pull/7294]
 - [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]
 
 9.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 ----
 - [***] Orders: Orders can now be edited within the app. [https://github.com/woocommerce/woocommerce-ios/pull/7300]
 - [*] In-Person Payments: Card Reader Manuals now appear based on country availability, consolidated into an unique view [https://github.com/woocommerce/woocommerce-ios/pull/7178]
-- [*] Login: Jetpack setup flow is now accessible from the Jetpack requirement screen. [https://github.com/woocommerce/woocommerce-ios/pull/7294]
+- [*] Login: Jetpack setup flow is now accessible from the Login with Store Address flow. [https://github.com/woocommerce/woocommerce-ios/pull/7294]
 - [*] In-Person Payments: The purchase card reader information card can be dismissed [https://github.com/woocommerce/woocommerce-ios/pull/7260]
 - [*] In-Person Payments: When dismissing the purchase card reader information card, the user can choose to be reminded in 14 days. [https://github.com/woocommerce/woocommerce-ios/pull/7271]
 - [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1275,3 +1275,38 @@ private extension PaymentMethod {
         }
     }
 }
+
+// MARK: - Login Jetpack Setup
+//
+extension WooAnalyticsEvent {
+    /// The source that user sets up Jetpack: on the web or natively on the app.
+    enum LoginJetpackSetupSource: String {
+        case web
+        case native
+    }
+
+    enum LoginJetpackSetupStep: String {
+        case automaticInstall = "automatic_install"
+        case wpcomLogin = "wpcom_login"
+        case authorize
+        case siteLogin = "site_login"
+        case pluginDetail = "plugin_detail"
+        case pluginInstallation = "plugin_installation"
+        case pluginActivation = "plugin_activation"
+        case pluginSetup = "plugin_setup"
+    }
+
+    /// Tracks when the user dismisses Jetpack Setup flow.
+    static func loginJetpackSetupDismissed(source: LoginJetpackSetupSource) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .loginJetpackSetupDismissed, properties: ["source": source.rawValue])
+    }
+
+    /// Tracks when the user completes Jetpack Setup flow.
+    static func loginJetpackSetupCompleted(source: LoginJetpackSetupSource) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .loginJetpackSetupCompleted, properties: ["source": source.rawValue])
+    }
+
+    static func loginJetpackSetupFlow(source: LoginJetpackSetupSource, step: LoginJetpackSetupStep) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .loginJetpackSetupFlow, properties: ["source": source.rawValue, "step": step.rawValue])
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1290,34 +1290,43 @@ private extension PaymentMethod {
 // MARK: - Login Jetpack Setup
 //
 extension WooAnalyticsEvent {
-    /// The source that user sets up Jetpack: on the web or natively on the app.
-    enum LoginJetpackSetupSource: String {
-        case web
-        case native
-    }
+    enum LoginJetpackSetup {
+        /// The source that user sets up Jetpack: on the web or natively on the app.
+        enum Source: String {
+            case web
+            case native
+        }
 
-    enum LoginJetpackSetupStep: String {
-        case automaticInstall = "automatic_install"
-        case wpcomLogin = "wpcom_login"
-        case authorize
-        case siteLogin = "site_login"
-        case pluginDetail = "plugin_detail"
-        case pluginInstallation = "plugin_installation"
-        case pluginActivation = "plugin_activation"
-        case pluginSetup = "plugin_setup"
-    }
+        enum Step: String {
+            case automaticInstall = "automatic_install"
+            case wpcomLogin = "wpcom_login"
+            case authorize
+            case siteLogin = "site_login"
+            case pluginDetail = "plugin_detail"
+            case pluginInstallation = "plugin_installation"
+            case pluginActivation = "plugin_activation"
+            case pluginSetup = "plugin_setup"
+        }
 
-    /// Tracks when the user dismisses Jetpack Setup flow.
-    static func loginJetpackSetupDismissed(source: LoginJetpackSetupSource) -> WooAnalyticsEvent {
-        WooAnalyticsEvent(statName: .loginJetpackSetupDismissed, properties: ["source": source.rawValue])
-    }
+        enum Key: String {
+            case source
+            case step
+        }
 
-    /// Tracks when the user completes Jetpack Setup flow.
-    static func loginJetpackSetupCompleted(source: LoginJetpackSetupSource) -> WooAnalyticsEvent {
-        WooAnalyticsEvent(statName: .loginJetpackSetupCompleted, properties: ["source": source.rawValue])
-    }
+        /// Tracks when the user dismisses Jetpack Setup flow.
+        static func setupDismissed(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginJetpackSetupDismissed, properties: [Key.source.rawValue: source.rawValue])
+        }
 
-    static func loginJetpackSetupFlow(source: LoginJetpackSetupSource, step: LoginJetpackSetupStep) -> WooAnalyticsEvent {
-        WooAnalyticsEvent(statName: .loginJetpackSetupFlow, properties: ["source": source.rawValue, "step": step.rawValue])
+        /// Tracks when the user completes Jetpack Setup flow.
+        static func setupCompleted(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginJetpackSetupCompleted, properties: [Key.source.rawValue: source.rawValue])
+        }
+
+        /// Tracks when the user reaches a new step in the setup flow
+        static func setupFlow(source: Source, step: Step) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginJetpackSetupFlow, properties: [Key.source.rawValue: source.rawValue,
+                                                                             Key.step.rawValue: step.rawValue])
+        }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -625,6 +625,12 @@ public enum WooAnalyticsStat: String {
     case closeAccountTapped = "close_account_tapped"
     case closeAccountSuccess = "close_account_success"
     case closeAccountFailed = "close_account_failed"
+
+    // MARK: Login Jetpack setup
+    case loginJetpackSetupButtonTapped = "login_jetpack_setup_button_tapped"
+    case loginJetpackSetupDismissed = "login_jetpack_setup_dismissed"
+    case loginJetpackSetupCompleted = "login_jetpack_setup_completed"
+    case loginJetpackSetupFlow = "login_jetpack_setup_flow"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -44,7 +44,7 @@ struct JetpackErrorViewModel: ULErrorViewModel {
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
         showJetpackSetupScreen(in: viewController)
-        analytics.track(.loginJetpackRequiredViewInstructionsButtonTapped)
+        analytics.track(.loginJetpackSetupButtonTapped)
     }
 
     private func showJetpackSetupScreen(in viewController: UIViewController?) {
@@ -52,7 +52,7 @@ struct JetpackErrorViewModel: ULErrorViewModel {
             return
         }
 
-        let connectionController = JetpackSetupWebViewController(siteURL: siteURL, onCompletion: jetpackSetupCompletionHandler)
+        let connectionController = JetpackSetupWebViewController(siteURL: siteURL, analytics: analytics, onCompletion: jetpackSetupCompletionHandler)
         viewController.navigationController?.show(connectionController, sender: nil)
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewController.swift
@@ -145,8 +145,7 @@ extension JetpackSetupWebViewController: WKNavigationDelegate {
 private extension JetpackSetupWebViewController {
     enum Constants {
         static let jetpackInstallString = "https://wordpress.com/jetpack/connect?url=%@&mobile_redirect=%@&from=mobile"
-        // TODO: update this URL with woocommerce:// when https://github.com/Automattic/wp-calypso/pull/65715 is merged.
-        static let mobileRedirectURL = "wordpress://jetpack-connection"
+        static let mobileRedirectURL = "woocommerce://jetpack-connected"
     }
 
     enum JetpackSetupWebSteps: CaseIterable {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewController.swift
@@ -60,7 +60,7 @@ final class JetpackSetupWebViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if isMovingFromParent {
-            analytics.track(event: .loginJetpackSetupDismissed(source: .web))
+            analytics.track(event: .LoginJetpackSetup.setupDismissed(source: .web))
         }
     }
 }
@@ -108,7 +108,7 @@ private extension JetpackSetupWebViewController {
     }
 
     func handleSetupCompletion() {
-        analytics.track(event: .loginJetpackSetupCompleted(source: .web))
+        analytics.track(event: .LoginJetpackSetup.setupCompleted(source: .web))
         activityIndicator.startAnimating()
         // tries re-syncing to get an updated store list
         // then attempts to present epilogue again
@@ -130,8 +130,8 @@ extension JetpackSetupWebViewController: WKNavigationDelegate {
             decisionHandler(.cancel)
             handleSetupCompletion()
         default:
-            if let match = JetpackSetupWebSteps.matchingStep(for: navigationURL) {
-                analytics.track(event: .loginJetpackSetupFlow(source: .web, step: match.trackingStep))
+            if let match = JetpackSetupWebStep.matchingStep(for: navigationURL) {
+                analytics.track(event: .LoginJetpackSetup.setupFlow(source: .web, step: match.trackingStep))
             }
             decisionHandler(.allow)
         }
@@ -148,7 +148,7 @@ private extension JetpackSetupWebViewController {
         static let mobileRedirectURL = "woocommerce://jetpack-connected"
     }
 
-    enum JetpackSetupWebSteps: CaseIterable {
+    enum JetpackSetupWebStep: CaseIterable {
         case automaticInstall
         case wpcomLogin
         case authorize
@@ -179,7 +179,7 @@ private extension JetpackSetupWebViewController {
             }
         }
 
-        var trackingStep: WooAnalyticsEvent.LoginJetpackSetupStep {
+        var trackingStep: WooAnalyticsEvent.LoginJetpackSetup.Step {
             switch self {
             case .automaticInstall: return .automaticInstall
             case .wpcomLogin: return .wpcomLogin

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewController.swift
@@ -56,18 +56,12 @@ final class JetpackSetupWebViewController: UIViewController {
         configureProgressBar()
         startLoading()
     }
-}
 
-/// Intercepts back navigation (selecting back button or swiping back).
-///
-extension JetpackSetupWebViewController {
-    override func shouldPopOnBackButton() -> Bool {
-        analytics.track(event: .loginJetpackSetupDismissed(source: .web))
-        return true
-    }
-
-    override func shouldPopOnSwipeBack() -> Bool {
-        return shouldPopOnBackButton()
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isMovingFromParent {
+            analytics.track(event: .loginJetpackSetupDismissed(source: .web))
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
@@ -89,7 +89,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
         XCTAssertEqual(firstEvent, "login_jetpack_required_screen_viewed")
     }
 
-    func test_viewModel_logs_an_event_when_see_instructions_button_is_tapped() throws {
+    func test_viewModel_logs_an_event_when_install_jetpack_button_is_tapped() throws {
         // Given
         let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, analytics: analytics) {}
 
@@ -100,7 +100,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
         // Then
         let firstEvent = try XCTUnwrap(analyticsProvider.receivedEvents.first)
-        XCTAssertEqual(firstEvent, "login_jetpack_required_view_instructions_button_tapped")
+        XCTAssertEqual(firstEvent, "login_jetpack_setup_button_tapped")
     }
 
     func test_viewModel_logs_an_event_when_the_what_is_jetpack_button_is_tapped() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7269 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds analytics to the Jetpack setup flow:

<p></p>



<figure class="wp-block-table">

Event | Trigger | Properties
-- | -- | --
login_jetpack_setup_button_tapped | The user taps the Install Jetpack button on the Jetpack error screen. |  
login_jetpack_setup_dismissed | The user taps the Cancel button or swipes down to dismiss the modal. | source: web \| native
login_jetpack_setup_completed | The Jetpack install flow completes. | source: web \| native
login_jetpack_setup_flow | User reaches a new step in the Jetpack setup flow | source: web \| nativestep:  automatic_install \| wpcom_login \| authorize \| site_login \|  plugin_detail \| plugin_installation \| plugin_activation \| plugin_setup

Also: update the `mobile_redirect` URL with `woocommerce://jetpack-connected` since https://github.com/Automattic/wp-calypso/pull/65715 has been merged and deployed.

</figure>

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create a JN site with WooCommerce and without Jetpack.
2. On the app, log out if necessary, then select Enter Site Address on the prologue screen.
3. Enter the JN site address, then log in with your WP.com account.
4. Notice that the Jetpack error screen is presented because your site doesn't have Jetpack. 
5. Select the Install Jetpack button, and notice in the console: `🔵 Tracked login_jetpack_setup_button_tapped`.
6. Tap or swipe back, notice in the console: `🔵 Tracked login_jetpack_setup_dismissed` with `source: web`.
7. Select the Install Jetpack button again and follow the instructions on the web view for the setup steps. Notice for each step, there's an event in the console: `🔵 Tracked login_jetpack_setup_flow` with the correct step and `source: web`.
8. At the last step, after tapping "Authorize" for authorizing your WP.com account for Jetpack, notice in the console: `🔵 Tracked login_jetpack_setup_completed, properties: [AnyHashable("source"): "web"]`, and the app should navigate to the home screen.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
