### PR TITLE
[Unified Order Editing] Add basic UI test for editing flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -171,6 +171,7 @@ struct OrderForm: View {
                         viewModel.finishEditing()
                         dismissHandler()
                     }
+                    .accessibilityIdentifier(Accessibility.doneButtonIdentifier)
                 case .loading:
                     ProgressView()
                 }
@@ -316,6 +317,7 @@ private extension OrderForm {
     enum Accessibility {
         static let createButtonIdentifier = "new-order-create-button"
         static let cancelButtonIdentifier = "new-order-cancel-button"
+        static let doneButtonIdentifier = "edit-order-done-button"
         static let addProductButtonIdentifier = "new-order-add-product-button"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -138,6 +138,7 @@ private extension OrderDetailsViewController {
                                          style: .plain,
                                          target: self,
                                          action: #selector(editOrder))
+        editButton.accessibilityIdentifier = "order-details-edit-button"
         editButton.isEnabled = viewModel.editButtonIsEnabled
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.unifiedOrderEditing) {
             navigationItem.rightBarButtonItem = editButton

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddFeeScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddFeeScreen.swift
@@ -32,10 +32,10 @@ public final class AddFeeScreen: ScreenObject {
     }
 
     /// Confirms entered fee and closes Add Fee screen.
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func confirmFee() throws -> NewOrderScreen {
+    public func confirmFee() throws -> UnifiedOrderScreen {
         doneButton.tap()
-        return try NewOrderScreen()
+        return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
@@ -15,10 +15,10 @@ public final class AddProductScreen: ScreenObject {
     }
 
     /// Selects a product from the list.
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func selectProduct(byName name: String) throws -> NewOrderScreen {
+    public func selectProduct(byName name: String) throws -> UnifiedOrderScreen {
         app.buttons.staticTexts[name].tap()
-        return try NewOrderScreen()
+        return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
@@ -47,10 +47,10 @@ public final class AddShippingScreen: ScreenObject {
     }
 
     /// Confirms entered shipping details and closes Add Shipping screen.
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func confirmShippingDetails() throws -> NewOrderScreen {
+    public func confirmShippingDetails() throws -> UnifiedOrderScreen {
         doneButton.tap()
-        return try NewOrderScreen()
+        return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
@@ -36,15 +36,15 @@ public final class CustomerDetailsScreen: ScreenObject {
     }
 
     /// Updates the order with minimal customer details.
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func enterCustomerDetails(name: String) throws -> NewOrderScreen {
+    public func enterCustomerDetails(name: String) throws -> UnifiedOrderScreen {
         billingFirstNameField.tap()
         billingFirstNameField.typeText(name)
         addressToggle.tap()
         shippingFirstNameField.tap()
         shippingFirstNameField.typeText(name)
         doneButton.tap()
-        return try NewOrderScreen()
+        return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
@@ -32,10 +32,10 @@ public final class CustomerNoteScreen: ScreenObject {
     }
 
     /// Confirms entered note and closes Customer Note screen.
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func confirmNote() throws -> NewOrderScreen {
+    public func confirmNote() throws -> UnifiedOrderScreen {
         doneButton.tap()
-        return try NewOrderScreen()
+        return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -220,4 +220,12 @@ public final class NewOrderScreen: ScreenObject {
         }
         return try OrdersScreen()
     }
+
+    @discardableResult
+    public func checkForExistingOrderTitle(byOrderNumber orderNumber: String) throws -> NewOrderScreen {
+        let orderNumberPredicate = NSPredicate(format: "label MATCHES %@", "Order #\(orderNumber)")
+        XCTAssertTrue(app.staticTexts.containing(orderNumberPredicate).element.exists)
+
+        return self
+    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/NewOrderScreen.swift
@@ -11,6 +11,10 @@ public final class NewOrderScreen: ScreenObject {
         $0.buttons["new-order-cancel-button"]
     }
 
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["edit-order-done-button"]
+    }
+
     private let orderStatusEditButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["order-status-section-edit-button"]
     }
@@ -41,6 +45,10 @@ public final class NewOrderScreen: ScreenObject {
     ///
     private var cancelButton: XCUIElement { cancelButtonGetter(app) }
 
+    /// Done button in the Navigation bar.
+    ///
+    private var doneButton: XCUIElement { doneButtonGetter(app) }
+
     /// Edit button in the Order Status section.
     ///
     private var orderStatusEditButton: XCUIElement { orderStatusEditButtonGetter(app) }
@@ -65,11 +73,24 @@ public final class NewOrderScreen: ScreenObject {
     ///
     private var addNoteButton: XCUIElement { addNoteButtonGetter(app) }
 
-    public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(
-            expectedElementGetters: [ createButtonGetter ],
-            app: app
-        )
+    public enum Flow {
+        case creation
+        case editing
+    }
+
+    public init(app: XCUIApplication = XCUIApplication(), flow: Flow = .creation) throws {
+        switch flow {
+        case .creation:
+            try super.init(
+                expectedElementGetters: [ createButtonGetter ],
+                app: app
+            )
+        case .editing:
+            try super.init(
+                expectedElementGetters: [ doneButtonGetter ],
+                app: app
+            )
+        }
     }
 
 // MARK: - Order Creation Navigation helpers

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
@@ -21,8 +21,8 @@ public final class OrderStatusScreen: ScreenObject {
     /// Selects a new order status from the list.
     /// - Returns: Order Status screen object (self).
     @discardableResult
-    public func selectOrderStatus(atIndex index: Int) throws -> NewOrderScreen {
+    public func selectOrderStatus(atIndex index: Int) throws -> UnifiedOrderScreen {
         orderStatusTable.cells.element(boundBy: index).tap()
-        return try NewOrderScreen()
+        return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -81,11 +81,11 @@ public final class OrdersScreen: ScreenObject {
     }
 
     /// Starts the order creation flow by navigating from the Orders screen to the New Order screen.
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func startOrderCreation() throws -> NewOrderScreen {
+    public func startOrderCreation() throws -> UnifiedOrderScreen {
         createButton.tap()
         newOrderButton.tap()
-        return try NewOrderScreen()
+        return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -78,8 +78,8 @@ public final class SingleOrderScreen: ScreenObject {
     }
 
     @discardableResult
-    public func tapEditOrderButton() throws -> NewOrderScreen {
+    public func tapEditOrderButton() throws -> UnifiedOrderScreen {
         editOrderButton.tap()
-        return try NewOrderScreen(flow: .editing)
+        return try UnifiedOrderScreen(flow: .editing)
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -6,6 +6,14 @@ public final class SingleOrderScreen: ScreenObject {
     // TODO: Remove force `try` once `ScreenObject` migration is completed
     let tabBar = try! TabNavComponent()
 
+    private let editOrderButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-details-edit-button"]
+    }
+
+    private let summaryCellGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["summary-table-view-cell-title-label"]
+    }
+
     private let collectPaymentButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["order-details-collect-payment-button"]
     }
@@ -14,7 +22,10 @@ public final class SingleOrderScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ { $0.staticTexts["summary-table-view-cell-title-label"]} ],
+            expectedElementGetters: [
+                summaryCellGetter,
+                editOrderButtonGetter
+            ],
             app: app
         )
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -80,6 +80,6 @@ public final class SingleOrderScreen: ScreenObject {
     @discardableResult
     public func tapEditOrderButton() throws -> NewOrderScreen {
         editOrderButton.tap()
-        return try NewOrderScreen()
+        return try NewOrderScreen(flow: .editing)
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -18,6 +18,8 @@ public final class SingleOrderScreen: ScreenObject {
         $0.buttons["order-details-collect-payment-button"]
     }
 
+    private var editOrderButton: XCUIElement { editOrderButtonGetter(app) }
+
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
@@ -73,5 +75,11 @@ public final class SingleOrderScreen: ScreenObject {
     public func goBackToOrdersScreen() throws -> OrdersScreen {
         pop()
         return try OrdersScreen()
+    }
+
+    @discardableResult
+    public func tapEditOrderButton() throws -> NewOrderScreen {
+        editOrderButton.tap()
+        return try NewOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -24,10 +24,7 @@ public final class SingleOrderScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [
-                summaryCellGetter,
-                editOrderButtonGetter
-            ],
+            expectedElementGetters: [ summaryCellGetter ],
             app: app
         )
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -1,7 +1,9 @@
 import ScreenObject
 import XCTest
 
-public final class NewOrderScreen: ScreenObject {
+/// This screen is used in both Order Create and Edit flows to reflect that these are unified in the app codebase
+///
+public final class UnifiedOrderScreen: ScreenObject {
 
     private let createButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["new-order-create-button"]
@@ -78,6 +80,9 @@ public final class NewOrderScreen: ScreenObject {
         case editing
     }
 
+    /// Since the screen is unified for creation and editing, pass a parameter to use the correct flow
+    /// - Parameter flow: order flow, default is `creation`.
+    ///
     public init(app: XCUIApplication = XCUIApplication(), flow: Flow = .creation) throws {
         switch flow {
         case .creation:
@@ -154,24 +159,24 @@ public final class NewOrderScreen: ScreenObject {
     }
 
     /// Changes the new order status to the second status in the Order Status list.
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func editOrderStatus() throws -> NewOrderScreen {
+    public func editOrderStatus() throws -> UnifiedOrderScreen {
       return try openOrderStatusScreen()
             .selectOrderStatus(atIndex: 1)
     }
 
     /// Select the first product from the addProductScreen
-    /// - Returns: New Order screen object.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func addProduct(byName name: String) throws -> NewOrderScreen {
+    public func addProduct(byName name: String) throws -> UnifiedOrderScreen {
         return try openAddProductScreen()
             .selectProduct(byName: name)
     }
 
     /// Adds minimal customer details on the Customer Details screen
-    /// - Returns: New Order screen object.
-    public func addCustomerDetails(name: String) throws -> NewOrderScreen {
+    /// - Returns: Unified Order screen object.
+    public func addCustomerDetails(name: String) throws -> UnifiedOrderScreen {
         return try openCustomerDetailsScreen()
             .enterCustomerDetails(name: name)
     }
@@ -180,8 +185,8 @@ public final class NewOrderScreen: ScreenObject {
     /// - Parameters:
     ///   - amount: Amount (in the store currency) to add for shipping.
     ///   - name: Name of the shipping method (e.g. "Free Shipping" or "Flat Rate").
-    /// - Returns: New Order screen object.
-    public func addShipping(amount: String, name: String) throws -> NewOrderScreen {
+    /// - Returns: Unified Order screen object.
+    public func addShipping(amount: String, name: String) throws -> UnifiedOrderScreen {
         return try openAddShippingScreen()
             .enterShippingAmount(amount)
             .enterShippingName(name)
@@ -191,8 +196,8 @@ public final class NewOrderScreen: ScreenObject {
     /// Adds a fee on the Add Fee screen.
     /// - Parameters:
     ///   - amount: Amount (in the store currency) to add as a fee.
-    /// - Returns: New Order screen object.
-    public func addFee(amount: String) throws -> NewOrderScreen {
+    /// - Returns: Unified Order screen object.
+    public func addFee(amount: String) throws -> UnifiedOrderScreen {
         return try openAddFeeScreen()
             .enterFixedFee(amount: amount)
             .confirmFee()
@@ -200,8 +205,8 @@ public final class NewOrderScreen: ScreenObject {
 
     /// Adds a note on the Customer Note screen.
     /// - Parameter text: Text to enter as the customer note.
-    /// - Returns: New Order screen object.
-    public func addCustomerNote(_ text: String) throws -> NewOrderScreen {
+    /// - Returns: Unified Order screen object.
+    public func addCustomerNote(_ text: String) throws -> UnifiedOrderScreen {
         return try openCustomerNoteScreen()
             .enterNote(text)
             .confirmNote()
@@ -221,8 +226,11 @@ public final class NewOrderScreen: ScreenObject {
         return try OrdersScreen()
     }
 
+    /// Checks the screen for existence of the title with correct order number.
+    /// - Parameter orderNumber: Existing order number to check.
+    /// - Returns: Unified Order screen object.
     @discardableResult
-    public func checkForExistingOrderTitle(byOrderNumber orderNumber: String) throws -> NewOrderScreen {
+    public func checkForExistingOrderTitle(byOrderNumber orderNumber: String) throws -> UnifiedOrderScreen {
         let orderNumberPredicate = NSPredicate(format: "label MATCHES %@", "Order #\(orderNumber)")
         XCTAssertTrue(app.staticTexts.containing(orderNumberPredicate).element.exists)
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1317,7 +1317,7 @@
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC5BA5F5287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5BA5F4287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift */; };
-		CC5C278727EE19A700B25D2A /* NewOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */; };
+		CC5C278727EE19A700B25D2A /* UnifiedOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5C278627EE19A600B25D2A /* UnifiedOrderScreen.swift */; };
 		CC5C278B27EE314F00B25D2A /* orders_3337_create_order.json in Resources */ = {isa = PBXBuildFile; fileRef = CC5C278A27EE314E00B25D2A /* orders_3337_create_order.json */; };
 		CC666F2427F329DC0045AF1E /* View+DiscardChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC666F2327F329DC0045AF1E /* View+DiscardChanges.swift */; };
 		CC666F2627F359590045AF1E /* OrdersTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC666F2527F359590045AF1E /* OrdersTopBannerFactory.swift */; };
@@ -3133,7 +3133,7 @@
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC5BA5F4287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomFieldsViewModelTests.swift; sourceTree = "<group>"; };
-		CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOrderScreen.swift; sourceTree = "<group>"; };
+		CC5C278627EE19A600B25D2A /* UnifiedOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedOrderScreen.swift; sourceTree = "<group>"; };
 		CC5C278A27EE314E00B25D2A /* orders_3337_create_order.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337_create_order.json; sourceTree = "<group>"; };
 		CC666F2327F329DC0045AF1E /* View+DiscardChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+DiscardChanges.swift"; sourceTree = "<group>"; };
 		CC666F2527F359590045AF1E /* OrdersTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersTopBannerFactory.swift; sourceTree = "<group>"; };
@@ -8259,7 +8259,7 @@
 			isa = PBXGroup;
 			children = (
 				F997173423DBEB1900592D8E /* OrdersScreen.swift */,
-				CC5C278627EE19A600B25D2A /* NewOrderScreen.swift */,
+				CC5C278627EE19A600B25D2A /* UnifiedOrderScreen.swift */,
 				C027470F2822673800985EAE /* CustomerDetailsScreen.swift */,
 				F997173623DBF02400592D8E /* SingleOrderScreen.swift */,
 				F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */,
@@ -8971,7 +8971,7 @@
 				3F0CF2FF2704490A00EF3D71 /* SettingsScreen.swift in Sources */,
 				3F0CF3052704490A00EF3D71 /* LoginEpilogueScreen.swift in Sources */,
 				C064EE2B2783480000D54B0D /* OrderDataStructs.swift in Sources */,
-				CC5C278727EE19A700B25D2A /* NewOrderScreen.swift in Sources */,
+				CC5C278727EE19A700B25D2A /* UnifiedOrderScreen.swift in Sources */,
 				3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */,
 				3F0CF3042704490A00EF3D71 /* PeriodStatsTable.swift in Sources */,
 				3F0CF3142704494A00EF3D71 /* TabNavComponent.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -20,6 +20,7 @@ final class OrdersTests: XCTestCase {
             .verifyOrdersScreenLoaded()
             .verifyOrdersList(orders: orders)
             .selectOrder(byOrderNumber: orders[0].number)
+            .verifySingleOrderScreenLoaded()
             .verifySingleOrder(order: orders[0])
             .goBackToOrdersScreen()
             .verifyOrdersScreenLoaded()

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -42,6 +42,17 @@ final class OrdersTests: XCTestCase {
             .verifySingleOrderScreenLoaded()
     }
 
+    func test_edit_existing_order() throws {
+        let orders = try GetMocks.readOrdersData()
+
+        try TabNavComponent().goToOrdersScreen()
+            .verifyOrdersScreenLoaded()
+            .verifyOrdersList(orders: orders)
+            .selectOrder(byOrderNumber: orders[0].number)
+            .verifySingleOrderScreenLoaded()
+            .tapEditOrderButton()
+    }
+
     func test_cancel_order_creation() throws {
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -51,6 +51,7 @@ final class OrdersTests: XCTestCase {
             .selectOrder(byOrderNumber: orders[0].number)
             .verifySingleOrderScreenLoaded()
             .tapEditOrderButton()
+            .checkForExistingOrderTitle(byOrderNumber: orders[0].number)
     }
 
     func test_cancel_order_creation() throws {

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -20,7 +20,6 @@ final class OrdersTests: XCTestCase {
             .verifyOrdersScreenLoaded()
             .verifyOrdersList(orders: orders)
             .selectOrder(byOrderNumber: orders[0].number)
-            .verifySingleOrderScreenLoaded()
             .verifySingleOrder(order: orders[0])
             .goBackToOrdersScreen()
             .verifyOrdersScreenLoaded()

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -46,10 +46,7 @@ final class OrdersTests: XCTestCase {
         let orders = try GetMocks.readOrdersData()
 
         try TabNavComponent().goToOrdersScreen()
-            .verifyOrdersScreenLoaded()
-            .verifyOrdersList(orders: orders)
             .selectOrder(byOrderNumber: orders[0].number)
-            .verifySingleOrderScreenLoaded()
             .tapEditOrderButton()
             .checkForExistingOrderTitle(byOrderNumber: orders[0].number)
     }


### PR DESCRIPTION
## Description

This PR adds a new basic test for the Order Editing flow.

Thanks @thehenrybyrd for pairing on these!

## Changes

Screen objects:

- Adds accessibility ID to Edit Order button, to use in the UI test.
- Updates the `SingleOrderScreen` with method to open Edit flow.
- Updates `NewOrderScreen` to have `flow` parameter and edition-related checks ("Done" instead of "Create").
- Renames `NewOrderScreen` to `UnifiedOrderScreen`.

Test:

- Updates the order test to check for Edit button availability.
- Adds new test that navigates to Edit flow and checks prefilled data (so far only order number in title).

## Testing

Confirm test passes in CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.