### PR TITLE
Bulk Order Actions: Add Swipe Actions To Order Cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -635,6 +635,21 @@ extension OrderListViewController: UITableViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         delegate?.orderListScrollViewDidScroll(scrollView)
     }
+
+    /// Provide an implementation to show cell swipe actions. Return `nil` to provide no action.
+    ///
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+
+        let markAsCompletedAction = UIContextualAction(style: .normal, title: Localization.markCompleted, handler: { _, _, completionHandler in
+            print("Mark as completed triggered...")
+            // TODO: Fire real action
+            completionHandler(true) // Tells the table that the action was performed and forces it to go back to its original state (un-swiped)
+        })
+        markAsCompletedAction.backgroundColor = .brand
+        markAsCompletedAction.image = .checkmarkImage
+
+        return UISwipeActionsConfiguration(actions: [markAsCompletedAction])
+    }
 }
 
 // MARK: - Finite State Machine Management
@@ -743,6 +758,8 @@ private extension OrderListViewController {
                    comment: "Message for empty Orders filtered results. The %@ is a placeholder for the filters entered by the user.")
         static let clearButton = NSLocalizedString("Clear Filters",
                                  comment: "Action to remove filters orders on the placeholder overlay when no orders match the filter on the Order List")
+
+        static let markCompleted = NSLocalizedString("Mark Completed", comment: "Title for the swipe order action to mark it as completed")
     }
 
     enum Settings {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -639,6 +639,13 @@ extension OrderListViewController: UITableViewDelegate {
     /// Provide an implementation to show cell swipe actions. Return `nil` to provide no action.
     ///
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        /// Fetch the order view model and make sure the order is not marked as completed before proceeding.
+        ///
+        guard let objectID = dataSource.itemIdentifier(for: indexPath),
+              let cellViewModel = viewModel.cellViewModel(withID: objectID),
+              cellViewModel.status != .completed else {
+                  return nil
+              }
 
         let markAsCompletedAction = UIContextualAction(style: .normal, title: Localization.markCompleted, handler: { _, _, completionHandler in
             print("Mark as completed triggered...")


### PR DESCRIPTION
Closes: #7340 

# Why

In order to measure what is the appetite merchant has for bulk actions, we are going to run an experiment where we will allow merchants to mark orders as completed by swiping an order in the orders list.

This PR makes sure that every non-completed order has a swipe action attached to it.

The action can be triggered by swiping the row all the way or by swiping & tapping on the "Mark as completed" button

# How

This PR involves two main changes.

- The first one is to provide an implementation for the `trailingSwipeActionsConfigurationForRowAt` method of the `TableViewDelegate`. By doing this, we gain access automatically to swipe actions. The implementation returns an empty `Mark Completed` action that will be filled in a next PR.

- The second change is to make sure that only non-completed orders can access the "Mark Completed" action. This is done by returning a `nil` implementation for the `trailingSwipeActionsConfigurationForRowAt` method. We are able to know if an order is completed or not by querying its cell view model.

# Demo

https://user-images.githubusercontent.com/562080/181116275-692074b4-3de3-47e1-b4f0-5caf459ad91a.mov

# Testing Steps

- Open the app and go to the orders list
- Try to swipe a completed order and see no action
- Try to swipe a non-completed order and see that the "Mark Completed" action is revealed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
