### PR TITLE
Support both local & remote notifications in the app

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -421,7 +421,7 @@ extension AppDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-        await ServiceLocator.pushNotesManager.handleUserResponseToNotification(response: response)
+        await ServiceLocator.pushNotesManager.handleUserResponseToNotification(response)
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -120,7 +120,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didReceiveRemoteNotification userInfo: [AnyHashable: Any],
                      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        ServiceLocator.pushNotesManager.handleNotification(userInfo, onBadgeUpdateCompletion: {}, completionHandler: completionHandler)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
@@ -438,8 +437,25 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                     "type": response.notification.request.identifier
                 ])
             default:
-                return
+                // Handles remote notifications.
+                let notificationContent = response.notification.request.content
+                ServiceLocator.pushNotesManager.handleNotification(notificationContent,
+                                                                   onBadgeUpdateCompletion: {
+                    // TODO
+                }) { backgroundFetchResult in
+                    // TODO
+                }
             }
         }
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
+        ServiceLocator.pushNotesManager.handleNotification(notification.request.content,
+                                                           onBadgeUpdateCompletion: {
+            // TODO
+        }) { backgroundFetchResult in
+            // TODO
+        }
+        return UNNotificationPresentationOptions(rawValue: 0)
     }
 }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -117,9 +117,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ServiceLocator.pushNotesManager.registrationDidFail(with: error)
     }
 
