### PR TITLE
Login Reminder: schedule a local notification 24 hours after an invalid WP.com email

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 2.1.0-beta.3'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2'
+  pod 'WordPressAuthenticator', '~> 2.1.0-beta.4'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 2.1.0-beta.3'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  # pod 'WordPressAuthenticator', '~> 2.1.0-beta.3'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2`)
+  - WordPressAuthenticator (~> 2.1.0-beta.4)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,6 +102,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -139,16 +141,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -171,7 +163,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 6df1f2bb614ea6dbb943f313687b46a980500fff
+  WordPressAuthenticator: 2043c2ab1620a9f5e4995b44f795a474d4dcaefd
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -187,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 02654d3064ddc3e056bb4be49bced5a1f302d9eb
+PODFILE CHECKSUM: 28dc22ffe86644efb09b4da9d936ce08700da265
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (2.1.0-beta.3):
+  - WordPressAuthenticator (2.1.0-beta.4):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 2.1.0-beta.3)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,8 +102,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -141,6 +139,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: c70fc242cd9aa6e36c2d395bfdf59be1bdb2faa2
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -163,7 +171,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 5882d5ba6084a20c0e660950363e456162a11296
+  WordPressAuthenticator: 6df1f2bb614ea6dbb943f313687b46a980500fff
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -179,6 +187,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 918b977da8de7fa51654420e8011f30808657095
+PODFILE CHECKSUM: 02654d3064ddc3e056bb4be49bced5a1f302d9eb
 
 COCOAPODS: 1.11.2

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -438,7 +438,7 @@ private extension AuthenticationManager {
             ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [notification.scenario])
             ServiceLocator.pushNotesManager.requestLocalNotification(notification,
                                                                      // 24 hours from now.
-                                                                     trigger: UNTimeIntervalNotificationTrigger(timeInterval: 86400, repeats: false))
+                                                                     trigger: UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false))
         }
     }
 }
@@ -508,8 +508,6 @@ private extension AuthenticationManager {
                         return .invalidEmailFromWPComLogin
                     case .wpComSiteAddress:
                         return .invalidEmailFromSiteAddressLogin
-                    case .other:
-                        break
                     }
                 }
             }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -422,15 +422,23 @@ private extension AuthenticationManager {
         }
 
         let wooAuthError = AuthenticationError.make(with: error)
+        let notification: LocalNotification?
         switch wooAuthError {
         case .notWPSite, .notValidAddress, .noSecureConnection:
-            let notification = LocalNotification(scenario: .loginSiteAddressError)
+            notification = LocalNotification(scenario: .loginSiteAddressError)
+        case .invalidEmailFromSiteAddressLogin:
+            notification = LocalNotification(scenario: .invalidEmailFromSiteAddressLogin)
+        case .invalidEmailFromWPComLogin:
+            notification = LocalNotification(scenario: .invalidEmailFromWPComLogin)
+        default:
+            notification = nil
+        }
+
+        if let notification = notification {
             ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [notification.scenario])
             ServiceLocator.pushNotesManager.requestLocalNotification(notification,
                                                                      // 24 hours from now.
                                                                      trigger: UNTimeIntervalNotificationTrigger(timeInterval: 86400, repeats: false))
-        default:
-            break
         }
     }
 }
