### PR TITLE
Add Unit Tests for checkCardPresentPaymentEligibility in OrderDetailsViewModel 

### DIFF
--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Yosemite
 
-final class CardPresentConfigurationLoader {
+protocol CardPresentConfigurationProtocol {
+    var configuration: CardPresentPaymentsConfiguration { get }
+}
+
+final class CardPresentConfigurationLoader: CardPresentConfigurationProtocol {
     init(stores: StoresManager = ServiceLocator.stores) {
         // This initializer is kept since this is where we'd check for
         // feature flags while developing support for a new country

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -84,7 +84,7 @@ final class OrderDetailsViewModel {
     }
 
     /// IPP Configuration loader
-    private lazy var configurationLoader = CardPresentConfigurationLoader(stores: stores)
+    private(set) lazy var configurationLoader = CardPresentConfigurationLoader(stores: stores)
 
     /// The datasource that will be used to render the Order Details screen
     ///

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -26,10 +26,12 @@ final class OrderDetailsViewModel {
 
     init(order: Order,
          stores: StoresManager = ServiceLocator.stores,
-         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         configurationLoader: CardPresentConfigurationProtocol = CardPresentConfigurationLoader(stores: ServiceLocator.stores)) {
         self.order = order
         self.stores = stores
         self.currencyFormatter = currencyFormatter
+
     }
 
     func update(order newOrder: Order) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -960,6 +960,7 @@
 		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
+		686D2088288AE36D00940350 /* MockCardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686D2087288AE36C00940350 /* MockCardPresentConfigurationLoader.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
 		68E952CC287536010095A23D /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CB287536010095A23D /* SafariView.swift */; };
 		68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */; };
@@ -2744,6 +2745,7 @@
 		6856D66A1963092C34D20674 /* Calendar+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Calendar+Extensions.swift"; sourceTree = "<group>"; };
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
+		686D2087288AE36C00940350 /* MockCardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
 		68E952CB287536010095A23D /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
@@ -5965,6 +5967,7 @@
 				EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */,
 				0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */,
 				0248042C2887C92A00991319 /* MockLoggedOutAppSettings.swift */,
+				686D2087288AE36C00940350 /* MockCardPresentConfigurationLoader.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10282,6 +10285,7 @@
 				02BC5AA424D27F8900C43326 /* ProductVariationFormViewModel+ObservablesTests.swift in Sources */,
 				CCCC5B1326CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift in Sources */,
 				D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */,
+				686D2088288AE36D00940350 /* MockCardPresentConfigurationLoader.swift in Sources */,
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,
 				0271139A24DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift in Sources */,
 				57A5D8DF253500F300AA54D6 /* RefundConfirmationViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentConfigurationLoader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentConfigurationLoader.swift
@@ -1,0 +1,10 @@
+@testable import WooCommerce
+import Yosemite
+
+final class MockCardPresentConfigurationLoader: CardPresentConfigurationProtocol {
+    var configuration: CardPresentPaymentsConfiguration {
+        .init(
+            country: SiteAddress().countryCode
+        )
+    }
+}


### PR DESCRIPTION
Work in progress
- [x] Add common protocol
- [x] Create initial Unit Tests for `isSupportedCountry`
- [x] Set to nil on tearDown
- [ ] Create more Unit Tests 

Closes: #7064 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR injects a `CardPresentConfigurationLoader` into the `OrderDetailsViewModel` constructor with the intention of improving its testability.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
