### PR TITLE
Login enhancement: Extract plugin setup web view model from view controller

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -52,7 +52,8 @@ struct JetpackErrorViewModel: ULErrorViewModel {
             return
         }
 
-        let connectionController = JetpackSetupWebViewController(siteURL: siteURL, analytics: analytics, onCompletion: jetpackSetupCompletionHandler)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: jetpackSetupCompletionHandler)
+        let connectionController = PluginSetupWebViewController(viewModel: viewModel)
         viewController.navigationController?.show(connectionController, sender: nil)
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
@@ -36,20 +36,20 @@ final class JetpackSetupWebViewModel: PluginSetupWebViewModel {
         analytics.track(event: .LoginJetpackSetup.setupDismissed(source: .web))
     }
 
-    func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
         let url = navigationURL.absoluteString
         switch url {
         // When the web view is about to navigate to the redirect URL for mobile, we can assume that the setup has completed.
         case Constants.mobileRedirectURL:
-            decisionHandler(.cancel)
             handleSetupCompletion()
+            return .cancel
         default:
             if let match = JetpackSetupWebStep.matchingStep(for: url) {
                 analytics.track(event: .LoginJetpackSetup.setupFlow(source: .web, step: match.trackingStep))
             } else if url.hasPrefix(Constants.jetpackAuthorizeURL) {
                 authorizedEmailAddress = getQueryStringParameter(url: url, param: Constants.userEmailParam)
             }
-            decisionHandler(.allow)
+            return .allow
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
@@ -32,7 +32,7 @@ final class JetpackSetupWebViewModel: PluginSetupWebViewModel {
         return url
     }
 
-    func trackDismissal() {
+    func handleDismissal() {
         analytics.track(event: .LoginJetpackSetup.setupDismissed(source: .web))
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
@@ -22,7 +22,7 @@ final class JetpackSetupWebViewModel: PluginSetupWebViewModel {
     }
 
     // MARK: - `PluginSetupWebViewModel` conformance
-    var title: String { Localization.title }
+    let title = Localization.title
 
     var initialURL: URL? {
         guard let escapedSiteURL = siteURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
@@ -87,8 +87,9 @@ private extension PluginSetupWebViewController {
                     self?.progressBar.setProgress(Float(progress), animated: true)
                 }
             }
-        let request = URLRequest(url: url)
-        webView.load(request)
+
+        let credentials = ServiceLocator.stores.sessionManager.defaultCredentials
+        webView.authenticateForWPComAndRedirect(to: url, credentials: credentials)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
@@ -98,11 +98,11 @@ private extension PluginSetupWebViewController {
 }
 
 extension PluginSetupWebViewController: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
         guard let navigationURL = navigationAction.request.url else {
-            return
+            return .allow
         }
-        viewModel.decidePolicy(for: navigationURL, decisionHandler: decisionHandler)
+        return await viewModel.decidePolicy(for: navigationURL)
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
@@ -88,8 +88,12 @@ private extension PluginSetupWebViewController {
                 }
             }
 
-        let credentials = ServiceLocator.stores.sessionManager.defaultCredentials
-        webView.authenticateForWPComAndRedirect(to: url, credentials: credentials)
+        if let credentials = ServiceLocator.stores.sessionManager.defaultCredentials {
+            webView.authenticateForWPComAndRedirect(to: url, credentials: credentials)
+        } else {
+            let request = URLRequest(url: url)
+            webView.load(request)
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
@@ -46,7 +46,7 @@ final class PluginSetupWebViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if isMovingFromParent {
-            viewModel.trackDismissal()
+            viewModel.handleDismissal()
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
@@ -1,0 +1,106 @@
+import Combine
+import UIKit
+import WebKit
+
+/// The web view to handle plugin setup in the login flow.
+///
+final class PluginSetupWebViewController: UIViewController {
+
+    private let viewModel: PluginSetupWebViewModel
+
+    /// Main web view
+    private lazy var webView: WKWebView = {
+        let webView = WKWebView(frame: .zero)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        return webView
+    }()
+
+    /// Progress bar for the web view
+    private lazy var progressBar: UIProgressView = {
+        let bar = UIProgressView(progressViewStyle: .bar)
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        return bar
+    }()
+
+    /// Strong reference for the subscription to update progress bar
+    private var progressSubscription: AnyCancellable?
+
+    init(viewModel: PluginSetupWebViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        configureWebView()
+        configureProgressBar()
+        startLoading()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isMovingFromParent {
+            viewModel.trackDismissal()
+        }
+    }
+}
+
+private extension PluginSetupWebViewController {
+    func configureNavigationBar() {
+        title = viewModel.title
+    }
+
+    func configureWebView() {
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
+            view.safeTopAnchor.constraint(equalTo: webView.topAnchor),
+            view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
+        ])
+    }
+
+    func configureProgressBar() {
+        view.addSubview(progressBar)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: progressBar.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: progressBar.trailingAnchor),
+            view.safeTopAnchor.constraint(equalTo: progressBar.topAnchor)
+        ])
+    }
+
+    func startLoading() {
+        guard let url = viewModel.initialURL else {
+            return
+        }
+        progressSubscription = webView.publisher(for: \.estimatedProgress)
+            .sink { [weak self] progress in
+                if progress == 1 {
+                    self?.progressBar.setProgress(0, animated: false)
+                } else {
+                    self?.progressBar.setProgress(Float(progress), animated: true)
+                }
+            }
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+}
+
+extension PluginSetupWebViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let navigationURL = navigationAction.request.url else {
+            return
+        }
+        viewModel.decidePolicy(for: navigationURL, decisionHandler: decisionHandler)
+    }
+
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        progressBar.setProgress(0, animated: false)
+    }
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewController.swift
@@ -45,7 +45,7 @@ final class PluginSetupWebViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if isMovingFromParent {
+        if isBeingDismissedInAnyWay {
             viewModel.handleDismissal()
         }
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
@@ -14,5 +14,5 @@ protocol PluginSetupWebViewModel {
     func handleDismissal()
 
     /// Handler for a navigation URL
-    func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void)
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
@@ -1,0 +1,18 @@
+import Foundation
+import WebKit
+
+/// Abstracts different configurations and logic for web view controllers
+/// used for setting up plugins during the login flow
+protocol PluginSetupWebViewModel {
+    /// Title for the view
+    var title: String { get }
+
+    /// Initial URL to be loaded on the web view
+    var initialURL: URL? { get }
+
+    /// Triggered when the web view is dismissed
+    func trackDismissal()
+
+    /// Handler for a navigation URL
+    func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void)
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
@@ -11,7 +11,7 @@ protocol PluginSetupWebViewModel {
     var initialURL: URL? { get }
 
     /// Triggered when the web view is dismissed
-    func trackDismissal()
+    func handleDismissal()
 
     /// Handler for a navigation URL
     func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void)

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -1,0 +1,54 @@
+import Alamofire
+import Foundation
+import WebKit
+import struct Yosemite.Credentials
+import class Networking.UserAgent
+
+/// An extension to authenticate WPCom automatically
+///
+extension WKWebView {
+    func authenticateForWPComAndRedirect(to url: URL, credentials: Credentials?) {
+        customUserAgent = UserAgent.defaultUserAgent
+        configureForSandboxEnvironment()
+        do {
+            try load(authenticatedPostData(with: credentials, redirectTo: url))
+        } catch {
+            DDLogError("⛔️ Cannot load the authenticated web view on WPCom")
+        }
+    }
+
+    private func authenticatedPostData(with credentials: Credentials?, redirectTo url: URL) throws -> URLRequest {
+        guard let username = credentials?.username,
+              let token = credentials?.authToken else {
+            return URLRequest(url: url)
+        }
+
+        var request = URLRequest(url: WooConstants.URLs.loginWPCom.asURL())
+        request.httpMethod = "POST"
+        request.httpShouldHandleCookies = true
+
+        let parameters = ["log": username,
+                          "redirect_to": url.absoluteString,
+                          "authorization": "Bearer " + token]
+
+        return try URLEncoding.default.encode(request, with: parameters)
+    }
+
+    /// For all test cases, to test against the staging server
+    /// please apply the following patch after replacing [secret] with a sandbox secret from the secret store.
+    ///
+    private func configureForSandboxEnvironment() {
+        #if DEBUG
+        if let cookie = HTTPCookie(properties: [
+            .domain: ".wordpress.com",
+            .path: "/",
+            .name: "store_sandbox",
+            .value: "[secret]",
+            .secure: "TRUE"
+        ]) {
+            configuration.websiteDataStore.httpCookieStore.setCookie(cookie) {
+            }
+        }
+        #endif
+    }
+}

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -9,7 +9,6 @@ import class Networking.UserAgent
 extension WKWebView {
     func authenticateForWPComAndRedirect(to url: URL, credentials: Credentials?) {
         customUserAgent = UserAgent.defaultUserAgent
-        configureForSandboxEnvironment()
         do {
             try load(authenticatedPostData(with: credentials, redirectTo: url))
         } catch {
@@ -32,23 +31,5 @@ extension WKWebView {
                           "authorization": "Bearer " + token]
 
         return try URLEncoding.default.encode(request, with: parameters)
-    }
-
-    /// For all test cases, to test against the staging server
-    /// please apply the following patch after replacing [secret] with a sandbox secret from the secret store.
-    ///
-    private func configureForSandboxEnvironment() {
-        #if DEBUG
-        if let cookie = HTTPCookie(properties: [
-            .domain: ".wordpress.com",
-            .path: "/",
-            .name: "store_sandbox",
-            .value: "[secret]",
-            .secure: "TRUE"
-        ]) {
-            configuration.websiteDataStore.httpCookieStore.setCookie(cookie) {
-            }
-        }
-        #endif
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1661,7 +1661,6 @@
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
-		DEBC3136287E9A5B00337AB5 /* JetpackSetupWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBC3134287E9A5B00337AB5 /* JetpackSetupWebViewController.swift */; };
 		DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
 		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
@@ -1687,6 +1686,9 @@
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */; };
+		DEF36DE82898D3CF00178AC2 /* JetpackSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */; };
+		DEF36DE92898D3CF00178AC2 /* PluginSetupWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */; };
+		DEF36DEA2898D3CF00178AC2 /* PluginSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
@@ -3486,7 +3488,6 @@
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEA426992875440500265B0C /* PaymentMethodsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsScreen.swift; sourceTree = "<group>"; };
-		DEBC3134287E9A5B00337AB5 /* JetpackSetupWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewController.swift; sourceTree = "<group>"; };
 		DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmails.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
 		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
@@ -3512,6 +3513,9 @@
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSelectedRate.swift; sourceTree = "<group>"; };
+		DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModel.swift; sourceTree = "<group>"; };
+		DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewController.swift; sourceTree = "<group>"; };
+		DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
@@ -7880,7 +7884,9 @@
 				FE28F7102684CA29004465C7 /* RoleErrorViewController.swift */,
 				FE28F7112684CA29004465C7 /* RoleErrorViewController.xib */,
 				FE28F7172684EE6A004465C7 /* RoleErrorViewModel.swift */,
