### PR TITLE
Bulk Order Actions: Submit "Mark As Completed" action

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -296,6 +296,23 @@ extension OrderListViewController {
             sender.endRefreshing()
         }
     }
+
+    private func markOrderAsCompleted(resultID: FetchResultSnapshotObjectID) {
+        guard let orderDetailsViewModel = viewModel.detailsViewModel(withID: resultID) else {
+            return DDLogError("⛔️ ViewModel for resultID: \(resultID) not found")
+        }
+        /// Actions that performs the mark completed request remotely.
+        let fulfillmentProcess = orderDetailsViewModel.markCompleted()
+
+        /// Messages configuration
+        let noticeConfiguration = OrderFulfillmentNoticePresenter.NoticeConfiguration(
+            successTitle: Localization.markCompletedNoticeTitle(orderID: orderDetailsViewModel.order.orderID),
+            errorTitle: Localization.markCompletedErrorNoticeTitle(orderID: orderDetailsViewModel.order.orderID))
+
+        /// Fires fulfillment action, observes its result and enqueue the appropriate notices.
+        let presenter = OrderFulfillmentNoticePresenter(noticeConfiguration: noticeConfiguration)
+        presenter.present(process: fulfillmentProcess)
+    }
 }
 
 // MARK: - Sync'ing Helpers
@@ -646,10 +663,8 @@ extension OrderListViewController: UITableViewDelegate {
               cellViewModel.status != .completed else {
                   return nil
               }
-
-        let markAsCompletedAction = UIContextualAction(style: .normal, title: Localization.markCompleted, handler: { _, _, completionHandler in
-            print("Mark as completed triggered...")
-            // TODO: Fire real action
+        let markAsCompletedAction = UIContextualAction(style: .normal, title: Localization.markCompleted, handler: { [weak self] _, _, completionHandler in
+            self?.markOrderAsCompleted(resultID: objectID)
             completionHandler(true) // Tells the table that the action was performed and forces it to go back to its original state (un-swiped)
         })
         markAsCompletedAction.backgroundColor = .brand
@@ -767,6 +782,22 @@ private extension OrderListViewController {
                                  comment: "Action to remove filters orders on the placeholder overlay when no orders match the filter on the Order List")
 
         static let markCompleted = NSLocalizedString("Mark Completed", comment: "Title for the swipe order action to mark it as completed")
+
+        static func markCompletedNoticeTitle(orderID: Int64) -> String {
+            let format = NSLocalizedString(
+                "Order #%1$d marked as completed",
+                comment: "Notice title when an order is marked as completed via a swipe action. Parameter: Order Number"
+            )
+            return String.localizedStringWithFormat(format, orderID)
+        }
+
+        static func markCompletedErrorNoticeTitle(orderID: Int64) -> String {
+            let format = NSLocalizedString(
+                "Error updating Order #%1$d",
+                comment: "Notice title when marking an order as completed via a swipe action fails. Parameter: Order Number"
+            )
+            return String.localizedStringWithFormat(format, orderID)
+        }
     }
 
     enum Settings {


### PR DESCRIPTION
Closes: #7341 #7342 

# Why

Now that we implemented the order swipe action in #7350, now it is time to mark the order as completed remotely and inform the user about the result of the action.

# How

This PR involves two main changes.

### In OrderFulfillmentNoticePresenter.swift

This class has been updated to:
- Receive custom notice messages, Before this PR the notice message was hard coded.
- Added a delay when showing the error notice to make sure the notice is always presented to the merchant.

### In OrderListViewController

I've added a function called `markOrderAsCompleted()` that will reuse the existing `OrderFulfillmentNoticePresenter` to fulfill (mark as completed) the desired order. This function configures the `OrderFulfillmentNoticePresenter` with our custom notice messages.


# Demo

https://user-images.githubusercontent.com/562080/181597768-c1626fe0-8cae-4a6e-93df-7e98761dcb9e.mov

https://user-images.githubusercontent.com/562080/181597782-27680f0b-fa8d-477e-9e68-d235bb7c508c.mov


# Testing Steps

### Case 1

- Go to the orders list screen
- Swipe to complete an order
- See that the order row changes status immediately 
- See that the success notice is presented
- Tap the undo button
- See that the order row reverts its original status

### Case 2

- Turn off the device(computer) internet connection
- Go to the orders list screen
- Swipe to complete an order
- See that the success notice is presented
- After the success notice is dismissed, see that the error notice is presented

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
