### PR TITLE
[Mobile Payments] Red badge on the Menu Tab Button

### DIFF
--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -43,9 +43,9 @@ final class MainTabViewModel {
     var onOrdersBadgeReload: ((String?) -> Void)?
 
     /// Callback to be executed when the menu tab badge needs to be reloaded
-    /// It provides a Bool with whether it should be hidden or not, and the badge type
+    /// It provides a Bool with whether it should be visible or not, and the badge type
     ///
-    var onMenuBadgeReload: ((Bool, NotificationBadgeType) -> Void)?
+    var showMenuBadge: ((Bool, NotificationBadgeType) -> Void)?
 
     /// Must be called during `MainTabBarController.viewDidAppear`. This will try and save the
     /// app installation date.
@@ -81,7 +81,7 @@ final class MainTabViewModel {
         }
 
         let action = NotificationCountAction.load(siteID: siteID, type: .kind(.comment)) { [weak self] count in
-            self?.onMenuBadgeReload?(count == 0, .primary)
+            self?.showMenuBadge?(count > 0, .primary)
         }
         storesManager.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -40,11 +40,11 @@ final class MainTabViewModel {
     /// Callback to be executed when this view model receives new data
     /// passing the string to be presented in the badge as a parameter
     ///
-    var onBadgeReload: ((String?) -> Void)?
+    var onOrdersBadgeReload: ((String?) -> Void)?
 
     /// Callback to be executed when the menu tab badge needs to be reloaded
     /// It provides a Bool with whether it should be hidden or not, and the badge type
-    /// 
+    ///
     var onMenuBadgeReload: ((Bool, NotificationBadgeType) -> Void)?
 
     /// Must be called during `MainTabBarController.viewDidAppear`. This will try and save the
@@ -139,11 +139,11 @@ private extension MainTabViewModel {
         guard let ordersStatus = ordersStatus,
               ordersStatus.slug == OrderStatusEnum.processing.rawValue,
               ordersStatus.total > 0 else {
-            onBadgeReload?(nil)
+            onOrdersBadgeReload?(nil)
             return
         }
 
-        onBadgeReload?(NumberFormatter.localizedOrNinetyNinePlus(ordersStatus.total))
+        onOrdersBadgeReload?(NumberFormatter.localizedOrNinetyNinePlus(ordersStatus.total))
     }
 
     func observeBadgeRefreshNotifications() {

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -61,6 +61,8 @@ final class MainTabViewModel {
         requestBadgeCount()
     }
 
+    /// Loads the the hub Menu tab badge and listens to any change to update it
+    ///
     func loadHubMenuTabBadge() {
         updateHubMenuTabBadge()
 

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -42,6 +42,8 @@ final class MainTabViewModel {
     ///
     var onBadgeReload: ((String?) -> Void)?
 
+    var onMenuBadgeReload: ((Bool, NotificationBadgeType) -> Void)?
+
     /// Must be called during `MainTabBarController.viewDidAppear`. This will try and save the
     /// app installation date.
     ///
@@ -57,6 +59,26 @@ final class MainTabViewModel {
         observeBadgeRefreshNotifications()
         updateBadgeFromCache()
         requestBadgeCount()
+    }
+
+    func loadHubMenuTabBadge() {
+        updateHubMenuTabBadge()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(updateHubMenuTabBadge),
+                                               name: .reviewsBadgeReloadRequired,
+                                               object: nil)
+    }
+
+    @objc func updateHubMenuTabBadge() {
+        guard let siteID = storesManager.sessionManager.defaultStoreID else {
+            return
+        }
+
+        let action = NotificationCountAction.load(siteID: siteID, type: .kind(.comment)) { [weak self] count in
+            self?.onMenuBadgeReload?(count == 0, .primary)
+        }
+        storesManager.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -42,6 +42,9 @@ final class MainTabViewModel {
     ///
     var onBadgeReload: ((String?) -> Void)?
 
+    /// Callback to be executed when the menu tab badge needs to be reloaded
+    /// It provides a Bool with whether it should be hidden or not, and the badge type
+    /// 
     var onMenuBadgeReload: ((Bool, NotificationBadgeType) -> Void)?
 
     /// Must be called during `MainTabBarController.viewDidAppear`. This will try and save the

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -530,7 +530,7 @@ private extension MainTabBarController {
 
 private extension MainTabBarController {
     func startListeningToOrdersBadge() {
-        viewModel.onBadgeReload = { [weak self] countReadableString in
+        viewModel.onOrdersBadgeReload = { [weak self] countReadableString in
             guard let self = self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -523,7 +523,6 @@ private extension MainTabBarController {
 
             self.notificationsBadge.updateBadge(with: input)
         }
-
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -152,7 +152,8 @@ final class MainTabBarController: UITabBarController {
         observeSiteIDForViewControllers()
         observeProductImageUploadStatusUpdates()
 
-        loadHubMenuTabNotificationCountAndUpdateBadge()
+        startListeningToHubMenuTabBadgeUpdates()
+        viewModel.loadHubMenuTabBadge()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -162,7 +163,7 @@ final class MainTabBarController: UITabBarController {
         /// We hook up KVO in this spot... because at the point in which `viewDidLoad` fires, we haven't really fully
         /// loaded the childViewControllers, and the tabBar isn't fully initialized.
         ///
-        startListeningToHubMenuTabBadgeUpdates()
+
         startListeningToOrdersBadge()
     }
 
@@ -513,31 +514,16 @@ private extension MainTabBarController {
     /// Setup: KVO Hooks.
     ///
     func startListeningToHubMenuTabBadgeUpdates() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(loadHubMenuTabNotificationCountAndUpdateBadge),
-                                               name: .reviewsBadgeReloadRequired,
-                                               object: nil)
-    }
+        viewModel.onMenuBadgeReload = { [weak self] hide, type in
+            guard let self = self else { return }
 
-    @objc func loadHubMenuTabNotificationCountAndUpdateBadge() {
-        guard let siteID = stores.sessionManager.defaultStoreID else {
-            return
+            let tab = self.isHubMenuFeatureFlagOn ? WooTab.hubMenu : WooTab.reviews
+            let tabIndex = tab.visibleIndex(self.isHubMenuFeatureFlagOn)
+            let input = NotificationsBadgeInput(hide: hide, type: type, tab: tab, tabBar: self.tabBar, tabIndex: tabIndex)
+
+            self.notificationsBadge.updateBadge(with: input)
         }
 
-        let action = NotificationCountAction.load(siteID: siteID, type: .kind(.comment)) { [weak self] count in
-            self?.updateHubMenuTabBadge(count: count)
-        }
-        stores.dispatch(action)
-    }
-
-    /// Displays or Hides the Dot on the Hub Menu tab, depending on the notification count
-    ///
-    func updateHubMenuTabBadge(count: Int) {
-        let tab = isHubMenuFeatureFlagOn ? WooTab.hubMenu : WooTab.reviews
-        let tabIndex = tab.visibleIndex(isHubMenuFeatureFlagOn)
-        let input = NotificationsBadgeInput(hide: count != 0, type: .primary, tab: tab, tabBar: tabBar, tabIndex: tabIndex)
-
-        notificationsBadge.updateBadge(with: input)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -514,12 +514,12 @@ private extension MainTabBarController {
     /// Setup: KVO Hooks.
     ///
     func startListeningToHubMenuTabBadgeUpdates() {
-        viewModel.onMenuBadgeReload = { [weak self] hide, type in
+        viewModel.showMenuBadge = { [weak self] shouldBeVisible, type in
             guard let self = self else { return }
 
             let tab = self.isHubMenuFeatureFlagOn ? WooTab.hubMenu : WooTab.reviews
             let tabIndex = tab.visibleIndex(self.isHubMenuFeatureFlagOn)
-            let input = NotificationsBadgeInput(hide: hide, type: type, tab: tab, tabBar: self.tabBar, tabIndex: tabIndex)
+            let input = NotificationsBadgeInput(shouldBeVisible: shouldBeVisible, type: type, tab: tab, tabBar: self.tabBar, tabIndex: tabIndex)
 
             self.notificationsBadge.updateBadge(with: input)
         }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -533,16 +533,11 @@ private extension MainTabBarController {
     /// Displays or Hides the Dot on the Hub Menu tab, depending on the notification count
     ///
     func updateHubMenuTabBadge(count: Int) {
-        if isHubMenuFeatureFlagOn {
-            let tab = WooTab.hubMenu
-            let tabIndex = tab.visibleIndex(isHubMenuFeatureFlagOn)
-            notificationsBadge.badgeCountWasUpdated(newValue: count, tab: tab, in: tabBar, tabIndex: tabIndex)
-        }
-        else {
-            let tab = WooTab.reviews
-            let tabIndex = tab.visibleIndex(isHubMenuFeatureFlagOn)
-            notificationsBadge.badgeCountWasUpdated(newValue: count, tab: tab, in: tabBar, tabIndex: tabIndex)
-        }
+        let tab = isHubMenuFeatureFlagOn ? WooTab.hubMenu : WooTab.reviews
+        let tabIndex = tab.visibleIndex(isHubMenuFeatureFlagOn)
+        let input = NotificationsBadgeInput(hide: count != 0, type: .primary, tab: tab, tabBar: tabBar, tabIndex: tabIndex)
+
+        notificationsBadge.updateBadge(with: input)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
+++ b/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
@@ -17,7 +17,7 @@ enum NotificationBadgeType {
 
 /// Gathers the necessary data to update the badge on a tabbar tab
 struct NotificationsBadgeInput {
-    let hide: Bool
+    let shouldBeVisible: Bool
     let type: NotificationBadgeType
     let tab: WooTab
     let tabBar: UITabBar
@@ -28,7 +28,7 @@ final class NotificationsBadgeController {
     /// Updates the tab badge depending on the provided input parameter
     ///
     func updateBadge(with input: NotificationsBadgeInput) {
-        input.hide ? hideDotOn(with: input) : showDotOn(with: input)
+        input.shouldBeVisible ? showDotOn(with: input) : hideDotOn(with: input)
     }
 
     /// Shows the dot in the specified WooTab

--- a/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
+++ b/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
@@ -1,39 +1,56 @@
 import Foundation
 import UIKit
 
+enum NotificationBadgeType {
+    case primary
+    case secondary
+
+    var color: UIColor {
+        switch self {
+        case .primary:
+            return .primary
+        case .secondary:
+            return .accent
+        }
+    }
+}
+
+struct NotificationsBadgeInput {
+    let hide: Bool
+    let type: NotificationBadgeType
+    let tab: WooTab
+    let tabBar: UITabBar
+    let tabIndex: Int
+}
+
 final class NotificationsBadgeController {
     /// Displays or Hides the Dot, depending on the new Badge Value
     ///
-    func badgeCountWasUpdated(newValue: Int, tab: WooTab, in tabBar: UITabBar, tabIndex: Int) {
-        guard newValue > 0 else {
-            hideDotOn(tab, in: tabBar, tabIndex: tabIndex)
-            return
-        }
-
-        showDotOn(tab, in: tabBar, tabIndex: tabIndex)
+    func updateBadge(with input: NotificationsBadgeInput) {
+        input.hide ? hideDotOn(with: input) : showDotOn(with: input)
     }
 
     /// Shows the dot in the specified WooTab
     ///
-    func showDotOn(_ tab: WooTab, in tabBar: UITabBar, tabIndex: Int) {
-        hideDotOn(tab, in: tabBar, tabIndex: tabIndex)
+    private func showDotOn(with input: NotificationsBadgeInput) {
+        hideDotOn(with: input)
         let dot = DotView(frame: CGRect(x: DotConstants.xOffset,
                                         y: DotConstants.yOffset,
                                         width: DotConstants.diameter,
                                         height: DotConstants.diameter),
                           color: UIColor.primary,
                           borderWidth: DotConstants.borderWidth)
-        dot.tag = dotTag(for: tab)
+        dot.tag = dotTag(for: input.tab)
         dot.isHidden = true
-        tabBar.orderedTabBarActionableViews[tabIndex].subviews.first?.insertSubview(dot, at: 1)
+        input.tabBar.orderedTabBarActionableViews[input.tabIndex].subviews.first?.insertSubview(dot, at: 1)
         dot.fadeIn()
     }
 
     /// Hides the Dot in the specified WooTab
     ///
-    func hideDotOn(_ tab: WooTab, in tabBar: UITabBar, tabIndex: Int) {
-        let tag = dotTag(for: tab)
-        if let subviews = tabBar.orderedTabBarActionableViews[tabIndex].subviews.first?.subviews {
+    private func hideDotOn(with input: NotificationsBadgeInput) {
+        let tag = dotTag(for: input.tab)
+        if let subviews = input.tabBar.orderedTabBarActionableViews[input.tabIndex].subviews.first?.subviews {
             for subview in subviews where subview.tag == tag {
                 subview.fadeOut() { _ in
                     subview.removeFromSuperview()
@@ -44,7 +61,7 @@ final class NotificationsBadgeController {
 
     /// Returns the DotView's Tag for the specified WooTab
     ///
-    func dotTag(for tab: WooTab) -> Int {
+    private func dotTag(for tab: WooTab) -> Int {
         return tab.identifierNumber + DotConstants.tagOffset
     }
 }
@@ -85,7 +102,7 @@ private class DotView: UIView {
     ///
     required init?(coder aDecoder: NSCoder) {
         color = UIColor.primary
-        
+
         super.init(coder: aDecoder)
         setupSubviews()
     }

--- a/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
+++ b/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
@@ -15,6 +15,7 @@ enum NotificationBadgeType {
     }
 }
 
+/// Gathers the necessary data to update the badge on a tabbar tab
 struct NotificationsBadgeInput {
     let hide: Bool
     let type: NotificationBadgeType
@@ -24,7 +25,7 @@ struct NotificationsBadgeInput {
 }
 
 final class NotificationsBadgeController {
-    /// Displays or Hides the Dot, depending on the new Badge Value
+    /// Updates the tab badge depending on the provided input parameter
     ///
     func updateBadge(with input: NotificationsBadgeInput) {
         input.hide ? hideDotOn(with: input) : showDotOn(with: input)

--- a/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
+++ b/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
@@ -17,11 +17,12 @@ final class NotificationsBadgeController {
     ///
     func showDotOn(_ tab: WooTab, in tabBar: UITabBar, tabIndex: Int) {
         hideDotOn(tab, in: tabBar, tabIndex: tabIndex)
-        let dot = PurpleDotView(frame: CGRect(x: DotConstants.xOffset,
-                                             y: DotConstants.yOffset,
-                                             width: DotConstants.diameter,
-                                             height: DotConstants.diameter),
-                               borderWidth: DotConstants.borderWidth)
+        let dot = DotView(frame: CGRect(x: DotConstants.xOffset,
+                                        y: DotConstants.yOffset,
+                                        width: DotConstants.diameter,
+                                        height: DotConstants.diameter),
+                          color: UIColor.primary,
+                          borderWidth: DotConstants.borderWidth)
         dot.tag = dotTag(for: tab)
         dot.isHidden = true
         tabBar.orderedTabBarActionableViews[tabIndex].subviews.first?.insertSubview(dot, at: 1)
@@ -63,15 +64,18 @@ private extension NotificationsBadgeController {
 }
 
 
-// MARK: - PurpleDot UIView
+// MARK: - DotView UIView
 //
-private class PurpleDotView: UIView {
+private class DotView: UIView {
 
     private var borderWidth = CGFloat(1) // Border line width defaults to 1
 
+    private let color: UIColor
+
     /// Designated Initializer
     ///
-    init(frame: CGRect, borderWidth: CGFloat) {
+    init(frame: CGRect, color: UIColor, borderWidth: CGFloat) {
+        self.color = color
         super.init(frame: frame)
         self.borderWidth = borderWidth
         setupSubviews()
@@ -80,6 +84,8 @@ private class PurpleDotView: UIView {
     /// Required Initializer
     ///
     required init?(coder aDecoder: NSCoder) {
+        color = UIColor.primary
+        
         super.init(coder: aDecoder)
         setupSubviews()
     }
@@ -93,7 +99,7 @@ private class PurpleDotView: UIView {
                                                y: rect.origin.y + borderWidth,
                                                width: rect.size.width - borderWidth * 2,
                                                height: rect.size.height - borderWidth * 2))
-        UIColor.primary.setFill()
+        color.setFill()
         path.fill()
 
         path.lineWidth = borderWidth

--- a/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
+++ b/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift
@@ -39,7 +39,7 @@ final class NotificationsBadgeController {
                                         y: DotConstants.yOffset,
                                         width: DotConstants.diameter,
                                         height: DotConstants.diameter),
-                          color: UIColor.primary,
+                          color: input.type.color,
                           borderWidth: DotConstants.borderWidth)
         dot.tag = dotTag(for: input.tab)
         dot.isHidden = true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7356 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the logic to add a red badge onto the Menu button of the tab bar, so in the next issue we can show/hide it depending on whether the user opens the menu and saw the new Payments hub menu button (to be implemented)
In order to achieve that we refactor `PurpleDotView` to a generic `DotView` that accepts any kind of color, and move the Menu tab badge logic from the `MainTabBarController` to the `MainTabViewModel`. This will make easier the priority (payments badge > reviews badge) business logic implementation.
On top of that, I slightly refactored the `NotificationsBadgeController` class to make it cleaner and accept more than one type of badge, which will make the badge rendering with different colors possible.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
As we didn't implement the show of the red badge depending on the Payments Hub Menu button, at the moment the badge is always hidden. To show that we can change this [line](https://github.com/woocommerce/woocommerce-ios/blob/6b9af8066f3339b4f4d3ea652089b212557f5fc7/WooCommerce/Classes/ViewModels/MainTabViewModel.swift#L84) to: 

`self?.showMenuBadge?(true, .secondary)
`

<img src="https://user-images.githubusercontent.com/1864060/181583991-d2ee3271-09e1-45cd-99c3-fa1d4046265c.png" width="375">

That way we will always show the badge no matter what, with the .secondary type (the red badge color).

#### Reviews testing

As we have refactored the badge logic, it is convenient to test the reviews badge in the Menu tab again:

1. Make sure you test on a device with the notifications enabled
2. Open the application
3. Leave a review on the browser to a product of the store you have active in the Woo app. You should receive a notification.
4. A purple badge with no number should be shown on the tab. If you open the Reviews in the Hub Menu it should disappear.

<img src="https://user-images.githubusercontent.com/1864060/181585681-932bfb0b-14c4-4aed-8c9c-311e4dafbbaf.png" width="375">

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

See above



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
