### PR TITLE
Login Prologue: fix feature carousel when onboarding is not shown

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -8,7 +8,7 @@ import Experiments
 ///
 final class LoginPrologueViewController: UIViewController {
     private let isNewToWooCommerceButtonShown: Bool
-    private let isOnboardingFeatureEnabled: Bool
+    private let isOnboardingFeatureShown: Bool
     private let analytics: Analytics
 
     /// Background View, to be placed surrounding the bottom area.
@@ -39,8 +39,7 @@ final class LoginPrologueViewController: UIViewController {
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         isNewToWooCommerceButtonShown = featureFlagService.isFeatureFlagEnabled(.newToWooCommerceLinkInLoginPrologue)
-
-        isOnboardingFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) && loggedOutAppSettings.hasFinishedOnboarding == false
+        isOnboardingFeatureShown = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) && loggedOutAppSettings.hasFinishedOnboarding == false
         self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
     }
@@ -92,8 +91,8 @@ private extension LoginPrologueViewController {
     /// This is contained in a child view so that this view's background doesn't scroll.
     ///
     func setupCarousel(isNewToWooCommerceButtonShown: Bool) {
-        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureEnabled ? [.getStarted] : [.stats, .orderManagement, .products, .reviews]
-        let carousel = LoginProloguePageViewController(pageTypes: pageTypes, showsSubtitle: isOnboardingFeatureEnabled)
+        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureShown ? [.getStarted] : [.stats, .orderManagement, .products, .reviews]
+        let carousel = LoginProloguePageViewController(pageTypes: pageTypes, showsSubtitle: isOnboardingFeatureShown)
         carousel.view.translatesAutoresizingMaskIntoConstraints = false
 
         addChild(carousel)

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -36,9 +36,11 @@ final class LoginPrologueViewController: UIViewController {
     // MARK: - Overridden Methods
 
     init(analytics: Analytics = ServiceLocator.analytics,
+         loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         isNewToWooCommerceButtonShown = featureFlagService.isFeatureFlagEnabled(.newToWooCommerceLinkInLoginPrologue)
-        isOnboardingFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding)
+
+        isOnboardingFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) && loggedOutAppSettings.hasFinishedOnboarding == false
         self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7384 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After introducing conditional login onboarding in https://github.com/woocommerce/woocommerce-ios/pull/7307, there is one condition on the UserDefaults that the login prologue isn't checking for whether the onboarding is "shown". Before this PR, the login prologue only checks whether the onboarding "can be shown", as a result only "Let's get started!" instead of the feature carousel is shown if the onboarding isn't shown.

This PR fixed this issue by also adding the condition on UserDefaults (abstracted in `LoggedOutAppSettingsProtocol`) to match its behavior in `AppCoordinator`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Log out if needed
- Skip or complete the onboarding if needed
- Relaunch the app --> the feature carousel should be shown on the prologue screen instead of "Let's get started!"

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screen Shot - iPhone 13 - 2022-08-02 at 11 32 15](https://user-images.githubusercontent.com/1945542/182289028-bdd63628-1483-4686-a364-d66eea4c09cd.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-02 at 11 31 27](https://user-images.githubusercontent.com/1945542/182289018-d022d194-8afb-4135-be0f-2dd86cfed3c7.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
