### PR TITLE
Fix bridging compiler warning

### DIFF
--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -839,7 +839,7 @@ final class AccountStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertEqual(result.failure as? NSError, error)
+        XCTAssertEqual(result.failure as NSError?, error)
     }
 }
 


### PR DESCRIPTION

### Description
A warning can be seen in Xcode, coming from `XCTAssertEqual(result.failure as NSError?, error)` at `Yosemite/YosemiteTests/Stores/AccountStoreTests.swift`:

```
Conditional downcast from 'Error?' to 'NSError' is a bridging conversion; did you mean to use 'as'?
```

This PR changes the `as? NSError` conditional downcast (from a less specific to a more specific type) to an `as NSError?` bridging conversion (from a concrete type to its Obj-C counterpart), as is the syntax the compiler expects.

### Testing instructions
- Check that the Xcode warning disappears
- The test passes correctly with 
```
(lldb) po result.failure
▿ Optional<Error>
  - some : Error Domain=disconnect Code=134 "(null)"
```


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
