### PR TITLE
[Orders] Update Orders empty state screen with call to action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Refund lines in the Order details screen now appear ordered from oldest to newest [https://github.com/woocommerce/woocommerce-ios/pull/7287]
 - [*] Login: when the app is in logged out state, an onboarding screen is shown before the prologue screen if the user hasn't finished or skipped it.  [https://github.com/woocommerce/woocommerce-ios/pull/7324]
 - [**] Orders: You can now view the Custom Fields for an order in the Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/7310]
+- [*] Orders: When a store has no orders yet, there is an updated message with a link to learn more on the Orders tab. [https://github.com/woocommerce/woocommerce-ios/pull/7328]
 
 9.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -541,12 +541,13 @@ private extension OrderListViewController {
     /// Creates EmptyStateViewController.Config when there are no orders available
     ///
     func noOrdersAvailableConfig() -> EmptyStateViewController.Config {
-        .simple(
-            message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
-            image: .waitingForCustomersImage,
-            onPullToRefresh: { [weak self] refreshControl in
-                self?.pullToRefresh(sender: refreshControl)
-            })
+        .withLink(message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
+                  image: .emptyOrdersImage,
+                  details: Localization.allOrdersEmptyStateDetail,
+                  linkTitle: Localization.learnMore,
+                  linkURL: WooConstants.URLs.blog.asURL()) { [weak self] refreshControl in
+            self?.pullToRefresh(sender: refreshControl)
+        }
     }
 
     /// Creates EmptyStateViewController.Config for no orders matching the filter empty view
@@ -735,6 +736,9 @@ private extension OrderListViewController {
     enum Localization {
         static let allOrdersEmptyStateMessage = NSLocalizedString("Waiting for your first order",
                                                                   comment: "The message shown in the Orders → All Orders tab if the list is empty.")
+        static let allOrdersEmptyStateDetail = NSLocalizedString("Explore how you can increase your store sales",
+                                                                 comment: "The detailed message shown in the Orders → All Orders tab if the list is empty.")
+        static let learnMore = NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty.")
         static let filteredOrdersEmptyStateMessage = NSLocalizedString("We're sorry, we couldn't find any order that match %@",
                    comment: "Message for empty Orders filtered results. The %@ is a placeholder for the filters entered by the user.")
         static let clearButton = NSLocalizedString("Clear Filters",


### PR DESCRIPTION
Closes: #7325

## Description

This updates the empty state screen on the Orders tab (when a store has no orders) to match Android and the latest designs, including a call to action linking to the WooCommerce.com blog.

## Changes

Updates the empty state config used when there are no orders on the store to use the updated image, detail text, and call to action text/link.

## Testing

1. Select a store with no orders.
2. Go to the Orders tab and confirm you see the updated empty state screen.
3. Tap the "Learn more" button and confirm you are directed to the WooCommerce.com blog.
4. Confirm you can still pull to refresh the screen as expected.
5. Confirm you can still filter the order list and get the expected empty state screen for an empty filter (different from the empty state when there are no orders).

## Screenshots

Before|After
-|-
<img src="https://user-images.githubusercontent.com/8658164/180451818-c2049aa2-cc58-4a56-a0c5-25633dd60134.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/180458636-2f94071f-24bb-4f72-868b-334204d2ff40.png" width="300px">

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
