### PR TITLE
[Elevate] Track when product form is loaded

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -314,6 +314,17 @@ extension WooAnalyticsEvent {
     }
 }
 
+// MARK: - Product Detail
+//
+extension WooAnalyticsEvent {
+    /// Namespace
+    enum ProductDetail {
+        static func loaded() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailLoaded, properties: [:])
+        }
+    }
+}
+
 // MARK: - Product Detail Add-ons
 //
 extension WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -319,8 +319,8 @@ extension WooAnalyticsEvent {
 extension WooAnalyticsEvent {
     /// Namespace
     enum ProductDetail {
-        static func loaded() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productDetailLoaded, properties: [:])
+        static func loaded(hasLinkedProducts: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailLoaded, properties: ["has_linked_products": hasLinkedProducts])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -388,6 +388,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Edit Product Events
     //
+    case productDetailLoaded = "product_detail_loaded"
     case productDetailUpdateButtonTapped = "product_detail_update_button_tapped"
     case productDetailUpdateSuccess = "product_detail_update_success"
     case productDetailUpdateError = "product_detail_update_error"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -858,7 +858,8 @@ private extension ProductFormViewController {
             return
         }
 
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded())
+        let hasLinkedProducts = product.upsellIDs.isNotEmpty || product.crossSellIDs.isNotEmpty
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -142,6 +142,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         productImageUploader.stopEmittingErrors(key: .init(siteID: viewModel.productModel.siteID,
                                                            productOrVariationID: productOrVariationID,
                                                            isLocalID: !viewModel.productModel.existsRemotely))
+
+        trackProductDetailLoaded()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -848,6 +850,15 @@ private extension ProductFormViewController {
 
     func trackEditProductAttributeRowTapped() {
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.Variations.editAttributesButtonTapped(productID: product.productID))
+    }
+
+    /// Tracks when the product form is loaded for a product (not product variation)
+    func trackProductDetailLoaded() {
+        guard viewModel is ProductFormViewModel else {
+            return
+        }
+
+        ServiceLocator.analytics.track(.productDetailLoaded)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -858,7 +858,7 @@ private extension ProductFormViewController {
             return
         }
 
-        ServiceLocator.analytics.track(.productDetailLoaded)
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -143,7 +143,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                                                            productOrVariationID: productOrVariationID,
                                                            isLocalID: !viewModel.productModel.existsRemotely))
 
-        trackProductDetailLoaded()
+        viewModel.trackProductFormLoaded()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -850,16 +850,6 @@ private extension ProductFormViewController {
 
     func trackEditProductAttributeRowTapped() {
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.Variations.editAttributesButtonTapped(productID: product.productID))
-    }
-
-    /// Tracks when the product form is loaded for a product (not product variation)
-    func trackProductDetailLoaded() {
-        guard viewModel is ProductFormViewModel else {
-            return
-        }
-
-        let hasLinkedProducts = product.upsellIDs.isNotEmpty || product.crossSellIDs.isNotEmpty
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -161,13 +161,16 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let isBackgroundImageUploadEnabled: Bool
 
+    private let analytics: Analytics
+
     init(product: EditableProductModel,
          formType: ProductFormType,
          productImageActionHandler: ProductImageActionHandler,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          productImagesUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
-         isBackgroundImageUploadEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload)) {
+         isBackgroundImageUploadEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload),
+         analytics: Analytics = ServiceLocator.analytics) {
         self.formType = formType
         self.productImageActionHandler = productImageActionHandler
         self.originalProduct = product
@@ -177,6 +180,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.storageManager = storageManager
         self.productImagesUploader = productImagesUploader
         self.isBackgroundImageUploadEnabled = isBackgroundImageUploadEnabled
+        self.analytics = analytics
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             guard let self = self else { return }
@@ -527,7 +531,7 @@ extension ProductFormViewModel {
 extension ProductFormViewModel {
     func trackProductFormLoaded() {
         let hasLinkedProducts = product.upsellIDs.isNotEmpty || product.crossSellIDs.isNotEmpty
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts))
+        analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -522,6 +522,15 @@ extension ProductFormViewModel {
     }
 }
 
+// MARK: Tracking
+//
+extension ProductFormViewModel {
+    func trackProductFormLoaded() {
+        let hasLinkedProducts = product.upsellIDs.isNotEmpty || product.crossSellIDs.isNotEmpty
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts))
+    }
+}
+
 // MARK: Miscellaneous
 
 private extension ProductFormViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -144,6 +144,11 @@ protocol ProductFormViewModelProtocol {
     /// Updates the original product variations(and attributes).
     /// This is needed because variations and attributes, remote updates, happen outside this view model and we need a way to sync the original product.
     func updateProductVariations(from product: Product)
+
+    // Tracking
+
+    /// Tracks when the product form is loaded
+    func trackProductFormLoaded()
 }
 
 extension ProductFormViewModelProtocol {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -392,3 +392,11 @@ extension ProductVariationFormViewModel {
         // no-op
     }
 }
+
+// MARK: Tracking
+//
+extension ProductVariationFormViewModel {
+    func trackProductFormLoaded() {
+        // no-op
+    }
+}


### PR DESCRIPTION
Closes: #7376

## Description

Add a new analytics event that is triggered when the product form (product detail screen) is loaded:

* `product_detail_loaded` with custom prop `has_linked_products: true | false` (1007-gh-Automattic/tracks-events-registration)

The property `has_linked_products` is `true` when the product detail screen loads with a product that has upsells or cross-sells.

## Changes

* Adds event to `WooAnalyticsStat` and a method with custom prop to `WooAnalyticsEvent`.
* Adds a method to `ProductFormViewModel` to call the analytics event method. The method is also added to `ProductFormViewModelProtocol` with a no-op method in `ProductVariationFormViewModel` because we don't want to track when the variation detail form is loaded. (I decided to add this to the VM rather than the VC for clarity about when we expect to trigger the event and for unit testing.)
* Calls the tracking method when the view loads in `ProductFormViewController`.
* Adds a unit test to confirm the event is fired correctly from the view model (and support for analytics unit tests).

## Testing

1. Build and run the app.
2. Go to the Products tab.
3. Select a product from the product list and confirm the event is fired with the correct property (`true` if the product has existing upsells/cross-sells).
4. Add a new product and confirm the event is fired with the correct property (`false`).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.