-				DEBC3134287E9A5B00337AB5 /* JetpackSetupWebViewController.swift */,
+				DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */,
+				DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */,
+				DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */,
 			);
 			path = "Navigation Exceptions";
 			sourceTree = "<group>";
@@ -9112,7 +9118,6 @@
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
 				31AD0B1126E9575F000B6391 /* CardPresentModalConnectingFailed.swift in Sources */,
-				DEBC3136287E9A5B00337AB5 /* JetpackSetupWebViewController.swift in Sources */,
 				576EA39425264C9B00AFC0B3 /* RefundConfirmationViewModel.swift in Sources */,
 				DEC51B00276AEE91009F3DF4 /* SystemStatusReportViewModel.swift in Sources */,
 				CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */,
@@ -9423,6 +9428,7 @@
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,
+				DEF36DE92898D3CF00178AC2 /* PluginSetupWebViewController.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				D8610D762570AE1F00A5DF27 /* NotWPErrorViewModel.swift in Sources */,
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,
@@ -9674,6 +9680,7 @@
 				DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */,
 				45DB705A26124C710064A6CF /* TitleAndTextFieldRow.swift in Sources */,
 				DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */,
+				DEF36DE82898D3CF00178AC2 /* JetpackSetupWebViewModel.swift in Sources */,
 				0270F47624D005B00005210A /* ProductFormViewModelProtocol.swift in Sources */,
 				268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
