### PR TITLE
Products: Silence parsing errors to unblock Products tab and log errors instead

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -620,6 +620,7 @@
 		DE2095BD27956D7900171F1C /* CouponReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BC27956D7900171F1C /* CouponReport.swift */; };
 		DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BE279583A100171F1C /* CouponReportListMapper.swift */; };
 		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
+		DE5CA111288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */; };
 		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
 		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
 		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
@@ -1306,6 +1307,7 @@
 		DE2095BC27956D7900171F1C /* CouponReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReport.swift; sourceTree = "<group>"; };
 		DE2095BE279583A100171F1C /* CouponReportListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapper.swift; sourceTree = "<group>"; };
 		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
+		DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-malformed-variations-and-image-alt.json"; sourceTree = "<group>"; };
 		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
 		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
 		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
@@ -1922,6 +1924,7 @@
 				DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */,
 				31D27C8E2602B553002EDB1D /* plugins.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
+				DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */,
 				02AAD53E250092A300BA1E26 /* product-add-or-delete.json */,
 				02698CF524C17FC1005337C4 /* product-alternative-types.json */,
 				02DD6491248A3EC00082523E /* product-external.json */,
@@ -2485,6 +2488,7 @@
 				31A451D327863A2E00FE81AA /* stripe-account-complete.json in Resources */,
 				EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */,
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
+				DE5CA111288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
 				03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */,
 				45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */,

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -384,7 +384,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
             do {
                 return try container.decode([Int64].self, forKey: .variations)
             } catch {
-                DDLogError("⛔️ Error parsing `variations` for `Product`: \(error)")
+                DDLogError("⛔️ Error parsing `variations` for Product ID \(productID): \(error)")
                 return []
             }
         }()

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -380,7 +380,14 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
 
         let attributes = try container.decode([ProductAttribute].self, forKey: .attributes)
         let defaultAttributes = try container.decode([ProductDefaultAttribute].self, forKey: .defaultAttributes)
-        let variations = try container.decode([Int64].self, forKey: .variations)
+        let variations: [Int64] = {
+            do {
+                return try container.decode([Int64].self, forKey: .variations)
+            } catch {
+                DDLogError("⛔️ Error parsing `variations` for `Product`: \(error)")
+                return []
+            }
+        }()
         let groupedProducts = try container.decode([Int64].self, forKey: .groupedProducts)
 
         let menuOrder = try container.decode(Int.self, forKey: .menuOrder)

--- a/Networking/Networking/Model/Product/ProductImage.swift
+++ b/Networking/Networking/Model/Product/ProductImage.swift
@@ -41,7 +41,7 @@ public struct ProductImage: Codable, Equatable, GeneratedCopiable, GeneratedFake
             do {
                 return try container.decodeIfPresent(String.self, forKey: .alt)
             } catch {
-                DDLogError("⛔️ Error parsing `alt` for `ProductImage`: \(error)")
+                DDLogError("⛔️ Error parsing `alt` for ProductImage ID \(imageID): \(error)")
                 return nil
             }
         }()

--- a/Networking/Networking/Model/Product/ProductImage.swift
+++ b/Networking/Networking/Model/Product/ProductImage.swift
@@ -37,7 +37,7 @@ public struct ProductImage: Codable, Equatable, GeneratedCopiable, GeneratedFake
         let dateModified = try container.decodeIfPresent(Date.self, forKey: .dateModified)
         let src = try container.decode(String.self, forKey: .src)
         let name = try container.decodeIfPresent(String.self, forKey: .name)
-        let alt = try container.decodeIfPresent(String.self, forKey: .alt)
+        let alt = try? container.decodeIfPresent(String.self, forKey: .alt)
 
         self.init(imageID: imageID,
                   dateCreated: dateCreated,

--- a/Networking/Networking/Model/Product/ProductImage.swift
+++ b/Networking/Networking/Model/Product/ProductImage.swift
@@ -37,7 +37,14 @@ public struct ProductImage: Codable, Equatable, GeneratedCopiable, GeneratedFake
         let dateModified = try container.decodeIfPresent(Date.self, forKey: .dateModified)
         let src = try container.decode(String.self, forKey: .src)
         let name = try container.decodeIfPresent(String.self, forKey: .name)
-        let alt = try? container.decodeIfPresent(String.self, forKey: .alt)
+        let alt: String? = {
+            do {
+                return try container.decodeIfPresent(String.self, forKey: .alt)
+            } catch {
+                DDLogError("⛔️ Error parsing `alt` for `ProductImage`: \(error)")
+                return nil
+            }
+        }()
 
         self.init(imageID: imageID,
                   dateCreated: dateCreated,

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -272,6 +272,23 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(firstOption.label, "Peperoni")
         XCTAssertEqual(firstOption.price, "3")
     }
+
+    func test_product_image_alt_is_nil_when_malformed() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadProductWithMalformedImageAltAndVariations())
+
+        // Then
+        XCTAssertFalse(product.images.isEmpty)
+        XCTAssertNil(product.images.first?.alt)
+    }
+
+    func test_product_variation_list_is_empty_when_malformed() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadProductWithMalformedImageAltAndVariations())
+
+        // Then
+        XCTAssertTrue(product.variations.isEmpty)
+    }
 }
 
 