@@ -465,7 +473,7 @@ extension AuthenticationManager {
         let wooAuthError = AuthenticationError.make(with: error)
 
         switch wooAuthError {
-        case .emailDoesNotMatchWPAccount:
+        case .emailDoesNotMatchWPAccount, .invalidEmailFromWPComLogin, .invalidEmailFromSiteAddressLogin:
             return NotWPAccountViewModel()
         case .notWPSite,
              .notValidAddress:
@@ -484,12 +492,28 @@ private extension AuthenticationManager {
     /// Maps error codes emitted by WPAuthenticator to a domain error object
     enum AuthenticationError: Int, Error {
         case emailDoesNotMatchWPAccount
+        case invalidEmailFromSiteAddressLogin
+        case invalidEmailFromWPComLogin
         case notWPSite
         case notValidAddress
         case noSecureConnection
         case unknown
 
         static func make(with error: Error) -> AuthenticationError {
+            if let error = error as? SignInError {
+                switch error {
+                case .invalidWPComEmail(let source):
+                    switch source {
+                    case .wpCom:
+                        return .invalidEmailFromWPComLogin
+                    case .wpComSiteAddress:
+                        return .invalidEmailFromSiteAddressLogin
+                    case .other:
+                        break
+                    }
+                }
+            }
+
             let error = error as NSError
 
             switch error.code {

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -15,8 +15,10 @@ struct LocalNotification {
 
     /// The scenario for the local notification.
     /// Its raw value is used for the identifier of a local notification and also the event property for analytics.
-    enum Scenario: String {
+    enum Scenario: String, CaseIterable {
         case loginSiteAddressError = "site_address_error"
+        case invalidEmailFromSiteAddressLogin = "site_address_email_error"
+        case invalidEmailFromWPComLogin = "wpcom_email_error"
     }
 
     /// The category of actions for a local notification.
@@ -47,8 +49,13 @@ extension LocalNotification {
         case .loginSiteAddressError:
             self.init(title: Localization.errorLoggingInTitle,
                       body: Localization.errorLoggingInBody,
-                      scenario: .loginSiteAddressError,
+                      scenario: scenario,
                       actions: .init(category: .loginError, actions: [.contactSupport, .loginWithWPCom]))
+        case .invalidEmailFromWPComLogin, .invalidEmailFromSiteAddressLogin:
+            self.init(title: Localization.errorLoggingInTitle,
+                      body: Localization.errorLoggingInBody,
+                      scenario: scenario,
+                      actions: .init(category: .loginError, actions: [.contactSupport]))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -267,15 +267,14 @@ private extension AppCoordinator {
             ])
         case UNNotificationDefaultActionIdentifier:
             // Triggered when the user taps on the notification itself instead of one of the actions.
-            switch response.notification.request.identifier {
-            case LocalNotification.Scenario.loginSiteAddressError.rawValue:
-                analytics.track(.loginLocalNotificationTapped, withProperties: [
-                    "action": "default",
-                    "type": response.notification.request.identifier
-                ])
-            default:
+            let requestIdentifier = response.notification.request.identifier
+            guard LocalNotification.Scenario.allCases.map({ $0.rawValue }).contains(requestIdentifier) else {
                 break
             }
+            analytics.track(.loginLocalNotificationTapped, withProperties: [
+                "action": "default",
+                "type": requestIdentifier
+            ])
         case UNNotificationDismissActionIdentifier:
             // Triggered when the user taps on the notification's "Clear" action.
             switch response.notification.request.identifier {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318 
<!-- Id number of the GitHub issue this PR addresses. -->

- [x] ⚠️ Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/652 ⚠️ 
- [x] ⚠️ Update Podfile after https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/652 is merged and released ⚠️ 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For Iteration 2, we want to schedule a local notification 24 hours after the user enters an invalid WP.com email during the login process. In order to differentiate the two login flows that lead to the email error, a custom error `SignInError` was added in the WPAuthenticator PR https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/652. In this PR, the new `SignInError` is converted to `AuthenticationError` which corresponds to two local notification scenarios.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please update the 24 hours schedule to a few seconds or a minute in `AuthenticationManager` (search for "86400") to test this PR (I used 5 seconds).

You can test this PR in a simulator.

#### WP.com flow - contact support action

- Reinstall the app to clear any previous notifications permission state if needed
- Skip the onboarding if needed
- Tap "Continue With WordPress.com"
- Enter an invalid email that doesn't belong to a WP.com account --> an error screen should be shown
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Long press on the notification to see actions --> there should be a "Contact Support" action
- Tap "Contact Support" --> it should open the app then show Zendesk support, with an event in the console: `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("type"): "wpcom_email_error", AnyHashable("action"): "contact_support"]`

#### WP.com flow - default action

- Continue from the previous test case
- Navigate back to the previous email form
- Tap "Continue" to submit an invalid email again
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Tap on the notification itself --> it should open the app, and an event should be logged `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("action"): "default", AnyHashable("type"): "wpcom_email_error"]`

#### Site address flow - contact support action

- Continue from the previous test case
- Navigate back to the prologue screen
- Tap "Enter Your Store Address"
- Enter a valid WP.com store address
- Enter an invalid email that doesn't belong to a WP.com account --> an error screen should be shown
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Long press on the notification to see actions --> there should be a "Contact Support" action
- Tap "Contact Support" --> it should open the app then show Zendesk support, with an event in the console: `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("action"): "contact_support", AnyHashable("type"): "site_address_email_error"]`

#### Site address flow - default action

- Continue from the previous test case
- Navigate back to the previous email form
- Tap "Continue" to submit an invalid email again
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Tap on the notification itself --> it should open the app, and an event should be logged `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("action"): "default", AnyHashable("type"): "site_address_email_error"]`

### Example screenshots
<!-- Include before and after images or gifs when appropriate. -->

Login with WP.com:

https://user-images.githubusercontent.com/1945542/181448242-b0a765c7-95b0-4eea-ad4f-c86ed6ae4a26.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