@@ -9928,6 +9935,7 @@
 				B541B21A2189F3A2008FE7C1 /* StringFormatter.swift in Sources */,
 				0279F0DF252DC12D0098D7DE /* ProductLoaderViewControllerModel+Init.swift in Sources */,
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
+				DEF36DEA2898D3CF00178AC2 /* PluginSetupWebViewModel.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1632,6 +1632,7 @@
 		DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */; };
 		DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4FB7722812AE96003D20D6 /* FilterListView.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
+		DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
@@ -3460,6 +3461,7 @@
 		DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCreationSuccess.swift; sourceTree = "<group>"; };
 		DE4FB7722812AE96003D20D6 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
+		DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Authenticated.swift"; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
@@ -7295,6 +7297,7 @@
 				450C6EE9286F4334002DB168 /* SitePlugin+Woo.swift */,
 				B9B6DEEE283F8B9F00901FB7 /* Site+URL.swift */,
 				021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */,
+				DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9420,6 +9423,7 @@
 				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
 				D8EE9692264D328A0033B2F9 /* ReceiptViewController.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
+				DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */,
 				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,
 				311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */,
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1689,6 +1689,7 @@
 		DEF36DE82898D3CF00178AC2 /* JetpackSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */; };
 		DEF36DE92898D3CF00178AC2 /* PluginSetupWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */; };
 		DEF36DEA2898D3CF00178AC2 /* PluginSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */; };
