### PR TITLE
Extract `logErrorAndExit` from Yosemite to WooFoundation

### DIFF
--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -178,7 +178,7 @@ public final class CoreDataManager: StorageManagerType {
                 viewContext.saveIfNeeded()
             }
         } catch {
-            fatalError("☠️ [CoreDataManager] Cannot delete stored objects! \(error)")
+            logErrorAndExit("☠️ [CoreDataManager] Cannot delete stored objects! \(error)")
         }
     }
 
@@ -235,7 +235,7 @@ extension CoreDataManager {
     ///
     var storeURL: URL {
         guard let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            fatalError("Okay: Missing Documents Folder?")
+            logErrorAndExit("Okay: Missing Documents Folder?")
         }
 
         return url.appendingPathComponent(name + ".sqlite")

--- a/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
+++ b/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import WooFoundation
 
 /// NSManagedObjectContext Storage Conformance
 ///
@@ -60,7 +61,7 @@ extension NSManagedObjectContext: StorageType {
     ///
     public func deleteObject<T: Object>(_ object: T) {
         guard let object = object as? NSManagedObject else {
-            fatalError("Invalid Object Kind")
+            logErrorAndExit("Invalid Object Kind")
         }
 
         delete(object)
@@ -114,7 +115,7 @@ extension NSManagedObjectContext: StorageType {
     ///
     public func loadObject<T: Object>(ofType type: T.Type, with objectID: T.ObjectID) -> T? {
         guard let objectID = objectID as? NSManagedObjectID else {
-            fatalError("Invalid ObjectID Kind")
+            logErrorAndExit("Invalid ObjectID Kind")
         }
 
         do {
@@ -137,7 +138,7 @@ extension NSManagedObjectContext: StorageType {
             try save()
         } catch {
             let nserror = error as NSError
-            fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            logErrorAndExit("Unresolved error \(nserror), \(nserror.userInfo)")
         }
     }
 

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		397702D42D32EAEEEA3B29FC /* Pods_WooFoundationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 532D4D63493CE8FA6F13C85B /* Pods_WooFoundationTests.framework */; };
 		686BE912288EE0D300967C86 /* TypedPredicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE911288EE0D300967C86 /* TypedPredicates.swift */; };
 		686BE915288EE2CA00967C86 /* TypedPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE914288EE2CA00967C86 /* TypedPredicateTests.swift */; };
+		6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6874E81328998AD300074A97 /* LogErrorAndExit.swift */; };
 		689D11D02891B3A300F6A83F /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689D11CF2891B3A300F6A83F /* CrashLogger.swift */; };
 		689D11D32891B7D800F6A83F /* MockCrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689D11D22891B7D800F6A83F /* MockCrashLogger.swift */; };
 		68FBC5B328926B2C00A05461 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBC5B228926B2C00A05461 /* Collection+Extensions.swift */; };
@@ -38,6 +39,7 @@
 		5BC355411C0A805BF29F38A6 /* Pods-WooFoundationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationTests.release.xcconfig"; path = "Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests.release.xcconfig"; sourceTree = "<group>"; };
 		686BE911288EE0D300967C86 /* TypedPredicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedPredicates.swift; sourceTree = "<group>"; };
 		686BE914288EE2CA00967C86 /* TypedPredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedPredicateTests.swift; sourceTree = "<group>"; };
+		6874E81328998AD300074A97 /* LogErrorAndExit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogErrorAndExit.swift; sourceTree = "<group>"; };
 		689D11CF2891B3A300F6A83F /* CrashLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashLogger.swift; sourceTree = "<group>"; };
 		689D11D22891B7D800F6A83F /* MockCrashLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCrashLogger.swift; sourceTree = "<group>"; };
 		68FBC5B228926B2C00A05461 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 			isa = PBXGroup;
 			children = (
 				B9C9C662283E7296001B879F /* Logging.swift */,
+				6874E81328998AD300074A97 /* LogErrorAndExit.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 			files = (
 				B9C9C659283E7195001B879F /* NSDecimalNumber+Helpers.swift in Sources */,
 				B9C9C663283E7296001B879F /* Logging.swift in Sources */,
+				6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */,
 				B9C9C65D283E71C8001B879F /* CurrencyFormatter.swift in Sources */,
 				689D11D32891B7D800F6A83F /* MockCrashLogger.swift in Sources */,
 				B987B06F284540D300C53CF6 /* CurrencyCode.swift in Sources */,

--- a/WooFoundation/WooFoundation/Internal/LogErrorAndExit.swift
+++ b/WooFoundation/WooFoundation/Internal/LogErrorAndExit.swift
@@ -1,12 +1,13 @@
 import Foundation
 
+
 /// Logs the error in CocoaLumberjack and stops app execution.
 ///
 /// Prefer to use this instead of `fatalError()` since messages in fatal errors are not shown
 /// in Sentry. Using this method, Sentry will still only show “Fatal error” in the Issue message
 /// but the `message` can now be accessed through the Encrypted Logging Console.
 ///
-internal func logErrorAndExit(_ message: String, file: StaticString = #file, line: UInt = #line) -> Never {
+public func logErrorAndExit(_ message: String, file: StaticString = #file, line: UInt = #line) -> Never {
     DDLogError(message)
     fatalError(message, file: file, line: line)
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -202,7 +202,6 @@
 		45ED6096257E7472007B4AC6 /* ProductAttributeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED6095257E7472007B4AC6 /* ProductAttributeStore.swift */; };
 		570B05CF246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */; };
 		57150E1124F462D900E81611 /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 57150E1024F462D900E81611 /* TestKit */; };