-    func application(_ application: UIApplication,
-                     didReceiveRemoteNotification userInfo: [AnyHashable: Any],
-                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    /// Called when the app receives a remote notification in the background.
+    /// For local/remote notification tap events, please refer to `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:)`.
+    /// When receiving a local/remote notification in the foreground, please refer to
+    /// `UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:)`.
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult {
+        await ServiceLocator.pushNotesManager.handleRemoteNotificationInTheBackground(userInfo: userInfo)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
@@ -418,44 +421,10 @@ extension AppDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-        switch response.actionIdentifier {
-        case LocalNotification.Action.contactSupport.rawValue:
-            guard let viewController = window?.rootViewController else {
-                return
-            }
-            ZendeskProvider.shared.showNewRequestIfPossible(from: viewController, with: nil)
-            ServiceLocator.analytics.track(.loginLocalNotificationTapped, withProperties: [
-                "action": "contact_support",
-                "type": response.notification.request.identifier
-            ])
-        default:
-            // Triggered when the user taps on the notification itself instead of one of the actions.
-            switch response.notification.request.identifier {
-            case LocalNotification.Scenario.loginSiteAddressError.rawValue:
-                ServiceLocator.analytics.track(.loginLocalNotificationTapped, withProperties: [
-                    "action": "default",
-                    "type": response.notification.request.identifier
-                ])
-            default:
-                // Handles remote notifications.
-                let notificationContent = response.notification.request.content
-                ServiceLocator.pushNotesManager.handleNotification(notificationContent,
-                                                                   onBadgeUpdateCompletion: {
-                    // TODO
-                }) { backgroundFetchResult in
-                    // TODO
-                }
-            }
-        }
+        await ServiceLocator.pushNotesManager.handleUserResponseToNotification(response: response)
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
-        ServiceLocator.pushNotesManager.handleNotification(notification.request.content,
-                                                           onBadgeUpdateCompletion: {
-            // TODO
-        }) { backgroundFetchResult in
-            // TODO
-        }
-        return UNNotificationPresentationOptions(rawValue: 0)
+        await ServiceLocator.pushNotesManager.handleNotificationInTheForeground(notification)
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -420,7 +420,7 @@ private extension AuthenticationManager {
 
         let wooAuthError = AuthenticationError.make(with: error)
         switch wooAuthError {
-        case .notWPSite, .notValidAddress:
+        case .notWPSite, .notValidAddress, .noSecureConnection:
             let notification = LocalNotification(scenario: .loginSiteAddressError)
             ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [notification.scenario])
             ServiceLocator.pushNotesManager.requestLocalNotification(notification,

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -45,6 +45,15 @@ final class PushNotificationsManager: PushNotesManager {
     /// Mutable reference to `inactiveNotifications`
     private let inactiveNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
+    /// An observable that emits values when a Local Notification is received.
+    ///
+    var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> {
+        localNotificationResponsesSubject.eraseToAnyPublisher()
+    }
+
+    /// Mutable reference to `localNotificationResponses`
+    private let localNotificationResponsesSubject = PassthroughSubject<UNNotificationResponse, Never>()
+
     /// Returns the current Application's State
     ///
     private var applicationState: UIApplication.State {
@@ -220,46 +229,69 @@ extension PushNotificationsManager {
         unregisterForRemoteNotifications()
     }
 
-
-    /// Handles a Remote Push Notification Payload. On completion the `completionHandler` will be executed.
+    /// Handles a Notification while in Foreground Mode. Currently, only remote notifications are handled in the foreground.
     ///
-    func handleNotification(_ content: UNNotificationContent,
-                            onBadgeUpdateCompletion: @escaping () -> Void,
-                            completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        DDLogVerbose("📱 Push Notification Received: \n\(content.userInfo)\n")
-
-        // Badge: Update
-        if let typeString = content.userInfo.string(forKey: APNSKey.type),
-           let type = Note.Kind(rawValue: typeString),
-           let siteID = siteID,
-           let notificationSiteID = content.userInfo[APNSKey.siteID] as? Int64 {
-            incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
-                self?.loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications(siteID: siteID, type: type)
-                onBadgeUpdateCompletion()
-            }
+    /// - Parameters:
+    ///     - userInfo: The Notification's Payload
+    ///     - completionHandler: A callback, to be executed on completion
+    ///
+    /// - Returns: True when handled. False otherwise
+    ///
+    func handleNotificationInTheForeground(_ notification: UNNotification) async -> UNNotificationPresentationOptions {
+        let content = notification.request.content
+        guard applicationState == .active, content.isRemoteNotification else {
+            // Local notifications are currently not handled when the app is in the foreground.
+            return UNNotificationPresentationOptions(rawValue: 0)
         }
 
-        // Badge: Reset
-        guard content.userInfo.string(forKey: APNSKey.type) != PushType.badgeReset else {
-            return
+        handleRemoteNotificationInAllAppStates(content.userInfo)
+
+        if let foregroundNotification = PushNotification.from(userInfo: content.userInfo) {
+            configuration.application
+                .presentInAppNotification(title: foregroundNotification.title,
+                                          subtitle: foregroundNotification.subtitle,
+                                          message: foregroundNotification.message,
+                                          actionTitle: Localization.viewInAppNotification) { [weak self] in
+                    guard let self = self else { return }
+                    self.presentDetails(for: foregroundNotification)
+                    self.foregroundNotificationsToViewSubject.send(foregroundNotification)
+                    ServiceLocator.analytics.track(.viewInAppPushNotificationPressed,
+                                                   withProperties: [AnalyticKey.type: foregroundNotification.kind.rawValue])
+                }
+
+            foregroundNotificationsSubject.send(foregroundNotification)
         }
 
-        // Analytics
-        trackNotification(with: content.userInfo)
+        _ = await synchronizeNotifications()
+        return UNNotificationPresentationOptions(rawValue: 0)
+    }
 
-        // Handling!
-        let handlers = [
-            handleSupportNotification,
-            handleForegroundNotification,
-            handleInactiveNotification,
-            handleBackgroundNotification
-        ]
-
-        for handler in handlers {
-            if handler(content, completionHandler) {
-                break
-            }
+    func handleUserResponseToNotification(response: UNNotificationResponse) async {
+        // Remote notification response is handled separately.
+        if let notification = PushNotification.from(userInfo: response.notification.request.content.userInfo) {
+            handleRemoteNotificationInAllAppStates(response.notification.request.content.userInfo)
+            return await handleInactiveRemoteNotification(notification: notification)
+        } else {
+            localNotificationResponsesSubject.send(response)
         }
+    }
+
+    /// Handles a Notification while in Background Mode
+    ///
+    /// - Parameters:
+    ///     - userInfo: The Notification's Payload
+    ///     - completionHandler: A callback, to be executed on completion
+    ///
+    /// - Returns: True when handled. False otherwise
+    ///
+    func handleRemoteNotificationInTheBackground(userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult {
+        guard applicationState == .background, let _ = userInfo[APNSKey.identifier] else {
+            return .noData
+        }
+
+        handleRemoteNotificationInAllAppStates(userInfo)
+
+        return await synchronizeNotifications()
     }
 
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
@@ -371,27 +403,50 @@ private extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
-    func handleSupportNotification(_ content: UNNotificationContent, completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
-
-        guard content.userInfo.string(forKey: APNSKey.type) == PushType.zendesk else {
-                return false
+    func handleSupportNotification(_ userInfo: [AnyHashable: Any]) -> Bool {
+        guard userInfo.string(forKey: APNSKey.type) == PushType.zendesk else {
+            return false
         }
 
-        self.configuration.supportManager.pushNotificationReceived()
+        configuration.supportManager.pushNotificationReceived()
 
-        trackNotification(with: content.userInfo)
+        trackNotification(with: userInfo)
 
         if applicationState == .inactive {
-            self.configuration.supportManager.displaySupportRequest(using: content.userInfo)
+            configuration.supportManager.displaySupportRequest(using: userInfo)
         }
-
-        completionHandler(.newData)
-
         return true
     }
 
+    /// Handles a Remote Push Notification Payload regardless of the application state.
+    ///
+    func handleRemoteNotificationInAllAppStates(_ userInfo: [AnyHashable: Any]) {
+        DDLogVerbose("📱 Push Notification Received: \n\(userInfo)\n")
 
-    /// Handles a Notification while in Foreground Mode
+        // Badge: Update
+        if let typeString = userInfo.string(forKey: APNSKey.type),
+           let type = Note.Kind(rawValue: typeString),
+           let siteID = siteID,
+           let notificationSiteID = userInfo[APNSKey.siteID] as? Int64 {
+            incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
+                self?.loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications(siteID: siteID, type: type)
+            }
+        }
+
+        // Badge: Reset
+        guard userInfo.string(forKey: APNSKey.type) != PushType.badgeReset else {
+            return
+        }
+
+        // Analytics
+        trackNotification(with: userInfo)
+
+        // Handles support notification in different app states.
+        // Note: support notifications are currently not working - https://github.com/woocommerce/woocommerce-ios/issues/3776
+        _ = handleSupportNotification(userInfo)
+    }
+
+    /// Handles a Remote Notification while in Inactive Mode
     ///
     /// - Parameters:
     ///     - userInfo: The Notification's Payload
@@ -399,75 +454,16 @@ private extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
-    func handleForegroundNotification(_ content: UNNotificationContent, completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
-        guard applicationState == .active, let _ = content.userInfo[APNSKey.identifier] else {
-            return false
-        }
-
-        if let foregroundNotification = PushNotification.from(userInfo: content.userInfo) {
-            configuration.application
-                .presentInAppNotification(title: foregroundNotification.title,
-                                          subtitle: foregroundNotification.subtitle,
-                                          message: foregroundNotification.message,
-                                          actionTitle: Localization.viewInAppNotification) { [weak self] in
-                    guard let self = self else { return }
-                    self.presentDetails(for: foregroundNotification)
-                    self.foregroundNotificationsToViewSubject.send(foregroundNotification)
-                    ServiceLocator.analytics.track(.viewInAppPushNotificationPressed, withProperties: [AnalyticKey.type: foregroundNotification.kind.rawValue])
-                }
-
-            foregroundNotificationsSubject.send(foregroundNotification)
-        }
-
-        synchronizeNotifications(completionHandler: completionHandler)
-
-        return true
-    }
-
-
-    /// Handles a Notification while in Inactive Mode
-    ///
-    /// - Parameters:
-    ///     - userInfo: The Notification's Payload
-    ///     - completionHandler: A callback, to be executed on completion
-    ///
-    /// - Returns: True when handled. False otherwise
-    ///
-    func handleInactiveNotification(_ content: UNNotificationContent, completionHandler: (UIBackgroundFetchResult) -> Void) -> Bool {
+    func handleInactiveRemoteNotification(notification: PushNotification) async {
         guard applicationState == .inactive else {
-            return false
+            return
         }
 
-        DDLogVerbose("📱 Handling Notification in Inactive State")
+        DDLogVerbose("📱 Handling Remote Notification in Inactive State")
 
-        if let notification = PushNotification.from(userInfo: content.userInfo) {
-            presentDetails(for: notification)
+        presentDetails(for: notification)
 
-            inactiveNotificationsSubject.send(notification)
-        }
-
-        completionHandler(.newData)
-
-        return true
-    }
-
-
-    /// Handles a Notification while in Background Mode
-    ///
-    /// - Parameters:
-    ///     - userInfo: The Notification's Payload
-    ///     - completionHandler: A callback, to be executed on completion
-    ///
-    /// - Returns: True when handled. False otherwise
-    ///
-    func handleBackgroundNotification(_ content: UNNotificationContent, completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
-        guard applicationState == .background, let _ = content.userInfo[APNSKey.identifier] else {
-            return false
-        }
-
-        synchronizeNotifications(completionHandler: completionHandler)
-
-        return true
+        inactiveNotificationsSubject.send(notification)
     }
 }
 
@@ -579,16 +575,18 @@ private extension PushNotificationsManager {
 
     /// Synchronizes all of the Notifications. On success this method will always signal `.newData`, and `.noData` on error.
     ///
-    func synchronizeNotifications(completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        let action = NotificationAction.synchronizeNotifications { error in
-            DDLogInfo("📱 Finished Synchronizing Notifications!")
+    func synchronizeNotifications() async -> UIBackgroundFetchResult {
+        await withCheckedContinuation { continuation in
+            let action = NotificationAction.synchronizeNotifications { error in
+                DDLogInfo("📱 Finished Synchronizing Notifications!")
 
-            let result = (error == nil) ? UIBackgroundFetchResult.newData : .noData
-            completionHandler(result)
+                let result = (error == nil) ? UIBackgroundFetchResult.newData : .noData
+                continuation.resume(returning: result)
+            }
+
+            DDLogInfo("📱 Synchronizing Notifications in \(applicationState.description) State...")
+            configuration.storesManager.dispatch(action)
         }
-
-        DDLogInfo("📱 Synchronizing Notifications in \(applicationState.description) State...")
-        configuration.storesManager.dispatch(action)
     }
 }
 
@@ -606,6 +604,14 @@ private extension PushNotification {
         let subtitle = alert.string(forKey: APNSKey.alertSubtitle)
         let message = alert.string(forKey: APNSKey.alertMessage)
         return PushNotification(noteID: noteID, kind: noteKind, title: title, subtitle: subtitle, message: message)
+    }
+}
+
+// MARK: - UNNotificationContent Extension
+
+private extension UNNotificationContent {
+    var isRemoteNotification: Bool {
+        userInfo[APNSKey.identifier] != nil
     }
 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -237,6 +237,7 @@ extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
+    @MainActor
     func handleNotificationInTheForeground(_ notification: UNNotification) async -> UNNotificationPresentationOptions {
         let content = notification.request.content
         guard applicationState == .active, content.isRemoteNotification else {
@@ -266,6 +267,7 @@ extension PushNotificationsManager {
         return UNNotificationPresentationOptions(rawValue: 0)
     }
 
+    @MainActor
     func handleUserResponseToNotification(response: UNNotificationResponse) async {
         // Remote notification response is handled separately.
         if let notification = PushNotification.from(userInfo: response.notification.request.content.userInfo) {
@@ -284,6 +286,7 @@ extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
+    @MainActor
     func handleRemoteNotificationInTheBackground(userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult {
         guard applicationState == .background, let _ = userInfo[APNSKey.identifier] else {
             return .noData
@@ -575,6 +578,7 @@ private extension PushNotificationsManager {
 
     /// Synchronizes all of the Notifications. On success this method will always signal `.newData`, and `.noData` on error.
     ///
+    @MainActor
     func synchronizeNotifications() async -> UIBackgroundFetchResult {
         await withCheckedContinuation { continuation in
             let action = NotificationAction.synchronizeNotifications { error in

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -45,13 +45,13 @@ final class PushNotificationsManager: PushNotesManager {
     /// Mutable reference to `inactiveNotifications`
     private let inactiveNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
-    /// An observable that emits values when a Local Notification is received.
+    /// An observable that emits values when a local notification is received.
     ///
     var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> {
         localNotificationResponsesSubject.eraseToAnyPublisher()
     }
 
-    /// Mutable reference to `localNotificationResponses`
+    /// Mutable reference to `localNotificationResponses`.
     private let localNotificationResponsesSubject = PassthroughSubject<UNNotificationResponse, Never>()
 
     /// Returns the current Application's State

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -47,7 +47,7 @@ final class PushNotificationsManager: PushNotesManager {
 
     /// An observable that emits values when a local notification is received.
     ///
-    var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> {
+    var localNotificationUserResponses: AnyPublisher<UNNotificationResponse, Never> {
         localNotificationResponsesSubject.eraseToAnyPublisher()
     }
 
@@ -268,27 +268,25 @@ extension PushNotificationsManager {
     }
 
     @MainActor
-    func handleUserResponseToNotification(response: UNNotificationResponse) async {
+    func handleUserResponseToNotification(_ response: UNNotificationResponse) async {
         // Remote notification response is handled separately.
         if let notification = PushNotification.from(userInfo: response.notification.request.content.userInfo) {
             handleRemoteNotificationInAllAppStates(response.notification.request.content.userInfo)
-            return await handleInactiveRemoteNotification(notification: notification)
+            await handleInactiveRemoteNotification(notification: notification)
         } else {
             localNotificationResponsesSubject.send(response)
         }
     }
 
-    /// Handles a Notification while in Background Mode
+    /// Handles a remote notification while the app is in the background.
     ///
-    /// - Parameters:
-    ///     - userInfo: The Notification's Payload
-    ///     - completionHandler: A callback, to be executed on completion
-    ///
-    /// - Returns: True when handled. False otherwise
-    ///
+    /// - Parameter userInfo: The notification's payload.
+    /// - Returns: Whether there is any data fetched in the background.
     @MainActor
     func handleRemoteNotificationInTheBackground(userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult {
-        guard applicationState == .background, let _ = userInfo[APNSKey.identifier] else {
+        guard applicationState == .background, // Proceeds only if the app is in background.
+              let _ = userInfo[APNSKey.identifier] // Ensures that we are only processing a remote notification.
+        else {
             return .noData
         }
 
@@ -449,14 +447,9 @@ private extension PushNotificationsManager {
         _ = handleSupportNotification(userInfo)
     }
 
-    /// Handles a Remote Notification while in Inactive Mode
+    /// Handles a remote notification while the app is inactive.
     ///
-    /// - Parameters:
-    ///     - userInfo: The Notification's Payload
-    ///     - completionHandler: A callback, to be executed on completion
-    ///
-    /// - Returns: True when handled. False otherwise
-    ///
+    /// - Parameter notification: Push notification content from a remote notification.
     func handleInactiveRemoteNotification(notification: PushNotification) async {
         guard applicationState == .inactive else {
             return

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -20,7 +20,7 @@ protocol PushNotesManager {
     ///
     var inactiveNotifications: AnyPublisher<PushNotification, Never> { get }
 
-    /// An observable that emits values when a Local Notification response is received.
+    /// An observable that emits values when a local notification response is received.
     ///
     var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> { get }
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -20,6 +20,10 @@ protocol PushNotesManager {
     ///
     var inactiveNotifications: AnyPublisher<PushNotification, Never> { get }
 
+    /// An observable that emits values when a Local Notification response is received.
+    ///
+    var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> { get }
+
     /// Resets the Badge Count.
     ///
     func resetBadgeCount(type: Note.Kind)
@@ -62,11 +66,20 @@ protocol PushNotesManager {
     ///
     func registerDeviceToken(with tokenData: Data, defaultStoreID: Int64)
 
-    /// Handles a Remote Push Notification Payload. On completion the `completionHandler` will be executed.
+    /// Handles a remote push notification payload when the app is in the background.
+    /// - Parameter userInfo: Push notification payload.
+    /// - Returns: The result of background sync of notifications.
+    func handleRemoteNotificationInTheBackground(userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult
+
+    /// Handles user's response to a local or remote notification.
+    /// - Parameter response: The user's response to a notification.
+    func handleUserResponseToNotification(response: UNNotificationResponse) async
+
+    /// Handles a local or remote notification when the app is in the foreground.
     ///
-    func handleNotification(_ content: UNNotificationContent,
-                            onBadgeUpdateCompletion: @escaping () -> Void,
-                            completionHandler: @escaping (UIBackgroundFetchResult) -> Void)
+    /// - Parameter notification: The local or remote notification received in the app.
+    /// - Returns: How the notification is displayed in the foreground.
+    func handleNotificationInTheForeground(_ notification: UNNotification) async -> UNNotificationPresentationOptions
 
     /// Requests a local notification to be scheduled under a given trigger.
     /// - Parameters:

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -64,7 +64,7 @@ protocol PushNotesManager {
 
     /// Handles a Remote Push Notification Payload. On completion the `completionHandler` will be executed.
     ///
-    func handleNotification(_ userInfo: [AnyHashable: Any],
+    func handleNotification(_ content: UNNotificationContent,
                             onBadgeUpdateCompletion: @escaping () -> Void,
                             completionHandler: @escaping (UIBackgroundFetchResult) -> Void)
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -36,7 +36,7 @@ protocol PushNotesManager {
     ///
     func reloadBadgeCount()
 
-    /// Registers the Application for Remote Notifgications.
+    /// Registers the Application for Remote Notifications.
     ///
     func registerForRemoteNotifications()
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -22,7 +22,7 @@ protocol PushNotesManager {
 
     /// An observable that emits values when a local notification response is received.
     ///
-    var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> { get }
+    var localNotificationUserResponses: AnyPublisher<UNNotificationResponse, Never> { get }
 
     /// Resets the Badge Count.
     ///
@@ -73,7 +73,7 @@ protocol PushNotesManager {
 
     /// Handles user's response to a local or remote notification.
     /// - Parameter response: The user's response to a notification.
-    func handleUserResponseToNotification(response: UNNotificationResponse) async
+    func handleUserResponseToNotification(_ response: UNNotificationResponse) async
 
     /// Handles a local or remote notification when the app is in the foreground.
     ///

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -66,7 +66,7 @@ final class AppCoordinator {
                 self.isLoggedIn = isLoggedIn
             }
 
-        localNotificationResponsesSubscription = ServiceLocator.pushNotesManager.localNotificationResponses.sink { [weak self] response in
+        localNotificationResponsesSubscription = ServiceLocator.pushNotesManager.localNotificationUserResponses.sink { [weak self] response in
             self?.handleLocalNotificationResponse(response)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -19,7 +19,8 @@ final class AppCoordinator {
     private let featureFlagService: FeatureFlagService
 
     private var storePickerCoordinator: StorePickerCoordinator?
-    private var cancellable: AnyCancellable?
+    private var authStatesSubscription: AnyCancellable?
+    private var localNotificationResponsesSubscription: AnyCancellable?
     private var isLoggedIn: Bool = false
 
     init(window: UIWindow,
@@ -46,7 +47,7 @@ final class AppCoordinator {
     }
 
     func start() {
-        cancellable = Publishers.CombineLatest(stores.isLoggedInPublisher, stores.needsDefaultStorePublisher)
+        authStatesSubscription = Publishers.CombineLatest(stores.isLoggedInPublisher, stores.needsDefaultStorePublisher)
             .sink {  [weak self] isLoggedIn, needsDefaultStore in
                 guard let self = self else { return }
 
@@ -64,6 +65,10 @@ final class AppCoordinator {
                 }
                 self.isLoggedIn = isLoggedIn
             }
+
+        localNotificationResponsesSubscription = ServiceLocator.pushNotesManager.localNotificationResponses.sink { [weak self] response in
+            self?.handleLocalNotificationResponse(response)
+        }
     }
 }
 
@@ -232,6 +237,31 @@ private extension AppCoordinator {
             onSuccess()
         }
         stores.dispatch(action)
+    }
+
+    func handleLocalNotificationResponse(_ response: UNNotificationResponse) {
+        switch response.actionIdentifier {
+        case LocalNotification.Action.contactSupport.rawValue:
+            guard let viewController = window.rootViewController else {
+                return
+            }
+            ZendeskProvider.shared.showNewRequestIfPossible(from: viewController, with: nil)
+            analytics.track(.loginLocalNotificationTapped, withProperties: [
+                "action": "contact_support",
+                "type": response.notification.request.identifier
+            ])
+        default:
+            // Triggered when the user taps on the notification itself instead of one of the actions.
+            switch response.notification.request.identifier {
+            case LocalNotification.Scenario.loginSiteAddressError.rawValue:
+                analytics.track(.loginLocalNotificationTapped, withProperties: [
+                    "action": "default",
+                    "type": response.notification.request.identifier
+                ])
+            default:
+                return
+            }
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 		02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */; };
 		028296EC237D28B600E84012 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296EA237D28B600E84012 /* TextViewViewController.swift */; };
 		028296ED237D28B600E84012 /* TextViewViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 028296EB237D28B600E84012 /* TextViewViewController.xib */; };
+		02829BAA288FA8B300951E1E /* MockUserNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02829BA9288FA8B300951E1E /* MockUserNotification.swift */; };
 		0282DD94233C9465006A5FDB /* SearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282DD93233C9465006A5FDB /* SearchUICommand.swift */; };
 		0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282DD95233C960C006A5FDB /* SearchResultCell.swift */; };
 		0282DD98233CA093006A5FDB /* OrderSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282DD97233CA093006A5FDB /* OrderSearchUICommand.swift */; };
@@ -2070,6 +2071,7 @@
 		02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HeaderFooterHelpers.swift"; sourceTree = "<group>"; };
 		028296EA237D28B600E84012 /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
 		028296EB237D28B600E84012 /* TextViewViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextViewViewController.xib; sourceTree = "<group>"; };
+		02829BA9288FA8B300951E1E /* MockUserNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserNotification.swift; sourceTree = "<group>"; };
 		0282DD93233C9465006A5FDB /* SearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUICommand.swift; sourceTree = "<group>"; };
 		0282DD95233C960C006A5FDB /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
 		0282DD97233CA093006A5FDB /* OrderSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchUICommand.swift; sourceTree = "<group>"; };
@@ -5967,6 +5969,7 @@
 				EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */,
 				0247F50D286E6CCD009C177E /* MockProductImageActionHandler.swift */,
 				0248042C2887C92A00991319 /* MockLoggedOutAppSettings.swift */,
+				02829BA9288FA8B300951E1E /* MockUserNotification.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10004,6 +10007,7 @@
 				FEEB2F6E268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift in Sources */,
 				31E906A326CC91A70099A985 /* CardReaderConnectionControllerTests.swift in Sources */,
 				02AB40822784297C00929CF3 /* ProductTableViewCellViewModelTests.swift in Sources */,
+				02829BAA288FA8B300951E1E /* MockUserNotification.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */,
 				DEC51B04276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -24,7 +24,7 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     private let inactiveNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
-    var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> {
+    var localNotificationUserResponses: AnyPublisher<UNNotificationResponse, Never> {
         localNotificationResponsesSubject.eraseToAnyPublisher()
     }
 
@@ -66,7 +66,7 @@ final class MockPushNotificationsManager: PushNotesManager {
         .noData
     }
 
-    func handleUserResponseToNotification(response: UNNotificationResponse) async {
+    func handleUserResponseToNotification(_ response: UNNotificationResponse) async {
 
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -24,6 +24,12 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     private let inactiveNotificationsSubject = PassthroughSubject<PushNotification, Never>()
 
+    var localNotificationResponses: AnyPublisher<UNNotificationResponse, Never> {
+        localNotificationResponsesSubject.eraseToAnyPublisher()
+    }
+
+    private let localNotificationResponsesSubject = PassthroughSubject<UNNotificationResponse, Never>()
+
     func resetBadgeCount(type: Note.Kind) {
 
     }
@@ -56,10 +62,16 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     }
 
-    func handleNotification(_ userInfo: [AnyHashable: Any],
-                            onBadgeUpdateCompletion: @escaping () -> Void,
-                            completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    func handleRemoteNotificationInTheBackground(userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult {
+        .noData
+    }
 
+    func handleUserResponseToNotification(response: UNNotificationResponse) async {
+
+    }
+
+    func handleNotificationInTheForeground(_ notification: UNNotification) async -> UNNotificationPresentationOptions {
+        .init(rawValue: 0)
     }
 
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockUserNotification.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockUserNotification.swift
@@ -1,0 +1,82 @@
+import UserNotifications
+
+/// Because `UNNotificationResponse` and `UNNotification` can only be initialized with `init(coder:)`,
+/// this `NSCoder` subclass can be used to mock these two classes.
+final class MockUserNotificationCoder: NSCoder {
+    private enum FieldKey: String {
+        case date, request, // `UNNotification`
+             notification, actionIdentifier // `UNNotificationResponse`
+    }
+    private let testIdentifier = "testIdentifier"
+    private let request: UNNotificationRequest
+
+    override var allowsKeyedCoding: Bool { true }
+
+    init(request: UNNotificationRequest) {
+        self.request = request
+    }
+
+    override func decodeObject(forKey key: String) -> Any? {
+        let fieldKey = FieldKey(rawValue: key)
+        switch fieldKey {
+            // `UNNotification` fields
+        case .date:
+            return Date()
+        case .request:
+            return request
+            // `UNNotificationResponse` fields
+        case .actionIdentifier:
+            return testIdentifier
+        case .notification:
+            return UNNotification(coder: self)
+        default:
+            return nil
+        }
+    }
+}
+
+final class MockNotificationContent: UNNotificationContent {
+    private let mockUserInfo: [AnyHashable: Any]
+
+    init(userInfo: [AnyHashable: Any]) {
+        mockUserInfo = userInfo
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var userInfo: [AnyHashable: Any] {
+        mockUserInfo
+    }
+}
+
+final class MockNotification: UNNotification {
+    init?(request: UNNotificationRequest) {
+        super.init(coder: MockUserNotificationCoder(request: request))
+    }
+
+    convenience init?(userInfo: [AnyHashable: Any]) {
+        self.init(request: .init(identifier: "",
+                                 content: MockNotificationContent(userInfo: userInfo),
+                                 trigger: nil))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+final class MockNotificationResponse: UNNotificationResponse {
+    init?(notificationUserInfo: [AnyHashable: Any]) {
+        let request = UNNotificationRequest.init(identifier: "",
+                                                 content: MockNotificationContent(userInfo: notificationUserInfo),
+                                                 trigger: nil)
+        super.init(coder: MockUserNotificationCoder(request: request))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1,7 +1,6 @@
 import Combine
 import Experiments
 import XCTest
-//import UserNotifications
 import Yosemite
 @testable import WooCommerce
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -313,7 +313,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         // When
         application.applicationState = .inactive
-        await manager.handleUserResponseToNotification(response: response)
+        await manager.handleUserResponseToNotification(response)
 
         // Then
         XCTAssertEqual(application.presentDetailsNoteIDs.first, 1234)
@@ -457,7 +457,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let response = try XCTUnwrap(MockNotificationResponse(notificationUserInfo: userinfo))
 
         // When
-        _ = await manager.handleUserResponseToNotification(response: response)
+        _ = await manager.handleUserResponseToNotification(response)
 
         // Then
         XCTAssertEqual(emittedNotifications.count, 1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After more regression testing on the remote notifications in https://github.com/woocommerce/woocommerce-ios/pull/7323, I realized that remote notifications weren't working as before. For more details on the behavior changes, please check p91TBi-9A0-p2.

In order to support different app states for both local & remote notifications with the new [UNUserNotificationCenterDelegate](https://href.li/?https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate) conformance, this PR updated the `PushNotesManager` protocol by replacing `handleNotification(_:onBadgeUpdateCompletion:completionHandler:)` with 3 functions to handle different app states:

- **Background state**: `handleRemoteNotificationInTheBackground(userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult`
- **Inactive state**: `handleUserResponseToNotification(response: UNNotificationResponse) async`
- **Foreground state:** `handleNotificationInTheForeground(_:) async -> UNNotificationPresentationOptions`

These are called in 3 separate callbacks in `AppDelegate` where they're triggered in [UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)](https://href.li/?https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application) and also [UNUserNotificationCenterDelegate](https://href.li/?https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate) conformance.

Due to the current PR size and the latest experimentation process, only pre-existing unit tests were updated from the `PushNotesManager` protocol changes.

Also, during testing, I noticed one type of site address error that wasn't handled before in `AuthenticationManager`. This PR added an error case `noSecureConnection` for this reason.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please help test the following scenarios to ensure both local & remote notifications are working properly, since remote notifications are one of the critical flows in the app:

#### Remote notifications - background & inactive states

- On a device, log in to a store if needed and enable push notifications permission
- Put the app in the background
- On web, place an order or leave a review for a product for one of the connected stores --> a push notification should be shown on the device. In the meantime, the Xcode console should show:
```
📱 Push Notification Received:  [AnyHashable("aps"): { … }
🔵 Tracked push_notification_received, properties: […]
📱 Synchronizing Notifications in Background State...
📱 Finished Synchronizing Notifications!
```
- Tap on the push notification --> it should open order details or review details for a new order / review push notification respectively. In the console, it should show:
```
📱 Push Notification Received: 
 🔵 Tracked push_notification_alert_pressed, properties: […]
📱 Handling Remote Notification in Inactive State
```

#### Remote notifications - foreground state

- On a device, log in to a store if needed and enable push notifications permission
- Leave the app in the foreground
- On web, place an order or leave a review for a product for one of the connected stores --> a notification should be received in the app, and an in-app notice should be shown shortly. In the meantime, the Xcode console should show:
```
📱 Push Notification Received: 
[AnyHashable("aps"): { … }]
🔵 Tracked push_notification_received, properties: […]
📱 Synchronizing Notifications in Active State...
📱 Finished Synchronizing Notifications!
```
- Tap on "View" in the in-app notice --> it should open order details or review details for a new order / review push notification respectively


#### Local notifications - background & inactive states

Please update the 24 hours schedule to a few seconds or a minute in `AuthenticationManager` (search for "86400") to test this PR.

- Reinstall the app to clear any previous notifications permission state
- Skip the onboarding if needed
- Tap "Enter Your Store Address"
- Enter an invalid store address or a store address that isn't a WP site --> an error screen should be shown
- Quickly put the app to the background since we don't support local notifications in the foreground for this iteration --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Tap on the notification itself --> it should open the app, and an event should be logged `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("action"): "default", AnyHashable("type"): "site_address_error"]`

#### Local notifications - foreground state

The expected behavior is that we don't handle local notifications when the app is in the foreground.

- Continue from the previous test case
- Tap "Enter Your Store Address"
- Enter an invalid store address or a store address that isn't a WP site --> an error screen should be shown
- Stay on the same screen for the duration you set for the local notification schedule --> no in-app notice or notification should be shown


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->