+		DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
@@ -3516,6 +3517,7 @@
 		DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewController.swift; sourceTree = "<group>"; };
 		DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewModel.swift; sourceTree = "<group>"; };
+		DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
@@ -5787,6 +5789,7 @@
 				5768315026694ADC00FDFB6C /* AuthenticationManagerTests.swift */,
 				FEED57F92686544D00E47FD9 /* RoleErrorViewModelTests.swift */,
 				FEEB2F6D268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift */,
+				DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -10204,6 +10207,7 @@
 				FEED57FA2686544D00E47FD9 /* RoleErrorViewModelTests.swift in Sources */,
 				03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */,
 				4535EE82281BE726004212B4 /* CouponCodeInputFormatterTests.swift in Sources */,
+				DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */,
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,
 				CCB366AF274518EC007D437A /* EditableOrderViewModelTests.swift in Sources */,
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
@@ -58,7 +58,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: { _ in })
 
         // When
-        viewModel.trackDismissal()
+        viewModel.handleDismissal()
 
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_jetpack_setup_dismissed" }))

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import WooCommerce
+
+final class JetpackSetupWebViewModelTests: XCTestCase {
+
+    func test_initial_url_is_correct() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: {_ in })
+
+        // Then
+        let expectedURL = "https://wordpress.com/jetpack/connect?url=https://test.com&mobile_redirect=woocommerce://jetpack-connected&from=mobile"
+        XCTAssertEqual(viewModel.initialURL?.absoluteString, expectedURL)
+    }
+
+    func test_completion_handler_is_called_when_navigating_to_mobile_redirect() throws {
+        // Given
+        let siteURL = "https://test.com"
+        var triggeredCompletion = false
+        let completionHandler: (String?) -> Void = { _ in
+            triggeredCompletion = true
+        }
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
+
+        // When
+        let url = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
+        viewModel.decidePolicy(for: url, decisionHandler: { _ in })
+
+        // Then
+        XCTAssertTrue(triggeredCompletion)
+    }
+
+    func test_completion_handler_returns_the_connected_email_from_url_query() throws {
+        // Given
+        let siteURL = "https://test.com"
+        let expectedEmail = "test@mail.com"
+        var authorizedEmail: String?
+        let completionHandler: (String?) -> Void = { email in
+            authorizedEmail = email
+        }
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
+
+        // When
+        let authorizeURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize?user_email=\(expectedEmail)"))
+        viewModel.decidePolicy(for: authorizeURL, decisionHandler: { _ in })
+        let finalUrl = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
+        viewModel.decidePolicy(for: finalUrl, decisionHandler: { _ in })
+
+        // Then
+        XCTAssertEqual(authorizedEmail, expectedEmail)
+    }
+
+    func test_dismissal_is_tracked() throws {
+        // Given
+        let siteURL = "https://test.com"
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: { _ in })
+
+        // When
+        viewModel.trackDismissal()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_jetpack_setup_dismissed" }))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "web")
+    }
+
+    func test_completion_is_tracked() throws {
+        // Given
+        let siteURL = "https://test.com"
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: { _ in })
+
+        // When
+        let url = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
+        viewModel.decidePolicy(for: url, decisionHandler: { _ in })
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_jetpack_setup_completed" }))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "web")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7236 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For #7236, we want to add a new screen for the error when a user tries to log in to a site that doesn't have WooCommerce. For this screen, we want to add a button to install Woo on a web view. This will be very similar to the flow with installing Jetpack, so this PR aims to extract the view model for Jetpack setup from the web view controller so that we can reuse the view controller logic later with Woo setup.

This PR also creates an extension of `WKWebView` and extracts some logic from `AuthenticatedWebView` to authenticate WPCom automatically and avoid forcing users to log in twice. I haven't removed the logic from `AuthenticatedWebView` though since that will require regression test for shipping labels, so I'll create a separate task for the migration after this PR is merged.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
We need to make sure that the Jetpack setup flow still works as before:
- Prerequisite: make sure to have a test site with WooCommerce and no Jetpack.
- To make sure any cookies are cleared from the app's browser, delete the app first.
- Select Enter site address.
- Proceed to log in with either WP.com credentials. After the login succeeds, notice that you reach the no Jetpack error screen.
- Select Install Jetpack and follow the instruction on the web view. 
- When you reach the Jetpack Authorization step, notice that you no longer have to enter WPCom credentials in the web view.
- After the authorization step, notice that the web view is dismissed, and the app navigates to the home screen.

### Screenshot

https://user-images.githubusercontent.com/5533851/182359228-84f5fbc6-62a2-4923-83af-799f648ee54f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
