### PR TITLE
Login Reminder: schedule a local notification 24 hours after the user encounters an error logging in with site address

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -48,7 +48,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .loginPrologueOnboarding:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .loginErrorNotifications:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -49,6 +49,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .loginPrologueOnboarding:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .loginErrorNotifications:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -101,4 +101,8 @@ public enum FeatureFlag: Int {
     /// Onboarding experiment on the login prologue screen
     ///
     case loginPrologueOnboarding
+
+    /// Local notifications scheduled 24 hours after certain login errors
+    ///
+    case loginErrorNotifications
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,6 @@
 - [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]
 - [*] Login: when the app is in logged out state, an onboarding screen is shown before the prologue screen if the user hasn't finished or skipped it.  [https://github.com/woocommerce/woocommerce-ios/pull/7324]
 - [**] Orders: You can now view the Custom Fields for an order in the Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/7310]
-- [*] Login: a local notification is scheduled after the user encounters an error from logging in with an invalid site address. Please see testing scenarios in the PR. [https://github.com/woocommerce/woocommerce-ios/pull/7323]
 
 9.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] In-Person Payments: When dismissing the purchase card reader information card, the user can choose to be reminded in 14 days. [https://github.com/woocommerce/woocommerce-ios/pull/7271]
 - [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]
 - [**] Orders: You can now view the Custom Fields for an order in the Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/7310]
