### PR TITLE
Login Onboarding: update copy and enable feature flag for all

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -46,7 +46,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .newToWooCommerceLinkInLoginPrologue:
             return true
         case .loginPrologueOnboarding:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] In-Person Payments: The purchase card reader information card can be dismissed [https://github.com/woocommerce/woocommerce-ios/pull/7260]
 - [*] In-Person Payments: When dismissing the purchase card reader information card, the user can choose to be reminded in 14 days. [https://github.com/woocommerce/woocommerce-ios/pull/7271]
 - [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]
+- [*] Login: when the app is in logged out state, an onboarding screen is shown before the prologue screen if the user hasn't finished or skipped it.  [https://github.com/woocommerce/woocommerce-ios/pull/7324]
 - [**] Orders: You can now view the Custom Fields for an order in the Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/7310]
 
 9.6

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Contains a feature carousel with buttons that end up on the login prologue screen.
 final class LoginOnboardingViewController: UIViewController {
     private let stackView: UIStackView = .init()
-    private lazy var pageViewController = LoginProloguePageViewController(pageTypes: [.stats, .orderManagement, .products],
+    private lazy var pageViewController = LoginProloguePageViewController(pageTypes: [.products, .orderManagement, .stats],
                                                                           showsSubtitle: true)
     private let onDismiss: () -> Void
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -17,7 +17,7 @@ enum LoginProloguePageType: CaseIterable {
             return NSLocalizedString("Track sales and high performing products",
                                      comment: "Caption displayed in promotional screens shown during the login flow.")
         case .orderManagement:
-            return NSLocalizedString("Manage your store orders on the go ",
+            return NSLocalizedString("Manage and edit orders on the go",
                                      comment: "Caption displayed in promotional screens shown during the login flow.")
         case .products:
             return NSLocalizedString("Edit and add new products from anywhere",
@@ -40,7 +40,7 @@ enum LoginProloguePageType: CaseIterable {
             return NSLocalizedString("You can manage quickly and easily.",
                                      comment: "Subtitle displayed in promotional screens shown during the login flow.")
         case .products:
-            return NSLocalizedString("We make it fast and easy to process effortlessly.",
+            return NSLocalizedString("We enable you to process them effortlessly.",
                                      comment: "Subtitle displayed in promotional screens shown during the login flow.")
         default:
             return nil


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7284 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updated the copy and order of the features based on the latest design pe5sF9-dj-p2#comment-386 (it's still pending editorial review but we're using the latest for release 9.7), and turned on the feature flag for all.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can manually return `false` in `LoggedOutAppSettings.hasFinishedOnboarding` to always show login onboarding for testing this PR.

- Launch the app
- Log out if needed --> login onboarding screen should be shown with the features UI in pe5sF9-dj-p2#comment-386

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

products | orders | stats
-- | -- | --
![Simulator Screen Shot - iPhone 13 - 2022-07-22 at 10 45 46](https://user-images.githubusercontent.com/1945542/180351701-b23dc097-3921-4783-9467-e13b917059ed.png) | ![Simulator Screen Shot - iPhone 13 - 2022-07-22 at 10 45 48](https://user-images.githubusercontent.com/1945542/180351713-f5d8c182-5d48-4c7b-a5e0-bb9f7a654b9d.png) | ![Simulator Screen Shot - iPhone 13 - 2022-07-22 at 10 45 49](https://user-images.githubusercontent.com/1945542/180351716-cfee3ba8-c439-422d-82a5-ff3c87816c27.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->