@@ -305,5 +322,11 @@ private extension ProductMapperTests {
     ///
     func mapLoadProductOnSaleWithEmptySalePriceResponse() -> Product? {
         return mapProduct(from: "product-on-sale-with-empty-sale-price")
+    }
+
+    /// Returns the ProductMapper output upon receiving `product` with malformed image `alt` and `variations`
+    ///
+    func mapLoadProductWithMalformedImageAltAndVariations() -> Product? {
+        return mapProduct(from: "product-malformed-variations-and-image-alt")
     }
 }

--- a/Networking/NetworkingTests/Responses/product-malformed-variations-and-image-alt.json
+++ b/Networking/NetworkingTests/Responses/product-malformed-variations-and-image-alt.json
@@ -1,0 +1,438 @@
+{
+    "data": {
+            "id": 282,
+            "name": "Book the Green Room",
+            "slug": "book-the-green-room",
+            "permalink": "https://example.com/product/book-the-green-room/",
+            "date_created": "2019-02-19T17:33:31",
+            "date_created_gmt": "2019-02-19T17:33:31",
+            "date_modified": "2019-02-19T17:48:01",
+            "date_modified_gmt": "2019-02-19T17:48:01",
+            "type": "booking",
+            "status": "publish",
+            "featured": false,
+            "catalog_visibility": "visible",
+            "description": "<p>This is the party room!</p>\n",
+            "short_description": "[contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests for $100.</p>\n",
+            "sku": "",
+            "price": "0",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": "2019-10-15T21:30:00",
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": "2019-10-27T21:29:59",
+            "price_html": "Free",
+            "on_sale": false,
+            "purchasable": true,
+            "total_sales": 0,
+            "virtual": true,
+            "downloadable": true,
+            "downloads": [
+              {
+                "id" : "1f9c11f99ceba63d4403c03bd5391b11",
+                "name" : "Song #1",
+                "file" : "https://example.com/woo-single-1.ogg"
+              },
+              {
+                "id" : "ec87d8b5-1361-4562-b4b8-18980b5a2cae",
+                "name" : "Artwork",
+                "file" : "https://example.com/cd_4_angle.jpg"
+              },
+              {
+                "id" : "240cd543-5457-498e-95e2-6b51fdaf15cc",
+                "name" : "Artwork 2",
+                "file" : "https://example.com/cd_4_flat.jpg"
+              }
+            ],
+            "download_limit": 1,
+            "download_expiry": 1,
+            "external_url": "http://somewhere.com",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "sold_individually": true,
+            "weight": "213",
+            "dimensions": {
+                "length": "12",
+                "width": "33",
+                "height": "54"
+            },
+            "shipping_required": false,
+            "shipping_taxable": false,
+            "shipping_class": "",
+            "shipping_class_id": 134,
+            "reviews_allowed": true,
+            "average_rating": "4.30",
+            "rating_count": 23,
+            "related_ids": [
+                31,
+                22,
+                369,
+                414,
+                56
+            ],
+            "upsell_ids":  [
+                99,
+                1234566
+            ],
+            "cross_sell_ids":  [
+                1234,
+                234234,
+                3
+            ],
+            "parent_id": 0,
+            "purchase_note": "Thank you!",
+            "categories": [
+                {
+                    "id": 36,
+                    "name": "Events",
+                    "slug": "events"
+                }
+            ],
+            "tags": [
+                {
+                    "id": 37,
+                    "name": "room",
+                    "slug": "room"
+                },
+                {
+                    "id": 38,
+                    "name": "party room",
+                    "slug": "party-room"
+                },
+                {
+                    "id": 39,
+                    "name": "30",
+                    "slug": "30"
+                },
+                {
+                    "id": 40,
+                    "name": "20+",
+                    "slug": "20"
+                },
+                {
+                    "id": 41,
+                    "name": "meeting room",
+                    "slug": "meeting-room"
+                },
+                {
+                    "id": 42,
+                    "name": "meetings",
+                    "slug": "meetings"
+                },
+                {
+                    "id": 43,
+                    "name": "parties",
+                    "slug": "parties"
+                },
+                {
+                    "id": 44,
+                    "name": "graduation",
+                    "slug": "graduation"
+                },
+                {
+                    "id": 45,
+                    "name": "birthday party",
+                    "slug": "birthday-party"
+                }
+            ],
+            "images": [
+                {
+                    "id": 19,
+                    "date_created": "2018-01-26T21:49:45",
+                    "date_created_gmt": "2018-01-26T21:49:45",
+                    "date_modified": "2018-01-26T21:50:11",
+                    "date_modified_gmt": "2018-01-26T21:50:11",
+                    "src": "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
+                    "name": "Vneck Tshirt",
+                    "alt": false
+                }
+            ],
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Color",
+                    "position": 1,
+                    "visible": true,
+                    "variation": true,
+                    "options": [
+                        "Purple",
+                        "Yellow",
+                        "Hot Pink",
+                        "Lime Green",
+                        "Teal"
+                    ]
+                },
+                {
+                    "id": 0,
+                    "name": "Size",
+                    "position": 0,
+                    "visible": true,
+                    "variation": true,
+                    "options": [
+                        "Small",
+                        "Medium",
+                        "Large"
+                    ]
+                }
+            ],
+            "default_attributes": [
+                {
+                    "id": 0,
+                    "name": "Color",
+                    "option": "Purple"
+                },
+                {
+                    "id": 0,
+                    "name": "Size",
+                    "option": "Medium"
+                }
+            ],
+            "variations": [
+                {
+                    "shipping_class" : "",
+                    "tax_class" : "",
+                    "date_on_sale_to" : null,
+                    "backorders_allowed" : false,
+                    "meta_data" : [
+                        {
+                            "id" : 524119,
+                            "key" : "_wc_gla_mc_status",
+                            "value" : "approved"
+                        },
+                        {
+                            "id" : 524219,
+                            "key" : "_wc_gla_sync_status",
+                            "value" : "synced"
+                        },
+                        {
+                            "id" : 628072,
+                            "key" : "_wc_gla_synced_at",
+                            "value" : "1656503473"
+                        },
+                        {
+                            "id" : 628073,
+                            "key" : "_wc_gla_google_ids",
+                            "value" : {
+                                "GH" : "online:en:GH:gla_21356"
+                            }
+                        }
+                    ],
+                    "id" : 21356,
+                    "downloads" : [
+                        
+                    ],
+                    "manage_stock" : "parent",
+                    "low_stock_amount" : null,
+                    "attributes" : [
+                        {
+                            "id" : 36,
+                            "name" : "Size",
+                            "option" : "88ml"
+                        }
+                    ],
+                    "download_limit" : -1,
+                    "downloadable" : false,
+                    "menu_order" : 0,
+                    "description" : "",
+                    "date_modified" : "2022-02-24T16:20:37",
+                    "virtual" : false,
+                    "tax_amount" : "0.00",
+                    "regular_price" : "170.00",
+                    "purchasable" : true,
+                    "date_on_sale_from" : null,
+                    "image" : {
+                        "id" : 21355,
+                        "src" : "https://i0.wp.com/iconiqbeautiville.com/wp-content/uploads/2022/02/wp-image-36334806925532-scaled.jpg?fit=1920%2C2560&ssl=1",
+                        "alt" : "",
+                        "date_created" : "2022-02-24T16:20:31",
+                        "date_modified" : "2022-02-24T16:20:31",
+                        "date_created_gmt" : "2022-02-24T16:20:31",
+                        "date_modified_gmt" : "2022-02-24T16:20:31",
+                        "name" : "wp-image-36334806925532.jpg"
+                    },
+                    "stock_quantity" : 1,
+                    "sku" : "",
+                    "date_created_gmt" : "2022-02-24T16:20:37",
+                    "sale_price" : "",
+                    "status" : "publish",
+                    "price" : "170.00",
+                    "date_created" : "2022-02-24T16:20:37",
+                    "stock_status" : "instock",
+                    "dimensions" : {
+                        "width" : "",
+                        "height" : "",
+                        "length" : ""
+                    },
+                    "shipping_class_id" : 0,
+                    "variations" : [
+                        
+                    ],
+                    "regular_display_price" : "170.00",
+                    "date_modified_gmt" : "2022-02-24T16:20:37",
+                    "backorders" : "no",
+                    "sales_display_price" : "170.00",
+                    "date_on_sale_to_gmt" : null,
+                    "barcode" : "",
+                    "download_expiry" : -1,
+                    "on_sale" : false,
+                    "weight" : "",
+                    "permalink" : "https://iconiqbeautiville.com/product/purito-comfy-water-sun-block-spf50-pa-60ml-2-fl-oz-ewg-all-green-ingredients-100-physical-sunscreen/?attribute_pa_size=88ml",
+                    "date_on_sale_from_gmt" : null,
+                    "tax_status" : "taxable",
+                    "backordered" : false
+                }
+            ],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 6779,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                },
+                {
+                    "id": 6780,
+                    "key": "_g_feedback_shortcode_5368fb4ef32094b7055b8732bb77a337bdd9331d",
+                    "value": "[contact-field label=\"Name\" type=\"name\" required=\"1\"][contact-field label=\"Email\" type=\"email\" required=\"1\"][contact-field label=\"Phone Number\" type=\"text\" required=\"1\"][contact-field label=\"Group or Organization Name (if any)\" type=\"text\"][contact-field label=\"Special Requests / Event Notes\" type=\"textarea\"]"
+                },
+                {
+                    "id": 6781,
+                    "key": "_g_feedback_shortcode_atts_5368fb4ef32094b7055b8732bb77a337bdd9331d",
+                    "value": {
+                        "to": "thuy.copeland@automattic.com",
+                        "subject": "Booking Event",
+                        "show_subject": "no",
+                        "widget": 0,
+                        "id": 282,
+                        "submit_button_text": "Submit"
+                    }
+                },
+                {
+                    "id": 6471,
+                    "key": "_product_addons",
+                    "value": [
+                        {
+                            "description": "Pizza topping",
+                            "title_format": "label",
+                            "required": 0,
+                            "restrictions": 0,
+                            "position": 0,
+                            "display": "radiobutton",
+                            "restrictions_type": "any_text",
+                            "min": 0,
+                            "max": 0,
+                            "options": [
+                                {
+                                    "label": "Peperoni",
+                                    "price_type": "flat_fee",
+                                    "price": "3",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "Extra cheese",
+                                    "price_type": "flat_fee",
+                                    "price": "4",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "Salami",
+                                    "price_type": "flat_fee",
+                                    "price": "3",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "Ham",
+                                    "price_type": "flat_fee",
+                                    "price": "3",
+                                    "image": ""
+                                }
+                            ],
+                            "type": "checkbox",
+                            "price": "",
+                            "price_type": "flat_fee",
+                            "adjust_price": 0,
+                            "name": "Topping",
+                            "description_enable": 1
+                        },
+                        {
+                            "description": "",
+                            "title_format": "label",
+                            "required": 0,
+                            "restrictions": 1,
+                            "position": 1,
+                            "display": "select",
+                            "restrictions_type": "any_text",
+                            "min": 0,
+                            "max": 3,
+                            "options": [
+                                {
+                                    "label": "",
+                                    "price_type": "flat_fee",
+                                    "price": "",
+                                    "image": ""
+                                }
+                            ],
+                            "type": "input_multiplier",
+                            "price": "2",
+                            "price_type": "quantity_based",
+                            "adjust_price": 1,
+                            "name": "Soda",
+                            "description_enable": 0
+                        },
+                        {
+                            "description": "",
+                            "title_format": "label",
+                            "required": 1,
+                            "restrictions": 0,
+                            "position": 2,
+                            "display": "radiobutton",
+                            "restrictions_type": "any_text",
+                            "min": 0,
+                            "max": 0,
+                            "options": [
+                                {
+                                    "label": "Yes",
+                                    "price_type": "flat_fee",
+                                    "price": "5",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "price_type": "flat_fee",
+                                    "price": "",
+                                    "image": ""
+                                }
+                            ],
+                            "type": "multiple_choice",
+                            "price": "",
+                            "price_type": "flat_fee",
+                            "adjust_price": 0,
+                            "name": "Delivery",
+                            "description_enable": 0
+                        }
+                    ]
+                },
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/282"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7293 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As reported in 5357954-zd-woothemes - a merchant with an incorrect type for the `alt` field of product images and  `variations` of products cannot load the product list since the decoding fails.

This PR attempts to unblock the Product tab by letting the parsing error go silent while logging the errors for tracking the issue if needed.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
I cannot detect which plugin causes the malformed response, so I'm adding extra unit tests for the model mappers.
Please feel free to test with a normal store that has product variations and images to make sure that every thing still works properly.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->