-		571D7E3F251BB9FA00606E96 /* LogErrorAndExit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571D7E3E251BB9FA00606E96 /* LogErrorAndExit.swift */; };
 		5726456F250BD4E4005BBD7C /* OrdersUpsertUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726456E250BD4E4005BBD7C /* OrdersUpsertUseCase.swift */; };
 		57264572250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57264571250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift */; };
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
@@ -598,7 +597,6 @@
 		45ED6091257E72F4007B4AC6 /* ProductAttributeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeAction.swift; sourceTree = "<group>"; };
 		45ED6095257E7472007B4AC6 /* ProductAttributeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeStore.swift; sourceTree = "<group>"; };
 		570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveProductReviewFromNoteUseCase.swift; sourceTree = "<group>"; };
-		571D7E3E251BB9FA00606E96 /* LogErrorAndExit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogErrorAndExit.swift; sourceTree = "<group>"; };
 		5726456E250BD4E4005BBD7C /* OrdersUpsertUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersUpsertUseCase.swift; sourceTree = "<group>"; };
 		57264571250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersUpsertUseCaseTests.swift; sourceTree = "<group>"; };
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
@@ -1517,7 +1515,6 @@
 				933A27342222352500C2143A /* Logging.swift */,
 				743057B2218B69D100441A76 /* Queue.swift */,
 				02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */,
-				571D7E3E251BB9FA00606E96 /* LogErrorAndExit.swift */,
 				247CE7AA2582DB9300F9D9D1 /* String+Extensions.swift */,
 			);
 			path = Internal;
@@ -2000,7 +1997,6 @@
 				D4CBAE6426D4464500BBE6D1 /* AnnouncementsAction.swift in Sources */,
 				CE43A90222A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift in Sources */,
 				B5C9DE182087FF0E006B910A /* Assert.swift in Sources */,
-				571D7E3F251BB9FA00606E96 /* LogErrorAndExit.swift in Sources */,
 				DE3C5B1D286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift in Sources */,
 				CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */,
 				247CE87225832E7000F9D9D1 /* MockProductReviewAction.swift in Sources */,

--- a/Yosemite/Yosemite/Base/Dispatcher.swift
+++ b/Yosemite/Yosemite/Base/Dispatcher.swift
@@ -1,5 +1,5 @@
 import Foundation
-
+import WooFoundation
 
 // MARK: - Action: Represents a Flux Action.
 //

--- a/Yosemite/Yosemite/Base/Store.swift
+++ b/Yosemite/Yosemite/Base/Store.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Storage
 import Networking
+import WooFoundation
 
 
 // MARK: - Store: Holds the data associated to a specific domain of the application.

--- a/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
+++ b/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WooFoundation
 
 extension OrderStatsV4Interval {
     /// Returns the interval start date by parsing the `dateStart` string.

--- a/Yosemite/Yosemite/Stores/NotificationCountStore.swift
+++ b/Yosemite/Yosemite/Stores/NotificationCountStore.swift
@@ -1,5 +1,6 @@
 import Storage
 import Networking
+import WooFoundation
 
 // MARK: - NotificationCountStore
 //


### PR DESCRIPTION
Preparation work for #2091

### Context for these changes:

When we call `fatalError()` in the app, we generally include a message that could help with debugging in the future when we look at the crash reports, however, at the moment [these are not logged in Sentry](https://github.com/woocommerce/woocommerce-ios/issues/2091).

We could intercept these by using WooFoundation's `CrashLogger` in order to log errors both into the app and Sentry, and to make the current logging framework-agnostic, which is currently split and implemented differently on each target.

### Description:

This PR moves the current `logErrorAndExit()` method from `Yosemite` to `WooFoundation`, so we can remove code duplication, and so this can be used across any target. This PR doesn't still doesn't change how we log errors to Sentry, and neither uses any sort of common `CrashLogger`, we'll deal with that later :) 

### Changes:

- Yosemite: Removes `logErrorAndExit` and imports WooFoundation where needed.
- WooFoundation: Adds `logErrorAndExit`
- Storage: Changes some cases of `fatalError()` to `logErrorAndExit()` where we already imported WooFoundation and we're passing an error message.

### Testing instructions:

Fatal Errors that happen on the Yosemite or Storage layer should behave as always, we can test this by forcing one. For example [here](https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval%2BDate.swift#L5-L10) 

1 - Add the extra `logErrorAndExit()` before the guard:

```
    /// Returns the interval start date by parsing the `dateStart` string.
    public func dateStart(timeZone: TimeZone) -> Date {
        logErrorAndExit("Failed to parse date: \(dateStart)") // Test
        guard let date = createDateFormatter(timeZone: timeZone).date(from: dateStart) else {
            logErrorAndExit("Failed to parse date: \(dateStart)")
        }
        return date
    }
```

2 - Run the app and see the crash
3 - Remove the line, and re-run the app
4 - Go to  Menu > Settings > Support > Application logs > Current
5 - Scroll a bit until you see the logged DDlog that says `"Failed to parse date: YOUR-SITE-DATE-HERE")`

<img width=450 src="https://user-images.githubusercontent.com/3812076/182433319-4d93414c-6b26-496f-ac54-618f9a4a22cc.png">


