### PR TITLE
[Bulk Order Actions] Update Analytics for Swipe To Complete

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -341,6 +341,7 @@ extension WooAnalyticsEvent {
         enum Flow: String {
             case creation
             case editing
+            case list
         }
 
         private enum Keys {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -434,8 +434,8 @@ extension OrderDetailsViewModel {
 
 extension OrderDetailsViewModel {
     /// Dispatches a network call in order to update `self.order`'s `status` to `.completed`.
-    func markCompleted() -> OrderFulfillmentUseCase.FulfillmentProcess {
-        OrderFulfillmentUseCase(order: order, stores: stores).fulfill()
+    func markCompleted(flow: WooAnalyticsEvent.Orders.Flow) -> OrderFulfillmentUseCase.FulfillmentProcess {
+        OrderFulfillmentUseCase(order: order, stores: stores, flow: flow).fulfill()
     }
 
     func syncOrder(onCompletion: ((Order?, Error?) -> ())? = nil) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -421,7 +421,7 @@ private extension OrderDetailsViewController {
         let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products, showAddOns: viewModel.dataSource.showAddOns)
         let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel) { [weak self] in
             guard let self = self else { return }
-            let fulfillmentProcess = self.viewModel.markCompleted()
+            let fulfillmentProcess = self.viewModel.markCompleted(flow: .editing)
             let presenter = OrderFulfillmentNoticePresenter()
             presenter.present(process: fulfillmentProcess)
         }
@@ -429,7 +429,7 @@ private extension OrderDetailsViewController {
     }
 
     func markOrderCompleteFromShippingLabels() {
-        let fulfillmentProcess = self.viewModel.markCompleted()
+        let fulfillmentProcess = self.viewModel.markCompleted(flow: .editing)
 
         var cancellables = Set<AnyCancellable>()
         var cancellable: AnyCancellable = AnyCancellable { }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
@@ -42,10 +42,12 @@ final class OrderFulfillmentUseCase {
     private let stores: StoresManager
     private let analytics: Analytics = ServiceLocator.analytics
     private let order: Order
+    private let flow: WooAnalyticsEvent.Orders.Flow
 
-    init(order: Order, stores: StoresManager) {
+    init(order: Order, stores: StoresManager, flow: WooAnalyticsEvent.Orders.Flow) {
         self.order = order
         self.stores = stores
+        self.flow = flow
     }
 
     /// Mark the `self.order` as `.completed`.
@@ -61,7 +63,7 @@ final class OrderFulfillmentUseCase {
     private func dispatchStatusUpdateAction(order: Order,
                                             status targetStatus: OrderStatusEnum,
                                             activity: Activity) -> FulfillmentProcess {
-        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: .editing, orderID: order.orderID, from: order.status, to: targetStatus))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderStatusChange(flow: flow, orderID: order.orderID, from: order.status, to: targetStatus))
 
         let result: Future<Void, FulfillmentError> = Future { promise in
             let action = OrderAction.updateOrderStatus(siteID: order.siteID, orderID: order.orderID, status: targetStatus) { error in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -315,7 +315,7 @@ extension OrderListViewController {
             return DDLogError("⛔️ ViewModel for resultID: \(resultID) not found")
         }
         /// Actions that performs the mark completed request remotely.
-        let fulfillmentProcess = orderDetailsViewModel.markCompleted()
+        let fulfillmentProcess = orderDetailsViewModel.markCompleted(flow: .list)
 
         /// Messages configuration
         let noticeConfiguration = OrderFulfillmentNoticePresenter.NoticeConfiguration(

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -55,7 +55,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 
         // When
-        _ = viewModel.markCompleted()
+        _ = viewModel.markCompleted(flow: .editing)
 
         // Then
         XCTAssertEqual(storesManager.receivedActions.count, 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderFulfillmentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderFulfillmentUseCaseTests.swift
@@ -27,7 +27,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
     func test_fulfill_dispatches_an_Action_to_change_the_status_to_completed() throws {
         // Given
         let order = MockOrders().empty().copy(siteID: 1_900, orderID: 981, status: .processing)
-        let useCase = OrderFulfillmentUseCase(order: order, stores: stores)
+        let useCase = OrderFulfillmentUseCase(order: order, stores: stores, flow: .editing)
 
         // When
         let process = useCase.fulfill()
@@ -42,7 +42,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
     func test_undo_dispatches_an_Action_to_change_the_status_back() throws {
         // Given
         let order = MockOrders().empty().copy(siteID: 98, orderID: 12, status: .failed)
-        let useCase = OrderFulfillmentUseCase(order: order, stores: stores)
+        let useCase = OrderFulfillmentUseCase(order: order, stores: stores, flow: .editing)
 
         let process = useCase.fulfill()
 
@@ -60,7 +60,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
     func test_retry_dispatches_an_Action_to_change_the_status_to_completed() throws {
         // Given
         let order = MockOrders().empty().copy(siteID: 498, orderID: 29, status: .pending)
-        let useCase = OrderFulfillmentUseCase(order: order, stores: stores)
+        let useCase = OrderFulfillmentUseCase(order: order, stores: stores, flow: .editing)
 
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             guard case let .updateOrderStatus(siteID: _, orderID: _, status: status, onCompletion: onCompletion) = action else {
@@ -104,7 +104,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
     func test_fulfill_returns_an_Error_if_the_Action_fails() throws {
         // Given
         let order = MockOrders().empty().copy(siteID: 500, orderID: 1, status: .pending)
-        let useCase = OrderFulfillmentUseCase(order: order, stores: stores)
+        let useCase = OrderFulfillmentUseCase(order: order, stores: stores, flow: .editing)
 
         mockUpdateOrderAction(from: stores, toCompleteWithError: SampleError.first)
 
@@ -131,7 +131,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
     func test_fulfill_finishes_with_no_Error_if_the_Action_succeeds() throws {
         // Given
         let order = MockOrders().empty().copy(siteID: 500, orderID: 1, status: .pending)
-        let useCase = OrderFulfillmentUseCase(order: order, stores: stores)
+        let useCase = OrderFulfillmentUseCase(order: order, stores: stores, flow: .editing)
 
         mockUpdateOrderAction(from: stores, toCompleteWithError: nil)
 


### PR DESCRIPTION
Closes: #7344 

# Why 

Now that the feature is complete, it is time to update the analytics events so we can adequately measure the experiment output.

# How

- Update the `orderStatusChange` event to receive a new option(`list`) for the flow property.

- Update the relevant parts to send the `list` flow or the `editing` flow when appropriate.

# Testing Steps

- Open the app On the simulator 
- Swipe to complete an order
- See a log similar to the following, making sure the `flow: list` property is present.

> 🔵 Tracked order_status_change, properties: [AnyHashable("blog_id"): 158689920, AnyHashable("to"): "completed", AnyHashable("from"): "pending", AnyHashable("id"): 3473, AnyHashable("is_wpcom_store"): true, AnyHashable("flow"): "list"]

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
