### PR TITLE
Add cancel button to the Upsell Card Reader banner dismiss dialog

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -29,6 +29,25 @@ struct FeatureAnnouncementCardView: View {
                             .foregroundColor(Color(.withColorStudio(.gray)))
                     }
                     .padding(.trailing, Layout.padding)
+                    .actionSheet(isPresented: $showingDismissAlert) {
+                        ActionSheet(
+                            title: Text(viewModel.dismissAlertTitle),
+                            message: Text(viewModel.dismissAlertMessage),
+                            buttons: [
+                                .default(Text(Localization.remindLaterButton),
+                                         action: {
+                                             viewModel.remindLaterTapped()
+                                             dismiss()
+                                         }),
+                                .default(Text(Localization.dontShowAgainButton),
+                                         action: {
+                                             viewModel.dontShowAgainTapped()
+                                             dismiss()
+                                         }),
+                                .cancel()
+                            ]
+                        )
+                    }
                     .alert(isPresented: $showingDismissAlert,
                            content: {
                         Alert(title: Text(viewModel.dismissAlertTitle),

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct FeatureAnnouncementCardView: View {
     private let viewModel: FeatureAnnouncementCardViewModel
-    @State private var showingDismissAlert = false
+    @State private var showingDismissActionSheet = false
 
     let dismiss: (() -> Void)?
     let callToAction: (() -> Void)?
@@ -23,13 +23,13 @@ struct FeatureAnnouncementCardView: View {
                 Spacer()
                 if let dismiss = dismiss {
                     Button(action: {
-                        showingDismissAlert = true
+                        showingDismissActionSheet = true
                     }) {
                         Image(systemName: "xmark")
                             .foregroundColor(Color(.withColorStudio(.gray)))
                     }
                     .padding(.trailing, Layout.padding)
-                    .actionSheet(isPresented: $showingDismissAlert) {
+                    .actionSheet(isPresented: $showingDismissActionSheet) {
                         ActionSheet(
                             title: Text(viewModel.dismissAlertTitle),
                             message: Text(viewModel.dismissAlertMessage),
@@ -48,19 +48,6 @@ struct FeatureAnnouncementCardView: View {
                             ]
                         )
                     }
-                    .alert(isPresented: $showingDismissAlert,
-                           content: {
-                        Alert(title: Text(viewModel.dismissAlertTitle),
-                              message: Text(viewModel.dismissAlertMessage),
-                              primaryButton: .cancel(Text(Localization.remindLaterButton), action: {
-                            viewModel.remindLaterTapped()
-                            dismiss()
-                        }),
-                              secondaryButton: .default(Text(Localization.dontShowAgainButton), action: {
-                            viewModel.dontShowAgainTapped()
-                            dismiss()
-                        }))
-                    })
                 }
             }
             .padding(.top, Layout.padding)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

⛔ Do not merge until [e2a89d2381dfad83df0f0a236d4e16384e44a46f](https://github.com/woocommerce/woocommerce-ios/commit/599cd6bb74e6410506cbce5c0c98508e8fea2814) is reverted: This is just to make testing easier. With that test code we:
- Reset the banner policy show when starting the app, so it can be shown again even if the user dismissed it before.
- Set the remind me later to 20 seconds instead of 14 days, so it can be tested faster.

Closes: #7305 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we want to add a cancel button to the upsell card reader dismiss dialog, so the user can leave the banner in the orders screen as it was.
As you can see in the code, we replace the original alert with an action sheet, since the former cannot include more than two buttons out of the box (and it's not expected to)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders, see the upsell card readers banner
2. Tap on dismiss. You will see an action sheet with a cancel button. 
3. Tap on cancel.
4. The upsell card readers banner is not dismissed.

<img src="https://user-images.githubusercontent.com/1864060/180768666-d2687aa3-fbb4-4cb4-8c0e-52e9ce1d80da.png" width="375">

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