+- [*] Login: a local notification is scheduled after the user encounters an error from logging in with an invalid site address. Please see testing scenarios in the PR. [https://github.com/woocommerce/woocommerce-ios/pull/7323]
 
 9.6
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -38,6 +38,7 @@ public enum WooAnalyticsStat: String {
     case loginEmailFormViewed = "login_email_form_viewed"
     case loginJetpackRequiredScreenViewed = "login_jetpack_required_screen_viewed"
     case loginJetpackRequiredViewInstructionsButtonTapped = "login_jetpack_required_view_instructions_button_tapped"
+    case loginLocalNotificationTapped = "login_local_notification_tapped"
     case loginWhatIsJetpackHelpScreenViewed = "login_what_is_jetpack_help_screen_viewed"
     case loginWhatIsJetpackHelpScreenOkButtonTapped = "login_what_is_jetpack_help_screen_ok_button_tapped"
     case loginWhatIsJetpackHelpScreenLearnMoreButtonTapped = "login_what_is_jetpack_help_screen_learn_more_button_tapped"

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -289,7 +289,10 @@ private extension AppDelegate {
     ///
     func setupPushNotificationsManagerIfPossible() {
         guard ServiceLocator.stores.isAuthenticated, ServiceLocator.stores.needsDefaultStore == false else {
-            return ServiceLocator.pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: true, onCompletion: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) {
+                ServiceLocator.pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: true, onCompletion: nil)
+            }
+            return
         }
 
         #if targetEnvironment(simulator)

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -413,5 +413,27 @@ extension AppDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+        switch response.actionIdentifier {
+        case LocalNotification.Action.contactSupport.rawValue:
+            guard let viewController = window?.rootViewController else {
+                return
+            }
+            ZendeskProvider.shared.showNewRequestIfPossible(from: viewController, with: nil)
+            ServiceLocator.analytics.track(.loginLocalNotificationTapped, withProperties: [
+                "action": "contact_support",
+                "type": response.notification.request.identifier
+            ])
+        default:
+            // Triggered when the user taps on the notification itself instead of one of the actions.
+            switch response.notification.request.identifier {
+            case LocalNotification.Scenario.loginSiteAddressError.rawValue:
+                ServiceLocator.analytics.track(.loginLocalNotificationTapped, withProperties: [
+                    "action": "default",
+                    "type": response.notification.request.identifier
+                ])
+            default:
+                return
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -305,6 +305,9 @@ private extension AppDelegate {
     }
 
     func setupUserNotificationCenter() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) else {
+            return
+        }
         UNUserNotificationCenter.current().delegate = self
     }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -421,14 +421,7 @@ private extension AuthenticationManager {
         let wooAuthError = AuthenticationError.make(with: error)
         switch wooAuthError {
         case .notWPSite, .notValidAddress:
-            let notification = LocalNotification(title: NSLocalizedString("Problems with logging in?",
-                                                                          comment: "Local notification title when the user encounters an error logging in " +
-                                                                          "with site address."),
-                                                 body: NSLocalizedString("Get some help!",
-                                                                         comment: "Local notification body when the user encounters an error logging in " +
-                                                                         "with site address."),
-                                                 scenario: .loginSiteAddressError,
-                                                 actions: .init(category: .loginError, actions: [.contactSupport]))
+            let notification = LocalNotification(scenario: .loginSiteAddressError)
             ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [notification.scenario])
             ServiceLocator.pushNotesManager.requestLocalNotification(notification,
                                                                      // 24 hours from now.

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -429,6 +429,7 @@ private extension AuthenticationManager {
                                                                          "with site address."),
                                                  scenario: .loginSiteAddressError,
                                                  actions: .init(category: .loginError, actions: [.contactSupport]))
+            ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [notification.scenario])
             ServiceLocator.pushNotesManager.requestLocalNotification(notification,
                                                                      // 24 hours from now.
                                                                      trigger: UNTimeIntervalNotificationTrigger(timeInterval: 86400, repeats: false))

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Content for a local notification to be converted to `UNNotificationContent`.
+struct LocalNotification {
+    let title: String
+    let body: String
+    let scenario: Scenario
+    let actions: CategoryActions?
+
+    /// A category of actions in a notification.
+    struct CategoryActions {
+        let category: Category
+        let actions: [Action]
+    }
+
+    /// The scenario for the local notification.
+    /// Its raw value is used for the identifier of a local notification and also the event property for analytics.
+    enum Scenario: String {
+        case loginSiteAddressError = "site_address_error"
+    }
+
+    /// The category of actions for a local notification.
+    enum Category: String {
+        case loginError
+    }
+
+    /// The action type in a local notification.
+    enum Action: String {
+        case contactSupport
+
+        /// The title of the action in a local notification.
+        var title: String {
+            switch self {
+            case .contactSupport:
+                return NSLocalizedString("Contact support", comment: "Local notification action to contact support.")
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -37,3 +37,26 @@ struct LocalNotification {
         }
     }
 }
+
+extension LocalNotification {
+    init(scenario: Scenario) {
+        switch scenario {
+        case .loginSiteAddressError:
+            self.init(title: Localization.errorLoggingInTitle,
+                      body: Localization.errorLoggingInBody,
+                      scenario: .loginSiteAddressError,
+                      actions: .init(category: .loginError, actions: [.contactSupport]))
+        }
+    }
+}
+
+private extension LocalNotification {
+    enum Localization {
+        static let errorLoggingInTitle = NSLocalizedString("Problems with logging in?",
+                                                           comment: "Local notification title when the user encounters an error logging in " +
+                                                           "with site address.")
+        static let errorLoggingInBody = NSLocalizedString("Get some help!",
+                                                          comment: "Local notification body when the user encounters an error logging in " +
+                                                          "with site address.")
+    }
+}

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -95,20 +95,20 @@ final class PushNotificationsManager: PushNotesManager {
 //
 extension PushNotificationsManager {
 
-    /// Requests Authorization to receive Push Notifications, *only* when the current Status is not determined.
+    /// Requests Authorization to receive Push Notifications, *only* when the current Status is not determined or provisional.
     ///
     /// - Parameter onCompletion: Closure to be executed on completion. Receives a Boolean indicating if we've got Push Permission.
     ///
-    func ensureAuthorizationIsRequested(onCompletion: ((Bool) -> Void)? = nil) {
+    func ensureAuthorizationIsRequested(includesProvisionalAuth: Bool, onCompletion: ((Bool) -> Void)? = nil) {
         let nc = configuration.userNotificationsCenter
 
         nc.loadAuthorizationStatus(queue: .main) { status in
-            guard status == .notDetermined else {
+            guard status == .notDetermined || status == .provisional else {
                 onCompletion?(status == .authorized)
                 return
             }
 
-            nc.requestAuthorization(queue: .main) { allowed in
+            nc.requestAuthorization(queue: .main, includesProvisionalAuth: includesProvisionalAuth) { allowed in
                 let stat: WooAnalyticsStat = allowed ? .pushNotificationOSAlertAllowed : .pushNotificationOSAlertDenied
                 ServiceLocator.analytics.track(stat)
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -99,7 +99,7 @@ extension PushNotificationsManager {
     ///
     /// - Parameter onCompletion: Closure to be executed on completion. Receives a Boolean indicating if we've got Push Permission.
     ///
-    func ensureAuthorizationIsRequested(includesProvisionalAuth: Bool, onCompletion: ((Bool) -> Void)? = nil) {
+    func ensureAuthorizationIsRequested(includesProvisionalAuth: Bool = false, onCompletion: ((Bool) -> Void)? = nil) {
         let nc = configuration.userNotificationsCenter
 
         nc.loadAuthorizationStatus(queue: .main) { status in
@@ -260,6 +260,54 @@ extension PushNotificationsManager {
                 break
             }
         }
+    }
+
+    func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
+        Task {
+            // TODO: 7318 - tech debt - replace `UNUserNotificationCenter.current()` with
+            // `configuration.userNotificationsCenter` for unit testing
+            let center = UNUserNotificationCenter.current()
+            let settings = await center.notificationSettings()
+            guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+                DDLogError("⛔️ Unable to request a local notification due to invalid authorization status: \(settings.authorizationStatus)")
+                return
+            }
+
+            let content = UNMutableNotificationContent()
+            content.title = notification.title
+            content.body = notification.body
+
+            if let categoryAndActions = notification.actions {
+                let categoryIdentifier = categoryAndActions.category.rawValue
+                let actions = categoryAndActions.actions.map {
+                    UNNotificationAction(identifier: $0.rawValue,
+                                         title: $0.title,
+                                         options: .foreground)
+                }
+                let category = UNNotificationCategory(identifier: categoryIdentifier,
+                                                      actions: actions,
+                                                      intentIdentifiers: [],
+                                                      hiddenPreviewsBodyPlaceholder: nil,
+                                                      categorySummaryFormat: nil,
+                                                      options: .allowAnnouncement)
+                center.setNotificationCategories([category])
+                content.categoryIdentifier = categoryIdentifier
+            }
+
+            let request = UNNotificationRequest(identifier: notification.scenario.rawValue,
+                                                content: content,
+                                                trigger: trigger)
+            do {
+                try await center.add(request)
+            } catch {
+                DDLogError("⛔️ Unable to request a local notification: \(error)")
+            }
+        }
+    }
+
+    func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: scenarios.map { $0.rawValue })
     }
 }
 

--- a/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
+++ b/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
@@ -12,7 +12,7 @@ protocol UserNotificationsCenterAdapter {
 
     /// Requests Push Notifications Authorization
     ///
-    func requestAuthorization(queue: DispatchQueue, completion: @escaping (Bool) -> Void)
+    func requestAuthorization(queue: DispatchQueue, includesProvisionalAuth: Bool, completion: @escaping (Bool) -> Void)
 
     /// Removes all push notifications that have been delivered or scheduled
     func removeAllNotifications()
@@ -35,8 +35,9 @@ extension UNUserNotificationCenter: UserNotificationsCenterAdapter {
 
     /// Requests Push Notifications Authorization
     ///
-    func requestAuthorization(queue: DispatchQueue = .main, completion: @escaping (Bool) -> Void) {
-        requestAuthorization(options: [.badge, .sound, .alert]) { (allowed, _)  in
+    func requestAuthorization(queue: DispatchQueue = .main, includesProvisionalAuth: Bool, completion: @escaping (Bool) -> Void) {
+        let options: UNAuthorizationOptions = includesProvisionalAuth ? [.badge, .sound, .alert, .provisional]: [.badge, .sound, .alert]
+        requestAuthorization(options: options) { (allowed, _)  in
             queue.async {
                 completion(allowed)
             }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -42,9 +42,10 @@ protocol PushNotesManager {
 
     /// Requests Authorization to receive Push Notifications, *only* when the current Status is not determined.
     ///
+    /// - Parameter includesProvisionalAuth: A boolean that indicates whether to request provisional authorization in order to send trial notifications.
     /// - Parameter onCompletion: Closure to be executed on completion. Receives a Boolean indicating if we've got Push Permission.
     ///
-    func ensureAuthorizationIsRequested(onCompletion: ((Bool) -> Void)?)
+    func ensureAuthorizationIsRequested(includesProvisionalAuth: Bool, onCompletion: ((Bool) -> Void)?)
 
     /// Handles Push Notifications Registration Errors. This method unregisters the current device from the WordPress.com
     /// Push Service.

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -67,4 +67,14 @@ protocol PushNotesManager {
     func handleNotification(_ userInfo: [AnyHashable: Any],
                             onBadgeUpdateCompletion: @escaping () -> Void,
                             completionHandler: @escaping (UIBackgroundFetchResult) -> Void)
+
+    /// Requests a local notification to be scheduled under a given trigger.
+    /// - Parameters:
+    ///   - notification: the notification content.
+    ///   - trigger: if nil, the local notification is delivered immediately.
+    func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?)
+
+    /// Cancels a local notification that was previously scheduled.
+    /// - Parameter scenarios: the scenarios of the notification to be cancelled.
+    func cancelLocalNotification(scenarios: [LocalNotification.Scenario])
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */; };
 		021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */; };
 		021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */; };
+		0221121E288973C20028F0AF /* LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0221121D288973C20028F0AF /* LocalNotification.swift */; };
 		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
 		0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */; };
 		0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */; };
@@ -1897,6 +1898,7 @@
 		021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringInputFormatter.swift; sourceTree = "<group>"; };
 		021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommand.swift; sourceTree = "<group>"; };
+		0221121D288973C20028F0AF /* LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotification.swift; sourceTree = "<group>"; };
 		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
 		0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelProductListFilterTests.swift; sourceTree = "<group>"; };
 		0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModel.swift; sourceTree = "<group>"; };
@@ -6710,6 +6712,7 @@
 				B5BBD6DD21B1703600E3207E /* PushNotificationsManager.swift */,
 				B509FED221C05121000076A9 /* SupportManagerAdapter.swift */,
 				B555530C21B57DC300449E71 /* UserNotificationsCenterAdapter.swift */,
+				0221121D288973C20028F0AF /* LocalNotification.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -9313,6 +9316,7 @@
 				57A49128250A7EB2000FEF21 /* OrderListViewController.swift in Sources */,
 				DE34771327F174C8009CA300 /* StatusView.swift in Sources */,
 				45DB704A26121F3C0064A6CF /* TitleAndValueRow.swift in Sources */,
+				0221121E288973C20028F0AF /* LocalNotification.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
 				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -44,7 +44,7 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     }
 
-    func ensureAuthorizationIsRequested(onCompletion: ((Bool) -> ())?) {
+    func ensureAuthorizationIsRequested(includesProvisionalAuth: Bool, onCompletion: ((Bool) -> ())?) {
 
     }
 
@@ -60,6 +60,12 @@ final class MockPushNotificationsManager: PushNotesManager {
                             onBadgeUpdateCompletion: @escaping () -> Void,
                             completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
 
+    }
+
+    func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
+    }
+
+    func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
@@ -31,7 +31,7 @@ final class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
 
     /// "Simulates" a UNUserNotificationCenter Status Request OP
     ///
-    func requestAuthorization(queue: DispatchQueue, completion: @escaping (Bool) -> Void) {
+    func requestAuthorization(queue: DispatchQueue, includesProvisionalAuth: Bool, completion: @escaping (Bool) -> Void) {
         requestAuthorizationWasCalled = true
         completion(requestAuthorizationIsSuccessful)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Please note that this is targeting release 9.7, and unit tests will be added separately due to the last-minute notice this sprint.

Ref: pe5sF9-h9-p2

For the first iteration:
- Focus on Scenario 2: Entered a site address and faced an error
- Proposed notification content for this scenario:
  - Title: Problems with logging in?
  - Description: Get some help!
  - Primary button action: Contact support – open support screen
  - Tracking: notification tap event

I first started implementing this behind a feature flag `loginErrorNotifications` since we originally planned to release next sprint, and it's currently enabled for all. This is the first time I worked with local notifications, please feel free to suggest anything. Major changes include:

- Updated `AppDelegate` to implement `UNUserNotificationCenterDelegate` in order to handle notification tap events. `AppDelegate` also starts requesting provisional authorization on app launch if the user is logged out
- Created a struct `LocalNotification` with enums to identify each scenario and its category and associated actions, so that we can use their raw values in `UNUserNotificationCenterDelegate`. This `LocalNotification` abstracts the notification content, and will be converted to `UNNotificationContent` in the implementation for `UNUserNotificationCenter`
- Updated `PushNotificationsManager`:
  - Added a parameter `includesProvisionalAuth: Bool` to `requestAuthorization` to allow provisional auth when the user is logged out. When the user is logged in, we don't want to include provisional auth so that a permission alert is shown to the user to grant permission for full push notifications (alerts/badges) as the behavior in production
  - Added two functions to request and cancel local notifications
- In `AuthenticationManager`, a local notification is scheduled 24 hours after handling an error from logging in with invalid site address

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please update the 24 hours schedule to a few seconds or a minute in `AuthenticationManager` (search for "86400") to test this PR.

Since local notifications work in simulators, feel free to test it in a simulator except for the last regression test on remote notifications.

#### Tapping on the notification itself

- Reinstall the app to clear any previous notifications permission state
- Skip the onboarding if needed
- Tap "Enter Your Store Address"
- Enter an invalid store address or a store address that isn't a WP site --> an error screen should be shown
- Quickly put the app to the background since we don't support local notifications in the foreground for this iteration --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Tap on the notification itself --> it should open the app, and an event should be logged `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("action"): "default", AnyHashable("type"): "site_address_error"]`

#### Tapping on the notification action to contact support

- Continue from the previous test case
- Go back to the prologue screen and tap "Enter Your Store Address"
- Enter an invalid store address or a store address that isn't a WP site --> an error screen should be shown
- Quickly put the app to the background since we don't support local notifications in the foreground for this iteration --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Long press on the notification --> there should be an action "Contact support"
- Tap "Contact support" --> it should open the app and prompt the Zendesk dialog, and an event should be logged `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("type"): "site_address_error", AnyHashable("action"): "contact_support"]`

#### There should only be up to one notification scheduled  for the same scenario

Note: Please update the 24 hours schedule to a minute in `AuthenticationManager` (search for "86400") so that you have enough time to trigger a notification again before the notification arrives.

- Continue from the previous test case
- Go back to the prologue screen and tap "Enter Your Store Address"
- Enter an invalid store address or a store address that isn't a WP site --> an error screen should be shown
- Quickly tap "Enter Another Store" then tap "Continue" to trigger the error scenario again --> an error screen should be shown
- Quickly put the app to the background since we don't support local notifications in the foreground for this iteration --> only one local notification should be shown after the duration you set in `AuthenticationManager`

#### The notification should be canceled after logging in

Note: Please update the 24 hours schedule to a minute or more in `AuthenticationManager` (search for "86400") so that you have enough time to log in.

- Continue from the previous test case
- Go back to the prologue screen and tap "Enter Your Store Address"
- Enter an invalid store address or a store address that isn't a WP site --> an error screen should be shown
- Quickly restart the login flow, and proceed to log in then quickly put the app to the background --> after the duration you set in `AuthenticationManager`, there should not be a notification in the Notification Center

#### Regression test: remote notifications

- On a device, log in to a store if needed and enable push notifications permission
- Put the app to the background
- On web, place an order or leave a review for a product for one of the connected stores --> a push notification should be shown on the device
- Tap on the push notification --> it should open order details or review details for a new order / review push notification respectively

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1945542/180344166-02bb6a46-bc4c-4326-a14d-2ab95234aa8c.mov

<img src="https://user-images.githubusercontent.com/1945542/180345381-ce8bb0b3-402d-4d0d-979a-db5d9f9b4bbf.png" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->