### PR TITLE
Appstore screenshots: Fix flaky tests for core data and notification

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -138,7 +138,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             )
 
             // show this notification seconds from now
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1.5, repeats: false)
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
 
             // choose a random identifier
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -160,7 +160,7 @@ extension ScreenObject {
         // This is a hack from https://stackoverflow.com/a/57356929
         // ☠️ Beware of breaking changes in future updates ☠️
         XCUIDevice.shared.perform(NSSelectorFromString("pressLockButton"))
-        sleep(2)
+        sleep(5)
         return self
     }
 

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockActionHandler.swift
@@ -40,7 +40,7 @@ extension MockActionHandler {
 
         var error: Error?
 
-        let storage = storageManager.writerDerivedStorage
+        let storage = storageManager.viewStorage
 
         storage.perform {
             let objects: [NSManagedObject] = mocks.map {

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -21,6 +21,8 @@ struct MockAppSettingsActionHandler: MockActionHandler {
             onCompletion(.failure(AppSettingsStoreErrors.noEligibilityErrorInfo))
         case .loadJetpackBenefitsBannerVisibility(_, _, let onCompletion):
             onCompletion(false)
+        case .getFeatureAnnouncementVisibility(_, let onCompletion):
+            onCompletion(.success(false))
         case .resetEligibilityErrorInfo,
                 .setTelemetryAvailability,
                 .loadOrdersSettings,

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
@@ -25,7 +25,7 @@ struct MockOrderActionHandler: MockActionHandler {
     }
 
     private func saveOrders(orders: [Order], onCompletion: @escaping () -> ()) {
-        let storage = storageManager.writerDerivedStorage
+        let storage = storageManager.viewStorage
 
         storage.perform {
             let updater = OrdersUpsertUseCase(storage: storage)

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -103,6 +103,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
             customer: Customers.MiraWorkman,
             status: .processing,
             total: 50.00,
+            needsPayment: true,
             items: [
                 createOrderItem(from: Products.malayaShades, count: 4),
                 createOrderItem(from: Products.blackCoralShades, count: 5),

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -320,6 +320,7 @@ extension MockObjectGraph {
         status: OrderStatusEnum,
         daysOld: Int = 0,
         total: Decimal,
+        needsPayment: Bool = false,
         items: [OrderItem] = []
     ) -> Order {
 
@@ -330,7 +331,7 @@ extension MockObjectGraph {
             customerID: 1,
             orderKey: "",
             isEditable: false,
-            needsPayment: false,
+            needsPayment: needsPayment,
             needsProcessing: false,
             number: "\(number)",
             status: status,

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -13,7 +13,7 @@ public class MockStoresManager: StoresManager {
 
     /// A derived stack we use for inserting data
     ///
-    private lazy var derivedStorage = storageManager.writerDerivedStorage
+    private lazy var derivedStorage = storageManager.viewStorage
 
     /// All of our action handlers
     private let appSettingsActionHandler: MockAppSettingsActionHandler

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ FASTLANE_DIR = __dir__
 DERIVED_DATA_DIR = File.join(FASTLANE_DIR, 'DerivedData')
 SCREENSHOTS_DIR =  File.join(FASTLANE_DIR, 'screenshots')
 IOS_LOCALES = %w[ar de-DE en-US es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant].freeze
-SIMULATOR_VERSION = '14.3' # For screenshots
+SIMULATOR_VERSION = '15.5' # For screenshots
 SCREENSHOT_DEVICES = [
   'iPhone 11 Pro Max',
   'iPhone 8 Plus',
@@ -616,7 +616,7 @@ platform :ios do
     sh('bundle exec pod install --verbose')
 
     # Ensure we're using the right version of Xcode
-    xcversion(version: '~> 12.0')
+    xcversion(version: '~> 13.4')
 
     scan(
       workspace: 'WooCommerce.xcworkspace',
@@ -629,7 +629,7 @@ platform :ios do
   desc 'Take Screenshots'
   lane :take_screenshots do |options|
     # Ensure we're using the right version of Xcode
-    xcversion(version: '~> 12.0')
+    xcversion(version: '~> 13.4')
 
     # By default, clear previous screenshots
     languages = IOS_LOCALES

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -86,8 +86,16 @@
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 11 Pro Max-5-light-product-add.png",
+			"screenshot": "iPhone 11 Pro Max-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+		},
+		// Get notified of every sale
+		{
+			"device": "iPhone 11 Pro Max",
+			"filename": "iPhone 11 Pro Max-05.png",
+			"background": "#674399",
+			"screenshot": "iPhone 11 Pro Max-5-dark-order-notification.png",
+			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 		// iPhone 8 Plus
@@ -120,8 +128,16 @@
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPhone 8 Plus-5-light-product-add.png",
+			"screenshot": "iPhone 8 Plus-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+		},
+		// Get notified of every sale
+		{
+			"device": "iPhone 8 Plus",
+			"filename": "iPhone 8 Plus-05.png",
+			"background": "#674399",
+			"screenshot": "iPhone 8 Plus-5-dark-order-notification.png",
+			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 
@@ -155,8 +171,16 @@
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-light-product-add.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+		},
+		// Get notified of every sale
+		{
+			"device": "iPad Pro 12.9 (2nd Generation)",
+			"filename": "iPad Pro (12.9-inch) (2nd generation)-05.png",
+			"background": "#674399",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-dark-order-notification.png",
+			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 
 		/// iPad Pro 12.9 (3rd Generation)
@@ -189,8 +213,16 @@
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-04.png",
 			"background": "#C9356E",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-light-product-add.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+		},
+		// Get notified of every sale
+		{
+			"device": "iPad Pro 12.9 (3rd Generation)",
+			"filename": "iPad Pro (12.9-inch) (3rd generation)-05.png",
+			"background": "#674399",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-dark-order-notification.png",
+			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		}
 	]
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When running the script for generating screenshots last week, I stumbled upon a lot of failures about two issues: 
- The mock orders not being loaded when the Orders tab is displayed
- Some push notification screenshots are all black, i.e no local notification was fine by the time the screenshots were taken.

About the first problem, I figured that the order list test only fails when run after a clean install, which means the orders were not saved to Core Data by the time the list tries to fetch the data. The quick fix is to save the mock orders into `viewStorage` instead of `writerDerivedStorage`. This saves the time it takes to sync between different Core Data contexts.

For the second problem, the fix is simply to increase wait time to make sure that the app has been sent to the background by the time the scheduled local notifications are fired.

This PR also includes some changes to the JSON file and `FastFile` for screenshots.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Open a simulator, select Device > Reset content and settings to mimick the automated script.
- Turn off the feature flag for `splitViewInOrdersTab`.
- Switch to WooCommerceScreenshots target and run the UI test for screenshots.
- Notice that the test passes.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
